### PR TITLE
config: check in appsettings.Development.json + scaffold Production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ appsettings.*.local.json
 **/appsettings.json
 **/appsettings.Development.json
 !**/appsettings.example.json
+# Checked-in reference config for the API (safe defaults; real secrets go in user-secrets)
+!src/RetailPulse.Api/appsettings.Development.json
 
 # Squad: ignore runtime state (logs, inbox, sessions)
 .squad/orchestration-log/

--- a/README.md
+++ b/README.md
@@ -84,14 +84,15 @@ dotnet user-secrets set "OpenAI:ApiKey" "<your-api-key>" --project src/RetailPul
 > dotnet user-secrets set "OpenAI:Endpoint" "<your-azure-openai-endpoint>" --project src/RetailPulse.Api
 > ```
 
-> **Want every setting in one place?** Copy the fully-commented template to a
-> local (git-ignored) override and tweak as needed:
-> ```bash
-> cp src/RetailPulse.Api/appsettings.example.json src/RetailPulse.Api/appsettings.Development.json
-> ```
-> It documents all sections (OpenAI, Security, FoundryAgent, ToolCache,
-> TokenPricing, Observability, …) with safe Development defaults. Keep real
-> secrets in user-secrets, not in the committed example.
+> **Every setting in one place:** [`src/RetailPulse.Api/appsettings.Development.json`](src/RetailPulse.Api/appsettings.Development.json)
+> is checked in as the reference local-dev config — it's loaded automatically
+> in Development and documents all sections (OpenAI, Security, FoundryAgent,
+> ToolCache, TokenPricing, Observability, …) with safe defaults. Edit it
+> directly for non-secret tweaks; keep real secrets in user-secrets, **not**
+> in this committed file. For deployment, see
+> [`appsettings.Production.json`](src/RetailPulse.Api/appsettings.Production.json),
+> which lists the production surface with placeholders (supply secrets via
+> environment variables or Azure Key Vault).
 
 ### 4. Run with Aspire
 

--- a/src/RetailPulse.Api/appsettings.Development.json
+++ b/src/RetailPulse.Api/appsettings.Development.json
@@ -1,29 +1,29 @@
 {
   // =====================================================================
-  //  RetailPulse.Api — LOCAL DEVELOPMENT settings template
+  //  RetailPulse.Api — appsettings.Development.json
   // ---------------------------------------------------------------------
-  //  HOW TO USE
-  //    1. Copy this file to `appsettings.Development.json` in the same
-  //       folder (that name is auto-loaded in Development and is
-  //       git-ignored, so your local edits/secrets never get committed):
-  //         Copy-Item appsettings.example.json appsettings.Development.json
-  //    2. Provide your LLM key. PREFERRED — keep it out of any file via
-  //       user-secrets (already wired for this project):
-  //         dotnet user-secrets set "OpenAI:ApiKey" "<your-key>" --project src/RetailPulse.Api
-  //       (Or set OpenAI.ApiKey below — but never commit a real key.)
-  //    3. Run with Aspire from the repo root:
-  //         dotnet run --project src/RetailPulse.AppHost
+  //  This file is CHECKED IN as the reference local-dev configuration and
+  //  is loaded automatically when the app runs in the Development
+  //  environment (it layers over appsettings.json). It documents every
+  //  setting the API reads, with safe defaults that boot out of the box.
+  //
+  //  PROVIDE YOUR LLM KEY (do NOT paste a real key into this committed file):
+  //    dotnet user-secrets set "OpenAI:ApiKey" "<your-key>" --project src/RetailPulse.Api
+  //  user-secrets override this file at runtime and are never committed.
+  //
+  //  RUN (from the repo root):
+  //    dotnet run --project src/RetailPulse.AppHost
   //
   //  NOTES
-  //    * Every value here is a safe Development default. With no changes,
-  //      the API boots: in Development a missing OpenAI.ApiKey falls back
-  //      to "demo-key" and the endpoint defaults to the dev APIM gateway.
-  //      The demo key returns 401 on real LLM calls — set a real key to
-  //      get working chat/agents.
+  //    * With no edits the API boots: in Development a missing
+  //      OpenAI.ApiKey falls back to "demo-key" and the endpoint defaults
+  //      to the dev APIM gateway. The demo key returns 401 on real LLM
+  //      calls — set a real key (via user-secrets) to get working chat.
   //    * `:` in a key maps to `__` as an environment variable
   //      (e.g. OpenAI:ApiKey -> OpenAI__ApiKey, $env:OpenAI__ApiKey).
   //    * JSON comments + trailing commas are allowed by the .NET JSON
-  //      configuration provider, so this file loads as-is once copied.
+  //      configuration provider, so this file loads as-is.
+  //    * For production settings see appsettings.Production.json.
   // =====================================================================
 
   "Logging": {

--- a/src/RetailPulse.Api/appsettings.Production.json
+++ b/src/RetailPulse.Api/appsettings.Production.json
@@ -1,8 +1,130 @@
 {
+  // =====================================================================
+  //  RetailPulse.Api — appsettings.Production.json
+  // ---------------------------------------------------------------------
+  //  Loaded automatically when ASPNETCORE_ENVIRONMENT=Production (layers
+  //  over appsettings.json). This file documents the production surface
+  //  with SAFE placeholders only.
+  //
+  //  SECRETS — NEVER COMMIT REAL VALUES HERE.
+  //    Supply secrets at deploy time via environment variables (`:` -> `__`,
+  //    e.g. OpenAI__ApiKey) or a secret store (Azure Key Vault / Container
+  //    Apps secrets). These override the placeholders below at runtime.
+  //
+  //  REQUIRED IN PRODUCTION (the app fails fast at startup if missing):
+  //    * OpenAI:ApiKey       — set via OpenAI__ApiKey or Key Vault
+  //    * OpenAI:Endpoint     — your production APIM AI Gateway URL
+  //    * Security:JwtAuthority / Security:JwtAudience — for bearer auth
+  // =====================================================================
+
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AllowedHosts": "*",
+
+  // ---- LLM / AI Gateway -------------------------------------------------
+  "OpenAI": {
+    // REQUIRED. Leave empty here; inject at deploy time (OpenAI__ApiKey or
+    // Key Vault). A blank value in Production makes the app fail fast.
+    "ApiKey": "",
+    // REQUIRED. Your production APIM AI Gateway (or Azure OpenAI) endpoint.
+    "Endpoint": "https://<your-prod-apim-gateway>.azure-api.net/inference",
+    "ApiVersion": "2025-03-01-preview",
+    // Optional: separate deployment for the intent router.
+    "RouterDeployment": ""
+  },
+
+  // ---- MCP tool server --------------------------------------------------
+  // Internal service URL in your production environment.
+  "McpServer": {
+    "BaseUrl": "https://<your-mcpserver-host>"
+  },
+
+  // ---- CORS -------------------------------------------------------------
+  // Production web origin(s). Used by Security:AllowedOrigins below as well.
+  "Cors": {
+    "AllowedOrigins": [
+      "https://<your-production-web-domain>"
+    ]
+  },
+
+  // ---- Security / Auth --------------------------------------------------
+  // Real bearer auth is enforced in Production (no DevelopmentAuthHandler).
+  "Security": {
+    "RequireAuth": true,
+    // REQUIRED. e.g. https://login.microsoftonline.com/<tenant-id>/v2.0
+    "JwtAuthority": "https://login.microsoftonline.com/<your-tenant-id>/v2.0",
+    // REQUIRED. The API's application (client) ID / audience.
+    "JwtAudience": "<your-api-audience>",
+    // Origins allowed by CORS in Production.
+    "AllowedOrigins": [
+      "https://<your-production-web-domain>"
+    ]
+  },
+
+  // ---- Optional: Azure AI Foundry hosted agent --------------------------
+  "FoundryAgent": {
+    "Enabled": false,
+    "ProjectEndpoint": "<your-foundry-project-endpoint>",
+    "ShipmentAgentName": "Distribution Analysis Specialist",
+    "ShipmentAgentId": "<your-agent-id>"
+  },
+
+  // ---- Telemetry --------------------------------------------------------
+  // Connection string injected by the host (AppHost / Key Vault / env).
+  "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
+  "Telemetry": {
+    // Keep false in production to avoid capturing prompt/completion content.
+    "EnableSensitiveData": false
+  },
+
+  // ---- Proactive alerts background service ------------------------------
+  "Alerts": {
+    "CheckIntervalMinutes": 5
+  },
+
+  // ---- Knowledge base (RAG) limits --------------------------------------
+  "Knowledge": {
+    "MaxDocumentSizeBytes": 10485760,
+    "MaxDocuments": 100,
+    "MaxChunks": 5000
+  },
+
+  // ---- Observability store (in-memory cost/session caps) ----------------
+  "Observability": {
+    "MaxCostEvents": 10000,
+    "CostEventTtlHours": 24,
+    "MaxSessions": 1000,
+    "MaxMessagesPerSession": 200
+  },
+
+  // ---- Tool-result cache ------------------------------------------------
+  "ToolCache": {
+    "Enabled": true,
+    "DefaultTtlMinutes": 30,
+    "ToolTtls": {
+      "GetHistoricalDemand": 60,
+      "GetSeasonalityFactors": 120,
+      "GenerateForecast": 30,
+      "IdentifyDemandRisks": 15,
+      "GetShipmentStats": 10,
+      "GetFieldSentiment": 15
+    }
+  },
+
+  // ---- Per-model token pricing (powers the cost dashboard) --------------
+  // USD per 1M tokens. Add/adjust models as needed; unknown models cost 0.
+  "TokenPricing": {
+    "gpt-5.5": { "InputPerMillion": 5.00, "OutputPerMillion": 30.00 },
+    "gpt-5.5-mini": { "InputPerMillion": 0.50, "OutputPerMillion": 2.00 },
+    "gpt-5.4-mini": { "InputPerMillion": 0.25, "OutputPerMillion": 2.00 },
+    "gpt-4o": { "InputPerMillion": 2.50, "OutputPerMillion": 10.00 },
+    "gpt-4o-mini": { "InputPerMillion": 0.15, "OutputPerMillion": 0.60 },
+    "claude-opus-4.6": { "InputPerMillion": 5.00, "OutputPerMillion": 25.00 },
+    "claude-sonnet-4.6": { "InputPerMillion": 3.00, "OutputPerMillion": 15.00 },
+    "claude-haiku-4.5": { "InputPerMillion": 1.00, "OutputPerMillion": 5.00 }
   }
 }


### PR DESCRIPTION
Per request: drop the `example` file and check in a real `appsettings.Development.json` as the reference local-dev config, plus a fully-scaffolded `appsettings.Production.json`.

### Changes
- **Renamed** `appsettings.example.json` -> `appsettings.Development.json` (auto-loaded in Development; header rewritten to reflect it's the checked-in reference, not a copy-me template).
- **Scaffolded** `appsettings.Production.json` with all 14 sections using production placeholders; required secrets (OpenAI key/endpoint, JWT authority/audience) marked as deploy-time env / Key Vault values.
- **.gitignore:** whitelisted `src/RetailPulse.Api/appsettings.Development.json` so the reference dev config is tracked; all other env/secret files stay ignored.
- **README:** setup + deployment now point at the checked-in Dev/Prod files instead of a copy-the-example step.

### Safety
- Secret-safe: placeholders / empty strings only (scanned).
- Both files validated under the .NET JSON config provider options (comment-skip + trailing commas); 14 sections each.