### PR TITLE
feat(web): telemetry-first nav with feature-flagged secondary tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ The SignalR `TelemetryHub` streams agent execution spans to connected clients in
 
 The React dashboard renders these as an interactive span timeline alongside the chat panel.
 
+The web app navigation is intentionally minimal by default: Chat, Real-Time Telemetry, and Observability. Real-Time Telemetry is always available, while Observability remains enabled by default for the AI Gateway via Azure APIM view of costs, token usage, and metrics. Secondary demo tabs such as Campaign Planner, Competitive, Knowledge Base, Health Council, Security, Cards, Stores, Financials, and Portfolio are gated behind `VITE_FEATURE_*` flags; copy `src/RetailPulse.Web/.env.example` to `.env.local` to enable them locally.
+
 ---
 
 ## Configuration

--- a/src/RetailPulse.Web/.env.example
+++ b/src/RetailPulse.Web/.env.example
@@ -1,0 +1,35 @@
+# Retail Pulse Web feature flags
+#
+# Real-Time Telemetry is always visible and remains the front-and-center app focus.
+# Secondary navigation tabs are hidden by default; set a flag to true (or 1) to enable a tab.
+# Copy this file to .env.local for local overrides. Do not put secrets in VITE_* variables.
+
+# Campaign Planner tab for promotion planning workflows. Default: false
+# VITE_FEATURE_CAMPAIGN_PLANNER=false
+
+# Competitive tab for competitive landscape dashboards. Default: false
+# VITE_FEATURE_COMPETITIVE=false
+
+# Knowledge Base tab for memory and knowledge exploration. Default: false
+# VITE_FEATURE_KNOWLEDGE_BASE=false
+
+# Health Council tab for multi-agent council views. Default: false
+# VITE_FEATURE_HEALTH_COUNCIL=false
+
+# Security tab for guardrails dashboards and configuration. Default: false
+# VITE_FEATURE_SECURITY=false
+
+# Cards tab for Adaptive Card rendering and previews. Default: false
+# VITE_FEATURE_CARDS=false
+
+# Stores tab for store operations, stockout risks, and heatmaps. Default: false
+# VITE_FEATURE_STORES=false
+
+# Financials tab for margin waterfall and driver views. Default: false
+# VITE_FEATURE_FINANCIALS=false
+
+# Portfolio tab for brand scorecards and explanations. Default: false
+# VITE_FEATURE_PORTFOLIO=false
+
+# Observability tab for AI Gateway cost, token usage, and APIM metrics. Default: true
+# VITE_FEATURE_OBSERVABILITY=true

--- a/src/RetailPulse.Web/README.md
+++ b/src/RetailPulse.Web/README.md
@@ -2,6 +2,27 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Feature flags / Navigation
+
+Retail Pulse keeps the default web navigation focused on **Chat**, **Real-Time Telemetry**, and **Observability**. Real-Time Telemetry is always visible and streams live agent spans, token totals, and cost estimates. Observability is enabled by default because it shows the AI Gateway via Azure APIM story: costs, token usage, and operational metrics.
+
+Secondary demo tabs are configuration-gated and hidden by default. To enable optional tabs locally, copy `.env.example` to `.env.local` and set the matching `VITE_FEATURE_*` flag to `true` or `1`.
+
+Available flags:
+
+| Flag | Default | Tab |
+|------|---------|-----|
+| `VITE_FEATURE_CAMPAIGN_PLANNER` | `false` | Campaign Planner |
+| `VITE_FEATURE_COMPETITIVE` | `false` | Competitive |
+| `VITE_FEATURE_KNOWLEDGE_BASE` | `false` | Knowledge Base |
+| `VITE_FEATURE_HEALTH_COUNCIL` | `false` | Health Council |
+| `VITE_FEATURE_SECURITY` | `false` | Security |
+| `VITE_FEATURE_CARDS` | `false` | Cards |
+| `VITE_FEATURE_STORES` | `false` | Stores |
+| `VITE_FEATURE_FINANCIALS` | `false` | Financials |
+| `VITE_FEATURE_PORTFOLIO` | `false` | Portfolio |
+| `VITE_FEATURE_OBSERVABILITY` | `true` | Observability |
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -24,6 +24,7 @@ import { MarginWaterfall, MarginDrivers } from './margin';
 import { PortfolioScorecard, BrandScoreCard, ExplanationPanel } from './scorecard';
 import type { AgentSpan, RoutingInfo, TokenUsage, ApprovalRequest, ApprovalDecision, Alert, SnoozeDuration, Trace, TraceSpan, StorePerformance, StockoutRisk, MarginWaterfallStep, MarginDriver, BrandScore, ExplanationData } from '../types';
 import { connectTelemetryHub } from '../services/telemetryHub';
+import { featureFlags } from '../config/featureFlags';
 
 const DRAWER_WIDTH_PX = 560;
 const DRAWER_BREAKPOINT_PX = 768;
@@ -428,86 +429,106 @@ export function Dashboard() {
             pendingApprovals={pendingApprovals}
             onClick={() => setTelemetryOpen(true)}
           />
-          <Button
-            appearance={activeView === 'promo' ? 'primary' : 'subtle'}
-            icon={<TargetArrow24Regular />}
-            onClick={() => setActiveView(prev => prev === 'promo' ? 'chat' : 'promo')}
-            style={activeView === 'promo' ? { backgroundColor: '#22c55e', borderColor: '#22c55e' } : undefined}
-          >
-            {activeView === 'promo' ? 'Back to Chat' : 'Campaign Planner'}
-          </Button>
-          <Button
-            appearance={activeView === 'competitive' ? 'primary' : 'subtle'}
-            icon={<Shield24Regular />}
-            onClick={() => setActiveView(prev => prev === 'competitive' ? 'chat' : 'competitive')}
-            style={activeView === 'competitive' ? { backgroundColor: '#ef4444', borderColor: '#ef4444' } : undefined}
-          >
-            {activeView === 'competitive' ? 'Back to Chat' : 'Competitive'}
-          </Button>
-          <Button
-            appearance={activeView === 'knowledge' ? 'primary' : 'subtle'}
-            icon={<Library24Regular />}
-            onClick={() => setActiveView(prev => prev === 'knowledge' ? 'chat' : 'knowledge')}
-            style={activeView === 'knowledge' ? { backgroundColor: '#06b6d4', borderColor: '#06b6d4' } : undefined}
-          >
-            {activeView === 'knowledge' ? 'Back to Chat' : 'Knowledge Base'}
-          </Button>
-          <Button
-            appearance={activeView === 'council' ? 'primary' : 'subtle'}
-            icon={<HeartPulse24Regular />}
-            onClick={() => setActiveView(prev => prev === 'council' ? 'chat' : 'council')}
-            style={activeView === 'council' ? { backgroundColor: '#0f7b0f', borderColor: '#0f7b0f' } : undefined}
-          >
-            {activeView === 'council' ? 'Back to Chat' : 'Health Council'}
-          </Button>
-          <Button
-            appearance={activeView === 'security' ? 'primary' : 'subtle'}
-            icon={<ShieldCheckmark24Regular />}
-            onClick={() => setActiveView(prev => prev === 'security' ? 'chat' : 'security')}
-            style={activeView === 'security' ? { backgroundColor: '#f59e0b', borderColor: '#f59e0b' } : undefined}
-          >
-            {activeView === 'security' ? 'Back to Chat' : 'Security'}
-          </Button>
-          <Button
-            appearance={activeView === 'cards' ? 'primary' : 'subtle'}
-            icon={<CardUi24Regular />}
-            onClick={() => setActiveView(prev => prev === 'cards' ? 'chat' : 'cards')}
-            style={activeView === 'cards' ? { backgroundColor: '#3b82f6', borderColor: '#3b82f6' } : undefined}
-          >
-            {activeView === 'cards' ? 'Back to Chat' : 'Cards'}
-          </Button>
-          <Button
-            appearance={activeView === 'observability' ? 'primary' : 'subtle'}
-            icon={<Eye24Regular />}
-            onClick={() => setActiveView(prev => prev === 'observability' ? 'chat' : 'observability')}
-            style={activeView === 'observability' ? { backgroundColor: '#06b6d4', borderColor: '#06b6d4' } : undefined}
-          >
-            {activeView === 'observability' ? 'Back to Chat' : 'Observability'}
-          </Button>
-          <Button
-            appearance={activeView === 'stores' ? 'primary' : 'subtle'}
-            icon={<Building24Regular />}
-            onClick={() => setActiveView(prev => prev === 'stores' ? 'chat' : 'stores')}
-            style={activeView === 'stores' ? { backgroundColor: '#22c55e', borderColor: '#22c55e' } : undefined}
-          >
-            {activeView === 'stores' ? 'Back to Chat' : 'Stores'}
-          </Button>
-          <Button
-            appearance={activeView === 'financials' ? 'primary' : 'subtle'}
-            icon={<Money24Regular />}
-            onClick={() => setActiveView(prev => prev === 'financials' ? 'chat' : 'financials')}
-            style={activeView === 'financials' ? { backgroundColor: '#3b82f6', borderColor: '#3b82f6' } : undefined}
-          >
-            {activeView === 'financials' ? 'Back to Chat' : 'Financials'}
-          </Button>
-          <Button
-            appearance={activeView === 'portfolio' ? 'primary' : 'subtle'}
-            icon={<Star24Regular />}
-            onClick={() => setActiveView(prev => prev === 'portfolio' ? 'chat' : 'portfolio')}
-            style={activeView === 'portfolio' ? { backgroundColor: '#8b5cf6', borderColor: '#8b5cf6' } : undefined}
-          >
-            {activeView === 'portfolio' ? 'Back to Chat' : 'Portfolio'}
-          </Button>
+          {featureFlags.campaignPlanner && (
+            <Button
+              appearance={activeView === 'promo' ? 'primary' : 'subtle'}
+              icon={<TargetArrow24Regular />}
+              onClick={() => setActiveView(prev => prev === 'promo' ? 'chat' : 'promo')}
+              style={activeView === 'promo' ? { backgroundColor: '#22c55e', borderColor: '#22c55e' } : undefined}
+            >
+              {activeView === 'promo' ? 'Back to Chat' : 'Campaign Planner'}
+            </Button>
+          )}
+          {featureFlags.competitive && (
+            <Button
+              appearance={activeView === 'competitive' ? 'primary' : 'subtle'}
+              icon={<Shield24Regular />}
+              onClick={() => setActiveView(prev => prev === 'competitive' ? 'chat' : 'competitive')}
+              style={activeView === 'competitive' ? { backgroundColor: '#ef4444', borderColor: '#ef4444' } : undefined}
+            >
+              {activeView === 'competitive' ? 'Back to Chat' : 'Competitive'}
+            </Button>
+          )}
+          {featureFlags.knowledgeBase && (
+            <Button
+              appearance={activeView === 'knowledge' ? 'primary' : 'subtle'}
+              icon={<Library24Regular />}
+              onClick={() => setActiveView(prev => prev === 'knowledge' ? 'chat' : 'knowledge')}
+              style={activeView === 'knowledge' ? { backgroundColor: '#06b6d4', borderColor: '#06b6d4' } : undefined}
+            >
+              {activeView === 'knowledge' ? 'Back to Chat' : 'Knowledge Base'}
+            </Button>
+          )}
+          {featureFlags.healthCouncil && (
+            <Button
+              appearance={activeView === 'council' ? 'primary' : 'subtle'}
+              icon={<HeartPulse24Regular />}
+              onClick={() => setActiveView(prev => prev === 'council' ? 'chat' : 'council')}
+              style={activeView === 'council' ? { backgroundColor: '#0f7b0f', borderColor: '#0f7b0f' } : undefined}
+            >
+              {activeView === 'council' ? 'Back to Chat' : 'Health Council'}
+            </Button>
+          )}
+          {featureFlags.security && (
+            <Button
+              appearance={activeView === 'security' ? 'primary' : 'subtle'}
+              icon={<ShieldCheckmark24Regular />}
+              onClick={() => setActiveView(prev => prev === 'security' ? 'chat' : 'security')}
+              style={activeView === 'security' ? { backgroundColor: '#f59e0b', borderColor: '#f59e0b' } : undefined}
+            >
+              {activeView === 'security' ? 'Back to Chat' : 'Security'}
+            </Button>
+          )}
+          {featureFlags.cards && (
+            <Button
+              appearance={activeView === 'cards' ? 'primary' : 'subtle'}
+              icon={<CardUi24Regular />}
+              onClick={() => setActiveView(prev => prev === 'cards' ? 'chat' : 'cards')}
+              style={activeView === 'cards' ? { backgroundColor: '#3b82f6', borderColor: '#3b82f6' } : undefined}
+            >
+              {activeView === 'cards' ? 'Back to Chat' : 'Cards'}
+            </Button>
+          )}
+          {featureFlags.observability && (
+            <Button
+              appearance={activeView === 'observability' ? 'primary' : 'subtle'}
+              icon={<Eye24Regular />}
+              onClick={() => setActiveView(prev => prev === 'observability' ? 'chat' : 'observability')}
+              style={activeView === 'observability' ? { backgroundColor: '#06b6d4', borderColor: '#06b6d4' } : undefined}
+            >
+              {activeView === 'observability' ? 'Back to Chat' : 'Observability'}
+            </Button>
+          )}
+          {featureFlags.stores && (
+            <Button
+              appearance={activeView === 'stores' ? 'primary' : 'subtle'}
+              icon={<Building24Regular />}
+              onClick={() => setActiveView(prev => prev === 'stores' ? 'chat' : 'stores')}
+              style={activeView === 'stores' ? { backgroundColor: '#22c55e', borderColor: '#22c55e' } : undefined}
+            >
+              {activeView === 'stores' ? 'Back to Chat' : 'Stores'}
+            </Button>
+          )}
+          {featureFlags.financials && (
+            <Button
+              appearance={activeView === 'financials' ? 'primary' : 'subtle'}
+              icon={<Money24Regular />}
+              onClick={() => setActiveView(prev => prev === 'financials' ? 'chat' : 'financials')}
+              style={activeView === 'financials' ? { backgroundColor: '#3b82f6', borderColor: '#3b82f6' } : undefined}
+            >
+              {activeView === 'financials' ? 'Back to Chat' : 'Financials'}
+            </Button>
+          )}
+          {featureFlags.portfolio && (
+            <Button
+              appearance={activeView === 'portfolio' ? 'primary' : 'subtle'}
+              icon={<Star24Regular />}
+              onClick={() => setActiveView(prev => prev === 'portfolio' ? 'chat' : 'portfolio')}
+              style={activeView === 'portfolio' ? { backgroundColor: '#8b5cf6', borderColor: '#8b5cf6' } : undefined}
+            >
+              {activeView === 'portfolio' ? 'Back to Chat' : 'Portfolio'}
+            </Button>
+          )}
           <Button
             appearance="subtle"
             icon={<Add24Regular />}
@@ -522,37 +543,37 @@ export function Dashboard() {
             aria-expanded={telemetryOpen}
             aria-controls="telemetry-drawer"
           >
-            {telemetryOpen ? 'Close' : 'Telemetry'}
+            {telemetryOpen ? 'Close' : 'Real-Time Telemetry'}
           </Button>
         </div>
       </header>
 
       <main className={styles.main}>
         <div className={`${styles.chatContainer} ${telemetryOpen ? styles.chatContainerOpen : ''}`}>
-          {activeView === 'promo' ? (
+          {activeView === 'promo' && featureFlags.campaignPlanner ? (
             <div style={{ overflow: 'auto', height: '100%' }}>
               <PromoTaskModule />
             </div>
-          ) : activeView === 'competitive' ? (
+          ) : activeView === 'competitive' && featureFlags.competitive ? (
             <CompetitiveDashboard />
-          ) : activeView === 'knowledge' ? (
+          ) : activeView === 'knowledge' && featureFlags.knowledgeBase ? (
             <KnowledgeBasePanel />
-          ) : activeView === 'council' ? (
+          ) : activeView === 'council' && featureFlags.healthCouncil ? (
             <CouncilPanel />
-          ) : activeView === 'security' ? (
+          ) : activeView === 'security' && featureFlags.security ? (
             <div style={{ overflow: 'auto', height: '100%' }}>
               <GuardrailsDashboard />
               <GuardrailsConfig />
             </div>
-          ) : activeView === 'cards' ? (
+          ) : activeView === 'cards' && featureFlags.cards ? (
             <div style={{ overflow: 'auto', height: '100%' }}>
               <AdaptiveCardPanel />
             </div>
-          ) : activeView === 'observability' ? (
+          ) : activeView === 'observability' && featureFlags.observability ? (
             <div style={{ overflow: 'auto', height: '100%' }}>
               <ObservabilityPanel />
             </div>
-          ) : activeView === 'stores' ? (
+          ) : activeView === 'stores' && featureFlags.stores ? (
             <div style={{ overflow: 'auto', height: '100%', padding: '20px' }}>
               <h2 style={{ color: 'var(--color-text)', fontFamily: "'Inter', system-ui, sans-serif", marginBottom: '16px', fontSize: '20px' }}>🏪 Store Operations</h2>
               <StoreHeatmap stores={demoStores} onStoreClick={(id) => setSelectedStore(demoStores.find(s => s.storeId === id) ?? null)} />
@@ -565,7 +586,7 @@ export function Dashboard() {
               </div>
               <StoreDetailDialog store={selectedStore} open={!!selectedStore} onClose={() => setSelectedStore(null)} />
             </div>
-          ) : activeView === 'financials' ? (
+          ) : activeView === 'financials' && featureFlags.financials ? (
             <div style={{ overflow: 'auto', height: '100%', padding: '24px' }}>
               <h2 style={{ color: 'var(--color-text)', fontFamily: "'Inter', system-ui, sans-serif", marginBottom: '20px', fontSize: '20px' }}>💰 Financials</h2>
               <MarginWaterfall steps={demoWaterfall} title="Q1 2026 P&L Waterfall" />
@@ -574,7 +595,7 @@ export function Dashboard() {
                 <MarginDrivers drivers={demoDrivers} />
               </div>
             </div>
-          ) : activeView === 'portfolio' ? (
+          ) : activeView === 'portfolio' && featureFlags.portfolio ? (
             <div style={{ overflow: 'auto', height: '100%', padding: '24px' }}>
               <h2 style={{ color: 'var(--color-text)', fontFamily: "'Inter', system-ui, sans-serif", marginBottom: '20px', fontSize: '20px' }}>⭐ Portfolio Scorecard</h2>
               {selectedBrand ? (

--- a/src/RetailPulse.Web/src/config/featureFlags.ts
+++ b/src/RetailPulse.Web/src/config/featureFlags.ts
@@ -1,0 +1,34 @@
+const featureFlagDefaults = {
+  campaignPlanner: false,
+  competitive: false,
+  knowledgeBase: false,
+  healthCouncil: false,
+  security: false,
+  cards: false,
+  stores: false,
+  financials: false,
+  portfolio: false,
+  observability: true,
+} as const;
+
+export type FeatureKey = keyof typeof featureFlagDefaults;
+
+export type FeatureFlags = Record<FeatureKey, boolean>;
+
+export function parseFeatureFlag(value: string | undefined, defaultValue: boolean): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' ? true : defaultValue;
+}
+
+export const featureFlags: FeatureFlags = {
+  campaignPlanner: parseFeatureFlag(import.meta.env.VITE_FEATURE_CAMPAIGN_PLANNER, featureFlagDefaults.campaignPlanner),
+  competitive: parseFeatureFlag(import.meta.env.VITE_FEATURE_COMPETITIVE, featureFlagDefaults.competitive),
+  knowledgeBase: parseFeatureFlag(import.meta.env.VITE_FEATURE_KNOWLEDGE_BASE, featureFlagDefaults.knowledgeBase),
+  healthCouncil: parseFeatureFlag(import.meta.env.VITE_FEATURE_HEALTH_COUNCIL, featureFlagDefaults.healthCouncil),
+  security: parseFeatureFlag(import.meta.env.VITE_FEATURE_SECURITY, featureFlagDefaults.security),
+  cards: parseFeatureFlag(import.meta.env.VITE_FEATURE_CARDS, featureFlagDefaults.cards),
+  stores: parseFeatureFlag(import.meta.env.VITE_FEATURE_STORES, featureFlagDefaults.stores),
+  financials: parseFeatureFlag(import.meta.env.VITE_FEATURE_FINANCIALS, featureFlagDefaults.financials),
+  portfolio: parseFeatureFlag(import.meta.env.VITE_FEATURE_PORTFOLIO, featureFlagDefaults.portfolio),
+  observability: parseFeatureFlag(import.meta.env.VITE_FEATURE_OBSERVABILITY, featureFlagDefaults.observability),
+};

--- a/src/RetailPulse.Web/src/vite-env.d.ts
+++ b/src/RetailPulse.Web/src/vite-env.d.ts
@@ -1,0 +1,18 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_FEATURE_CAMPAIGN_PLANNER?: string;
+  readonly VITE_FEATURE_COMPETITIVE?: string;
+  readonly VITE_FEATURE_KNOWLEDGE_BASE?: string;
+  readonly VITE_FEATURE_HEALTH_COUNCIL?: string;
+  readonly VITE_FEATURE_SECURITY?: string;
+  readonly VITE_FEATURE_CARDS?: string;
+  readonly VITE_FEATURE_STORES?: string;
+  readonly VITE_FEATURE_FINANCIALS?: string;
+  readonly VITE_FEATURE_PORTFOLIO?: string;
+  readonly VITE_FEATURE_OBSERVABILITY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
Makes **Real-Time Telemetry** the front-and-center focus of the web app and hides secondary navigation tabs behind build-time configuration.

### Why
The Real-Time Telemetry button was getting pushed off-screen by the 11-button header overflow — it was only reachable via the Approvals flyout. The app's focus is Real-Time Telemetry and the AI Gateway (Azure APIM) view of costs, token usage, and metrics.

### Changes
- **Real-Time Telemetry button** is now always visible and relabeled `Real-Time Telemetry`.
- **Feature flags** (`src/config/featureFlags.ts`) read `VITE_FEATURE_*` env vars. Secondary tabs default **off**: Campaign Planner, Competitive, Knowledge Base, Health Council, Security, Cards, Stores, Financials, Portfolio.
- **Observability defaults on** — it is the AI Gateway / APIM cost, token-usage, and metrics dashboard, central to the project focus.
- Each nav button **and** its view render are gated by the flag (defense-in-depth — a disabled view can never display; falls back to Chat).
- Adds `.env.example` documenting every flag + `vite-env.d.ts` typings.
- Docs: root `README.md` and web `README.md` explain the minimal-by-default nav and how to enable optional tabs via `.env.local`.

### Validation
- `tsc --noEmit`: **0 errors**
- `npm test`: **279 / 279 pass**
- `npm run build`: **succeeds**

Working as Chick (Frontend). No functionality removed — every view remains reachable when its flag is enabled.