### PR TITLE
build(web): add JavaScript esproj so RetailPulse.Web shows in the solution

### DIFF
--- a/RetailPulse.slnx
+++ b/RetailPulse.slnx
@@ -6,6 +6,7 @@
     <Project Path="src/RetailPulse.McpServer/RetailPulse.McpServer.csproj" />
     <Project Path="src/RetailPulse.ServiceDefaults/RetailPulse.ServiceDefaults.csproj" />
     <Project Path="src/RetailPulse.TeamsBot/RetailPulse.TeamsBot.csproj" />
+    <Project Path="src/RetailPulse.Web/RetailPulse.Web.esproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/RetailPulse.Tests/RetailPulse.Tests.csproj" />

--- a/src/RetailPulse.Web/README.md
+++ b/src/RetailPulse.Web/README.md
@@ -23,6 +23,22 @@ Available flags:
 | `VITE_FEATURE_PORTFOLIO` | `false` | Portfolio |
 | `VITE_FEATURE_OBSERVABILITY` | `true` | Observability |
 
+## Visual Studio integration
+
+This project appears in the `RetailPulse.slnx` solution via a JavaScript project
+file (`RetailPulse.Web.esproj`, using `Microsoft.VisualStudio.JavaScript.SDK`) so
+it shows up in Solution Explorer. The project is **built and run with npm/Vite,
+not with `dotnet`**:
+
+- At runtime the Aspire AppHost launches it (`AddNpmApp` → `npm run dev`).
+- CI builds it in a dedicated frontend job (`npm install` + `npm run build`).
+
+The `.esproj` is intentionally configured as visibility-only
+(`ShouldRunNpmInstall=false`, `ShouldRunBuildScript=false`), so a solution-wide
+`dotnet build`/`dotnet restore` (and the .NET CI job) never invokes Node/npm.
+Use the npm scripts below (or the VS UI) to install, build, run, and test the app.
+VS users need the Node.js workload installed locally.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)

--- a/src/RetailPulse.Web/RetailPulse.Web.esproj
+++ b/src/RetailPulse.Web/RetailPulse.Web.esproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.VisualStudio.JavaScript.SDK/1.0.5906584">
+
+  <PropertyGroup>
+    <!--
+      Visibility-only project so Visual Studio shows RetailPulse.Web in Solution
+      Explorer. The app is built and run via npm (Vite), NOT via dotnet/MSBuild:
+        - The Aspire AppHost launches it at runtime (AddNpmApp -> `npm run dev`).
+        - CI builds it in a dedicated frontend job (`npm install` + `npm run build`).
+
+      ShouldRunNpmInstall/ShouldRunBuildScript are disabled so that a solution
+      `dotnet build`/`dotnet restore` (including the .NET CI job) never invokes
+      Node/npm. Building this project explicitly inside VS still works via the
+      BuildCommand below.
+    -->
+    <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
+    <ShouldRunBuildScript>false</ShouldRunBuildScript>
+    <StartupCommand>npm run dev</StartupCommand>
+    <BuildCommand>npm run build</BuildCommand>
+    <BuildOutputFolder>$(MSBuildProjectDirectory)\dist</BuildOutputFolder>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Makes `RetailPulse.Web` appear in Visual Studio's Solution Explorer.

### Root cause
The web app is a raw Vite/npm project with **no VS/MSBuild project file** and was not referenced in `RetailPulse.slnx`. The Aspire AppHost launches it at runtime via `AddNpmApp("frontend", "../RetailPulse.Web", "dev")`, so it runs fine but VS has nothing to show.

### Changes
- Add `src/RetailPulse.Web/RetailPulse.Web.esproj` (`Microsoft.VisualStudio.JavaScript.SDK` 1.0.5906584).
- Reference it in `RetailPulse.slnx` under `/src/`.
- Configure it **visibility-only** — `ShouldRunNpmInstall=false` + `ShouldRunBuildScript=false` — so a solution-wide `dotnet build`/`dotnet restore` (and the .NET CI job) never invokes Node/npm. `StartupCommand=npm run dev` (F5), `BuildCommand=npm run build`, output `dist`.
- **AppHost unchanged** — runtime/Aspire behavior is identical; the esproj is purely for VS visibility.
- Document VS integration in the web README.

### Why visibility-only
`ci.yml` builds the solution with `dotnet` and has a *separate* npm frontend job. Letting the esproj run npm during `dotnet build` would make the .NET job invoke Node. Disabling the build/install scripts keeps the frontend job as the sole owner of install/build.

### CI parity (validated locally on the slnx)
- `dotnet restore`: ok
- `dotnet build -c Release`: **0 warnings / 0 errors, npm NOT invoked**
- `dotnet list package --vulnerable`: **0 vulnerable** (esproj skipped)
- `dotnet format --verify-no-changes`: **exit 0** — esproj skipped with a harmless `".esproj not associated with a language"` info message (non-failing)

Working as Costco (Backend), Chick (Frontend) consulted on npm script names. Note: VS users need the Node.js workload installed locally.