### PR TITLE
fix(observability): wire Cost Dashboard to live data and harden export

### DIFF
--- a/.squad/agents/chick/history.md
+++ b/.squad/agents/chick/history.md
@@ -73,3 +73,30 @@ See **history-archive.md** for detailed session work entries from May 14-16, inc
 - Trace Dashboard & Chat Sanitization
 - Suppress routing metadata on errors
 - Frontend Code Review Fixes
+
+---
+
+## ✅ Observability Conversation Export Crash Fix (2026-06-30)
+
+**Task:** Fix Observability → Conversation Export crash: `Cannot read properties of undefined (reading 'toLocaleString')`.
+
+**Changes:**
+- `fetchExportSessions` now defensively normalizes export session fields in `observabilityApi.ts`.
+- `ConversationExport.tsx` guards missing `agentsUsed` and `totalTokens` before rendering.
+- Added regression coverage in `ConversationExport.test.tsx` and `observabilityApi.test.ts`.
+
+**Validation:** Frontend suite passed, 281/281 tests; build clean.
+
+**Lesson:** `fetchExportSessions` previously lacked the defensive field normalization that its sibling observability fetchers use; that gap caused the crash.
+
+---
+
+## ✅ Observability Cost Dashboard Endpoint Fan-Out (2026-06-30)
+
+**Task:** Fix blank/non-live Cost Dashboard data and idle empty states.
+
+**Changes:** `fetchCostDashboard` now fans out to `/costs`, `/costs/agents`, `/costs/trend`, and `/costs/tools`; `CostDashboard` refreshes every 10 seconds and renders empty states for idle trend/agents/tools. Chick also fixed Publix's reviewer-found defect where all-zero trend buckets rendered a zero-line chart instead of the empty state.
+
+**Validation:** Frontend suite passed, 285/285 tests.
+
+**Lesson:** The Cost Dashboard broke because the frontend read `trend`, `agentBreakdown`, and `topTools` off the summary-only `/costs` response. Top Tools required the new backend tracing endpoint because `UsageEvent` lacks duration.

--- a/.squad/agents/costco/history.md
+++ b/.squad/agents/costco/history.md
@@ -97,3 +97,15 @@ Detailed work from June 3, May 18, May 16, and May 15 available in **history-arc
 - Asp.Versioning.Http 8.1.0 → 10.0.0 upgrade analysis
 - coverlet.collector 6.0.4 → 10.0.1 upgrade analysis
 - Older telemetry, timeout, and API session work
+
+---
+
+### 2026-06-30T16:54:45-04:00 — Observability Cost Dashboard Top Tools Endpoint
+
+**Status:** ✅ Complete — backend suite passed (RetailPulse.Tests 1,998 passed; LoadTests 2 skipped)
+
+**What:** Added `ToolUsageStat`, `ITraceCollector.GetToolStats`, the `InMemoryTraceCollector` aggregation, and `GET /api/observability/costs/tools`.
+
+**Why:** The Cost Dashboard was broken because the frontend read `trend`, `agentBreakdown`, and `topTools` from the summary-only `/costs` response instead of calling the dedicated endpoints. Top Tools needed a new tracing-backed endpoint because `UsageEvent` has tool names but no duration; duration lives on tool trace spans.
+
+**Team impact:** Duration-aware tool usage stats should be sourced from `ITraceCollector`, not `ICostTracker` usage events.

--- a/.squad/agents/publix/history.md
+++ b/.squad/agents/publix/history.md
@@ -118,3 +118,15 @@ Hosting full production chat endpoint in tests is expensive and tightly coupled 
 **Reviewer:** Publix (Tester) — independent review required because Kroger (Lead) is the fix author and cannot self-certify security patches.
 
 **Commit:** cc4a28e
+
+---
+
+### 2026-06-30T16:54:45-04:00 — Observability Cost Dashboard Contract Validation
+
+**Status:** ✅ PASS after targeted frontend fix
+
+**What:** Validated the cross-boundary contract for `/costs`, `/costs/agents`, `/costs/trend?days=`, and `/costs/tools?period=` plus full backend/frontend suites. First pass failed because idle all-zero trend buckets rendered a chart instead of the empty state. After Chick fixed trend presence detection, re-review passed.
+
+**Validation:** backend suite 1,998 passed / 2 skipped; frontend suite 285 passed; frontend build passed.
+
+**Lesson:** Observability dashboard tests must verify that the frontend calls dedicated endpoints for trend/agent/tool data and that idle all-zero trend data renders an empty state, not a misleading zero-line chart.

--- a/.squad/decisions-archive.md
+++ b/.squad/decisions-archive.md
@@ -1067,3 +1067,15 @@ The AI model occasionally emits raw function call syntax (`to=functions.ToolName
 
 
 
+
+
+## Archive — 2026-06-30T16:40:20-04:00
+
+Entries archived from decisions.md (size 21,856 bytes; policy: archive when >= 20,480 bytes; entries older than 30 days).
+
+---
+
+### 2026-05-20T08:43:48Z: User directive
+**By:** Brian Swiger (via Copilot)
+**What:** The project owner's name is Brian Swiger (not "Brady"). Always address them as Brian.
+**Why:** User request — captured for team memory

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,11 +2,6 @@
 
 ## Active Decisions
 
-### 2026-05-20T08:43:48Z: User directive
-**By:** Brian Swiger (via Copilot)
-**What:** The project owner's name is Brian Swiger (not "Brady"). Always address them as Brian.
-**Why:** User request — captured for team memory
-
 ### 2026-06-03T11:22:49Z: Asp.Versioning.Http upgraded 8.1.0 → 10.0.0 (deferral resolved)
 
 **By:** Costco (Backend Dev)
@@ -292,3 +287,13 @@ The web dashboard now keeps **Real-Time Telemetry always visible** (relabeled "R
 - All meaningful changes require team consensus
 - Document architectural decisions here
 - Keep history focused on work, decisions focused on direction
+
+### 2026-06-30: RetailPulse.Web visibility via JavaScript .esproj
+**By:** Costco (Backend), requested by Brian Swiger
+**What:** Add `src/RetailPulse.Web/RetailPulse.Web.esproj` (Microsoft.VisualStudio.JavaScript.SDK 1.0.5906584) and reference it in `RetailPulse.slnx` so the React/Vite web app appears in Visual Studio Solution Explorer.
+**Design — visibility-only:** `ShouldRunNpmInstall=false` and `ShouldRunBuildScript=false`. A solution-wide `dotnet build`/`dotnet restore` (and the .NET CI job in ci.yml) must NEVER invoke Node/npm. The separate `npm` frontend CI job remains the sole owner of install/build. F5 uses `StartupCommand=npm run dev`; `BuildCommand=npm run build`; output `dist`.
+**Out of scope:** AppHost unchanged — `AddNpmApp("frontend", "../RetailPulse.Web", "dev")` still drives runtime; the esproj is purely for VS visibility. Aspire runtime behavior is identical.
+**Validated (CI parity, local):** restore ok; build -c Release 0/0 with npm not invoked; `dotnet list package --vulnerable` 0 vulnerable; `dotnet format --verify-no-changes` exit 0 (harmless ".esproj not associated with a language" info message, non-failing).
+**Local prerequisite:** VS users need the Node.js development workload installed.
+**Shipped:** PR #8 → main (0a56fcf).
+**Why:** User asked why the web project wasn't visible in VS; root cause was a missing MSBuild project file and no slnx entry.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -297,3 +297,26 @@ The web dashboard now keeps **Real-Time Telemetry always visible** (relabeled "R
 **Local prerequisite:** VS users need the Node.js development workload installed.
 **Shipped:** PR #8 → main (0a56fcf).
 **Why:** User asked why the web project wasn't visible in VS; root cause was a missing MSBuild project file and no slnx entry.
+
+### 2026-06-30T16:54:45-04:00: Observability Cost Dashboard uses live endpoint fan-out
+
+**By:** Kroger (Lead), Costco (Backend), Chick (Frontend), Publix (QA)
+
+The Cost Dashboard was blank because the frontend treated `GET /api/observability/costs` as if it returned `trend`, `agentBreakdown`, and `topTools`. That endpoint returns only the summary `CostSummary`. The dashboard now fans out to the dedicated endpoints and assembles the existing frontend `CostDashboardData` shape:
+
+- `GET /api/observability/costs?period=` -> summary, with `avgCostPerRequest` computed from total cost/request count.
+- `GET /api/observability/costs/agents?period=` -> agent breakdown.
+- `GET /api/observability/costs/trend?days=` -> trend buckets; frontend translates `today/week/month` to `1/7/30` days and formats dates for the chart.
+- `GET /api/observability/costs/tools?period=` -> top tools.
+
+Top Tools required a new backend endpoint because `UsageEvent` records tool names but has no duration data. The source of truth is now `ITraceCollector`: `ToolUsageStat` is derived from trace spans whose operation starts with `tool.`, grouping by `Tags["tool.name"]` or the operation suffix and aggregating call count, total tokens, and average duration.
+
+The dashboard now refreshes every 10 seconds while mounted and shows empty states for idle trend, agent breakdown, and top tools. Idle all-zero trend buckets are treated as empty; genuinely nonzero low values still render.
+
+**Validation:** backend suite passed (RetailPulse.Tests 1,998 passed; LoadTests 2 skipped); frontend suite passed (285 tests); frontend build passed. Publix initially rejected the all-zero trend empty-state behavior, then re-approved after Chick's targeted fix.
+
+**Team impact:**
+- **Backend / Costco:** Tool usage statistics belong in tracing, not cost usage events, whenever duration is required.
+- **Frontend / Chick:** Observability summary endpoints must not be assumed to contain nested dashboard collections; call the dedicated endpoints and map fields explicitly.
+- **QA / Publix:** Contract validation for observability dashboards should include idle/empty states and cross-endpoint field names.
+

--- a/src/RetailPulse.Api/Endpoints/ObservabilityEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ObservabilityEndpoints.cs
@@ -60,6 +60,15 @@ public static class ObservabilityEndpoints
         })
         .WithName("GetCostsByAgent").RequireAuthorization().RequireRateLimiting("relaxed");
 
+        app.MapGet("/api/observability/costs/tools", (HttpContext http, ITraceCollector traceCollector) =>
+        {
+            string periodStr = http.Request.Query["period"].FirstOrDefault() ?? "week";
+            DateTimeOffset cutoff = GetCostPeriodCutoff(periodStr, DateTimeOffset.UtcNow);
+            IReadOnlyList<ToolUsageStat> stats = traceCollector.GetToolStats(cutoff);
+            return Results.Ok(stats);
+        })
+        .WithName("GetToolStats").RequireAuthorization().RequireRateLimiting("relaxed");
+
         app.MapGet("/api/observability/costs/trend", async (HttpContext http, ICostTracker costTracker, CancellationToken ct) =>
         {
             string? daysStr = http.Request.Query["days"].FirstOrDefault();
@@ -184,5 +193,19 @@ public static class ObservabilityEndpoints
         .WithName("GetSessionTraces").RequireAuthorization().RequireRateLimiting("relaxed");
 
         return app;
+    }
+
+    internal static DateTimeOffset GetCostPeriodCutoff(string? period, DateTimeOffset nowUtc)
+    {
+        DateTimeOffset utcNow = nowUtc.ToUniversalTime();
+
+        return period?.ToLowerInvariant() switch
+        {
+            "today" => new DateTimeOffset(utcNow.Date, TimeSpan.Zero),
+            "week" => utcNow.AddDays(-7),
+            "month" => utcNow.AddDays(-30),
+            "all" => DateTimeOffset.MinValue,
+            _ => utcNow.AddDays(-7)
+        };
     }
 }

--- a/src/RetailPulse.Api/Tracing/InMemoryTraceCollector.cs
+++ b/src/RetailPulse.Api/Tracing/InMemoryTraceCollector.cs
@@ -194,6 +194,27 @@ public class InMemoryTraceCollector : ITraceCollector
         return summaries;
     }
 
+    public IReadOnlyList<ToolUsageStat> GetToolStats(DateTimeOffset since, int top = 10)
+    {
+        if (top <= 0)
+            return [];
+
+        TraceSpan[] spans = [.. _traces.Values.SelectMany(bag => bag.ToArray())];
+
+        return [.. spans
+            .Where(span => span.StartTime >= since && IsToolSpan(span))
+            .GroupBy(GetToolName, StringComparer.OrdinalIgnoreCase)
+            .Select(group => new ToolUsageStat(
+                group.Key,
+                group.Count(),
+                group.Sum(span => span.InputTokens + span.OutputTokens),
+                group.Average(span => span.DurationMs)))
+            .OrderByDescending(stat => stat.CallCount)
+            .ThenByDescending(stat => stat.TotalTokens)
+            .ThenBy(stat => stat.ToolName, StringComparer.OrdinalIgnoreCase)
+            .Take(top)];
+    }
+
     /// <summary>
     /// Notifies SignalR clients that a trace is complete. Call after all spans
     /// for a request have been captured.
@@ -246,4 +267,21 @@ public class InMemoryTraceCollector : ITraceCollector
 
     private static string? GetTag(IDictionary<string, string> tags, string key)
         => tags.TryGetValue(key, out string? value) ? value : null;
+
+    private static bool IsToolSpan(TraceSpan span)
+        => span.OperationName.StartsWith("tool.", StringComparison.OrdinalIgnoreCase)
+            || (span.Tags is not null
+                && span.Tags.TryGetValue("span.type", out string? spanType)
+                && string.Equals(spanType, "tool", StringComparison.OrdinalIgnoreCase));
+
+    private static string GetToolName(TraceSpan span)
+    {
+        return span.Tags is not null
+            && span.Tags.TryGetValue("tool.name", out string? toolName)
+            && !string.IsNullOrWhiteSpace(toolName)
+                ? toolName
+                : span.OperationName.StartsWith("tool.", StringComparison.OrdinalIgnoreCase)
+                    ? span.OperationName["tool.".Length..]
+                    : span.OperationName;
+    }
 }

--- a/src/RetailPulse.Contracts/Tracing/ITraceCollector.cs
+++ b/src/RetailPulse.Contracts/Tracing/ITraceCollector.cs
@@ -18,6 +18,11 @@ public record TraceSpan(
 );
 
 /// <summary>
+/// Aggregated usage statistics for a tool across captured trace spans.
+/// </summary>
+public record ToolUsageStat(string ToolName, int CallCount, int TotalTokens, double AvgDurationMs);
+
+/// <summary>
 /// Summary of a complete trace including all spans and aggregated metrics.
 /// </summary>
 public record TraceSummary(
@@ -92,6 +97,11 @@ public interface ITraceCollector
     /// Returns null if the trace ID is not found.
     /// </summary>
     StructuredTraceSummary? GetStructuredSummary(string traceId);
+
+    /// <summary>
+    /// Returns aggregated tool usage stats for tool spans captured since the cutoff.
+    /// </summary>
+    IReadOnlyList<ToolUsageStat> GetToolStats(DateTimeOffset since, int top = 10);
 
     /// <summary>
     /// Current number of traces stored in the ring buffer.

--- a/src/RetailPulse.Web/src/__tests__/ConversationExport.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ConversationExport.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+import ConversationExport from '../components/observability/ConversationExport';
+import type { ExportSession } from '../types';
+
+const mockSessions = [
+  {
+    sessionId: 'session-missing-fields',
+    startTime: '2026-05-13T10:00:00Z',
+    messageCount: 3,
+  },
+] as unknown as ExportSession[];
+
+vi.mock('../services/observabilityApi', () => ({
+  fetchExportSessions: vi.fn(() => Promise.resolve(mockSessions)),
+  fetchExportPreview: vi.fn(),
+  exportSession: vi.fn(),
+}));
+
+const wrap = (ui: React.ReactNode) => (
+  <FluentProvider theme={teamsDarkTheme}>{ui}</FluentProvider>
+);
+
+describe('ConversationExport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders sessions with missing optional backend fields without crashing', async () => {
+    render(wrap(<ConversationExport />));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('export-row-session-missing-fields')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/CostDashboard.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/CostDashboard.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
 import CostDashboard from '../components/observability/CostDashboard';
+import { fetchCostDashboard } from '../services/observabilityApi';
 import type { CostDashboardData } from '../types';
 
 // Mock recharts to avoid canvas issues in jsdom
@@ -54,6 +55,7 @@ const wrap = (ui: React.ReactNode) => (
 describe('CostDashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fetchCostDashboard).mockResolvedValue(mockData);
   });
 
   it('renders the cost dashboard container', async () => {
@@ -96,8 +98,49 @@ describe('CostDashboard', () => {
     });
   });
 
+  it('renders friendly empty states for idle chart sections', async () => {
+    vi.mocked(fetchCostDashboard).mockResolvedValueOnce({
+      summary: {
+        totalTokens: 0,
+        totalCost: 0,
+        requestCount: 0,
+        avgCostPerRequest: 0,
+      },
+      trend: [],
+      agentBreakdown: [],
+      topTools: [],
+    });
+
+    render(wrap(<CostDashboard />));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trend-empty')).toHaveTextContent('No data yet — start a chat to see activity.');
+      expect(screen.getByTestId('agent-breakdown-empty')).toHaveTextContent('No data yet — start a chat to see activity.');
+      expect(screen.getByTestId('tools-empty')).toHaveTextContent('No data yet — start a chat to see activity.');
+    });
+  });
+
+  it('treats zero-filled trend buckets as empty without hiding active sections', async () => {
+    vi.mocked(fetchCostDashboard).mockResolvedValueOnce({
+      ...mockData,
+      trend: [
+        { date: 'Jun 24', cost: 0, tokens: 0 },
+        { date: 'Jun 25', cost: 0, tokens: 0 },
+        { date: 'Jun 26', cost: 0, tokens: 0 },
+      ],
+    });
+
+    render(wrap(<CostDashboard />));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trend-empty')).toHaveTextContent('No data yet — start a chat to see activity.');
+      expect(screen.queryByTestId('area-chart')).not.toBeInTheDocument();
+      expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+      expect(screen.getByTestId('tools-table')).toBeInTheDocument();
+    });
+  });
+
   it('changes period when tab is clicked', async () => {
-    const { fetchCostDashboard } = await import('../services/observabilityApi');
     render(wrap(<CostDashboard />));
     await waitFor(() => {
       expect(screen.getByText('Today')).toBeInTheDocument();

--- a/src/RetailPulse.Web/src/__tests__/observabilityApi.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/observabilityApi.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fetchCostDashboard, fetchExportSessions } from '../services/observabilityApi';
+
+const originalFetch = globalThis.fetch;
+
+describe('observabilityApi.fetchExportSessions', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('normalizes sessions with missing backend fields', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([
+        null,
+        'not-a-session',
+        {
+          sessionId: 'session-missing-fields',
+          messageCount: 3,
+        },
+      ]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ) as unknown as typeof fetch;
+
+    const sessions = await fetchExportSessions();
+
+    expect(sessions).toEqual([
+      {
+        sessionId: 'session-missing-fields',
+        startTime: '',
+        messageCount: 3,
+        agentsUsed: [],
+        totalTokens: 0,
+      },
+    ]);
+  });
+});
+
+describe('observabilityApi.fetchCostDashboard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('fans out to cost endpoints and maps backend shapes', async () => {
+    globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/observability/costs?period=week') {
+        return Promise.resolve(new Response(JSON.stringify({
+          totalTokens: 1000,
+          totalCost: 2,
+          requestCount: 4,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      if (url === '/api/observability/costs/agents?period=week') {
+        return Promise.resolve(new Response(JSON.stringify([
+          { agentId: 'chick', tokens: 600, cost: 1.25, requests: 3, topTool: 'chart' },
+        ]), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      if (url === '/api/observability/costs/trend?days=7') {
+        return Promise.resolve(new Response(JSON.stringify({
+          days: [{ date: '2026-06-30T00:00:00Z', cost: 0.5, tokens: 250 }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      if (url === '/api/observability/costs/tools?period=week') {
+        return Promise.resolve(new Response(JSON.stringify([
+          { toolName: 'SearchInventory', callCount: 5, totalTokens: 300, avgDurationMs: 42 },
+        ]), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    }) as unknown as typeof fetch;
+
+    const dashboard = await fetchCostDashboard('week');
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(4);
+    expect(dashboard).toEqual({
+      summary: {
+        totalTokens: 1000,
+        totalCost: 2,
+        requestCount: 4,
+        avgCostPerRequest: 0.5,
+      },
+      trend: [{
+        date: new Date('2026-06-30T00:00:00Z').toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+        cost: 0.5,
+        tokens: 250,
+      }],
+      agentBreakdown: [{
+        agentName: 'chick',
+        totalCost: 1.25,
+        totalTokens: 600,
+        requestCount: 3,
+      }],
+      topTools: [{
+        toolName: 'SearchInventory',
+        callCount: 5,
+        totalTokens: 300,
+        avgDurationMs: 42,
+      }],
+    });
+  });
+
+  it('keeps secondary endpoint failures isolated', async () => {
+    globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/observability/costs?period=today') {
+        return Promise.resolve(new Response(JSON.stringify({
+          totalTokens: 10,
+          totalCost: 0.2,
+          requestCount: 2,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      return Promise.resolve(new Response(null, { status: 500 }));
+    }) as unknown as typeof fetch;
+
+    const dashboard = await fetchCostDashboard('today');
+
+    expect(dashboard.summary.avgCostPerRequest).toBe(0.1);
+    expect(dashboard.trend).toEqual([]);
+    expect(dashboard.agentBreakdown).toEqual([]);
+    expect(dashboard.topTools).toEqual([]);
+  });
+});

--- a/src/RetailPulse.Web/src/components/observability/ConversationExport.tsx
+++ b/src/RetailPulse.Web/src/components/observability/ConversationExport.tsx
@@ -353,12 +353,12 @@ export default function ConversationExport() {
                   <td className={styles.tableCell}>{session.messageCount}</td>
                   <td className={styles.tableCell}>
                     <div className={styles.agentPills}>
-                      {session.agentsUsed.map(agent => (
+                      {session.agentsUsed?.map(agent => (
                         <span key={agent} className={styles.agentPill}>{agent}</span>
                       ))}
                     </div>
                   </td>
-                  <td className={styles.tableCellMuted}>{session.totalTokens.toLocaleString()}</td>
+                  <td className={styles.tableCellMuted}>{(session.totalTokens ?? 0).toLocaleString()}</td>
                   <td className={styles.actionCell}>
                     <button
                       className={styles.actionBtn}

--- a/src/RetailPulse.Web/src/components/observability/CostDashboard.tsx
+++ b/src/RetailPulse.Web/src/components/observability/CostDashboard.tsx
@@ -182,6 +182,15 @@ const useStyles = makeStyles({
     borderRadius: '12px',
     padding: '20px',
   },
+  emptyState: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '220px',
+    color: 'var(--color-text-muted)',
+    fontSize: '14px',
+    textAlign: 'center',
+  },
 });
 
 const METRIC_CARDS = [
@@ -216,21 +225,36 @@ export default function CostDashboard() {
   const [data, setData] = useState<CostDashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const hasTrend = data?.trend.some(d => d.cost > 0 || d.tokens > 0) ?? false;
 
   useEffect(() => {
-    const controller = new AbortController();
-    fetchCostDashboard(period, controller.signal)
-      .then(result => {
-        setData(result);
-        setError(null);
-        setLoading(false);
-      })
-      .catch(e => {
-        if (controller.signal.aborted) return;
-        setError(e instanceof Error ? e.message : 'Failed to load cost data');
-        setLoading(false);
-      });
-    return () => { controller.abort(); };
+    let controller: AbortController | null = null;
+
+    const load = (showLoading: boolean) => {
+      controller?.abort();
+      controller = new AbortController();
+      const currentController = controller;
+      if (showLoading) setLoading(true);
+      fetchCostDashboard(period, currentController.signal)
+        .then(result => {
+          setData(result);
+          setError(null);
+          setLoading(false);
+        })
+        .catch(e => {
+          if (currentController.signal.aborted) return;
+          setError(e instanceof Error ? e.message : 'Failed to load cost data');
+          setLoading(false);
+        });
+    };
+
+    load(true);
+    const intervalId = window.setInterval(() => load(false), 10000);
+
+    return () => {
+      controller?.abort();
+      window.clearInterval(intervalId);
+    };
   }, [period]);
 
   const handlePeriodChange = (p: ObservabilityPeriod) => {
@@ -290,105 +314,117 @@ export default function CostDashboard() {
             {/* Trend Chart */}
             <div className={styles.chartHalf}>
               <div className={styles.chartTitle}>📈 Cost Trend</div>
-              <ResponsiveContainer width="100%" height={220}>
-                <AreaChart data={data.trend}>
-                  <defs>
-                    <linearGradient id="costGradient" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor={OBSERVABILITY_COLORS.trendLine} stopOpacity={0.3} />
-                      <stop offset="95%" stopColor={OBSERVABILITY_COLORS.trendLine} stopOpacity={0} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" stroke={OBSERVABILITY_COLORS.gridLine} />
-                  <XAxis
-                    dataKey="date"
-                    tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
-                    axisLine={{ stroke: OBSERVABILITY_COLORS.gridLine }}
-                    tickLine={false}
-                  />
-                  <YAxis
-                    tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
-                    axisLine={{ stroke: OBSERVABILITY_COLORS.gridLine }}
-                    tickLine={false}
-                    tickFormatter={(v: number) => `$${v.toFixed(2)}`}
-                  />
-                  <Tooltip content={<CustomTooltip />} />
-                  <Area
-                    type="monotone"
-                    dataKey="cost"
-                    stroke={OBSERVABILITY_COLORS.trendLine}
-                    strokeWidth={2}
-                    fill="url(#costGradient)"
-                  />
-                </AreaChart>
-              </ResponsiveContainer>
+              {!hasTrend ? (
+                <div className={styles.emptyState} data-testid="trend-empty">No data yet — start a chat to see activity.</div>
+              ) : (
+                <ResponsiveContainer width="100%" height={220}>
+                  <AreaChart data={data.trend}>
+                    <defs>
+                      <linearGradient id="costGradient" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor={OBSERVABILITY_COLORS.trendLine} stopOpacity={0.3} />
+                        <stop offset="95%" stopColor={OBSERVABILITY_COLORS.trendLine} stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke={OBSERVABILITY_COLORS.gridLine} />
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+                      axisLine={{ stroke: OBSERVABILITY_COLORS.gridLine }}
+                      tickLine={false}
+                    />
+                    <YAxis
+                      tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+                      axisLine={{ stroke: OBSERVABILITY_COLORS.gridLine }}
+                      tickLine={false}
+                      tickFormatter={(v: number) => `$${v.toFixed(2)}`}
+                    />
+                    <Tooltip content={<CustomTooltip />} />
+                    <Area
+                      type="monotone"
+                      dataKey="cost"
+                      stroke={OBSERVABILITY_COLORS.trendLine}
+                      strokeWidth={2}
+                      fill="url(#costGradient)"
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              )}
             </div>
 
             {/* Agent Breakdown */}
             <div className={styles.chartHalf}>
               <div className={styles.chartTitle}>🤖 Agent Cost Breakdown</div>
-              <ResponsiveContainer width="100%" height={220}>
-                <BarChart data={data.agentBreakdown} layout="vertical">
-                  <CartesianGrid strokeDasharray="3 3" stroke={OBSERVABILITY_COLORS.gridLine} horizontal={false} />
-                  <XAxis
-                    type="number"
-                    tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
-                    axisLine={{ stroke: OBSERVABILITY_COLORS.gridLine }}
-                    tickLine={false}
-                    tickFormatter={(v: number) => `$${v.toFixed(2)}`}
-                  />
-                  <YAxis
-                    dataKey="agentName"
-                    type="category"
-                    tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
-                    axisLine={{ stroke: OBSERVABILITY_COLORS.gridLine }}
-                    tickLine={false}
-                    width={110}
-                  />
-                  <Tooltip
-                    labelFormatter={(label: React.ReactNode) => String(label)}
-                    formatter={(value) => [`$${Number(value).toFixed(4)}`, 'Cost']}
-                    contentStyle={{
-                      background: 'var(--color-bg-elevated)',
-                      border: `1px solid ${OBSERVABILITY_COLORS.cardBorder}`,
-                      borderRadius: '8px',
-                      fontSize: '12px',
-                      color: 'var(--color-text)',
-                    }}
-                  />
-                  <Bar
-                    dataKey="totalCost"
-                    fill={OBSERVABILITY_COLORS.barFill}
-                    radius={[0, 6, 6, 0]}
-                    maxBarSize={28}
-                  />
-                </BarChart>
-              </ResponsiveContainer>
+              {data.agentBreakdown.length === 0 ? (
+                <div className={styles.emptyState} data-testid="agent-breakdown-empty">No data yet — start a chat to see activity.</div>
+              ) : (
+                <ResponsiveContainer width="100%" height={220}>
+                  <BarChart data={data.agentBreakdown} layout="vertical">
+                    <CartesianGrid strokeDasharray="3 3" stroke={OBSERVABILITY_COLORS.gridLine} horizontal={false} />
+                    <XAxis
+                      type="number"
+                      tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+                      axisLine={{ stroke: OBSERVABILITY_COLORS.gridLine }}
+                      tickLine={false}
+                      tickFormatter={(v: number) => `$${v.toFixed(2)}`}
+                    />
+                    <YAxis
+                      dataKey="agentName"
+                      type="category"
+                      tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+                      axisLine={{ stroke: OBSERVABILITY_COLORS.gridLine }}
+                      tickLine={false}
+                      width={110}
+                    />
+                    <Tooltip
+                      labelFormatter={(label: React.ReactNode) => String(label)}
+                      formatter={(value) => [`$${Number(value).toFixed(4)}`, 'Cost']}
+                      contentStyle={{
+                        background: 'var(--color-bg-elevated)',
+                        border: `1px solid ${OBSERVABILITY_COLORS.cardBorder}`,
+                        borderRadius: '8px',
+                        fontSize: '12px',
+                        color: 'var(--color-text)',
+                      }}
+                    />
+                    <Bar
+                      dataKey="totalCost"
+                      fill={OBSERVABILITY_COLORS.barFill}
+                      radius={[0, 6, 6, 0]}
+                      maxBarSize={28}
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
             </div>
           </div>
 
           {/* Top Tools Table */}
           <div className={styles.chartSection}>
             <div className={styles.chartTitle}>🔧 Top Tools</div>
-            <table className={styles.toolsTable} data-testid="tools-table">
-              <thead>
-                <tr>
-                  <th className={styles.tableHead}>Tool</th>
-                  <th className={styles.tableHead}>Calls</th>
-                  <th className={styles.tableHead}>Total Tokens</th>
-                  <th className={styles.tableHead}>Avg Duration</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.topTools.map(tool => (
-                  <tr key={tool.toolName}>
-                    <td className={styles.tableCell} style={{ fontWeight: 600 }}>{tool.toolName}</td>
-                    <td className={styles.tableCellMuted}>{tool.callCount.toLocaleString()}</td>
-                    <td className={styles.tableCellMuted}>{tool.totalTokens.toLocaleString()}</td>
-                    <td className={styles.tableCellMuted}>{tool.avgDurationMs.toFixed(0)}ms</td>
+            {data.topTools.length === 0 ? (
+              <div className={styles.emptyState} data-testid="tools-empty">No data yet — start a chat to see activity.</div>
+            ) : (
+              <table className={styles.toolsTable} data-testid="tools-table">
+                <thead>
+                  <tr>
+                    <th className={styles.tableHead}>Tool</th>
+                    <th className={styles.tableHead}>Calls</th>
+                    <th className={styles.tableHead}>Total Tokens</th>
+                    <th className={styles.tableHead}>Avg Duration</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {data.topTools.map(tool => (
+                    <tr key={tool.toolName}>
+                      <td className={styles.tableCell} style={{ fontWeight: 600 }}>{tool.toolName}</td>
+                      <td className={styles.tableCellMuted}>{tool.callCount.toLocaleString()}</td>
+                      <td className={styles.tableCellMuted}>{tool.totalTokens.toLocaleString()}</td>
+                      <td className={styles.tableCellMuted}>{tool.avgDurationMs.toFixed(0)}ms</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
           </div>
         </>
       )}

--- a/src/RetailPulse.Web/src/services/observabilityApi.ts
+++ b/src/RetailPulse.Web/src/services/observabilityApi.ts
@@ -13,21 +13,80 @@ export async function fetchCostDashboard(
   period: ObservabilityPeriod,
   signal?: AbortSignal,
 ): Promise<CostDashboardData> {
-  const res = await fetch(`${BASE}/costs?period=${period}`, { signal });
-  if (!res.ok) throw new Error(`Cost data fetch failed: ${res.status}`);
-  const raw = await res.json();
-  // Backend may return flat summary fields or nested structure
-  const summary = raw.summary ?? {
-    totalTokens: raw.totalTokens ?? 0,
-    totalCost: raw.totalCost ?? 0,
-    requestCount: raw.requestCount ?? 0,
-    avgCostPerRequest: raw.avgCostPerRequest ?? (raw.requestCount ? raw.totalCost / raw.requestCount : 0),
+  const daysByPeriod: Record<ObservabilityPeriod, number> = {
+    today: 1,
+    week: 7,
+    month: 30,
   };
+
+  const safeFetchJson = async (url: string, required = false): Promise<unknown> => {
+    try {
+      const res = await fetch(url, { signal });
+      if (res.status === 404) return null;
+      if (!res.ok) {
+        if (required) throw new Error(`Cost data fetch failed: ${res.status}`);
+        return null;
+      }
+      return res.json();
+    } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') throw e;
+      if (required) throw e;
+      return null;
+    }
+  };
+
+  const [summaryRaw, agentsRaw, trendRaw, toolsRaw] = await Promise.all([
+    safeFetchJson(`${BASE}/costs?period=${period}`, true),
+    safeFetchJson(`${BASE}/costs/agents?period=${period}`),
+    safeFetchJson(`${BASE}/costs/trend?days=${daysByPeriod[period]}`),
+    safeFetchJson(`${BASE}/costs/tools?period=${period}`),
+  ]);
+
+  const raw = (summaryRaw ?? {}) as Partial<CostDashboardData['summary']> & { summary?: Partial<CostDashboardData['summary']> };
+  const summarySource = raw.summary ?? raw;
+  const requestCount = summarySource.requestCount ?? 0;
+  const totalCost = summarySource.totalCost ?? 0;
+  const summary = {
+    totalTokens: summarySource.totalTokens ?? 0,
+    totalCost,
+    requestCount,
+    avgCostPerRequest: summarySource.avgCostPerRequest ?? (requestCount ? totalCost / requestCount : 0),
+  };
+
+  const agentBreakdown = Array.isArray(agentsRaw)
+    ? agentsRaw.map(agent => ({
+      agentName: agent?.agentId ?? '',
+      totalCost: agent?.cost ?? 0,
+      totalTokens: agent?.tokens ?? 0,
+      requestCount: agent?.requests ?? 0,
+    }))
+    : [];
+
+  const trendDays = (trendRaw as { days?: Array<{ date?: string; cost?: number; tokens?: number }> } | null)?.days;
+  const trend = Array.isArray(trendDays)
+    ? trendDays.map(day => ({
+      date: day?.date
+        ? new Date(day.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+        : '',
+      cost: day?.cost ?? 0,
+      tokens: day?.tokens ?? 0,
+    }))
+    : [];
+
+  const topTools = Array.isArray(toolsRaw)
+    ? toolsRaw.map(tool => ({
+      toolName: tool?.toolName ?? '',
+      callCount: tool?.callCount ?? 0,
+      totalTokens: tool?.totalTokens ?? 0,
+      avgDurationMs: tool?.avgDurationMs ?? 0,
+    }))
+    : [];
+
   return {
     summary,
-    trend: raw.trend ?? [],
-    agentBreakdown: raw.agentBreakdown ?? [],
-    topTools: raw.topTools ?? [],
+    trend,
+    agentBreakdown,
+    topTools,
   };
 }
 
@@ -71,7 +130,16 @@ export async function fetchExportSessions(signal?: AbortSignal): Promise<ExportS
   if (res.status === 404) return [];
   if (!res.ok) throw new Error(`Sessions fetch failed: ${res.status}`);
   const data = await res.json();
-  return Array.isArray(data) ? data : [];
+  if (!Array.isArray(data)) return [];
+  return data
+    .filter((session): session is Partial<ExportSession> => typeof session === 'object' && session !== null)
+    .map(session => ({
+      sessionId: session.sessionId ?? '',
+      startTime: session.startTime ?? '',
+      messageCount: session.messageCount ?? 0,
+      agentsUsed: Array.isArray(session.agentsUsed) ? session.agentsUsed : [],
+      totalTokens: session.totalTokens ?? 0,
+    }));
 }
 
 export async function fetchExportPreview(

--- a/src/RetailPulse.Web/src/types/index.ts
+++ b/src/RetailPulse.Web/src/types/index.ts
@@ -491,7 +491,7 @@ export interface CostTrendPoint {
   date: string;
   cost: number;
   tokens: number;
-  requests: number;
+  requests?: number;
 }
 
 export interface AgentCostBreakdown {

--- a/tests/RetailPulse.Tests/Observability/ToolUsageStatsTests.cs
+++ b/tests/RetailPulse.Tests/Observability/ToolUsageStatsTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Api.Tracing;
+using RetailPulse.Contracts.Tracing;
+
+namespace RetailPulse.Tests.Observability;
+
+public class ToolUsageStatsTests
+{
+    [Fact]
+    public void GetToolStats_GroupsCountsTokensAndAveragesDuration()
+    {
+        var collector = new InMemoryTraceCollector();
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        collector.CaptureSpan(MakeSpan("trace-1", "tool.GetInventory", now, durationMs: 100, inputTokens: 10, outputTokens: 5, toolName: "GetInventory"));
+        collector.CaptureSpan(MakeSpan("trace-2", "tool.GetInventory", now.AddSeconds(1), durationMs: 300, inputTokens: 20, outputTokens: 15, toolName: "GetInventory"));
+        collector.CaptureSpan(MakeSpan("trace-3", "agent.worker.process", now, durationMs: 500, inputTokens: 100, outputTokens: 100));
+
+        IReadOnlyList<ToolUsageStat> stats = collector.GetToolStats(now.AddMinutes(-1));
+
+        stats.Should().ContainSingle();
+        stats[0].ToolName.Should().Be("GetInventory");
+        stats[0].CallCount.Should().Be(2);
+        stats[0].TotalTokens.Should().Be(50);
+        stats[0].AvgDurationMs.Should().Be(200);
+    }
+
+    [Fact]
+    public void GetToolStats_UsesSpanTypeTagForToolSpans()
+    {
+        var collector = new InMemoryTraceCollector();
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        collector.CaptureSpan(MakeSpan(
+            "trace-1",
+            "custom.tool.operation",
+            now,
+            durationMs: 75,
+            tags: new Dictionary<string, string>
+            {
+                ["span.type"] = "tool",
+                ["tool.name"] = "LookupInventory"
+            }));
+
+        IReadOnlyList<ToolUsageStat> stats = collector.GetToolStats(now.AddMinutes(-1));
+
+        stats.Should().ContainSingle();
+        stats[0].ToolName.Should().Be("LookupInventory");
+        stats[0].CallCount.Should().Be(1);
+        stats[0].TotalTokens.Should().Be(0);
+        stats[0].AvgDurationMs.Should().Be(75);
+    }
+
+    [Fact]
+    public void GetToolStats_OrdersByCallCountThenTokensAndHonorsTop()
+    {
+        var collector = new InMemoryTraceCollector();
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        collector.CaptureSpan(MakeSpan("trace-a", "tool.A", now, inputTokens: 500, outputTokens: 500));
+        collector.CaptureSpan(MakeSpan("trace-b1", "tool.B", now));
+        collector.CaptureSpan(MakeSpan("trace-b2", "tool.B", now));
+        collector.CaptureSpan(MakeSpan("trace-c1", "tool.C", now, inputTokens: 300));
+        collector.CaptureSpan(MakeSpan("trace-c2", "tool.C", now, outputTokens: 300));
+
+        IReadOnlyList<ToolUsageStat> stats = collector.GetToolStats(now.AddMinutes(-1), top: 2);
+
+        stats.Should().HaveCount(2);
+        stats[0].ToolName.Should().Be("C");
+        stats[0].CallCount.Should().Be(2);
+        stats[0].TotalTokens.Should().Be(600);
+        stats[1].ToolName.Should().Be("B");
+    }
+
+    [Fact]
+    public void GetToolStats_FiltersBySinceCutoff()
+    {
+        var collector = new InMemoryTraceCollector();
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        collector.CaptureSpan(MakeSpan("old-trace", "tool.OldTool", now.AddDays(-8)));
+        collector.CaptureSpan(MakeSpan("new-trace", "tool.NewTool", now.AddDays(-1)));
+
+        IReadOnlyList<ToolUsageStat> stats = collector.GetToolStats(now.AddDays(-7));
+
+        stats.Should().ContainSingle();
+        stats[0].ToolName.Should().Be("NewTool");
+    }
+
+    [Fact]
+    public void GetToolStats_EmptyCollectorReturnsEmptyList()
+    {
+        var collector = new InMemoryTraceCollector();
+
+        IReadOnlyList<ToolUsageStat> stats = collector.GetToolStats(DateTimeOffset.MinValue);
+
+        stats.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetCostPeriodCutoff_UsesCostEndpointPeriodSemantics()
+    {
+        DateTimeOffset now = new(2026, 6, 30, 17, 11, 0, TimeSpan.Zero);
+
+        ObservabilityEndpoints.GetCostPeriodCutoff("today", now).Should().Be(new DateTimeOffset(2026, 6, 30, 0, 0, 0, TimeSpan.Zero));
+        ObservabilityEndpoints.GetCostPeriodCutoff("week", now).Should().Be(now.AddDays(-7));
+        ObservabilityEndpoints.GetCostPeriodCutoff("month", now).Should().Be(now.AddDays(-30));
+        ObservabilityEndpoints.GetCostPeriodCutoff("all", now).Should().Be(DateTimeOffset.MinValue);
+        ObservabilityEndpoints.GetCostPeriodCutoff("bad-value", now).Should().Be(now.AddDays(-7));
+    }
+
+    private static TraceSpan MakeSpan(
+        string traceId,
+        string operationName,
+        DateTimeOffset startTime,
+        double durationMs = 100,
+        int inputTokens = 0,
+        int outputTokens = 0,
+        string? toolName = null,
+        IDictionary<string, string>? tags = null)
+    {
+        Dictionary<string, string>? spanTags = tags is null ? null : new Dictionary<string, string>(tags);
+        if (toolName is not null)
+        {
+            spanTags ??= [];
+            spanTags["tool.name"] = toolName;
+        }
+
+        return new TraceSpan(
+            SpanId: Guid.NewGuid().ToString("N"),
+            TraceId: traceId,
+            ParentSpanId: null,
+            OperationName: operationName,
+            StartTime: startTime,
+            EndTime: startTime.AddMilliseconds(durationMs),
+            DurationMs: durationMs,
+            InputTokens: inputTokens,
+            OutputTokens: outputTokens,
+            Tags: spanTags);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the Observability dashboard reported as `failing` and `showing static data / not matching live telemetry`.

### Bug fixes
- **Export crash**: `ConversationExport` threw `Cannot read properties of undefined (reading 'toLocaleString')` when a session lacked `totalTokens`. Added field normalization in `fetchExportSessions` (matching sibling fetchers) plus component guards.
- **Empty dashboard panels**: Cost Trend, Agent Breakdown, and Top Tools were permanently empty because the frontend read those arrays off the summary-only `/costs` response. Now fans out to `/costs`, `/costs/agents`, `/costs/trend` and a **new** `/costs/tools` endpoint, with correct field mappings.
- **Frozen feel**: dashboard fetched once; now refreshes every 10s without skeleton flicker.
- **Idle UX**: added empty states (incl. an all-zero-trend guard so idle renders `No data yet` instead of a zero-line chart).

### Backend
- New `ToolUsageStat` + `ITraceCollector.GetToolStats` (per-tool stats sourced from trace spans, which carry duration) and `GET /api/observability/costs/tools`.

### Validation
- Backend: **1998 passed** / 2 skipped.
- Frontend: **285/285 passed**, `npm run build` clean.
- Reviewer (Tester) verdict: **PASS** after one rejection cycle on the idle-trend empty state.

Team: Kroger (design), Costco (backend), Chick (frontend), Publix (validation).