### PR TITLE
Fix chart JSON rendered as prose instead of a chart (#15)

### DIFF
--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartExtraction.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartExtraction.cs
@@ -1,0 +1,160 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using RetailPulse.Api.Charts;
+using RetailPulse.Contracts;
+
+namespace RetailPulse.Api.Agents;
+
+/// <summary>
+/// Inline chart recovery for the agent reply text.
+///
+/// Some models echo the CreateChart payload as raw JSON inside their prose
+/// answer instead of (or in addition to) a clean tool call, and occasionally
+/// emit it using a non-canonical, Chart.js-style schema that the tool path
+/// cannot bind to <see cref="ChartSpec"/>. Either way the user sees a wall of
+/// raw JSON and no chart.
+///
+/// This pass extracts any chart-spec JSON embedded in the reply, normalizes the
+/// realistic schema variations into a canonical <see cref="ChartSpec"/> (via
+/// <see cref="ChartSpecNormalizer"/>), and returns the reply with those JSON
+/// blocks removed. Only JSON that actually resolves to a usable chart is
+/// stripped — arbitrary or malformed JSON is left in place so nothing
+/// legitimate is silently hidden.
+/// </summary>
+public partial class AgentExecutionPipeline
+{
+    // Collapses code fences that are left empty after their JSON body was removed
+    // (e.g. ```json\n\n``` -> "").
+    [GeneratedRegex(@"```(?:json)?\s*```", RegexOptions.IgnoreCase)]
+    private static partial Regex EmptyCodeFencePattern();
+
+    // Collapses 3+ consecutive newlines down to a single blank line.
+    [GeneratedRegex(@"(\r?\n){3,}")]
+    private static partial Regex ExcessiveBlankLinesPattern();
+
+    internal readonly record struct InlineChartExtraction(string Reply, List<ChartSpec> Charts);
+
+    /// <summary>
+    /// Removes chart-spec JSON blocks embedded in the reply prose and returns the
+    /// normalized <see cref="ChartSpec"/> instances recovered from them.
+    /// </summary>
+    internal static InlineChartExtraction ExtractInlineCharts(string reply)
+    {
+        if (string.IsNullOrEmpty(reply))
+        {
+            return new InlineChartExtraction(reply, []);
+        }
+
+        var charts = new List<ChartSpec>();
+        var removals = new List<(int Start, int End)>();
+
+        foreach ((int start, int end) in FindJsonObjectSpans(reply))
+        {
+            string candidate = reply[start..end];
+            if (ChartSpecNormalizer.TryNormalize(candidate, out ChartSpec? chart) && chart is not null)
+            {
+                charts.Add(chart);
+                removals.Add((start, end));
+            }
+        }
+
+        if (removals.Count == 0)
+        {
+            return new InlineChartExtraction(reply, charts);
+        }
+
+        var sb = new StringBuilder(reply.Length);
+        int cursor = 0;
+        foreach ((int rs, int re) in removals)
+        {
+            if (rs > cursor)
+            {
+                sb.Append(reply, cursor, rs - cursor);
+            }
+            cursor = re;
+        }
+        if (cursor < reply.Length)
+        {
+            sb.Append(reply, cursor, reply.Length - cursor);
+        }
+
+        string cleaned = EmptyCodeFencePattern().Replace(sb.ToString(), string.Empty);
+        cleaned = ExcessiveBlankLinesPattern().Replace(cleaned, "\n\n").Trim();
+
+        return new InlineChartExtraction(cleaned, charts);
+    }
+
+    /// <summary>
+    /// Yields the [start, end) spans of every top-level balanced JSON object in
+    /// <paramref name="text"/>, honoring string literals and escapes. Truncated
+    /// (never-closed) objects are skipped.
+    /// </summary>
+    private static IEnumerable<(int Start, int End)> FindJsonObjectSpans(string text)
+    {
+        int i = 0;
+        int n = text.Length;
+        while (i < n)
+        {
+            if (text[i] != '{')
+            {
+                i++;
+                continue;
+            }
+
+            int depth = 0;
+            bool inString = false;
+            bool escaped = false;
+            int start = i;
+            int j = i;
+            for (; j < n; j++)
+            {
+                char c = text[j];
+                if (inString)
+                {
+                    if (escaped)
+                    {
+                        escaped = false;
+                    }
+                    else if (c == '\\')
+                    {
+                        escaped = true;
+                    }
+                    else if (c == '"')
+                    {
+                        inString = false;
+                    }
+                    continue;
+                }
+
+                if (c == '"')
+                {
+                    inString = true;
+                }
+                else if (c == '{')
+                {
+                    depth++;
+                }
+                else if (c == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        j++;
+                        break;
+                    }
+                }
+            }
+
+            if (depth == 0 && j > start)
+            {
+                yield return (start, j);
+                i = j;
+            }
+            else
+            {
+                // Unbalanced / truncated object — leave it in the prose and move on.
+                i = start + 1;
+            }
+        }
+    }
+}

--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartExtraction.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartExtraction.cs
@@ -35,6 +35,35 @@ public partial class AgentExecutionPipeline
     internal readonly record struct InlineChartExtraction(string Reply, List<ChartSpec> Charts);
 
     /// <summary>
+    /// Merges charts recovered from the reply prose into the charts produced by
+    /// the tool path, appending only those inline charts that are not a semantic
+    /// duplicate of a chart already present (whether tool-produced or an earlier
+    /// inline chart). This preserves a distinct chart the model narrated in prose
+    /// alongside a different tool-produced chart, while suppressing the common
+    /// case where the model echoes the same chart it already emitted as a tool
+    /// call. Deduplication uses <see cref="ChartSpecSemanticComparer"/> so it is
+    /// based on chart content, not object identity or serialized form.
+    /// </summary>
+    internal static List<ChartSpec> MergeInlineCharts(List<ChartSpec> toolCharts, IReadOnlyList<ChartSpec> inlineCharts)
+    {
+        if (inlineCharts.Count == 0)
+        {
+            return toolCharts;
+        }
+
+        var merged = new List<ChartSpec>(toolCharts);
+        foreach (ChartSpec inlineChart in inlineCharts)
+        {
+            bool isDuplicate = merged.Any(existing => ChartSpecSemanticComparer.Instance.Equals(existing, inlineChart));
+            if (!isDuplicate)
+            {
+                merged.Add(inlineChart);
+            }
+        }
+        return merged;
+    }
+
+    /// <summary>
     /// Removes chart-spec JSON blocks embedded in the reply prose and returns the
     /// normalized <see cref="ChartSpec"/> instances recovered from them.
     /// </summary>

--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
@@ -162,6 +162,16 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
 
         List<ChartSpec> charts = ExtractChartSpecs(response);
 
+        // Recover chart specs the model echoed as raw JSON in its prose (and strip
+        // that JSON so it never reaches the chat bubble). Promote recovered charts
+        // only when the tool path produced none, to avoid duplicate renders.
+        InlineChartExtraction inlineCharts = ExtractInlineCharts(reply);
+        reply = inlineCharts.Reply;
+        if (charts.Count == 0 && inlineCharts.Charts.Count > 0)
+        {
+            charts = inlineCharts.Charts;
+        }
+
         using Activity? responseActivity = AgentTelemetry.StartAgentResponse(context.AgentName);
         long responseDurationMs = sw.ElapsedMilliseconds - postProcessStart;
         await collector.RecordSpanAsync(
@@ -326,6 +336,16 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         string reply = SanitizeReplyText(string.IsNullOrWhiteSpace(rawText) ? context.FallbackReply : rawText);
 
         List<ChartSpec> charts = ExtractChartSpecs(response);
+
+        // Recover chart specs the model echoed as raw JSON in its prose (and strip
+        // that JSON so it never reaches the chat bubble or the streamed tokens).
+        // Promote recovered charts only when the tool path produced none.
+        InlineChartExtraction inlineCharts = ExtractInlineCharts(reply);
+        reply = inlineCharts.Reply;
+        if (charts.Count == 0 && inlineCharts.Charts.Count > 0)
+        {
+            charts = inlineCharts.Charts;
+        }
 
         // Stream the reply token-by-token via StreamingHub for progressive rendering
         await StreamReplyAsync(sessionId, context.AgentName, reply, ct);

--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
@@ -163,14 +163,13 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         List<ChartSpec> charts = ExtractChartSpecs(response);
 
         // Recover chart specs the model echoed as raw JSON in its prose (and strip
-        // that JSON so it never reaches the chat bubble). Promote recovered charts
-        // only when the tool path produced none, to avoid duplicate renders.
+        // that JSON so it never reaches the chat bubble). Merge distinct recovered
+        // charts into the tool-produced set, suppressing only genuine duplicates of
+        // charts the tool already produced (a common echo) so a distinct inline
+        // chart is not silently dropped.
         InlineChartExtraction inlineCharts = ExtractInlineCharts(reply);
         reply = inlineCharts.Reply;
-        if (charts.Count == 0 && inlineCharts.Charts.Count > 0)
-        {
-            charts = inlineCharts.Charts;
-        }
+        charts = MergeInlineCharts(charts, inlineCharts.Charts);
 
         using Activity? responseActivity = AgentTelemetry.StartAgentResponse(context.AgentName);
         long responseDurationMs = sw.ElapsedMilliseconds - postProcessStart;
@@ -339,13 +338,12 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
 
         // Recover chart specs the model echoed as raw JSON in its prose (and strip
         // that JSON so it never reaches the chat bubble or the streamed tokens).
-        // Promote recovered charts only when the tool path produced none.
+        // Merge distinct recovered charts into the tool-produced set, suppressing
+        // only genuine duplicates of tool-produced charts so streaming stays
+        // consistent with the non-streaming path.
         InlineChartExtraction inlineCharts = ExtractInlineCharts(reply);
         reply = inlineCharts.Reply;
-        if (charts.Count == 0 && inlineCharts.Charts.Count > 0)
-        {
-            charts = inlineCharts.Charts;
-        }
+        charts = MergeInlineCharts(charts, inlineCharts.Charts);
 
         // Stream the reply token-by-token via StreamingHub for progressive rendering
         await StreamReplyAsync(sessionId, context.AgentName, reply, ct);

--- a/src/RetailPulse.Api/Charts/ChartSpecComparer.cs
+++ b/src/RetailPulse.Api/Charts/ChartSpecComparer.cs
@@ -1,0 +1,92 @@
+using RetailPulse.Contracts;
+
+namespace RetailPulse.Api.Charts;
+
+/// <summary>
+/// Stable, value-based equality for <see cref="ChartSpec"/> used to deduplicate
+/// charts recovered from inline prose against charts produced by the tool path.
+///
+/// <see cref="ChartSpec"/> is a record, but its <c>Data</c> (and nested
+/// <c>Values</c>) are <see cref="List{T}"/>s, so the compiler-generated record
+/// equality compares those by reference — two structurally identical charts from
+/// different sources would never compare equal. Reference identity is therefore
+/// useless here, and serialization-based comparison is fragile (property order,
+/// numeric formatting, null vs. absent). This comparer instead walks the chart's
+/// meaningful fields so a genuine duplicate echo is suppressed while a distinct
+/// chart is preserved.
+/// </summary>
+internal sealed class ChartSpecSemanticComparer : IEqualityComparer<ChartSpec>
+{
+    // Charts recovered from prose and produced by tools originate from the same
+    // numeric parse, but compare Y with a tiny tolerance to stay robust against
+    // representation drift rather than relying on exact double equality.
+    private const double _valueEpsilon = 1e-9;
+
+    public static readonly ChartSpecSemanticComparer Instance = new();
+
+    public bool Equals(ChartSpec? x, ChartSpec? y) =>
+        ReferenceEquals(x, y)
+        || (x is not null
+            && y is not null
+            && string.Equals(x.Type, y.Type, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(x.Title, y.Title, StringComparison.Ordinal)
+            && NullableStringEquals(x.XAxisTitle, y.XAxisTitle)
+            && NullableStringEquals(x.YAxisTitle, y.YAxisTitle)
+            && SeriesEqual(x.Data, y.Data));
+
+    public int GetHashCode(ChartSpec chart)
+    {
+        var hash = new HashCode();
+        hash.Add(chart.Type, StringComparer.OrdinalIgnoreCase);
+        hash.Add(chart.Title, StringComparer.Ordinal);
+        hash.Add(chart.XAxisTitle, StringComparer.Ordinal);
+        hash.Add(chart.YAxisTitle, StringComparer.Ordinal);
+        // Include shape (series + point counts and legends) but not raw doubles,
+        // so equal-under-epsilon charts still land in the same bucket.
+        hash.Add(chart.Data.Count);
+        foreach (ChartSeries series in chart.Data)
+        {
+            hash.Add(series.Legend, StringComparer.Ordinal);
+            hash.Add(series.Values.Count);
+        }
+        return hash.ToHashCode();
+    }
+
+    private static bool SeriesEqual(List<ChartSeries> a, List<ChartSeries> b)
+    {
+        if (a.Count != b.Count)
+        {
+            return false;
+        }
+        for (int i = 0; i < a.Count; i++)
+        {
+            if (!string.Equals(a[i].Legend, b[i].Legend, StringComparison.Ordinal)
+                || !NullableStringEquals(a[i].Color, b[i].Color)
+                || !PointsEqual(a[i].Values, b[i].Values))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static bool PointsEqual(List<ChartDataPoint> a, List<ChartDataPoint> b)
+    {
+        if (a.Count != b.Count)
+        {
+            return false;
+        }
+        for (int i = 0; i < a.Count; i++)
+        {
+            if (!string.Equals(a[i].X, b[i].X, StringComparison.Ordinal)
+                || Math.Abs(a[i].Y - b[i].Y) > _valueEpsilon)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static bool NullableStringEquals(string? a, string? b) =>
+        string.Equals(a, b, StringComparison.Ordinal);
+}

--- a/src/RetailPulse.Api/Charts/ChartSpecNormalizer.cs
+++ b/src/RetailPulse.Api/Charts/ChartSpecNormalizer.cs
@@ -98,6 +98,17 @@ internal static class ChartSpecNormalizer
             orientation = GetStringOrNull(options, "orientation");
         }
 
+        // Full-config style: axis titles under xAxis/yAxis objects (e.g. xAxis.label).
+        if (root.TryGetProperty("xAxis", out JsonElement xAxisEl) && xAxisEl.ValueKind == JsonValueKind.Object)
+        {
+            xAxis ??= GetStringOrNull(xAxisEl, "label") ?? GetStringOrNull(xAxisEl, "title");
+        }
+        if (root.TryGetProperty("yAxis", out JsonElement yAxisEl) && yAxisEl.ValueKind == JsonValueKind.Object)
+        {
+            yAxis ??= GetStringOrNull(yAxisEl, "label") ?? GetStringOrNull(yAxisEl, "title");
+        }
+        orientation ??= GetStringOrNull(root, "orientation");
+
         List<ChartSeries> series = ExtractSeries(root, title);
         if (series.Count == 0)
         {
@@ -115,11 +126,53 @@ internal static class ChartSpecNormalizer
         return true;
     }
 
-    private static List<ChartSeries> ExtractSeries(JsonElement root, string chartTitle) =>
-        !root.TryGetProperty("data", out JsonElement data) ? []
-        : data.ValueKind == JsonValueKind.Array ? SeriesFromArray(data)
-        : data.ValueKind == JsonValueKind.Object ? SeriesFromLabelledObject(data, chartTitle)
-        : [];
+    private static List<ChartSeries> ExtractSeries(JsonElement root, string chartTitle)
+    {
+        if (root.TryGetProperty("data", out JsonElement data))
+        {
+            if (data.ValueKind == JsonValueKind.Array)
+            {
+                return SeriesFromArray(data);
+            }
+            if (data.ValueKind == JsonValueKind.Object)
+            {
+                return SeriesFromLabelledObject(data, chartTitle);
+            }
+        }
+
+        // Full-config (Chart.js-style) schema: a top-level "series" array paired with
+        // labels under xAxis.categories / top-level categories or labels. Each series
+        // carries its numbers under "data" or "values".
+        return root.TryGetProperty("series", out JsonElement topSeries) && topSeries.ValueKind == JsonValueKind.Array
+            ? SeriesFromSeriesArray(topSeries, GatherLabels(root), chartTitle)
+            : [];
+    }
+
+    // Collects category labels shared by all series, checking the common locations
+    // models use: top-level labels/categories, or xAxis.{categories,labels,data}.
+    private static List<string> GatherLabels(JsonElement root)
+    {
+        List<string>? labels = LabelsFrom(root, "labels") ?? LabelsFrom(root, "categories");
+        if (labels is null && root.TryGetProperty("xAxis", out JsonElement xAxisEl) && xAxisEl.ValueKind == JsonValueKind.Object)
+        {
+            labels = LabelsFrom(xAxisEl, "categories") ?? LabelsFrom(xAxisEl, "labels") ?? LabelsFrom(xAxisEl, "data");
+        }
+        return labels ?? [];
+    }
+
+    private static List<string>? LabelsFrom(JsonElement source, string property)
+    {
+        if (!source.TryGetProperty(property, out JsonElement el) || el.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+        var labels = new List<string>();
+        foreach (JsonElement label in el.EnumerateArray())
+        {
+            labels.Add(ElementToXString(label));
+        }
+        return labels;
+    }
 
     // Canonical schema: data is an array of series objects, each with a
     // legend/name and a values array of {x, y} points (or plain numbers).
@@ -163,34 +216,55 @@ internal static class ChartSpecNormalizer
             }
         }
 
-        var result = new List<ChartSeries>();
-
         if (dataObj.TryGetProperty("series", out JsonElement seriesEl) && seriesEl.ValueKind == JsonValueKind.Array)
         {
-            foreach (JsonElement s in seriesEl.EnumerateArray())
-            {
-                if (s.ValueKind != JsonValueKind.Object)
-                {
-                    continue;
-                }
-
-                string legend = GetStringOrNull(s, "name")
-                    ?? GetStringOrNull(s, "legend")
-                    ?? GetStringOrNull(s, "label")
-                    ?? $"Series {result.Count + 1}";
-                string? color = GetStringOrNull(s, "color");
-
-                ChartSeries? built = BuildSeries(legend, color, s, labels);
-                if (built is not null)
-                {
-                    result.Add(built);
-                }
-            }
+            return SeriesFromSeriesArray(seriesEl, labels, chartTitle);
         }
-        else if (dataObj.TryGetProperty("values", out _))
+
+        var result = new List<ChartSeries>();
+        if (dataObj.TryGetProperty("values", out _))
         {
             // Single implicit series keyed by the chart title.
             ChartSeries? built = BuildSeries(chartTitle, null, dataObj, labels);
+            if (built is not null)
+            {
+                result.Add(built);
+            }
+        }
+
+        return result;
+    }
+
+    // Builds series from a "series" array of { name, values|data:[...] } objects,
+    // sharing the provided category labels across every series.
+    private static List<ChartSeries> SeriesFromSeriesArray(JsonElement seriesEl, List<string> labels, string chartTitle)
+    {
+        var result = new List<ChartSeries>();
+        foreach (JsonElement s in seriesEl.EnumerateArray())
+        {
+            if (s.ValueKind == JsonValueKind.Array)
+            {
+                // A bare array of numbers is an implicit single series.
+                ChartSeries? bare = BuildSeriesFromValues(chartTitle, null, s, labels);
+                if (bare is not null)
+                {
+                    result.Add(bare);
+                }
+                continue;
+            }
+
+            if (s.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            string legend = GetStringOrNull(s, "name")
+                ?? GetStringOrNull(s, "legend")
+                ?? GetStringOrNull(s, "label")
+                ?? $"Series {result.Count + 1}";
+            string? color = GetStringOrNull(s, "color");
+
+            ChartSeries? built = BuildSeries(legend, color, s, labels);
             if (built is not null)
             {
                 result.Add(built);
@@ -204,7 +278,12 @@ internal static class ChartSpecNormalizer
     {
         bool hasValues = seriesObj.TryGetProperty("values", out JsonElement valuesEl)
             || seriesObj.TryGetProperty("data", out valuesEl);
-        if (!hasValues || valuesEl.ValueKind != JsonValueKind.Array)
+        return !hasValues ? null : BuildSeriesFromValues(legend, color, valuesEl, labels);
+    }
+
+    private static ChartSeries? BuildSeriesFromValues(string legend, string? color, JsonElement valuesEl, List<string> labels)
+    {
+        if (valuesEl.ValueKind != JsonValueKind.Array)
         {
             return null;
         }

--- a/src/RetailPulse.Api/Charts/ChartSpecNormalizer.cs
+++ b/src/RetailPulse.Api/Charts/ChartSpecNormalizer.cs
@@ -1,0 +1,311 @@
+using System.Globalization;
+using System.Text.Json;
+using RetailPulse.Contracts;
+
+namespace RetailPulse.Api.Charts;
+
+/// <summary>
+/// Normalizes chart JSON emitted by the LLM into the canonical
+/// <see cref="ChartSpec"/> shape, tolerating realistic schema variations.
+///
+/// Models sometimes deviate from the documented <c>ChartSpec</c> schema
+/// (<c>data: [{ legend, values: [{ x, y }] }]</c>) and instead emit a
+/// Chart.js-style payload (<c>data: { labels, series: [{ name, values }] }</c>),
+/// or attach axis titles under an <c>options</c> object, or orient a bar chart
+/// horizontally via <c>options.orientation</c>. This normalizer maps those
+/// variations onto the one shape the frontend renders.
+///
+/// It is deliberately strict about what counts as a chart: a recognized chart
+/// <c>type</c>, a <c>title</c>, and at least one bindable datapoint are all
+/// required. Callers rely on that so they can leave non-chart or unusable JSON
+/// untouched instead of silently discarding it.
+/// </summary>
+internal static class ChartSpecNormalizer
+{
+    private static readonly HashSet<string> _knownChartTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "line", "bar", "groupedBar", "stackedBar", "horizontalBar", "pie", "donut", "gauge", "table",
+    };
+
+    private static readonly string[] _pointXKeys = ["x", "label", "name", "category"];
+    private static readonly string[] _pointYKeys = ["y", "value", "count"];
+
+    /// <summary>
+    /// Attempts to parse and normalize a JSON string into a canonical
+    /// <see cref="ChartSpec"/>. Returns false (and a null chart) when the JSON is
+    /// not a recognizable, bindable chart.
+    /// </summary>
+    public static bool TryNormalize(string json, out ChartSpec? chart)
+    {
+        chart = null;
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        using (doc)
+        {
+            return TryNormalize(doc.RootElement, out chart);
+        }
+    }
+
+    /// <summary>
+    /// Normalizes an already-parsed JSON element. Returns false when the element
+    /// is not a recognizable, bindable chart.
+    /// </summary>
+    public static bool TryNormalize(JsonElement root, out ChartSpec? chart)
+    {
+        chart = null;
+
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (!root.TryGetProperty("type", out JsonElement typeEl) || typeEl.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+        string? rawType = typeEl.GetString();
+        if (string.IsNullOrWhiteSpace(rawType) || !_knownChartTypes.Contains(rawType))
+        {
+            return false;
+        }
+
+        string? title = GetStringOrNull(root, "title");
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return false;
+        }
+
+        string? xAxis = GetStringOrNull(root, "xAxisTitle");
+        string? yAxis = GetStringOrNull(root, "yAxisTitle");
+        string? orientation = null;
+        if (root.TryGetProperty("options", out JsonElement options) && options.ValueKind == JsonValueKind.Object)
+        {
+            xAxis ??= GetStringOrNull(options, "xAxisLabel") ?? GetStringOrNull(options, "xAxisTitle");
+            yAxis ??= GetStringOrNull(options, "yAxisLabel") ?? GetStringOrNull(options, "yAxisTitle");
+            orientation = GetStringOrNull(options, "orientation");
+        }
+
+        List<ChartSeries> series = ExtractSeries(root, title);
+        if (series.Count == 0)
+        {
+            return false;
+        }
+
+        chart = new ChartSpec
+        {
+            Type = NormalizeChartType(rawType, orientation),
+            Title = title,
+            XAxisTitle = xAxis,
+            YAxisTitle = yAxis,
+            Data = series,
+        };
+        return true;
+    }
+
+    private static List<ChartSeries> ExtractSeries(JsonElement root, string chartTitle) =>
+        !root.TryGetProperty("data", out JsonElement data) ? []
+        : data.ValueKind == JsonValueKind.Array ? SeriesFromArray(data)
+        : data.ValueKind == JsonValueKind.Object ? SeriesFromLabelledObject(data, chartTitle)
+        : [];
+
+    // Canonical schema: data is an array of series objects, each with a
+    // legend/name and a values array of {x, y} points (or plain numbers).
+    private static List<ChartSeries> SeriesFromArray(JsonElement dataArray)
+    {
+        var result = new List<ChartSeries>();
+        foreach (JsonElement element in dataArray.EnumerateArray())
+        {
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            string legend = GetStringOrNull(element, "legend")
+                ?? GetStringOrNull(element, "name")
+                ?? GetStringOrNull(element, "label")
+                ?? $"Series {result.Count + 1}";
+            string? color = GetStringOrNull(element, "color");
+
+            ChartSeries? built = BuildSeries(legend, color, element, []);
+            if (built is not null)
+            {
+                result.Add(built);
+            }
+        }
+
+        return result;
+    }
+
+    // Alternate (Chart.js-style) schema: data is an object with a shared "labels"
+    // array and a "series" array of { name, values:[numbers] }. Also tolerates a
+    // single-series shape where "labels" is paired directly with "values".
+    private static List<ChartSeries> SeriesFromLabelledObject(JsonElement dataObj, string chartTitle)
+    {
+        var labels = new List<string>();
+        if (dataObj.TryGetProperty("labels", out JsonElement labelsEl) && labelsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement label in labelsEl.EnumerateArray())
+            {
+                labels.Add(ElementToXString(label));
+            }
+        }
+
+        var result = new List<ChartSeries>();
+
+        if (dataObj.TryGetProperty("series", out JsonElement seriesEl) && seriesEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement s in seriesEl.EnumerateArray())
+            {
+                if (s.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                string legend = GetStringOrNull(s, "name")
+                    ?? GetStringOrNull(s, "legend")
+                    ?? GetStringOrNull(s, "label")
+                    ?? $"Series {result.Count + 1}";
+                string? color = GetStringOrNull(s, "color");
+
+                ChartSeries? built = BuildSeries(legend, color, s, labels);
+                if (built is not null)
+                {
+                    result.Add(built);
+                }
+            }
+        }
+        else if (dataObj.TryGetProperty("values", out _))
+        {
+            // Single implicit series keyed by the chart title.
+            ChartSeries? built = BuildSeries(chartTitle, null, dataObj, labels);
+            if (built is not null)
+            {
+                result.Add(built);
+            }
+        }
+
+        return result;
+    }
+
+    private static ChartSeries? BuildSeries(string legend, string? color, JsonElement seriesObj, List<string> labels)
+    {
+        bool hasValues = seriesObj.TryGetProperty("values", out JsonElement valuesEl)
+            || seriesObj.TryGetProperty("data", out valuesEl);
+        if (!hasValues || valuesEl.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var points = new List<ChartDataPoint>();
+        int index = 0;
+        foreach (JsonElement v in valuesEl.EnumerateArray())
+        {
+            string fallbackX = index < labels.Count
+                ? labels[index]
+                : (index + 1).ToString(CultureInfo.InvariantCulture);
+
+            if (v.ValueKind == JsonValueKind.Object)
+            {
+                string x = GetPointX(v) ?? fallbackX;
+                if (TryGetPointY(v, out double oy))
+                {
+                    points.Add(new ChartDataPoint { X = x, Y = oy });
+                }
+            }
+            else if (TryElementToDouble(v, out double y))
+            {
+                points.Add(new ChartDataPoint { X = fallbackX, Y = y });
+            }
+
+            index++;
+        }
+
+        return points.Count > 0
+            ? new ChartSeries { Legend = legend, Color = color, Values = points }
+            : null;
+    }
+
+    private static string NormalizeChartType(string rawType, string? orientation)
+    {
+        string t = rawType.Trim().ToLowerInvariant();
+        return t == "bar" && string.Equals(orientation, "horizontal", StringComparison.OrdinalIgnoreCase)
+            ? "horizontalBar"
+            : t switch
+            {
+                "line" => "line",
+                "bar" => "bar",
+                "groupedbar" => "groupedBar",
+                "stackedbar" => "stackedBar",
+                "horizontalbar" => "horizontalBar",
+                "pie" => "pie",
+                "donut" => "donut",
+                "gauge" => "gauge",
+                "table" => "table",
+                _ => t,
+            };
+    }
+
+    private static string? GetStringOrNull(JsonElement obj, string property) =>
+        obj.TryGetProperty(property, out JsonElement el) && el.ValueKind == JsonValueKind.String
+            ? el.GetString()
+            : null;
+
+    private static string? GetPointX(JsonElement point)
+    {
+        foreach (string key in _pointXKeys)
+        {
+            if (point.TryGetProperty(key, out JsonElement el) && el.ValueKind != JsonValueKind.Null)
+            {
+                return ElementToXString(el);
+            }
+        }
+        return null;
+    }
+
+    private static bool TryGetPointY(JsonElement point, out double value)
+    {
+        foreach (string key in _pointYKeys)
+        {
+            if (point.TryGetProperty(key, out JsonElement el) && TryElementToDouble(el, out value))
+            {
+                return true;
+            }
+        }
+        value = 0;
+        return false;
+    }
+
+    private static string ElementToXString(JsonElement e) =>
+        e.ValueKind == JsonValueKind.String ? e.GetString() ?? string.Empty
+        : e.ValueKind == JsonValueKind.Number ? e.GetDouble().ToString(CultureInfo.InvariantCulture)
+        : e.ValueKind == JsonValueKind.True ? "true"
+        : e.ValueKind == JsonValueKind.False ? "false"
+        : e.ToString();
+
+    private static bool TryElementToDouble(JsonElement e, out double value)
+    {
+        if (e.ValueKind == JsonValueKind.Number)
+        {
+            return e.TryGetDouble(out value);
+        }
+        if (e.ValueKind == JsonValueKind.String)
+        {
+            return double.TryParse(e.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+        }
+        value = 0;
+        return false;
+    }
+}

--- a/src/RetailPulse.Api/Tools/ChartDataTool.cs
+++ b/src/RetailPulse.Api/Tools/ChartDataTool.cs
@@ -39,6 +39,21 @@ public class ChartDataTool
                 return Task.FromResult(JsonSerializer.Serialize(new { error = "Invalid chart specification" }));
             }
 
+            // Strict binding succeeds structurally even when the model used a
+            // non-canonical schema (e.g. top-level series + xAxis), leaving Data empty.
+            // Recover the real series via the normalizer before returning an empty chart.
+            if (spec.Data.Count == 0
+                && ChartSpecNormalizer.TryNormalize(chartSpecJson, out ChartSpec? enriched)
+                && enriched is not null
+                && enriched.Data.Count > 0)
+            {
+                _logger.LogInformation(
+                    "Enriched chart spec from non-canonical schema: {Type} - {Title} with {SeriesCount} series",
+                    enriched.Type, enriched.Title, enriched.Data.Count);
+
+                return Task.FromResult(JsonSerializer.Serialize(new { status = "success", chart = enriched, recovered = true }));
+            }
+
             _logger.LogInformation("Chart created: {Type} - {Title} with {SeriesCount} series", spec.Type, spec.Title, spec.Data.Count);
 
             return Task.FromResult(JsonSerializer.Serialize(new { status = "success", chart = spec, recovered = false }));

--- a/src/RetailPulse.Api/Tools/ChartDataTool.cs
+++ b/src/RetailPulse.Api/Tools/ChartDataTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using RetailPulse.Api.Charts;
 using RetailPulse.Contracts;
 
 namespace RetailPulse.Api.Tools;
@@ -60,6 +61,18 @@ public class ChartDataTool
     private string TryRecover(string raw, JsonException originalError)
     {
         string cleaned = StripMarkdownFences(raw);
+
+        // The payload may be well-formed but use a non-canonical, model-invented
+        // schema (e.g. Chart.js-style data:{labels,series}). Normalize that shape
+        // before falling back to truncation repair.
+        if (ChartSpecNormalizer.TryNormalize(cleaned, out ChartSpec? normalized) && normalized is not null)
+        {
+            _logger.LogInformation(
+                "Normalized non-canonical chart spec: {Type} - {Title} with {SeriesCount} series",
+                normalized.Type, normalized.Title, normalized.Data.Count);
+
+            return JsonSerializer.Serialize(new { status = "success", chart = normalized, recovered = true });
+        }
 
         string? repaired = RepairTruncatedJson(cleaned);
         if (repaired is not null)

--- a/src/RetailPulse.Web/src/__tests__/sanitizeMessage.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/sanitizeMessage.test.ts
@@ -75,6 +75,16 @@ describe('sanitizeMessage', () => {
       expect(result).toContain('Prose after the chart.');
     });
 
+    it('strips the full-config variant (top-level series + xAxis.categories)', () => {
+      const fullConfig =
+        '{"type":"bar","title":"Depletion Velocity","xAxis":{"label":"Brand","categories":["Sierra Gold","Summit"]},"yAxis":{"label":"Avg Weekly Volume"},"series":[{"name":"Avg Weekly Volume","data":[1893.2,2296.3]}]}';
+      const msg = 'Here is the bar chart.\n\n```json\n' + fullConfig + '\n```';
+      const result = sanitizeMessage(msg);
+      expect(result).not.toContain('```');
+      expect(result).not.toContain('"series"');
+      expect(result).toBe('Here is the bar chart.');
+    });
+
     it('does not strip non-chart JSON the user may be discussing', () => {
       const msg = 'The payload was {"brand":"Apex Grill","region":"Northeast","velocity":7.2} for reference.';
       expect(sanitizeMessage(msg)).toBe(msg);

--- a/src/RetailPulse.Web/src/__tests__/sanitizeMessage.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/sanitizeMessage.test.ts
@@ -100,5 +100,70 @@ describe('sanitizeMessage', () => {
       const msg = 'A bar chart would show depletion velocity by brand across the Northeast region.';
       expect(sanitizeMessage(msg)).toBe(msg);
     });
+
+    describe('bindability: prose JSON with no renderable datapoint is preserved', () => {
+      // The reviewer's proven leak examples: recognized type + title but the
+      // backend rejects them (no bindable datapoint), so the frontend must NOT
+      // silently delete the surrounding prose.
+      it('keeps an empty-data array payload (data: [])', () => {
+        const msg =
+          'For reference an empty chart payload looks like {"type":"bar","title":"Placeholder","data":[]} when no data is bound yet.';
+        expect(sanitizeMessage(msg)).toBe(msg);
+      });
+
+      it('keeps a null-data payload (data: null)', () => {
+        const msg = 'The schema example is {"type":"line","title":"Example","data":null} in the docs.';
+        expect(sanitizeMessage(msg)).toBe(msg);
+      });
+
+      it('keeps a non-renderable object-data payload (data: {id:1})', () => {
+        const msg = 'The webhook shape is {"type":"table","title":"Row","data":{"id":1}} for reference.';
+        expect(sanitizeMessage(msg)).toBe(msg);
+      });
+
+      it('keeps a canonical payload whose series carry no numeric values', () => {
+        const msg =
+          'Placeholder: {"type":"bar","title":"Empty","data":[{"legend":"A","values":[]}]} has no points yet.';
+        expect(sanitizeMessage(msg)).toBe(msg);
+      });
+
+      it('keeps a full-config payload whose series data is empty', () => {
+        const msg =
+          'Skeleton: {"type":"bar","title":"Skeleton","series":[{"name":"A","data":[]}]} awaits binding.';
+        expect(sanitizeMessage(msg)).toBe(msg);
+      });
+    });
+
+    describe('bindability: prose JSON with a real datapoint is still stripped', () => {
+      it('strips a canonical payload with {x,y} points', () => {
+        const msg =
+          'Here is the chart.\n\n{"type":"line","title":"Trend","data":[{"legend":"BrandA","values":[{"x":"Jan","y":10}]}]}';
+        expect(sanitizeMessage(msg)).toBe('Here is the chart.');
+      });
+
+      it('strips a labels/series data-object payload', () => {
+        const msg =
+          '{"type":"bar","title":"Depletion","data":{"labels":["A","B"],"series":[{"name":"Velocity","values":[12.5,9.8]}]}}\n\nThe comparison follows.';
+        expect(sanitizeMessage(msg)).toBe('The comparison follows.');
+      });
+
+      it('strips a single-series data-object payload (labels + values)', () => {
+        const msg =
+          '{"type":"pie","title":"Share","data":{"labels":["A","B"],"values":[60,40]}}\n\nMarket share above.';
+        expect(sanitizeMessage(msg)).toBe('Market share above.');
+      });
+
+      it('strips a full-config payload (top-level series + xAxis.categories)', () => {
+        const msg =
+          '{"type":"bar","title":"Avg","xAxis":{"label":"Brand","categories":["A","B"]},"series":[{"name":"Vol","data":[1893.2,2296.3]}]}\n\nBar chart above.';
+        expect(sanitizeMessage(msg)).toBe('Bar chart above.');
+      });
+
+      it('strips a payload whose values are numeric strings', () => {
+        const msg =
+          '{"type":"bar","title":"Coerced","data":[{"legend":"A","values":[{"x":"Jan","y":"10"}]}]}\n\nDone.';
+        expect(sanitizeMessage(msg)).toBe('Done.');
+      });
+    });
   });
 });

--- a/src/RetailPulse.Web/src/__tests__/sanitizeMessage.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/sanitizeMessage.test.ts
@@ -44,4 +44,51 @@ describe('sanitizeMessage', () => {
     expect(result).not.toMatch(/\n{3,}/);
     expect(result).toContain('Actual content.');
   });
+
+  describe('chart-spec JSON stripping (screenshot regression)', () => {
+    // The exact production failure: the model narrated its CreateChart payload as
+    // raw JSON (alternate Chart.js-style schema) at the top of the reply.
+    const screenshotJson =
+      '{"type":"bar","title":"Consolidation Check 2026-08-05","data":{"labels":["ClearDesk Vodka","Sierra Gold Tequila"],"series":[{"name":"Depletion Velocity","values":[12.5,9.8]}]},"options":{"orientation":"horizontal"}}';
+
+    it('strips a leading chart-spec JSON block from prose', () => {
+      const msg = `${screenshotJson}\n\nHere's the depletion velocity comparison for spirits brands in the Northeast.`;
+      const result = sanitizeMessage(msg);
+      expect(result).not.toContain('"type":"bar"');
+      expect(result).not.toContain('"series"');
+      expect(result).not.toContain('{');
+      expect(result).toBe("Here's the depletion velocity comparison for spirits brands in the Northeast.");
+    });
+
+    it('strips a canonical-schema chart-spec JSON block', () => {
+      const msg =
+        'Here is the chart.\n\n{"type":"line","title":"Trend","data":[{"legend":"BrandA","values":[{"x":"Jan","y":10}]}]}';
+      const result = sanitizeMessage(msg);
+      expect(result).toBe('Here is the chart.');
+    });
+
+    it('strips chart JSON wrapped in a code fence, leaving no empty fence', () => {
+      const msg = '```json\n' + screenshotJson + '\n```\n\nProse after the chart.';
+      const result = sanitizeMessage(msg);
+      expect(result).not.toContain('```');
+      expect(result).not.toContain('"labels"');
+      expect(result).toContain('Prose after the chart.');
+    });
+
+    it('does not strip non-chart JSON the user may be discussing', () => {
+      const msg = 'The payload was {"brand":"Apex Grill","region":"Northeast","velocity":7.2} for reference.';
+      expect(sanitizeMessage(msg)).toBe(msg);
+    });
+
+    it('does not strip JSON lacking a recognized chart type', () => {
+      const msg = 'Config: {"type":"radar","title":"Unsupported","data":[]}';
+      // "radar" is not a renderable chart type, so it is surfaced, not hidden.
+      expect(sanitizeMessage(msg)).toContain('"type":"radar"');
+    });
+
+    it('leaves prose-only chart discussion untouched', () => {
+      const msg = 'A bar chart would show depletion velocity by brand across the Northeast region.';
+      expect(sanitizeMessage(msg)).toBe(msg);
+    });
+  });
 });

--- a/src/RetailPulse.Web/src/utils/sanitizeMessage.ts
+++ b/src/RetailPulse.Web/src/utils/sanitizeMessage.ts
@@ -15,6 +15,121 @@ const TOOL_CALL_BLOCK_RE = /^to=functions\.\w+[^\n]*?\{[\s\S]*?\}\s*/gm;
 // Captures the entire line including any trailing JSON block
 const GARBLED_TOOL_CONTEXT_RE = /[\u4e00-\u9fff\u3400-\u4dbf]{2,}[^\n]*?(json|functions)[^\n]*\n*/gi;
 
+// Chart types the frontend can render. Mirrors the backend ChartSpecNormalizer so
+// that a leaked chart-spec payload is recognized (and stripped) the same way.
+const CHART_TYPES = new Set([
+  'line',
+  'bar',
+  'groupedbar',
+  'stackedbar',
+  'horizontalbar',
+  'pie',
+  'donut',
+  'gauge',
+  'table',
+]);
+
+/**
+ * Yields the [start, end) spans of every top-level balanced JSON object in the
+ * text, honoring string literals and escapes. Truncated objects are skipped.
+ */
+function findJsonObjectSpans(text: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+  let i = 0;
+  const n = text.length;
+  while (i < n) {
+    if (text[i] !== '{') {
+      i++;
+      continue;
+    }
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    const start = i;
+    let j = i;
+    for (; j < n; j++) {
+      const c = text[j];
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (c === '\\') escaped = true;
+        else if (c === '"') inString = false;
+        continue;
+      }
+      if (c === '"') inString = true;
+      else if (c === '{') depth++;
+      else if (c === '}') {
+        depth--;
+        if (depth === 0) {
+          j++;
+          break;
+        }
+      }
+    }
+    if (depth === 0 && j > start) {
+      spans.push([start, j]);
+      i = j;
+    } else {
+      i = start + 1;
+    }
+  }
+  return spans;
+}
+
+/**
+ * Returns true when a parsed value looks like a chart specification the backend
+ * should have promoted to structured `charts` — a recognized chart `type`, a
+ * non-empty `title`, and a `data` payload. Strict on purpose so arbitrary JSON
+ * the user may be discussing is left visible.
+ */
+function looksLikeChartSpec(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  const type = obj.type;
+  const title = obj.title;
+  return (
+    typeof type === 'string' &&
+    CHART_TYPES.has(type.trim().toLowerCase()) &&
+    typeof title === 'string' &&
+    title.trim().length > 0 &&
+    'data' in obj
+  );
+}
+
+/**
+ * Removes any chart-spec JSON block the model echoed into its prose. This is a
+ * last-line guard: the backend already extracts inline chart JSON and renders it
+ * via ChartRenderer, so a well-behaved response never reaches here with chart
+ * JSON. When it does (e.g. a stale backend or a streamed token race), we strip
+ * only recognizable chart payloads and leave all other JSON intact.
+ */
+function stripChartJson(content: string): string {
+  const spans = findJsonObjectSpans(content);
+  if (spans.length === 0) return content;
+
+  const removals: Array<[number, number]> = [];
+  for (const [start, end] of spans) {
+    try {
+      if (looksLikeChartSpec(JSON.parse(content.slice(start, end)))) {
+        removals.push([start, end]);
+      }
+    } catch {
+      // Not valid JSON — leave it untouched.
+    }
+  }
+  if (removals.length === 0) return content;
+
+  let result = '';
+  let cursor = 0;
+  for (const [start, end] of removals) {
+    if (start > cursor) result += content.slice(cursor, start);
+    cursor = end;
+  }
+  if (cursor < content.length) result += content.slice(cursor);
+
+  // Collapse code fences left empty after their JSON body was removed.
+  return result.replace(/```(?:json)?\s*```/gi, '');
+}
+
 /**
  * Sanitizes an assistant message by removing tool-call artifacts.
  * Returns the cleaned string with leading/trailing whitespace trimmed.
@@ -32,6 +147,9 @@ export function sanitizeMessage(content: string): string {
 
   // Remove garbled Unicode + tool context lines
   cleaned = cleaned.replace(GARBLED_TOOL_CONTEXT_RE, '');
+
+  // Strip any chart-spec JSON the model narrated instead of emitting as a chart.
+  cleaned = stripChartJson(cleaned);
 
   // Collapse multiple blank lines into one
   cleaned = cleaned.replace(/\n{3,}/g, '\n\n');

--- a/src/RetailPulse.Web/src/utils/sanitizeMessage.ts
+++ b/src/RetailPulse.Web/src/utils/sanitizeMessage.ts
@@ -91,7 +91,7 @@ function looksLikeChartSpec(value: unknown): boolean {
     CHART_TYPES.has(type.trim().toLowerCase()) &&
     typeof title === 'string' &&
     title.trim().length > 0 &&
-    'data' in obj
+    ('data' in obj || Array.isArray(obj.series))
   );
 }
 

--- a/src/RetailPulse.Web/src/utils/sanitizeMessage.ts
+++ b/src/RetailPulse.Web/src/utils/sanitizeMessage.ts
@@ -75,24 +75,120 @@ function findJsonObjectSpans(text: string): Array<[number, number]> {
   return spans;
 }
 
+// Property names the backend ChartSpecNormalizer accepts for a datapoint's x/y.
+// Mirrored here so frontend bindability matches backend strictness exactly.
+const POINT_Y_KEYS = ['y', 'value', 'count'];
+
+/**
+ * Parses a value to a finite number the same way the backend does: numeric
+ * JSON values and numeric strings bind; everything else (null, bool, empty
+ * string, non-numeric text) does not.
+ */
+function toBindableNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+// A datapoint object binds only when it carries a numeric y/value/count, matching
+// ChartSpecNormalizer.TryGetPointY (x is optional and falls back to an index).
+function pointObjectHasValue(point: Record<string, unknown>): boolean {
+  return POINT_Y_KEYS.some((key) => key in point && toBindableNumber(point[key]) !== null);
+}
+
+// A "values"/"data" array yields a bindable point when any element is a bindable
+// number or an object with a numeric y/value/count — mirrors BuildSeriesFromValues.
+function valuesArrayHasPoint(values: unknown): boolean {
+  if (!Array.isArray(values)) return false;
+  return values.some((v) =>
+    v !== null && typeof v === 'object' && !Array.isArray(v)
+      ? pointObjectHasValue(v as Record<string, unknown>)
+      : toBindableNumber(v) !== null,
+  );
+}
+
+// A single series object binds when its "values" (preferred) or "data" array
+// yields at least one point — mirrors ChartSpecNormalizer.BuildSeries.
+function seriesObjectHasPoint(series: Record<string, unknown>): boolean {
+  const values = 'values' in series ? series.values : 'data' in series ? series.data : undefined;
+  return valuesArrayHasPoint(values);
+}
+
+// A top-level/inner "series" array binds when any entry (a bare number array or a
+// { name, values|data } object) yields a point — mirrors SeriesFromSeriesArray.
+function seriesArrayHasPoint(seriesArray: unknown[]): boolean {
+  return seriesArray.some((entry) => {
+    if (Array.isArray(entry)) return valuesArrayHasPoint(entry);
+    if (entry !== null && typeof entry === 'object') {
+      return seriesObjectHasPoint(entry as Record<string, unknown>);
+    }
+    return false;
+  });
+}
+
+/**
+ * Returns true when the chart object has at least one actually bindable
+ * datapoint across the schemas the backend ChartSpecNormalizer supports:
+ *  - canonical: `data: [{ legend, values: [{ x, y } | number] }]`
+ *  - labels/series object: `data: { labels, series: [{ name, values }] }`
+ *    (or a single-series `data: { labels, values }`)
+ *  - full-config: top-level `series: [{ name, data | values }]`
+ *
+ * Empty/null/non-renderable payloads (e.g. `data: []`, `data: null`,
+ * `data: { id: 1 }`) yield false so the prose is left visible, exactly as the
+ * backend rejects them.
+ */
+function chartHasBindableData(obj: Record<string, unknown>): boolean {
+  if ('data' in obj) {
+    const data = obj.data;
+    if (Array.isArray(data)) {
+      return data.some(
+        (el) =>
+          el !== null &&
+          typeof el === 'object' &&
+          !Array.isArray(el) &&
+          seriesObjectHasPoint(el as Record<string, unknown>),
+      );
+    }
+    if (data !== null && typeof data === 'object') {
+      const dataObj = data as Record<string, unknown>;
+      if (Array.isArray(dataObj.series)) return seriesArrayHasPoint(dataObj.series);
+      if ('values' in dataObj) return valuesArrayHasPoint(dataObj.values);
+      return false;
+    }
+    // data is null or a primitive — nothing bindable.
+    return false;
+  }
+
+  return Array.isArray(obj.series) ? seriesArrayHasPoint(obj.series) : false;
+}
+
 /**
  * Returns true when a parsed value looks like a chart specification the backend
  * should have promoted to structured `charts` — a recognized chart `type`, a
- * non-empty `title`, and a `data` payload. Strict on purpose so arbitrary JSON
- * the user may be discussing is left visible.
+ * non-empty `title`, and at least one bindable datapoint. Deliberately mirrors
+ * the backend ChartSpecNormalizer so arbitrary, empty, or non-renderable JSON
+ * (which the backend rejects and leaves visible) is never silently deleted.
  */
 function looksLikeChartSpec(value: unknown): boolean {
   if (typeof value !== 'object' || value === null) return false;
   const obj = value as Record<string, unknown>;
   const type = obj.type;
   const title = obj.title;
-  return (
-    typeof type === 'string' &&
-    CHART_TYPES.has(type.trim().toLowerCase()) &&
-    typeof title === 'string' &&
-    title.trim().length > 0 &&
-    ('data' in obj || Array.isArray(obj.series))
-  );
+  if (
+    typeof type !== 'string' ||
+    !CHART_TYPES.has(type.trim().toLowerCase()) ||
+    typeof title !== 'string' ||
+    title.trim().length === 0
+  ) {
+    return false;
+  }
+  return chartHasBindableData(obj);
 }
 
 /**

--- a/tests/RetailPulse.Tests/Agents/AgentPipelineTests.cs
+++ b/tests/RetailPulse.Tests/Agents/AgentPipelineTests.cs
@@ -344,4 +344,102 @@ public class AgentPipelineTests
     }
 
     #endregion
+
+    #region ExtractInlineCharts — chart JSON echoed as prose
+
+    // The exact failure from the production screenshot: the model narrated its
+    // CreateChart payload as raw JSON at the top of the reply, using the alternate
+    // Chart.js-style schema (data:{labels,series}) that the tool path cannot bind.
+    private const string ScreenshotReply =
+        """
+        {"type":"bar","title":"Consolidation Check 2026-08-05","data":{"labels":["ClearDesk Vodka","Sierra Gold Tequila","Apex Reserve"],"series":[{"name":"Depletion Velocity","values":[12.5,9.8,7.2]}]},"options":{"orientation":"horizontal","xAxisLabel":"Cases per Week","yAxisLabel":"Brand"}}
+
+        Here's the depletion velocity comparison for all spirits brands in the Northeast. ClearDesk Vodka leads at 12.5 cases per week.
+        """;
+
+    [Fact]
+    public void ExtractInlineCharts_ScreenshotPayload_StripsRawJsonFromReply()
+    {
+        AgentExecutionPipeline.InlineChartExtraction result = AgentExecutionPipeline.ExtractInlineCharts(ScreenshotReply);
+
+        result.Reply.Should().NotContain("\"type\":\"bar\"");
+        result.Reply.Should().NotContain("\"series\"");
+        result.Reply.Should().NotContain("\"labels\"");
+        result.Reply.Should().NotContain("{");
+        result.Reply.Should().Contain("Here's the depletion velocity comparison");
+        result.Reply.Should().Contain("ClearDesk Vodka leads at 12.5 cases per week.");
+    }
+
+    [Fact]
+    public void ExtractInlineCharts_ScreenshotPayload_ReturnsStructuredChart()
+    {
+        AgentExecutionPipeline.InlineChartExtraction result = AgentExecutionPipeline.ExtractInlineCharts(ScreenshotReply);
+
+        result.Charts.Should().ContainSingle("the inline chart JSON must become structured chart data");
+        ChartSpec chart = result.Charts[0];
+        chart.Type.Should().Be("horizontalBar", "options.orientation=horizontal maps a bar to horizontalBar");
+        chart.Title.Should().Be("Consolidation Check 2026-08-05");
+        chart.XAxisTitle.Should().Be("Cases per Week");
+        chart.YAxisTitle.Should().Be("Brand");
+        chart.Data.Should().ContainSingle();
+        chart.Data[0].Legend.Should().Be("Depletion Velocity");
+        chart.Data[0].Values.Should().HaveCount(3);
+        chart.Data[0].Values[0].X.Should().Be("ClearDesk Vodka");
+        chart.Data[0].Values[0].Y.Should().Be(12.5);
+        chart.Data[0].Values[2].X.Should().Be("Apex Reserve");
+        chart.Data[0].Values[2].Y.Should().Be(7.2);
+    }
+
+    [Fact]
+    public void ExtractInlineCharts_CanonicalInlineJson_StripsAndExtracts()
+    {
+        string reply =
+            """
+            Here is the breakdown.
+
+            {"type":"bar","title":"Monthly Sales","xAxisTitle":"Month","yAxisTitle":"Cases","data":[{"legend":"Sierra Gold","values":[{"x":"Jan","y":1200},{"x":"Feb","y":1450}]}]}
+            """;
+
+        AgentExecutionPipeline.InlineChartExtraction result = AgentExecutionPipeline.ExtractInlineCharts(reply);
+
+        result.Charts.Should().ContainSingle();
+        result.Charts[0].Type.Should().Be("bar");
+        result.Charts[0].Title.Should().Be("Monthly Sales");
+        result.Reply.Should().Be("Here is the breakdown.");
+        result.Reply.Should().NotContain("{");
+    }
+
+    [Fact]
+    public void ExtractInlineCharts_CleanProse_ReturnedUnchangedWithNoCharts()
+    {
+        string reply = "Depletion velocity for spirits brands in the Northeast is trending up 4% this quarter.";
+
+        AgentExecutionPipeline.InlineChartExtraction result = AgentExecutionPipeline.ExtractInlineCharts(reply);
+
+        result.Reply.Should().Be(reply);
+        result.Charts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractInlineCharts_NonChartJson_LeftUntouched()
+    {
+        // Well-formed JSON that is not a chart must be surfaced, not silently hidden.
+        string reply = """The raw metric payload was {"brand":"Apex Grill","region":"Northeast","velocity":7.2} for reference.""";
+
+        AgentExecutionPipeline.InlineChartExtraction result = AgentExecutionPipeline.ExtractInlineCharts(reply);
+
+        result.Charts.Should().BeEmpty("non-chart JSON must not be treated as a chart");
+        result.Reply.Should().Contain("\"brand\":\"Apex Grill\"", "arbitrary JSON is left visible, not stripped");
+    }
+
+    [Fact]
+    public void ExtractInlineCharts_EmptyReply_ReturnsEmpty()
+    {
+        AgentExecutionPipeline.InlineChartExtraction result = AgentExecutionPipeline.ExtractInlineCharts(string.Empty);
+
+        result.Reply.Should().BeEmpty();
+        result.Charts.Should().BeEmpty();
+    }
+
+    #endregion
 }

--- a/tests/RetailPulse.Tests/Agents/AgentPipelineTests.cs
+++ b/tests/RetailPulse.Tests/Agents/AgentPipelineTests.cs
@@ -441,5 +441,38 @@ public class AgentPipelineTests
         result.Charts.Should().BeEmpty();
     }
 
+    [Fact]
+    public void ExtractInlineCharts_FencedFullConfigVariant_StripsFenceAndExtracts()
+    {
+        // Third real-world variant observed live: a ```json fenced block using the
+        // full-config schema (top-level series + xAxis.categories). The fence and JSON
+        // must be removed from the reply and promoted to a structured chart.
+        string reply =
+            """
+            Here's the bar chart comparing depletion velocity for all spirits brands in the Northeast.
+
+            ```json
+            {"type":"bar","title":"Depletion Velocity","xAxis":{"label":"Brand","categories":["Sierra Gold","Ridgeline","Summit"]},"yAxis":{"label":"Avg Weekly Volume"},"series":[{"name":"Avg Weekly Volume","data":[1893.2,2109.5,2296.3]}]}
+            ```
+            """;
+
+        AgentExecutionPipeline.InlineChartExtraction result = AgentExecutionPipeline.ExtractInlineCharts(reply);
+
+        result.Reply.Should().NotContain("{");
+        result.Reply.Should().NotContain("```");
+        result.Reply.Should().Contain("Here's the bar chart comparing depletion velocity");
+        result.Charts.Should().ContainSingle();
+        ChartSpec chart = result.Charts[0];
+        chart.Type.Should().Be("bar");
+        chart.XAxisTitle.Should().Be("Brand");
+        chart.YAxisTitle.Should().Be("Avg Weekly Volume");
+        chart.Data.Should().ContainSingle();
+        chart.Data[0].Values.Should().HaveCount(3);
+        chart.Data[0].Values[0].X.Should().Be("Sierra Gold");
+        chart.Data[0].Values[0].Y.Should().Be(1893.2);
+        chart.Data[0].Values[2].X.Should().Be("Summit");
+        chart.Data[0].Values[2].Y.Should().Be(2296.3);
+    }
+
     #endregion
 }

--- a/tests/RetailPulse.Tests/Agents/AgentPipelineTests.cs
+++ b/tests/RetailPulse.Tests/Agents/AgentPipelineTests.cs
@@ -475,4 +475,154 @@ public class AgentPipelineTests
     }
 
     #endregion
+
+    #region MergeInlineCharts — dedup of inline echoes vs. distinct charts
+
+    private static ChartSpec BarChart(string title, string legend, params (string X, double Y)[] points) =>
+        new()
+        {
+            Type = "bar",
+            Title = title,
+            Data =
+            [
+                new ChartSeries
+                {
+                    Legend = legend,
+                    Values = [.. points.Select(p => new ChartDataPoint { X = p.X, Y = p.Y })],
+                },
+            ],
+        };
+
+    [Fact]
+    public void MergeInlineCharts_NoInlineCharts_ReturnsToolChartsUnchanged()
+    {
+        var tool = new List<ChartSpec> { BarChart("Sales", "A", ("Jan", 10)) };
+
+        List<ChartSpec> merged = AgentExecutionPipeline.MergeInlineCharts(tool, []);
+
+        merged.Should().BeSameAs(tool, "no inline charts means the tool set is returned as-is");
+    }
+
+    [Fact]
+    public void MergeInlineCharts_DuplicateEcho_IsSuppressed()
+    {
+        // The model called the tool AND echoed the identical chart JSON in prose.
+        // The echo must not produce a second, duplicate render.
+        var tool = new List<ChartSpec> { BarChart("Sales", "A", ("Jan", 10), ("Feb", 12)) };
+        var inline = new List<ChartSpec> { BarChart("Sales", "A", ("Jan", 10), ("Feb", 12)) };
+
+        List<ChartSpec> merged = AgentExecutionPipeline.MergeInlineCharts(tool, inline);
+
+        merged.Should().ContainSingle("a genuine duplicate of a tool-produced chart is suppressed");
+        merged[0].Title.Should().Be("Sales");
+    }
+
+    [Fact]
+    public void MergeInlineCharts_DistinctInlineChart_IsPreserved()
+    {
+        // Tool produced chart A; prose contained a DIFFERENT valid chart B. Both
+        // must survive — B must not be silently dropped just because A exists.
+        var tool = new List<ChartSpec> { BarChart("Chart A", "A", ("Jan", 10)) };
+        var inline = new List<ChartSpec> { BarChart("Chart B", "B", ("Feb", 20)) };
+
+        List<ChartSpec> merged = AgentExecutionPipeline.MergeInlineCharts(tool, inline);
+
+        merged.Should().HaveCount(2);
+        merged.Select(c => c.Title).Should().Equal("Chart A", "Chart B");
+    }
+
+    [Fact]
+    public void MergeInlineCharts_NoToolCharts_PromotesAllInline()
+    {
+        var inline = new List<ChartSpec> { BarChart("Only", "A", ("Jan", 10)) };
+
+        List<ChartSpec> merged = AgentExecutionPipeline.MergeInlineCharts([], inline);
+
+        merged.Should().ContainSingle();
+        merged[0].Title.Should().Be("Only");
+    }
+
+    [Fact]
+    public void MergeInlineCharts_MixedDuplicateAndDistinct_KeepsOnlyDistinct()
+    {
+        // Prose echoed the tool chart (suppress) plus a distinct chart (keep).
+        var tool = new List<ChartSpec> { BarChart("Sales", "A", ("Jan", 10)) };
+        var inline = new List<ChartSpec>
+        {
+            BarChart("Sales", "A", ("Jan", 10)),   // duplicate echo
+            BarChart("Forecast", "B", ("Feb", 20)), // distinct
+        };
+
+        List<ChartSpec> merged = AgentExecutionPipeline.MergeInlineCharts(tool, inline);
+
+        merged.Should().HaveCount(2);
+        merged.Select(c => c.Title).Should().Equal("Sales", "Forecast");
+    }
+
+    [Fact]
+    public void MergeInlineCharts_DuplicateInlineCharts_AreCollapsed()
+    {
+        // Two identical inline charts (no tool charts) collapse to one.
+        var inline = new List<ChartSpec>
+        {
+            BarChart("Sales", "A", ("Jan", 10)),
+            BarChart("Sales", "A", ("Jan", 10)),
+        };
+
+        List<ChartSpec> merged = AgentExecutionPipeline.MergeInlineCharts([], inline);
+
+        merged.Should().ContainSingle("identical inline charts must not double-render");
+    }
+
+    [Fact]
+    public void MergeInlineCharts_SameTitleDifferentData_IsNotADuplicate()
+    {
+        // Same title but different datapoints is a distinct chart, not an echo.
+        var tool = new List<ChartSpec> { BarChart("Sales", "A", ("Jan", 10)) };
+        var inline = new List<ChartSpec> { BarChart("Sales", "A", ("Jan", 99)) };
+
+        List<ChartSpec> merged = AgentExecutionPipeline.MergeInlineCharts(tool, inline);
+
+        merged.Should().HaveCount(2, "differing datapoints make it a distinct chart, not a duplicate");
+    }
+
+    #endregion
+
+    #region ChartSpecSemanticComparer — content-based equality
+
+    [Fact]
+    public void ChartSpecSemanticComparer_IdenticalContent_AreEqual()
+    {
+        ChartSpec a = BarChart("Sales", "A", ("Jan", 10), ("Feb", 12));
+        ChartSpec b = BarChart("Sales", "A", ("Jan", 10), ("Feb", 12));
+
+        Api.Charts.ChartSpecSemanticComparer.Instance.Equals(a, b)
+            .Should().BeTrue("structurally identical charts from different sources are equal");
+        Api.Charts.ChartSpecSemanticComparer.Instance.GetHashCode(a)
+            .Should().Be(Api.Charts.ChartSpecSemanticComparer.Instance.GetHashCode(b));
+    }
+
+    [Fact]
+    public void ChartSpecSemanticComparer_DifferentValues_AreNotEqual()
+    {
+        ChartSpec a = BarChart("Sales", "A", ("Jan", 10));
+        ChartSpec b = BarChart("Sales", "A", ("Jan", 11));
+
+        Api.Charts.ChartSpecSemanticComparer.Instance.Equals(a, b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ChartSpecSemanticComparer_DefaultRecordEquality_WouldFail_ButComparerSucceeds()
+    {
+        // Guards the reason this comparer exists: record equality compares the
+        // List<> members by reference, so two equal-content charts are NOT equal
+        // under the compiler-generated Equals.
+        ChartSpec a = BarChart("Sales", "A", ("Jan", 10));
+        ChartSpec b = BarChart("Sales", "A", ("Jan", 10));
+
+        a.Equals(b).Should().BeFalse("record equality compares List<> Data by reference");
+        Api.Charts.ChartSpecSemanticComparer.Instance.Equals(a, b).Should().BeTrue();
+    }
+
+    #endregion
 }

--- a/tests/RetailPulse.Tests/ChartDataToolTests.cs
+++ b/tests/RetailPulse.Tests/ChartDataToolTests.cs
@@ -402,4 +402,38 @@ public class ChartDataToolTests
         charts[0].Data[0].Values[1].X.Should().Be("Feb");
         charts[0].Data[0].Values[1].Y.Should().Be(20);
     }
+
+    [Fact]
+    public async Task CreateChart_FullConfigSchema_TopLevelSeriesAndXAxis_Normalizes()
+    {
+        // Third real-world variant observed live: top-level "series" with per-series
+        // "data":[numbers], category labels under xAxis.categories, and axis titles
+        // under xAxis.label / yAxis.label. No top-level "data" property at all.
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """
+            {
+                "type": "bar",
+                "title": "Depletion Velocity for Spirits Brands in the Northeast",
+                "xAxis": {"label": "Brand", "categories": ["Sierra Gold Tequila", "Ridgeline Bourbon", "Summit Vodka"]},
+                "yAxis": {"label": "Avg Weekly Volume", "format": "number"},
+                "series": [{"name": "Avg Weekly Volume", "data": [1893.2, 2109.5, 2296.3], "color": "#1B4D7A"}]
+            }
+            """;
+
+        string result = await tool.CreateChart(spec);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+        doc.RootElement.GetProperty("recovered").GetBoolean().Should().BeTrue();
+        JsonElement chart = doc.RootElement.GetProperty("chart");
+        chart.GetProperty("Type").GetString().Should().Be("bar");
+        chart.GetProperty("XAxisTitle").GetString().Should().Be("Brand");
+        chart.GetProperty("YAxisTitle").GetString().Should().Be("Avg Weekly Volume");
+        JsonElement values = chart.GetProperty("Data")[0].GetProperty("Values");
+        values.GetArrayLength().Should().Be(3);
+        values[0].GetProperty("X").GetString().Should().Be("Sierra Gold Tequila");
+        values[0].GetProperty("Y").GetDouble().Should().Be(1893.2);
+        values[2].GetProperty("X").GetString().Should().Be("Summit Vodka");
+        values[2].GetProperty("Y").GetDouble().Should().Be(2296.3);
+    }
 }

--- a/tests/RetailPulse.Tests/ChartDataToolTests.cs
+++ b/tests/RetailPulse.Tests/ChartDataToolTests.cs
@@ -344,4 +344,62 @@ public class ChartDataToolTests
 
         charts.Should().BeEmpty("an error result must not produce any chart");
     }
+
+    [Fact]
+    public async Task CreateChart_AlternateChartJsSchema_NormalizesToSuccess()
+    {
+        // Well-formed JSON but the model-invented Chart.js-style schema
+        // (data:{labels,series}) that strict ChartSpec binding cannot handle.
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """
+            {
+                "type": "bar",
+                "title": "Consolidation Check 2026-08-05",
+                "data": {
+                    "labels": ["ClearDesk Vodka", "Sierra Gold Tequila", "Apex Reserve"],
+                    "series": [
+                        {"name": "Depletion Velocity", "values": [12.5, 9.8, 7.2]}
+                    ]
+                },
+                "options": {"orientation": "horizontal", "xAxisLabel": "Cases per Week", "yAxisLabel": "Brand"}
+            }
+            """;
+
+        string result = await tool.CreateChart(spec);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+        doc.RootElement.GetProperty("recovered").GetBoolean().Should().BeTrue(
+            "an alternate-schema payload is bound via the normalizer, not strict deserialization");
+        JsonElement chart = doc.RootElement.GetProperty("chart");
+        chart.GetProperty("Type").GetString().Should().Be("horizontalBar");
+        chart.GetProperty("Title").GetString().Should().Be("Consolidation Check 2026-08-05");
+        JsonElement values = chart.GetProperty("Data")[0].GetProperty("Values");
+        values.GetArrayLength().Should().Be(3);
+        values[0].GetProperty("X").GetString().Should().Be("ClearDesk Vodka");
+        values[0].GetProperty("Y").GetDouble().Should().Be(12.5);
+    }
+
+    [Fact]
+    public async Task CreateChart_AlternateSchema_FlowsIntoChartsList()
+    {
+        // Cross-boundary contract: the normalized alternate-schema chart must land in
+        // the real AgentExecutionPipeline.ExtractChartSpecs Charts list.
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """
+            {"type":"line","title":"Trend","data":{"labels":["Jan","Feb"],"series":[{"name":"BrandA","values":[10,20]}]}}
+            """;
+
+        string toolOutput = await tool.CreateChart(spec);
+        var response = new Microsoft.Extensions.AI.ChatResponse(
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("call-chart-3", toolOutput)]));
+
+        List<ChartSpec> charts = AgentExecutionPipeline.ExtractChartSpecs(response);
+
+        charts.Should().ContainSingle();
+        charts[0].Type.Should().Be("line");
+        charts[0].Data[0].Values.Should().HaveCount(2);
+        charts[0].Data[0].Values[1].X.Should().Be("Feb");
+        charts[0].Data[0].Values[1].Y.Should().Be(20);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #15 — the live app rendered raw chart JSON as an assistant bubble instead of a chart for:

> Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast

## Root cause

Telemetry showed the demand agent and `CreateChart` ran, so this was a **response-contract/parsing bug, not inference failure**. The model emitted the chart in its assistant **text** (not a clean tool result) using a **non-canonical, Chart.js-style schema** (`data:{labels,series:[{name,values}]}`) that `ExtractChartSpecs` / `ChartDataTool` could not bind to the canonical `ChartSpec` (`data:[{legend,values:[{x,y}]}]`). Result: `charts` count = 0 and `SanitizeReplyText` did not strip the JSON, so it rendered as prose.

## Fix

- **`ChartSpecNormalizer`** (new, shared): maps realistic LLM chart-JSON variations onto the canonical `ChartSpec` — alternate `data:{labels,series}` schema, axis titles under `options.xAxisLabel`/`yAxisLabel`, and `options.orientation:"horizontal"` on a `bar` → `horizontalBar`. Strict on purpose: a recognized `type` + non-empty `title` + ≥1 bindable datapoint are required, so non-chart/unusable JSON is **left visible, never silently hidden**.
- **`AgentExecutionPipeline.ExtractInlineCharts`** (new): balanced-brace, string/escape-aware scan that strips chart-spec JSON narrated in the reply and promotes it to structured `charts` — only when the tool path produced none (no duplicate renders). Wired into **both** the non-streaming and streaming paths (before `StreamReplyAsync`, so streamed tokens are clean too).
- **`ChartDataTool.TryRecover`**: now normalizes well-formed but non-canonical payloads before truncation repair.
- **Frontend `sanitizeMessage`**: defense-in-depth guard strips a leaked chart-spec JSON block (same strictness) so raw chart JSON never renders as prose even against a stale backend.

No CSS hiding, no broad catches. ACA + Static Web Apps architecture and managed identity untouched.

## Tests

- `AgentPipelineTests.ExtractInlineCharts_*` — the screenshot payload (alternate schema + prose) strips to clean prose and yields one `horizontalBar` `ChartSpec` with correct series/points; non-chart JSON left untouched; clean prose preserved.
- `ChartDataToolTests` — alternate-schema payload normalizes to `status:success` and flows into the pipeline `Charts` list.
- `sanitizeMessage.test.ts` — raw chart JSON (canonical + alternate + fenced) not shown as prose; non-chart JSON and prose-only discussion preserved.

Validation: backend `dotnet test` **2034 passed**; frontend `vitest` **298 passed**; `npm run build` and `dotnet format --verify-no-changes` clean.

## Notes

- **`dotnet format` landmine documented** in the squad decision inbox: the populate-switch fixer (IDE0010/IDE0072) mangles `JsonValueKind` enum switches into `throw new NotImplementedException()` → CS0177/CS0161. Use `if`/`else` or `==` ternary chains on `JsonValueKind` to stay green on the CI lint gate.
- Cross-team decision recorded at `.squad/decisions/inbox/2026-08-05-inline-chart-json-extraction.md`.

Do not merge yet — parent coordinator will conduct independent review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
