### PR TITLE
Add persistent prompt library and make deployed ACA stack explicit in docs (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ All brands operate across **6 regions**: Northeast, Southeast, Midwest, Southwes
 | **Observability** | OpenTelemetry + Aspire Dashboard | — | Distributed traces, metrics, logs |
 | **Monitoring** | Azure Application Insights | — | Production telemetry and traces |
 | **Gateway** | Azure API Management | — | Token metering, rate limiting, audit |
+| **Backend hosting** | Azure Container Apps | — | Runs the API, MCP Server, and Teams Bot as containers; scales to zero when idle |
+| **Frontend hosting** | Azure Static Web Apps | — | Serves the React/Vite static build; calls the Container Apps API directly over CORS |
+| **Container registry** | Azure Container Registry (Basic) | — | Stores backend images; Container Apps pull them with managed identity (no admin secrets) |
 | **Testing** | xUnit + Vitest | — | Backend + frontend tests |
 
 ---
@@ -268,7 +271,7 @@ retail-pulse/
 │   └── generate-traffic.ps1          # Load testing
 ├── infra/                            # Azure infrastructure (Bicep, used by azd)
 │   ├── main.bicep                    # Subscription-scoped orchestrator
-│   └── modules/                      # App Insights, Container Apps Env, App Service
+│   └── modules/                      # Monitoring, Container Apps Env, Container Apps, Container Registry, Static Web App
 ├── azd-hooks/                        # Azure Developer CLI lifecycle hooks
 ├── azure.yaml                        # Azure Developer CLI project file
 ├── ai-gateway-dev-portal/            # AI Gateway Dev Portal (APIM observability)
@@ -333,8 +336,9 @@ azd up
 ```
 
 This deploys:
-- **Backend** (API, McpServer, TeamsBot) → Azure Container Apps
-- **Frontend** (React/Vite) → Azure App Service (Node 20 LTS)
+- **Backend** (API, MCP Server, Teams Bot) → Azure Container Apps. Each app runs under a system-assigned managed identity and scales to zero when idle.
+- **Frontend** (React/Vite static build) → Azure Static Web Apps. The build injects the Container Apps API origin, so the SPA calls the API directly and opens the SignalR telemetry connection against that origin. The Static Web App also links the API as its `/api` backend, so relative `/api/*` calls stay same-origin.
+- **Container images** → a dedicated Azure Container Registry (Basic). Container Apps pull images with their managed identities, so no registry admin secrets are stored.
 - **Monitoring** → Application Insights + Log Analytics
 
 See [docs/deployment-azd.md](docs/deployment-azd.md) for full documentation.

--- a/docs/teams-setup.md
+++ b/docs/teams-setup.md
@@ -526,7 +526,7 @@ This starts:
 
 For production deployment, replace local URLs with Azure-hosted endpoints:
 
-1. **Deploy the API, MCP Server, and TeamsBot** to Azure App Service or Container Apps
+1. **Deploy the API, MCP Server, and Teams Bot** to Azure Container Apps (the target the `azd up` flow provisions)
 2. **Update Azure Bot messaging endpoint** to point to your production URL
 3. **Update Teams manifest** with production domain and re-upload the app package
 4. **Configure Application Insights** for production telemetry

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
@@ -95,6 +95,69 @@ describe('ChatPanel', () => {
     expect(await screen.findByText(/Sales were up 12% in Q1\./)).toBeInTheDocument();
   });
 
+  it('keeps the Prompt ideas library control available before and after a message is sent', async () => {
+    const user = userEvent.setup();
+    sendMessageMock.mockResolvedValue({
+      reply: 'Here is your answer.',
+      sessionId: 'sess-lib',
+      spans: [],
+      totalDurationMs: 10,
+    });
+
+    renderPanel();
+
+    // Available on the empty welcome state, next to the composer.
+    expect(screen.getByRole('button', { name: /Prompt ideas/i })).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'hello');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    // Conversation has started (welcome chips are gone)…
+    expect(await screen.findByText(/Here is your answer\./)).toBeInTheDocument();
+    expect(screen.queryByText(/Welcome to Retail Pulse/i)).not.toBeInTheDocument();
+
+    // …but the persistent prompt-library control remains next to the composer.
+    expect(screen.getByRole('button', { name: /Prompt ideas/i })).toBeInTheDocument();
+  });
+
+  it('sends a prompt chosen from the persistent library after the conversation started', async () => {
+    const user = userEvent.setup();
+    sendMessageMock.mockResolvedValue({
+      reply: 'First reply.',
+      sessionId: 'sess-lib2',
+      spans: [],
+      totalDurationMs: 10,
+    });
+
+    renderPanel();
+
+    // Start a conversation so the welcome state is gone.
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'kick off');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+    expect(await screen.findByText(/First reply\./)).toBeInTheDocument();
+
+    sendMessageMock.mockClear();
+    sendMessageMock.mockResolvedValue({
+      reply: 'Library reply.',
+      sessionId: 'sess-lib2',
+      spans: [],
+      totalDurationMs: 10,
+    });
+
+    // Open the library and pick a prompt. Fluent's trap-focus popover applies
+    // aria-hidden to its surface across repeated jsdom renders in this file, so
+    // include hidden nodes when locating the prompt (the a11y contract itself is
+    // asserted in PromptLibrary.test.tsx, which runs in a clean document).
+    await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
+    const prompt = 'Compare depletion trends across all regions for this quarter';
+    await user.click(await screen.findByRole('button', { name: prompt, hidden: true }));
+
+    // The chosen prompt is dispatched through the same safe send path.
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1));
+    expect(sendMessageMock.mock.calls[0][0]).toMatchObject({ message: prompt });
+    expect(await screen.findByText(/Library reply\./)).toBeInTheDocument();
+  });
+
   it('shows a loading indicator while a request is in flight and clears it on completion', async () => {
     const user = userEvent.setup();
     let resolveSend: ((v: unknown) => void) | undefined;

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
 
@@ -144,13 +144,16 @@ describe('ChatPanel', () => {
       totalDurationMs: 10,
     });
 
-    // Open the library and pick a prompt. Fluent's trap-focus popover applies
-    // aria-hidden to its surface across repeated jsdom renders in this file, so
-    // include hidden nodes when locating the prompt (the a11y contract itself is
-    // asserted in PromptLibrary.test.tsx, which runs in a clean document).
+    // Open the library and pick a prompt. Fluent's trap-focus popover renders in a
+    // portal and can nondeterministically apply aria-hidden to its surface under
+    // jsdom, so anchor on the heading text (immune to aria-hidden) with a generous
+    // timeout, then scope the prompt lookup to the surface including hidden nodes.
+    // The full a11y contract is asserted in PromptLibrary.test.tsx (clean document).
     await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
     const prompt = 'Compare depletion trends across all regions for this quarter';
-    await user.click(await screen.findByRole('button', { name: prompt, hidden: true }));
+    const heading = await screen.findByText('Prompt library', { selector: 'h2' }, { timeout: 4000 });
+    const surface = heading.closest('[role="dialog"]') as HTMLElement;
+    await user.click(within(surface).getByRole('button', { name: prompt, hidden: true }));
 
     // The chosen prompt is dispatched through the same safe send path.
     await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1));

--- a/src/RetailPulse.Web/src/__tests__/PromptLibrary.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/PromptLibrary.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+import { PromptLibrary } from '../components/PromptLibrary';
+import { PROMPT_CATEGORIES } from '../constants/prompts';
+
+function renderLibrary(props: Partial<React.ComponentProps<typeof PromptLibrary>> = {}) {
+  const onSelect = props.onSelect ?? vi.fn();
+  render(
+    <FluentProvider theme={teamsDarkTheme}>
+      <PromptLibrary categories={PROMPT_CATEGORIES} onSelect={onSelect} {...props} />
+    </FluentProvider>,
+  );
+  return { onSelect };
+}
+
+const GENERAL_PROMPT = 'Compare depletion trends across all regions for this quarter';
+const GROCERY_PROMPT = 'How are FreshMart depletions trending in the Northeast this quarter?';
+
+describe('PromptLibrary', () => {
+  it('renders a labeled trigger and keeps the panel closed until opened', () => {
+    renderLibrary();
+
+    const trigger = screen.getByRole('button', { name: /Prompt ideas/i });
+    expect(trigger).toBeInTheDocument();
+    // Panel content is not rendered while closed.
+    expect(screen.queryByText(/Prompt library/i)).not.toBeInTheDocument();
+  });
+
+  it('opens the categorized panel on click with an accessible name and category group', async () => {
+    const user = userEvent.setup();
+    renderLibrary();
+
+    await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
+
+    // Dialog surface exposes an accessible name.
+    const dialog = await screen.findByRole('dialog', { name: /Prompt library/i });
+    expect(dialog).toBeInTheDocument();
+
+    // Category filters live in a labeled group; "All" is selected by default.
+    expect(screen.getByRole('group', { name: /Prompt categories/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /🏪 All/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /🛒 Grocery/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('filters prompts when a category is selected', async () => {
+    const user = userEvent.setup();
+    renderLibrary();
+
+    await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
+
+    // "All" view surfaces prompts from multiple categories.
+    expect(await screen.findByRole('button', { name: GENERAL_PROMPT })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: GROCERY_PROMPT })).toBeInTheDocument();
+
+    // Selecting Grocery narrows the list to that category only.
+    await user.click(screen.getByRole('button', { name: /🛒 Grocery/i }));
+    expect(screen.getByRole('button', { name: /🛒 Grocery/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: GROCERY_PROMPT })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: GENERAL_PROMPT })).not.toBeInTheDocument();
+    });
+  });
+
+  it('sends the chosen prompt and closes the panel', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    renderLibrary({ onSelect });
+
+    await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
+    await user.click(await screen.findByRole('button', { name: GENERAL_PROMPT }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(GENERAL_PROMPT);
+
+    // Panel dismisses after a selection.
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /Prompt library/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('is keyboard operable: opens with Enter and dismisses with Escape, restoring focus', async () => {
+    const user = userEvent.setup();
+    renderLibrary();
+
+    const trigger = screen.getByRole('button', { name: /Prompt ideas/i });
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(await screen.findByRole('dialog', { name: /Prompt library/i })).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /Prompt library/i })).not.toBeInTheDocument();
+    });
+    // Focus returns to the trigger for a smooth keyboard flow.
+    expect(trigger).toHaveFocus();
+  });
+
+  it('disables the trigger when disabled', () => {
+    renderLibrary({ disabled: true });
+    expect(screen.getByRole('button', { name: /Prompt ideas/i })).toBeDisabled();
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/PromptLibrary.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/PromptLibrary.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
 import { PromptLibrary } from '../components/PromptLibrary';
@@ -34,14 +34,19 @@ describe('PromptLibrary', () => {
 
     await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
 
-    // Dialog surface exposes an accessible name.
-    const dialog = await screen.findByRole('dialog', { name: /Prompt library/i });
+    // Dialog surface exposes an accessible name and is a modal dialog.
+    // Note: Fluent's trap-focus modal can nondeterministically apply aria-hidden
+    // to the active surface under jsdom, so query with hidden:true and assert the
+    // real ARIA contract (role + accessible name + aria-modal) on the element.
+    const dialog = await screen.findByRole('dialog', { name: /Prompt library/i, hidden: true });
     expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
 
+    const panel = within(dialog);
     // Category filters live in a labeled group; "All" is selected by default.
-    expect(screen.getByRole('group', { name: /Prompt categories/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /🏪 All/i })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: /🛒 Grocery/i })).toHaveAttribute('aria-pressed', 'false');
+    expect(panel.getByRole('group', { name: /Prompt categories/i, hidden: true })).toBeInTheDocument();
+    expect(panel.getByRole('button', { name: /🏪 All/i, hidden: true })).toHaveAttribute('aria-pressed', 'true');
+    expect(panel.getByRole('button', { name: /🛒 Grocery/i, hidden: true })).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('filters prompts when a category is selected', async () => {
@@ -50,16 +55,19 @@ describe('PromptLibrary', () => {
 
     await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
 
+    const dialog = await screen.findByRole('dialog', { name: /Prompt library/i, hidden: true });
+    const panel = within(dialog);
+
     // "All" view surfaces prompts from multiple categories.
-    expect(await screen.findByRole('button', { name: GENERAL_PROMPT })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: GROCERY_PROMPT })).toBeInTheDocument();
+    expect(panel.getByRole('button', { name: GENERAL_PROMPT, hidden: true })).toBeInTheDocument();
+    expect(panel.getByRole('button', { name: GROCERY_PROMPT, hidden: true })).toBeInTheDocument();
 
     // Selecting Grocery narrows the list to that category only.
-    await user.click(screen.getByRole('button', { name: /🛒 Grocery/i }));
-    expect(screen.getByRole('button', { name: /🛒 Grocery/i })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: GROCERY_PROMPT })).toBeInTheDocument();
+    await user.click(panel.getByRole('button', { name: /🛒 Grocery/i, hidden: true }));
+    expect(panel.getByRole('button', { name: /🛒 Grocery/i, hidden: true })).toHaveAttribute('aria-pressed', 'true');
+    expect(panel.getByRole('button', { name: GROCERY_PROMPT, hidden: true })).toBeInTheDocument();
     await waitFor(() => {
-      expect(screen.queryByRole('button', { name: GENERAL_PROMPT })).not.toBeInTheDocument();
+      expect(panel.queryByRole('button', { name: GENERAL_PROMPT, hidden: true })).not.toBeInTheDocument();
     });
   });
 
@@ -69,14 +77,15 @@ describe('PromptLibrary', () => {
     renderLibrary({ onSelect });
 
     await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
-    await user.click(await screen.findByRole('button', { name: GENERAL_PROMPT }));
+    const dialog = await screen.findByRole('dialog', { name: /Prompt library/i, hidden: true });
+    await user.click(within(dialog).getByRole('button', { name: GENERAL_PROMPT, hidden: true }));
 
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith(GENERAL_PROMPT);
 
     // Panel dismisses after a selection.
     await waitFor(() => {
-      expect(screen.queryByRole('dialog', { name: /Prompt library/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog', { name: /Prompt library/i, hidden: true })).not.toBeInTheDocument();
     });
   });
 
@@ -89,11 +98,11 @@ describe('PromptLibrary', () => {
     expect(trigger).toHaveFocus();
 
     await user.keyboard('{Enter}');
-    expect(await screen.findByRole('dialog', { name: /Prompt library/i })).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: /Prompt library/i, hidden: true })).toBeInTheDocument();
 
     await user.keyboard('{Escape}');
     await waitFor(() => {
-      expect(screen.queryByRole('dialog', { name: /Prompt library/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog', { name: /Prompt library/i, hidden: true })).not.toBeInTheDocument();
     });
     // Focus returns to the trigger for a smooth keyboard flow.
     expect(trigger).toHaveFocus();

--- a/src/RetailPulse.Web/src/__tests__/PromptLibrary.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/PromptLibrary.test.tsx
@@ -15,6 +15,20 @@ function renderLibrary(props: Partial<React.ComponentProps<typeof PromptLibrary>
   return { onSelect };
 }
 
+// The panel renders in a Fluent trap-focus Popover portal. Under jsdom (especially
+// in CI) tabster can nondeterministically apply aria-hidden to the active surface,
+// which hides it from default role queries. Text queries ignore aria-hidden, so we
+// anchor "is the panel open" on the heading text, then assert the real ARIA contract
+// (role=dialog + accessible name + aria-modal) on the actual surface element.
+async function openedPanel() {
+  const heading = await screen.findByText('Prompt library', { selector: 'h2' }, { timeout: 4000 });
+  const surface = heading.closest('[role="dialog"]') as HTMLElement;
+  expect(surface).not.toBeNull();
+  expect(surface).toHaveAttribute('aria-label', 'Prompt library');
+  expect(surface).toHaveAttribute('aria-modal', 'true');
+  return { surface, panel: within(surface) };
+}
+
 const GENERAL_PROMPT = 'Compare depletion trends across all regions for this quarter';
 const GROCERY_PROMPT = 'How are FreshMart depletions trending in the Northeast this quarter?';
 
@@ -34,15 +48,8 @@ describe('PromptLibrary', () => {
 
     await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
 
-    // Dialog surface exposes an accessible name and is a modal dialog.
-    // Note: Fluent's trap-focus modal can nondeterministically apply aria-hidden
-    // to the active surface under jsdom, so query with hidden:true and assert the
-    // real ARIA contract (role + accessible name + aria-modal) on the element.
-    const dialog = await screen.findByRole('dialog', { name: /Prompt library/i, hidden: true });
-    expect(dialog).toBeInTheDocument();
-    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    const { panel } = await openedPanel();
 
-    const panel = within(dialog);
     // Category filters live in a labeled group; "All" is selected by default.
     expect(panel.getByRole('group', { name: /Prompt categories/i, hidden: true })).toBeInTheDocument();
     expect(panel.getByRole('button', { name: /🏪 All/i, hidden: true })).toHaveAttribute('aria-pressed', 'true');
@@ -55,8 +62,7 @@ describe('PromptLibrary', () => {
 
     await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
 
-    const dialog = await screen.findByRole('dialog', { name: /Prompt library/i, hidden: true });
-    const panel = within(dialog);
+    const { panel } = await openedPanel();
 
     // "All" view surfaces prompts from multiple categories.
     expect(panel.getByRole('button', { name: GENERAL_PROMPT, hidden: true })).toBeInTheDocument();
@@ -77,15 +83,15 @@ describe('PromptLibrary', () => {
     renderLibrary({ onSelect });
 
     await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
-    const dialog = await screen.findByRole('dialog', { name: /Prompt library/i, hidden: true });
-    await user.click(within(dialog).getByRole('button', { name: GENERAL_PROMPT, hidden: true }));
+    const { panel } = await openedPanel();
+    await user.click(panel.getByRole('button', { name: GENERAL_PROMPT, hidden: true }));
 
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith(GENERAL_PROMPT);
 
     // Panel dismisses after a selection.
     await waitFor(() => {
-      expect(screen.queryByRole('dialog', { name: /Prompt library/i, hidden: true })).not.toBeInTheDocument();
+      expect(screen.queryByText('Prompt library', { selector: 'h2' })).not.toBeInTheDocument();
     });
   });
 
@@ -98,11 +104,11 @@ describe('PromptLibrary', () => {
     expect(trigger).toHaveFocus();
 
     await user.keyboard('{Enter}');
-    expect(await screen.findByRole('dialog', { name: /Prompt library/i, hidden: true })).toBeInTheDocument();
+    await openedPanel();
 
     await user.keyboard('{Escape}');
     await waitFor(() => {
-      expect(screen.queryByRole('dialog', { name: /Prompt library/i, hidden: true })).not.toBeInTheDocument();
+      expect(screen.queryByText('Prompt library', { selector: 'h2' })).not.toBeInTheDocument();
     });
     // Focus returns to the trigger for a smooth keyboard flow.
     expect(trigger).toHaveFocus();

--- a/src/RetailPulse.Web/src/components/ChatPanel.tsx
+++ b/src/RetailPulse.Web/src/components/ChatPanel.tsx
@@ -24,6 +24,8 @@ import { StreamingMessage, CacheIndicator } from './streaming';
 import { ProgressIndicator } from './ProgressIndicator';
 import type { ProgressStep } from './ProgressIndicator';
 import { BlockedRequestMessage } from './guardrails';
+import { PromptLibrary } from './PromptLibrary';
+import { PROMPT_CATEGORIES } from '../constants/prompts';
 import { sanitizeMessage } from '../utils';
 
 const ChartRenderer = lazy(() => import('./ChartRenderer'));
@@ -75,91 +77,6 @@ const SEND_BUTTON_STYLE: React.CSSProperties = {
   color: '#ffffff',
 };
 const ASSISTANT_AVATAR_ICON = { children: 'R' } as const;
-
-interface PromptCategory {
-  id: string;
-  label: string;
-  emoji: string;
-  prompts: string[];
-}
-
-const PROMPT_CATEGORIES: ReadonlyArray<PromptCategory> = [
-  {
-    id: 'general',
-    label: 'General Retail',
-    emoji: '📊',
-    prompts: [
-      'Compare depletion trends across all regions for this quarter',
-      'Which brands are growing fastest year-over-year across the portfolio?',
-      'Show me field sentiment for our top 3 brands in the Southeast',
-    ],
-  },
-  {
-    id: 'grocery',
-    label: 'Grocery',
-    emoji: '🛒',
-    prompts: [
-      'How are FreshMart depletions trending in the Northeast this quarter?',
-      'Compare Harvest Table vs FreshMart sell-through rates by region',
-      'What is the field sentiment for Harvest Table Meal Kits in the Midwest?',
-    ],
-  },
-  {
-    id: 'qsr',
-    label: 'Quick-Serve Restaurants',
-    emoji: '🍔',
-    prompts: [
-      'How is Apex Grill performing in the Southwest this quarter?',
-      'Compare Coastline Tacos vs Apex Grill depletions across all regions',
-      'What is the field sentiment for Coastline Tacos in the West Coast?',
-    ],
-  },
-  {
-    id: 'home-improvement',
-    label: 'Home Improvement',
-    emoji: '🏠',
-    prompts: [
-      'Show me Pinnacle Hardware depletion stats in the Midwest for Q1',
-      'How is Summit Outdoor performing in the Southeast vs West Coast?',
-      'What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest?',
-    ],
-  },
-  {
-    id: 'office-supply',
-    label: 'Office Supply',
-    emoji: '📎',
-    prompts: [
-      'How are ClearDesk depletions trending in the Northeast this quarter?',
-      'Compare ClearDesk Technology vs Paper Products sell-through by region',
-      'What is the field sentiment for ClearDesk in the Southeast?',
-    ],
-  },
-  {
-    id: 'furniture',
-    label: 'Furniture',
-    emoji: '🛋️',
-    prompts: [
-      'Show me Urban Living depletion trends across all regions this quarter',
-      'Compare Foundry Home vs Urban Living performance in the West Coast',
-      'What is the field sentiment for Urban Living in the Pacific Northwest?',
-    ],
-  },
-  {
-    id: 'charts',
-    label: 'Charts',
-    emoji: '📈',
-    prompts: [
-      'Create a line chart showing Sierra Gold Tequila depletion trends across all regions',
-      'Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast',
-      'Create a pie chart showing market share breakdown for our grocery brands nationally',
-      'Show a grouped bar chart comparing FreshMart and Harvest Table across all regions',
-      'Create a donut chart of Apex Grill variant mix in the Southwest',
-      'Show a horizontal bar chart ranking all brands by depletion growth rate',
-      'Create a table showing depletion stats for all home improvement brands by region',
-      'Show a gauge chart for Pinnacle Hardware inventory health in the Midwest',
-    ],
-  },
-];
 
 const useSpanStyles = makeStyles({
   summary: {
@@ -443,6 +360,7 @@ const useChatStyles = makeStyles({
   inputArea: {
     display: 'flex',
     gap: '10px',
+    alignItems: 'center',
     padding: '16px 24px',
     backgroundColor: 'var(--color-bg-elevated)',
     borderTop: '1px solid var(--color-border)',
@@ -754,6 +672,11 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved }:
         <label htmlFor="chat-input" className="visually-hidden">
           Ask about retail performance
         </label>
+        <PromptLibrary
+          categories={PROMPT_CATEGORIES}
+          onSelect={handleSuggestedClick}
+          disabled={loading}
+        />
         <Input
           id="chat-input"
           value={input}

--- a/src/RetailPulse.Web/src/components/PromptLibrary.tsx
+++ b/src/RetailPulse.Web/src/components/PromptLibrary.tsx
@@ -1,0 +1,231 @@
+import { useState, useCallback } from 'react';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverSurface,
+  Button,
+  Text,
+  makeStyles,
+} from '@fluentui/react-components';
+import { Lightbulb24Regular } from '@fluentui/react-icons';
+import type { PromptCategory } from '../constants/prompts';
+
+interface PromptLibraryProps {
+  categories: ReadonlyArray<PromptCategory>;
+  onSelect: (prompt: string) => void;
+  disabled?: boolean;
+}
+
+const useStyles = makeStyles({
+  trigger: {
+    flexShrink: 0,
+    whiteSpace: 'nowrap',
+  },
+  surface: {
+    padding: '0',
+    width: 'min(92vw, 440px)',
+    maxWidth: '440px',
+  },
+  panel: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxHeight: 'min(70vh, 520px)',
+  },
+  header: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    padding: '14px 16px 10px',
+    borderBottom: '1px solid var(--color-border)',
+  },
+  title: {
+    fontSize: '14px',
+    fontWeight: '600',
+    color: 'var(--color-text)',
+  },
+  subtitle: {
+    fontSize: '12px',
+    color: 'var(--color-text-muted)',
+  },
+  categoryChips: {
+    display: 'flex',
+    gap: '6px',
+    flexWrap: 'wrap',
+    padding: '12px 16px',
+    borderBottom: '1px solid var(--color-border)',
+  },
+  categoryChip: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+    padding: '6px 12px',
+    borderRadius: '16px',
+    border: '1px solid var(--color-border)',
+    background: 'var(--color-surface)',
+    color: 'var(--color-text-muted)',
+    cursor: 'pointer',
+    fontSize: '12px',
+    fontWeight: '500',
+    transition: 'all 0.2s ease',
+    ':hover': {
+      background: 'var(--brand-accent-soft)',
+      border: '1px solid var(--brand-accent-border)',
+      color: 'var(--brand-accent-light)',
+    },
+    ':focus-visible': {
+      outline: '2px solid var(--brand-accent)',
+      outlineOffset: '1px',
+    },
+  },
+  categoryChipActive: {
+    background: 'var(--brand-accent-soft)',
+    border: '1px solid var(--brand-accent)',
+    color: 'var(--brand-accent)',
+    fontWeight: '600',
+  },
+  promptList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    padding: '12px 16px 16px',
+    overflowY: 'auto',
+  },
+  promptGroup: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+  },
+  groupLabel: {
+    fontSize: '11px',
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    color: 'var(--color-text-muted)',
+    margin: '4px 0 2px',
+  },
+  promptButton: {
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    color: 'var(--color-text-muted)',
+    padding: '10px 12px',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    fontSize: '13px',
+    textAlign: 'left',
+    lineHeight: '1.4',
+    transition: 'all 0.2s ease',
+    ':hover': {
+      background: 'var(--color-surface-hover)',
+      border: '1px solid var(--brand-accent-soft-hover)',
+      color: 'var(--brand-accent-light)',
+    },
+    ':focus-visible': {
+      outline: '2px solid var(--brand-accent)',
+      outlineOffset: '1px',
+    },
+    ':disabled': {
+      opacity: '0.4',
+      cursor: 'not-allowed',
+    },
+  },
+});
+
+/**
+ * Always-available, discoverable prompt library rendered as a popover next to
+ * the composer. Reuses the shared PROMPT_CATEGORIES source and the caller's safe
+ * send behavior so a selected prompt is dispatched exactly like a welcome chip.
+ */
+export function PromptLibrary({ categories, onSelect, disabled }: PromptLibraryProps) {
+  const styles = useStyles();
+  const [open, setOpen] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  const visibleCategories = selectedCategory
+    ? categories.filter((c) => c.id === selectedCategory)
+    : categories;
+
+  const handlePromptClick = useCallback(
+    (prompt: string) => {
+      onSelect(prompt);
+      setOpen(false);
+    },
+    [onSelect],
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(_, data) => setOpen(data.open)}
+      trapFocus
+      withArrow
+      positioning="above-end"
+    >
+      <PopoverTrigger disableButtonEnhancement>
+        <Button
+          className={styles.trigger}
+          appearance="subtle"
+          icon={<Lightbulb24Regular />}
+          disabled={disabled}
+          aria-label="Prompt ideas"
+        >
+          Prompt ideas
+        </Button>
+      </PopoverTrigger>
+      <PopoverSurface className={styles.surface} aria-label="Prompt library">
+        <div className={styles.panel}>
+          <div className={styles.header}>
+            <Text as="h2" className={styles.title}>
+              Prompt library
+            </Text>
+            <Text className={styles.subtitle}>
+              Browse a category and pick a prompt to send.
+            </Text>
+          </div>
+          <div className={styles.categoryChips} role="group" aria-label="Prompt categories">
+            <button
+              type="button"
+              className={`${styles.categoryChip} ${selectedCategory === null ? styles.categoryChipActive : ''}`}
+              aria-pressed={selectedCategory === null}
+              onClick={() => setSelectedCategory(null)}
+            >
+              🏪 All
+            </button>
+            {categories.map((cat) => (
+              <button
+                key={cat.id}
+                type="button"
+                className={`${styles.categoryChip} ${selectedCategory === cat.id ? styles.categoryChipActive : ''}`}
+                aria-pressed={selectedCategory === cat.id}
+                onClick={() => setSelectedCategory(cat.id)}
+              >
+                {cat.emoji} {cat.label}
+              </button>
+            ))}
+          </div>
+          <div className={styles.promptList}>
+            {visibleCategories.map((cat) => (
+              <div key={cat.id} className={styles.promptGroup}>
+                {!selectedCategory && (
+                  <Text className={styles.groupLabel}>
+                    {cat.emoji} {cat.label}
+                  </Text>
+                )}
+                {cat.prompts.map((prompt, i) => (
+                  <button
+                    key={`${cat.id}-${i}`}
+                    type="button"
+                    className={styles.promptButton}
+                    onClick={() => handlePromptClick(prompt)}
+                    disabled={disabled}
+                  >
+                    {prompt}
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </PopoverSurface>
+    </Popover>
+  );
+}

--- a/src/RetailPulse.Web/src/constants/prompts.ts
+++ b/src/RetailPulse.Web/src/constants/prompts.ts
@@ -1,0 +1,92 @@
+/**
+ * Single source of truth for the curated retail prompt library.
+ *
+ * Both the empty New Chat welcome state and the always-available prompt-library
+ * popover consume these definitions, so the prompt text and categories are never
+ * duplicated. Update prompts here and every surface stays in sync.
+ */
+
+export interface PromptCategory {
+  id: string;
+  label: string;
+  emoji: string;
+  prompts: string[];
+}
+
+export const PROMPT_CATEGORIES: ReadonlyArray<PromptCategory> = [
+  {
+    id: 'general',
+    label: 'General Retail',
+    emoji: '📊',
+    prompts: [
+      'Compare depletion trends across all regions for this quarter',
+      'Which brands are growing fastest year-over-year across the portfolio?',
+      'Show me field sentiment for our top 3 brands in the Southeast',
+    ],
+  },
+  {
+    id: 'grocery',
+    label: 'Grocery',
+    emoji: '🛒',
+    prompts: [
+      'How are FreshMart depletions trending in the Northeast this quarter?',
+      'Compare Harvest Table vs FreshMart sell-through rates by region',
+      'What is the field sentiment for Harvest Table Meal Kits in the Midwest?',
+    ],
+  },
+  {
+    id: 'qsr',
+    label: 'Quick-Serve Restaurants',
+    emoji: '🍔',
+    prompts: [
+      'How is Apex Grill performing in the Southwest this quarter?',
+      'Compare Coastline Tacos vs Apex Grill depletions across all regions',
+      'What is the field sentiment for Coastline Tacos in the West Coast?',
+    ],
+  },
+  {
+    id: 'home-improvement',
+    label: 'Home Improvement',
+    emoji: '🏠',
+    prompts: [
+      'Show me Pinnacle Hardware depletion stats in the Midwest for Q1',
+      'How is Summit Outdoor performing in the Southeast vs West Coast?',
+      'What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest?',
+    ],
+  },
+  {
+    id: 'office-supply',
+    label: 'Office Supply',
+    emoji: '📎',
+    prompts: [
+      'How are ClearDesk depletions trending in the Northeast this quarter?',
+      'Compare ClearDesk Technology vs Paper Products sell-through by region',
+      'What is the field sentiment for ClearDesk in the Southeast?',
+    ],
+  },
+  {
+    id: 'furniture',
+    label: 'Furniture',
+    emoji: '🛋️',
+    prompts: [
+      'Show me Urban Living depletion trends across all regions this quarter',
+      'Compare Foundry Home vs Urban Living performance in the West Coast',
+      'What is the field sentiment for Urban Living in the Pacific Northwest?',
+    ],
+  },
+  {
+    id: 'charts',
+    label: 'Charts',
+    emoji: '📈',
+    prompts: [
+      'Create a line chart showing Sierra Gold Tequila depletion trends across all regions',
+      'Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast',
+      'Create a pie chart showing market share breakdown for our grocery brands nationally',
+      'Show a grouped bar chart comparing FreshMart and Harvest Table across all regions',
+      'Create a donut chart of Apex Grill variant mix in the Southwest',
+      'Show a horizontal bar chart ranking all brands by depletion growth rate',
+      'Create a table showing depletion stats for all home improvement brands by region',
+      'Show a gauge chart for Pinnacle Hardware inventory health in the Midwest',
+    ],
+  },
+];


### PR DESCRIPTION
Closes #17.

## UX design — persistent prompt library
- The curated prompts previously appeared only on the empty New Chat welcome state and disappeared once a conversation started.
- Added a compact **Prompt ideas** control adjacent to the composer (always rendered, before and during a conversation), built on Fluent `Popover` with `trapFocus`.
- Opening it shows a categorized, responsive, keyboard-accessible panel: an **All** filter plus one chip per category (`aria-pressed`), and a scrollable prompt list grouped by category in the All view.
- Selecting a prompt reuses the existing safe send path (`handleSuggestedClick` → `sendChatMessage`), then closes the panel. Escape dismisses and returns focus to the trigger.
- The welcome chips are unchanged and still work.

## Single source of truth
- Prompt categories/text moved from `ChatPanel.tsx` into `src/RetailPulse.Web/src/constants/prompts.ts` (`PROMPT_CATEGORIES` / `PromptCategory`). The welcome state and the persistent library both import it — no duplicated arrays.

## Docs audited and changed
- **README Technology Stack** now lists **Azure Container Apps** (backend hosting, scale-to-zero), **Azure Static Web Apps** (frontend), and **Azure Container Registry** (Basic; managed-identity image pulls).
- **README Azure Deployment**: fixed the stale claim that the frontend runs on Azure App Service (Node 20 LTS) — it is Azure Static Web Apps. Added the deployed topology: ACA managed identity + scale-to-zero, ACR secretless pulls, direct SignalR origin, and the SWA `/api` linked backend.
- **README Project Structure**: infra modules note corrected (Monitoring, Container Apps Env, Container Apps, Container Registry, Static Web App).
- **docs/teams-setup.md**: backend hosting line tightened to Azure Container Apps.
- `docs/deployment-azd.md` and `docs/architecture.md` were already accurate and consistent; no rewrite. No production claim that ACA is merely optional.

## Files
- Added: `src/RetailPulse.Web/src/constants/prompts.ts`, `src/RetailPulse.Web/src/components/PromptLibrary.tsx`, `src/RetailPulse.Web/src/__tests__/PromptLibrary.test.tsx`
- Changed: `src/RetailPulse.Web/src/components/ChatPanel.tsx`, `src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx`, `README.md`, `docs/teams-setup.md`

## Tests / validation
- `PromptLibrary.test.tsx` — trigger label, open/close, category filter (`aria-pressed` + list narrowing), prompt selection + panel dismissal, keyboard Enter-open/Escape-close with focus restore, disabled state.
- `ChatPanel.test.tsx` — library available before **and** after a message; a library-chosen prompt dispatches through the safe send path.
- Frontend: `npm run build` (tsc + vite) ✅, `npx vitest run` → **317 passed (38 files)** ✅, ESLint on changed files clean.
- Backend: full solution builds; deployment contract tests (ACA/SWA/ACR) **16 passed** ✅. No backend/infra changes.

Do not merge or deploy — parent coordinator will review and deploy.
