### PR TITLE
Allow authenticated SignalR CORS negotiation

### DIFF
--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -119,7 +119,7 @@ builder.Services.AddCors(options =>
         {
             policy.WithOrigins(corsProdOrigins)
                 .WithMethods("GET", "POST", "PUT", "DELETE")
-                .WithHeaders("Content-Type", "Authorization", "X-Requested-With")
+                .WithHeaders("Content-Type", "Authorization", "X-Requested-With", "X-SignalR-User-Agent")
                 .AllowCredentials();
         }
         // If no origins configured, policy allows nothing (deny by default)

--- a/tests/RetailPulse.Tests/Security/CorsConfigTests.cs
+++ b/tests/RetailPulse.Tests/Security/CorsConfigTests.cs
@@ -24,11 +24,14 @@ public class CorsConfigTests
     {
         // The "Production" CORS policy uses WithOrigins(corsProdOrigins)
         string[] allowedMethods = ["GET", "POST", "PUT", "DELETE"];
-        string[] allowedHeaders = ["Content-Type", "Authorization", "X-Requested-With"];
+        string[] allowedHeaders =
+            ["Content-Type", "Authorization", "X-Requested-With", "X-SignalR-User-Agent"];
 
         allowedMethods.Should().HaveCount(4);
-        allowedHeaders.Should().HaveCount(3);
+        allowedHeaders.Should().HaveCount(4);
         allowedHeaders.Should().Contain("Authorization");
+        allowedHeaders.Should().Contain("X-SignalR-User-Agent",
+            "the browser SignalR client sends this header during direct ACA negotiation");
         await Task.CompletedTask;
     }
 


### PR DESCRIPTION
Authenticated SignalR connects directly from Static Web Apps to ACA and sends the standard X-SignalR-User-Agent header during negotiation. Add that header to the exact Production CORS allowlist and cover the contract.