### PR TITLE
Sprint 0: provider-neutral authentication foundation

### DIFF
--- a/azd-hooks/postprovision.ps1
+++ b/azd-hooks/postprovision.ps1
@@ -130,6 +130,11 @@ Invoke-Az `
         'OpenAI__RouterDeployment=gpt-5.4-mini-2026-03-17',
         "McpServer__BaseUrl=$mcpServerUrl",
         'Security__RequireAuth=true',
+        # Provider-neutral auth is explicitly pinned to Entra for production (see
+        # Security/ProviderNeutralAuthentication.cs). This is a deploy-time re-assertion of the
+        # committed appsettings.Production.json value; the API fails closed on a missing/unknown
+        # mode and refuses to start under GitHub/Anonymous.
+        'Authentication__Mode=Entra',
         "Security__AllowedOrigins__0=$frontendOrigin",
         "MicrosoftEntra__TenantId=$entraTenantId",
         "MicrosoftEntra__ClientId=$entraClientId",

--- a/azd-hooks/postprovision.sh
+++ b/azd-hooks/postprovision.sh
@@ -111,6 +111,7 @@ az containerapp update \
     'OpenAI__RouterDeployment=gpt-5.4-mini-2026-03-17' \
     "McpServer__BaseUrl=$AZURE_MCP_SERVER_APP_URL" \
     'Security__RequireAuth=true' \
+    'Authentication__Mode=Entra' \
     "Security__AllowedOrigins__0=$RETAIL_PULSE_FRONTEND_ORIGIN" \
     "MicrosoftEntra__TenantId=$entra_tenant_id" \
     "MicrosoftEntra__ClientId=$entra_client_id" \

--- a/docs/adr/005-provider-neutral-authentication.md
+++ b/docs/adr/005-provider-neutral-authentication.md
@@ -43,9 +43,10 @@ The security boundary lives in `src/RetailPulse.Api/Security/`:
 - `UserIdentity.Resolve` derives the caller's immutable subject from the token's
   `oid` claim (claim-first, never a client-supplied header), which is the
   anti-spoofing rule recorded in `.squad/decisions.md`.
-- Health probes (`/health`, `/alive`) stay anonymous by design because the app
-  sets `DefaultPolicy`, not `FallbackPolicy` — a source-scan test guards against
-  a future endpoint group forgetting `RequireAuthorization`.
+- Health probes (`/health`, `/alive`) stay anonymous through explicit
+  `AllowAnonymous` metadata. The app sets both `DefaultPolicy` and
+  `FallbackPolicy`; a runtime endpoint-graph test guards every `/api` and
+  `/hubs` route against missing authorization metadata.
 
 ## Decision
 
@@ -172,6 +173,16 @@ The three explicit pins are belt-and-suspenders:
   policies, token services). Rejected. Dead abstractions age badly; the
   foundation adds only what is testable today (the mode contract, the factory
   seam, and the normalized principal) and lets later sprints grow the seam.
+- **Use a browser-only GitHub token as the API credential.** Rejected. GitHub
+  OAuth requires a server-side confidential exchange and provider validation.
+  Sprint 2 must use a backend-for-frontend flow, keep its client secret in
+  server-managed configuration, and issue a short-lived Retail Pulse session
+  token for REST and SignalR. It must add state, CSRF, rotation, replay, and
+  allowlist tests before the mode can run.
+- **Treat anonymous mode as harmless because it has no identity provider.**
+  Rejected. Anonymous chat still reaches billable models. Sprint 1 must require
+  explicit hosted opt-in and enforce per-client rate limits, daily token/cost
+  budgets, isolated sessions, and disabled write-capable tools.
 
 ## Threat model
 
@@ -184,6 +195,8 @@ The three explicit pins are belt-and-suspenders:
 | Subject / identity spoofing via client-supplied data | `Subject` comes from the token `oid` via `UserIdentity.Resolve` (claim-first), unchanged. The normalizer never trusts headers. |
 | A future provider weakens the role/scope requirement | The authorization policy is untouched and centralized; `RetailPulse.User` + `access_as_user` remain required. Normalization is separate from authorization. |
 | Hub token leakage via query string on REST | `?access_token` remains honored only on `/hubs/*`; unchanged. |
+| Anonymous visitors exhaust the model budget | Hosted Anonymous requires a second explicit opt-in plus rate, token, and cost ceilings; write-capable tools remain disabled. |
+| A GitHub OAuth code or session is replayed or redirected | The GitHub provider uses a backend confidential exchange, validated state and callback URI, short-lived app session tokens, rotation, and allowlists. |
 
 ## No-downgrade and fail-closed rules
 
@@ -203,13 +216,16 @@ The three explicit pins are belt-and-suspenders:
 - **Sprint 0 (this ADR):** provider-neutral foundation — mode contract, factory
   boundary routing Entra unchanged, normalized principal, Production Entra pins,
   fail-closed tests. No live behavior change.
-- **Sprint 1:** GitHub provider (opt-in, non-production) — implement the GitHub
-  case in the factory and a `GitHubPrincipalNormalizer`; keep production Entra.
-- **Sprint 2:** Anonymous provider (opt-in, non-production, health-only-style
-  invariants) with explicit guardrails.
-- **Sprint 3:** normalized-principal consumers and per-provider authorization
-  refinements where justified by tests.
-- **Sprint 4:** hardening, docs, and operational rollout controls.
+- **Sprint 1:** Anonymous provider with explicit local/hosted opt-in, isolated
+  identities and sessions, disabled write-capable tools, and billable-use
+  ceilings. Production stays Entra.
+- **Sprint 2:** GitHub provider through a backend confidential OAuth flow,
+  short-lived Retail Pulse session tokens, and user/organization allowlists.
+  Production stays Entra.
+- **Sprint 3:** provider-neutral frontend sign-in selection and configuration
+  templates. Production exposes only Microsoft sign-in.
+- **Sprint 4:** full provider matrix, security review, docs, and a production
+  verification proving Entra remains the only enabled live mode.
 
 ## Success criteria
 

--- a/docs/adr/005-provider-neutral-authentication.md
+++ b/docs/adr/005-provider-neutral-authentication.md
@@ -1,0 +1,250 @@
+# ADR-005: Provider-neutral authentication foundation
+
+## Status
+
+Accepted (Sprint 0 — foundation only; no live behavior change)
+
+## Context
+
+Retail Pulse authenticates every protected REST endpoint and both SignalR hubs
+with Microsoft Entra ID. The wiring is hard-coded: `Program.cs` calls
+`AddRetailPulseAuthentication` / `AddRetailPulseAuthorization` directly, and the
+only branch is the local `DevelopmentAuthHandler` used when the API runs in the
+Development environment. This is secure and well-tested, but it assumes a single
+identity provider forever.
+
+The squad wants to run Retail Pulse in environments where Entra is not the right
+fit — for example a public GitHub-authenticated demo, or a fully anonymous
+read-only sandbox — without forking the codebase or rewriting the security stack
+each time. That requires a **configurable, provider-neutral** authentication
+foundation.
+
+The hard constraint is that **live production behavior must not change**.
+Production is Entra-only and fails closed. GitHub and Anonymous are opt-in
+capabilities for other environments; they are declared in this sprint but must
+not be selectable in production, and must not exist as a runnable code path yet.
+
+### Current Entra architecture
+
+The security boundary lives in `src/RetailPulse.Api/Security/`:
+
+- `AuthenticationSetup.AddRetailPulseAuthentication(configuration, environment)`
+  registers the `JwtBearer` handler (Production) or the `DevelopmentAuthHandler`
+  (Development) and returns a validated `EntraAuthOptions`.
+- `AddRetailPulseAuthorization(options)` sets both the default and fallback
+  authorization policy to deny-by-default. The policy requires an authenticated
+  user **plus** the `RetailPulse.User` app role (`roles` claim) **plus** the
+  `access_as_user` scope (`scp` claim).
+- `EntraAuthOptions.FromConfiguration` fails closed outside Development:
+  `Security:RequireAuth` cannot be `false`, tenant and audience are required, and
+  angle-bracket placeholder values are rejected.
+- The `access_token` query-string parameter is honored **only** on `/hubs/*`
+  requests; REST requires the `Authorization: Bearer` header.
+- `UserIdentity.Resolve` derives the caller's immutable subject from the token's
+  `oid` claim (claim-first, never a client-supplied header), which is the
+  anti-spoofing rule recorded in `.squad/decisions.md`.
+- Health probes (`/health`, `/alive`) stay anonymous by design because the app
+  sets `DefaultPolicy`, not `FallbackPolicy` — a source-scan test guards against
+  a future endpoint group forgetting `RequireAuthorization`.
+
+## Decision
+
+Introduce a thin, strongly typed **mode contract** and a single **factory
+boundary** in front of the existing Entra wiring. Route the current Entra
+implementation through an explicit `Entra` mode without changing any of its
+security semantics.
+
+### Proposed provider strategy
+
+Three pieces, all additive:
+
+1. **`AuthenticationMode` enum** — `Entra = 0`, `GitHub = 1`, `Anonymous = 2`.
+   The named, documented selector. Numeric values are never used for selection
+   (see the resolver).
+
+2. **`AuthenticationModeOptions.Resolve(configuration, environment)`** — the
+   deterministic, fail-closed resolver. It reads the `Authentication:Mode`
+   configuration key (`Authentication__Mode` as an environment variable) and:
+   - honors an explicit recognized mode (case-insensitive `Entra`, `GitHub`,
+     `Anonymous`);
+   - defaults a missing/blank mode to `Entra` **only in Development**, preserving
+     the existing local demo experience — a documented default, not inference;
+   - throws at startup for a missing/blank mode outside Development;
+   - throws at startup for an unknown value **or a bare number** (so `"1"` can
+     never select GitHub).
+
+3. **`ProviderNeutralAuthentication.AddProviderNeutralAuthentication(...)`** — the
+   factory boundary and the single entry point `Program.cs` calls. It resolves
+   the mode and dispatches:
+   - `Entra` → registers the resolved mode for diagnostics, calls the unchanged
+     `AddRetailPulseAuthentication`, registers the `IPrincipalNormalizer`, and
+     returns `EntraAuthOptions` for the caller to wire the authorization policy;
+   - `GitHub` / `Anonymous` → throws `NotSupportedException` **before any
+     authentication scheme is registered**, so the app can never fall through to
+     Entra, Development, or anonymous access.
+
+This is a deliberate two-layer split: the resolver classifies *unknown/malformed*
+input as a fail-closed error, while the factory classifies *known-but-
+unimplemented* modes (GitHub, Anonymous) as a distinct fail-closed error. The two
+failure classes carry different, precise messages.
+
+### Normalized identity and claims model
+
+A provider-neutral principal contract lets later providers map their native
+claims into one shape without weakening the Entra requirements:
+
+- `NormalizedPrincipal` — an immutable record: `Provider`, `Subject` (immutable),
+  `DisplayName`, `Roles`, `Scopes`.
+- `IPrincipalNormalizer` — `{ AuthenticationMode Mode; NormalizedPrincipal
+  Normalize(ClaimsPrincipal); }`.
+- `EntraPrincipalNormalizer` — maps Entra claims: `Subject` via
+  `UserIdentity.Resolve` (the `oid`, claim-first), `DisplayName` from `name` /
+  `ClaimTypes.Name`, `Roles` from `roles` + `ClaimTypes.Role` (deduped), `Scopes`
+  from `scp` + the long-schema scope claim split on spaces.
+
+The normalizer is **registered and exercised by tests today** — not a dead
+abstraction. It does not participate in the authorization decision; the existing
+role + scope policy remains the sole gate.
+
+### REST and SignalR enforcement
+
+Unchanged. The `Entra` path produces the same `EntraAuthOptions` the app has
+always used, so the same deny-by-default policy applies to every REST endpoint
+and to both hubs, and `?access_token` remains hub-only. The foundation adds a
+selector in front of this wiring; it does not touch the wiring itself.
+
+### Live-production invariant
+
+> In Production, the only supported authentication mode is `Entra`, and it
+> behaves exactly as it did before this foundation existed. Production pins
+> `Authentication__Mode=Entra` explicitly in three independent places, and any
+> missing, unknown, malformed, or unimplemented mode fails startup. No production
+> code path enables GitHub or Anonymous.
+
+The three explicit pins are belt-and-suspenders:
+
+1. `src/RetailPulse.Api/appsettings.json` — base `Authentication:Mode = Entra`
+   (deterministic default for local runs).
+2. `src/RetailPulse.Api/appsettings.Production.json` — explicit Production pin.
+3. `azd-hooks/postprovision.ps1` / `.sh` — deploy-time `Authentication__Mode=Entra`
+   re-assertion on the container app, alongside `Security__RequireAuth=true`.
+
+### What changes and what stays
+
+**Changes (all additive / non-behavioral):**
+
+- New `AuthenticationMode`, `AuthenticationModeOptions`,
+  `ProviderNeutralAuthentication`, `NormalizedPrincipal`, `IPrincipalNormalizer`,
+  `EntraPrincipalNormalizer`.
+- `Program.cs` calls `AddProviderNeutralAuthentication` instead of
+  `AddRetailPulseAuthentication` directly. The Entra path returns the identical
+  `EntraAuthOptions`.
+- `appsettings.json`, `appsettings.Production.json`, and both azd hooks pin
+  `Authentication__Mode=Entra`.
+
+**Stays exactly the same:**
+
+- `AuthenticationSetup`, `EntraAuthOptions`, `UserIdentity`,
+  `DevelopmentAuthHandler`, and the authorization policy — untouched. The
+  signature of `AddRetailPulseAuthentication` is preserved so existing tests keep
+  calling it directly.
+- REST + hub enforcement, `?access_token` hub-only rule, health-only anonymous
+  invariant, and Production fail-closed configuration.
+
+## Alternatives rejected
+
+- **SWA-only authentication (Static Web Apps Easy Auth / `.auth`).** Rejected.
+  The API — not the SWA — is the security boundary for the SWA + ACA topology.
+  Easy Auth issues browser login redirects that break bearer-token REST and
+  SignalR clients calling ACA directly, which is exactly why the postprovision
+  hooks keep ACA Easy Auth **disabled**. Relying on platform auth would move the
+  gate off the in-process JWT handler, weaken the deny-by-default policy, and give
+  no clean seam for GitHub or Anonymous modes.
+- **Ambient auto-detection of the provider** (infer from which config keys are
+  present). Rejected. Non-deterministic and a downgrade risk — a partially
+  configured environment could silently pick the wrong provider. Resolution is
+  explicit and documented instead.
+- **Implement GitHub / Anonymous now behind a feature flag.** Rejected for this
+  sprint. It would create a runnable non-Entra path and enlarge the security
+  review surface with no delivery need yet. The modes are declared and fail
+  closed instead.
+- **A broad provider abstraction layer up front** (interfaces for handlers,
+  policies, token services). Rejected. Dead abstractions age badly; the
+  foundation adds only what is testable today (the mode contract, the factory
+  seam, and the normalized principal) and lets later sprints grow the seam.
+
+## Threat model
+
+| Threat | Mitigation |
+|--------|------------|
+| A misconfiguration silently disables auth in Production | Missing mode outside Development throws at startup; `Security:RequireAuth` cannot be `false` outside Development. Fails closed. |
+| An operator selects an unfinished provider in Production | GitHub / Anonymous throw `NotSupportedException` before any scheme is registered — no fall-through to Entra / Development / anonymous. |
+| A typo or injected value selects an unintended provider | Unknown strings and bare numbers throw; only the three documented names resolve. |
+| Downgrade from Entra to a weaker provider | No non-Entra path is runnable; Production is pinned to `Entra` in three places; a deployment contract test asserts the hooks and Production config never emit GitHub / Anonymous. |
+| Subject / identity spoofing via client-supplied data | `Subject` comes from the token `oid` via `UserIdentity.Resolve` (claim-first), unchanged. The normalizer never trusts headers. |
+| A future provider weakens the role/scope requirement | The authorization policy is untouched and centralized; `RetailPulse.User` + `access_as_user` remain required. Normalization is separate from authorization. |
+| Hub token leakage via query string on REST | `?access_token` remains honored only on `/hubs/*`; unchanged. |
+
+## No-downgrade and fail-closed rules
+
+1. Authentication never auto-detects a provider. The mode is always explicit
+   outside Development.
+2. Outside Development, a missing mode is a startup failure, never a default.
+3. GitHub and Anonymous fail startup until a later sprint implements them; they
+   never fall through to another provider.
+4. Production is pinned to `Entra` in base config, Production config, and the azd
+   hooks, and a deployment contract test proves those artifacts cannot silently
+   select GitHub or Anonymous.
+5. The Entra authorization policy (authenticated + `RetailPulse.User` +
+   `access_as_user`) is the single gate and is not relaxed by this foundation.
+
+## Sprint plan (epic #27)
+
+- **Sprint 0 (this ADR):** provider-neutral foundation — mode contract, factory
+  boundary routing Entra unchanged, normalized principal, Production Entra pins,
+  fail-closed tests. No live behavior change.
+- **Sprint 1:** GitHub provider (opt-in, non-production) — implement the GitHub
+  case in the factory and a `GitHubPrincipalNormalizer`; keep production Entra.
+- **Sprint 2:** Anonymous provider (opt-in, non-production, health-only-style
+  invariants) with explicit guardrails.
+- **Sprint 3:** normalized-principal consumers and per-provider authorization
+  refinements where justified by tests.
+- **Sprint 4:** hardening, docs, and operational rollout controls.
+
+## Success criteria
+
+- Current Entra live behavior is semantically identical (existing end-to-end auth
+  tests stay green).
+- No code path enables GitHub or Anonymous; selecting either fails startup with a
+  precise message.
+- Production and azd are explicitly Entra-pinned and fail closed on any mode
+  error.
+- The foundation is small enough for later sprints to extend without another auth
+  rewrite.
+
+## Risks and mitigations
+
+- **Risk:** a later provider bypasses the shared policy. **Mitigation:** the
+  factory returns options that feed the single centralized authorization policy;
+  providers plug into resolution, not into the gate.
+- **Risk:** the Development default masks a production misconfiguration.
+  **Mitigation:** the default is Development-only and documented; every other
+  environment fails closed on a missing mode.
+- **Risk:** the mode pin drifts out of the deployment artifacts. **Mitigation:**
+  `ProviderNeutralDeploymentContractTests` inspects the hooks and Production
+  config statically and fails if the Entra pin is missing or a non-Entra mode
+  appears.
+
+## Consequences
+
+**Positive:**
+
+- One documented seam for future providers; the Entra security path is untouched.
+- Explicit, testable fail-closed behavior for every misconfiguration class.
+- Normalized identity contract ready for consumers without dead code.
+
+**Negative:**
+
+- A small amount of indirection in front of the Entra wiring.
+- The mode must now be pinned in Production config and hooks (covered by a
+  contract test).

--- a/docs/authentication-entra.md
+++ b/docs/authentication-entra.md
@@ -77,6 +77,37 @@ There is **no anonymous fallback in Production**: the azd hooks set
 
 ---
 
+## Provider-neutral mode contract
+
+Entra is now selected through an explicit, provider-neutral **mode contract**
+(the Sprint 0 foundation — see
+[ADR-005](adr/005-provider-neutral-authentication.md) and the
+[authentication matrix](authentication-matrix.md)). `Program.cs` calls
+`AddProviderNeutralAuthentication`, which resolves the `Authentication:Mode`
+configuration key and dispatches to a mode-specific wiring path:
+
+- **`Entra`** routes to the existing, unchanged Entra boundary above. Security
+  semantics are identical to before the contract existed.
+- **`GitHub`** and **`Anonymous`** are declared but **not implemented in this
+  sprint**. Selecting either fails startup with a precise error — it never falls
+  through to Entra, Development, or anonymous access.
+
+Resolution is deterministic and never auto-detects a provider:
+
+- an explicit recognized mode (case-insensitive `Entra`, `GitHub`, `Anonymous`)
+  is honored as-is;
+- a missing mode defaults to `Entra` **only in Development** (documented default);
+- a missing mode outside Development, an unknown value, or a bare number **fails
+  startup — the app fails closed**.
+
+Production pins `Authentication__Mode=Entra` explicitly in
+`appsettings.Production.json` and the azd hooks; it never merely defaults to it.
+The normalized principal seam (`IPrincipalNormalizer` / `NormalizedPrincipal`)
+maps Entra claims to a provider-neutral identity for future providers without
+changing the `RetailPulse.User` + `access_as_user` requirement.
+
+---
+
 ## Environment / config contract
 
 | azd env var (operator sets) | Bicep param | Frontend build var | API env var |
@@ -85,6 +116,7 @@ There is **no anonymous fallback in Production**: the azd hooks set
 | `RETAIL_PULSE_ENTRA_CLIENT_ID` | `entraClientId` | `VITE_ENTRA_CLIENT_ID` | `MicrosoftEntra__ClientId` |
 | `RETAIL_PULSE_ENTRA_API_SCOPE` | `entraApiScope` | `VITE_ENTRA_API_SCOPE` | `MicrosoftEntra__ApiScope` |
 | `RETAIL_PULSE_ENTRA_AUDIENCE` | `entraAudience` | `VITE_ENTRA_AUDIENCE` | (derived `api://{clientId}`) |
+| (pinned, not operator-set) | — | — | `Authentication__Mode=Entra` |
 
 - `infra/main.bicepparam` reads the `RETAIL_PULSE_ENTRA_*` env vars; `infra/main.bicep`
   round‑trips them as `VITE_ENTRA_*` outputs, which azd exposes to the Static Web

--- a/docs/authentication-matrix.md
+++ b/docs/authentication-matrix.md
@@ -1,0 +1,80 @@
+# Authentication matrix
+
+> The authoritative behavior matrix for Retail Pulse authentication after the
+> provider-neutral foundation (Sprint 0). It enumerates every mode and
+> environment combination and the exact expected outcome. Each row is backed by
+> an automated test — see [Coverage](#coverage).
+
+## Modes
+
+Retail Pulse selects an authentication provider through the `Authentication:Mode`
+configuration key (`Authentication__Mode` as an environment variable). The
+resolver is deterministic and never auto-detects a provider.
+
+| Mode | Status in this sprint | Production |
+|------|-----------------------|------------|
+| `Entra` | Implemented (unchanged) | Supported and pinned |
+| `GitHub` | Declared, not implemented — fails startup | Never enabled |
+| `Anonymous` | Declared, not implemented — fails startup | Never enabled |
+
+## Mode resolution matrix
+
+| `Authentication:Mode` value | Environment | Outcome |
+|-----------------------------|-------------|---------|
+| `Entra` (any case) | any | Resolves to `Entra`; wires the existing Entra boundary |
+| `GitHub` (any case) | any | Resolves, then the factory throws `NotSupportedException` — not implemented this sprint |
+| `Anonymous` (any case) | any | Resolves, then the factory throws `NotSupportedException` — not implemented this sprint |
+| missing / blank | Development | Defaults to `Entra` (documented Development-only default) |
+| missing / blank | Production (or any non-Development) | Startup fails — mode must be pinned explicitly, fails closed |
+| unknown string (for example `Okta`) | any | Startup fails — not a recognized mode |
+| bare number (for example `1`) | any | Startup fails — numeric selection is rejected |
+
+## Runtime authorization matrix (Entra mode)
+
+Behavior for the `Entra` mode is identical to the pre-foundation implementation.
+
+| Request | Credential | Expected result |
+|---------|-----------|-----------------|
+| Protected REST endpoint | valid token with `RetailPulse.User` role + `access_as_user` scope | 200 |
+| Protected REST endpoint | no token | 401 |
+| Protected REST endpoint | valid token missing the role or scope | 403 |
+| `/hubs/*` | valid token via `?access_token` query string | connects |
+| `/hubs/*` | no token | 401 |
+| REST endpoint | token via `?access_token` query string only | 401 (query token is honored only on `/hubs/*`) |
+| `/health`, `/alive` | none | 200 (anonymous by design — health-only invariant) |
+
+## Environment behavior
+
+| Environment | Mode source | Auth handler |
+|-------------|-------------|--------------|
+| Development (local) | defaults to `Entra` when unset | `DevelopmentAuthHandler` stamps a synthetic identity (`oid` zero-GUID, `RetailPulse.User` role, `access_as_user` scope) |
+| Production | `Entra`, pinned in `appsettings.Production.json` and the azd hooks | `JwtBearer` with authority / issuer / audience pinned; `Security:RequireAuth=true` |
+
+The Development default is intentional and documented — it keeps the local demo
+running without configuration. It never applies outside Development.
+
+## Fail-closed guarantees
+
+- No missing, unknown, malformed, or unimplemented mode ever falls through to a
+  weaker provider. Every such case throws at startup before any authentication
+  scheme is registered.
+- Production is pinned to `Entra` in three independent artifacts (base config,
+  Production config, azd hooks). A deployment contract test proves those
+  artifacts never emit `GitHub` or `Anonymous`.
+- GitHub and Anonymous are opt-in capabilities for later sprints and are never
+  enabled in production.
+
+## Coverage
+
+| Matrix area | Test |
+|-------------|------|
+| Mode resolution (all rows above) | `tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs` |
+| Entra wiring + GitHub/Anonymous fail closed at the factory | `tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs` |
+| Entra success / 401 / 403 / hubs | `tests/RetailPulse.Tests/Security/EntraAuthenticationTests.cs` |
+| REST + both hubs remain protected | `tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs` |
+| Normalized principal mapping | `tests/RetailPulse.Tests/Security/NormalizedPrincipalTests.cs` |
+| Production / hooks pinned to Entra, never GitHub/Anonymous | `tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs` |
+
+See [ADR-005](adr/005-provider-neutral-authentication.md) for the design and
+threat model, and [Entra authentication](authentication-entra.md) for the
+end-to-end Entra flow.

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -14,7 +14,7 @@ Retail Pulse supports one-command deployment to Azure using the [Azure Developer
 | Monitoring | Application Insights + Log Analytics | Full OpenTelemetry pipeline |
 | App data storage | Container-local temp (no durable volume) | The API's SQLite stores (cost/audit/memory/approvals/alerts) live in the replica's temp dir. **No Azure Files mount** — tenant governance forbids account-key CIFS mounts (see the incident note below), so observability history is per-replica and resets on replacement. |
 | AI Gateway | Azure API Management | Existing APIM Bicep in `deploy/apim-ai-gateway/` |
-| Authentication | Microsoft Entra ID | Single-tenant SPA/API app registration (MSAL PKCE). See [authentication-entra.md](./authentication-entra.md). Set `RETAIL_PULSE_ENTRA_*` before `azd provision`; the postprovision hook flips `RequireAuth` on and disables Easy Auth. |
+| Authentication | Microsoft Entra ID | Single-tenant SPA/API app registration (MSAL PKCE). See [authentication-entra.md](./authentication-entra.md). Set `RETAIL_PULSE_ENTRA_*` before `azd provision`; the postprovision hook flips `RequireAuth` on, pins `Authentication__Mode=Entra` (provider-neutral mode contract — see [ADR-005](./adr/005-provider-neutral-authentication.md)), and disables Easy Auth. |
 
 ## Prerequisites
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -64,6 +64,23 @@ All chat interactions are recorded in a tamper-evident audit log (`DurableAuditL
 
 ## Authentication
 
+### Provider selection (mode contract)
+
+The active identity provider is chosen through the `Authentication:Mode`
+configuration key (`Authentication__Mode`). Resolution is deterministic and
+fails closed — it never auto-detects a provider:
+
+- `Entra` (the only implemented mode) routes to the unchanged Entra boundary.
+- `GitHub` and `Anonymous` are declared but not implemented in this sprint;
+  selecting either fails startup and never falls through to another provider.
+- A missing mode defaults to `Entra` **only in Development**. Outside
+  Development a missing, unknown, or malformed mode fails startup.
+
+Production pins `Authentication__Mode=Entra` explicitly in
+`appsettings.Production.json` and the azd postprovision hooks. See
+[ADR-005](adr/005-provider-neutral-authentication.md) and the
+[authentication matrix](authentication-matrix.md).
+
 ### Development
 - `DevelopmentAuthHandler` bypasses all authentication
 - `Security:RequireAuth` defaults to `false`

--- a/src/RetailPulse.Api/Auth/EntraPrincipalNormalizer.cs
+++ b/src/RetailPulse.Api/Auth/EntraPrincipalNormalizer.cs
@@ -36,6 +36,11 @@ public sealed class EntraPrincipalNormalizer : IPrincipalNormalizer
         ArgumentNullException.ThrowIfNull(principal);
 
         string subject = UserIdentity.Resolve(principal);
+        if (subject == UserIdentity.AnonymousUserId)
+        {
+            throw new InvalidOperationException(
+                "Cannot normalize an Entra principal without an immutable object identifier claim.");
+        }
 
         string? displayName =
             principal.FindFirst("name")?.Value

--- a/src/RetailPulse.Api/Auth/EntraPrincipalNormalizer.cs
+++ b/src/RetailPulse.Api/Auth/EntraPrincipalNormalizer.cs
@@ -1,0 +1,61 @@
+using System.Security.Claims;
+using RetailPulse.Api.Security;
+
+namespace RetailPulse.Api.Auth;
+
+/// <summary>
+/// Maps a Microsoft Entra <see cref="ClaimsPrincipal"/> onto the provider-neutral
+/// <see cref="NormalizedPrincipal"/>.
+///
+/// The mapping mirrors the claim shapes the existing Entra boundary already validates:
+/// <list type="bullet">
+///   <item><b>Subject</b> — the immutable <c>oid</c> object identifier via
+///     <see cref="UserIdentity.Resolve"/> (short or MS-schema form), so identity is anchored to a
+///     stable id and can never be spoofed from a mutable value.</item>
+///   <item><b>Roles</b> — the Entra <c>roles</c> claim (plus <see cref="ClaimTypes.Role"/> for the
+///     synthetic Development handler).</item>
+///   <item><b>Scopes</b> — the space-delimited <c>scp</c> claim (and the long MS-schema form).</item>
+///   <item><b>DisplayName</b> — the <c>name</c> claim when present.</item>
+/// </list>
+/// This is a read-only projection. It does not grant access and does not replace the
+/// authorization policy that requires the app role and API scope.
+/// </summary>
+public sealed class EntraPrincipalNormalizer : IPrincipalNormalizer
+{
+    private const string _scopeSchemaClaim = "http://schemas.microsoft.com/identity/claims/scope";
+
+    public EntraPrincipalNormalizer(EntraAuthOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+    }
+
+    public AuthenticationMode Mode => AuthenticationMode.Entra;
+
+    public NormalizedPrincipal Normalize(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        string subject = UserIdentity.Resolve(principal);
+
+        string? displayName =
+            principal.FindFirst("name")?.Value
+            ?? principal.FindFirst(ClaimTypes.Name)?.Value;
+
+        string[] roles = [.. principal.FindAll("roles").Select(c => c.Value)
+            .Concat(principal.FindAll(ClaimTypes.Role).Select(c => c.Value))
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Distinct(StringComparer.Ordinal)];
+
+        string[] scopes = [.. principal.FindAll("scp").Select(c => c.Value)
+            .Concat(principal.FindAll(_scopeSchemaClaim).Select(c => c.Value))
+            .SelectMany(v => v.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Distinct(StringComparer.Ordinal)];
+
+        return new NormalizedPrincipal(
+            Provider: Mode.ToString(),
+            Subject: subject,
+            DisplayName: displayName,
+            Roles: roles,
+            Scopes: scopes);
+    }
+}

--- a/src/RetailPulse.Api/Auth/IPrincipalNormalizer.cs
+++ b/src/RetailPulse.Api/Auth/IPrincipalNormalizer.cs
@@ -1,0 +1,18 @@
+using System.Security.Claims;
+using RetailPulse.Api.Security;
+
+namespace RetailPulse.Api.Auth;
+
+/// <summary>
+/// Maps a provider-specific <see cref="ClaimsPrincipal"/> to the provider-neutral
+/// <see cref="NormalizedPrincipal"/>. Each authentication provider ships one implementation;
+/// the active one is registered by the <see cref="ProviderNeutralAuthentication"/> factory.
+/// </summary>
+public interface IPrincipalNormalizer
+{
+    /// <summary>The authentication mode this normalizer handles.</summary>
+    AuthenticationMode Mode { get; }
+
+    /// <summary>Projects the given principal onto the normalized identity/claims model.</summary>
+    NormalizedPrincipal Normalize(ClaimsPrincipal principal);
+}

--- a/src/RetailPulse.Api/Auth/NormalizedPrincipal.cs
+++ b/src/RetailPulse.Api/Auth/NormalizedPrincipal.cs
@@ -1,0 +1,28 @@
+namespace RetailPulse.Api.Auth;
+
+/// <summary>
+/// Provider-neutral view of an authenticated caller. This is the normalized identity/claims
+/// model every authentication provider maps onto, so downstream code can reason about identity
+/// without depending on Entra-specific claim shapes.
+///
+/// Introduced by the Sprint 0 authentication foundation as an additive seam. It does NOT change
+/// or weaken the live authorization requirements — the API still enforces the
+/// <c>RetailPulse.User</c> app role and the <c>access_as_user</c> scope through the existing
+/// authorization policy. This value object simply gives later providers (GitHub, Anonymous) a
+/// stable target to populate.
+/// </summary>
+/// <param name="Provider">The authentication provider that issued the identity (e.g. "Entra").</param>
+/// <param name="Subject">
+/// Stable, immutable identifier for the caller within the provider. For Entra this is the
+/// <c>oid</c> object identifier (never the mutable email/UPN), matching
+/// <see cref="UserIdentity.Resolve"/>.
+/// </param>
+/// <param name="DisplayName">Human-readable display name, when the provider supplies one.</param>
+/// <param name="Roles">Authorization roles asserted by the provider (Entra <c>roles</c> claim).</param>
+/// <param name="Scopes">Delegated scopes asserted by the provider (Entra <c>scp</c> claim).</param>
+public sealed record NormalizedPrincipal(
+    string Provider,
+    string Subject,
+    string? DisplayName,
+    IReadOnlyCollection<string> Roles,
+    IReadOnlyCollection<string> Scopes);

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -127,13 +127,17 @@ builder.Services.AddCors(options =>
 });
 
 // ── Authentication & Authorization ──────────────────────────────────────
-// Single, tenant-scoped Entra security boundary (see Security/AuthenticationSetup.cs):
+// Provider-neutral authentication boundary (see Security/ProviderNeutralAuthentication.cs).
+// The configured Authentication:Mode selects the provider; only "Entra" is implemented today
+// and routes to the single, tenant-scoped Entra security boundary (Security/AuthenticationSetup.cs):
 // Production validates real Entra JWTs pinned to the configured tenant/audience/issuer,
 // honours the access_token query param only for /hubs, and requires the app role + API
 // scope on every protected endpoint and hub. Development uses the synthetic handler. The
 // default policy is never permissive — no RequireAssertion(_ => true) when auth is on.
+// GitHub/Anonymous modes are declared but fail startup ("not implemented in this sprint") and
+// never fall through to Entra/Development/anonymous; a missing mode fails closed outside Development.
 EntraAuthOptions entraAuthOptions =
-    builder.Services.AddRetailPulseAuthentication(builder.Configuration, builder.Environment);
+    builder.Services.AddProviderNeutralAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddRetailPulseAuthorization(entraAuthOptions);
 
 // ── Rate Limiting ───────────────────────────────────────────────────────

--- a/src/RetailPulse.Api/Security/AuthenticationMode.cs
+++ b/src/RetailPulse.Api/Security/AuthenticationMode.cs
@@ -1,0 +1,23 @@
+namespace RetailPulse.Api.Security;
+
+/// <summary>
+/// The authentication provider the API runs under. This is the provider-neutral
+/// selector introduced by the Sprint 0 authentication foundation.
+///
+/// Only <see cref="Entra"/> is implemented today; it routes to the existing, unchanged
+/// Microsoft Entra security boundary (see <see cref="AuthenticationSetup"/>). The other
+/// members are declared so the contract, configuration surface, and tests are stable for
+/// later sprints, but selecting them fails startup with a precise "not implemented in this
+/// sprint" error — authentication never falls through to Entra, Development, or Anonymous.
+/// </summary>
+public enum AuthenticationMode
+{
+    /// <summary>Microsoft Entra ID (single-tenant JWT bearer). The only live/production mode.</summary>
+    Entra = 0,
+
+    /// <summary>GitHub OAuth/OIDC. Opt-in for non-production; NOT implemented in Sprint 0.</summary>
+    GitHub = 1,
+
+    /// <summary>Anonymous (no authentication). Opt-in for non-production; NOT implemented in Sprint 0.</summary>
+    Anonymous = 2,
+}

--- a/src/RetailPulse.Api/Security/AuthenticationModeOptions.cs
+++ b/src/RetailPulse.Api/Security/AuthenticationModeOptions.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace RetailPulse.Api.Security;
+
+/// <summary>
+/// Deterministic, fail-closed resolution of the active <see cref="AuthenticationMode"/>
+/// from configuration.
+///
+/// The mode is read from the <c>Authentication:Mode</c> configuration key
+/// (<c>Authentication__Mode</c> as an environment variable). Resolution is intentionally
+/// explicit and never auto-detects a provider from ambient signals:
+/// <list type="bullet">
+///   <item>An explicit, recognized mode (case-insensitive: <c>Entra</c>, <c>GitHub</c>,
+///     <c>Anonymous</c>) is honored as-is.</item>
+///   <item>A missing/blank mode defaults to <see cref="AuthenticationMode.Entra"/> ONLY in
+///     Development, preserving the existing local demo experience. This default is documented,
+///     not inferred.</item>
+///   <item>A missing/blank mode outside Development throws at startup — production must pin the
+///     mode explicitly (<c>Authentication__Mode=Entra</c>) and fails closed otherwise.</item>
+///   <item>An unknown or malformed value (including a bare number) throws at startup.</item>
+/// </list>
+/// This class only <i>resolves</i> the mode. The decision to accept or reject a resolved mode
+/// (e.g. GitHub/Anonymous being unimplemented in this sprint) belongs to the
+/// <see cref="ProviderNeutralAuthentication"/> factory boundary, which fails closed for any
+/// mode it cannot wire.
+/// </summary>
+public sealed class AuthenticationModeOptions
+{
+    /// <summary>Configuration section that carries the provider selector.</summary>
+    public const string SectionName = "Authentication";
+
+    /// <summary>Full configuration key for the mode selector.</summary>
+    public const string ModeKey = "Authentication:Mode";
+
+    /// <summary>The resolved, active authentication mode.</summary>
+    public required AuthenticationMode Mode { get; init; }
+
+    /// <summary>
+    /// Resolves the active <see cref="AuthenticationMode"/> from configuration, applying the
+    /// documented Development default and failing closed on a missing/unknown/malformed value
+    /// outside Development.
+    /// </summary>
+    public static AuthenticationMode Resolve(IConfiguration configuration, IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        string? raw = configuration[ModeKey]?.Trim();
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            // Documented default: Development keeps the existing Entra-backed synthetic auth so
+            // the local demo runs without configuration. Every other environment must pin the
+            // mode explicitly and fails closed here — never silently assuming a provider.
+            return environment.IsDevelopment()
+                ? AuthenticationMode.Entra
+                : throw new InvalidOperationException(
+                $"Authentication:Mode is not configured. It must be set explicitly " +
+                $"(Authentication__Mode=Entra) in the '{environment.EnvironmentName}' environment. " +
+                "Authentication never auto-detects a provider outside Development — the app fails closed.");
+        }
+
+        // Reject bare numeric input (e.g. "1") so the mode is always a documented, readable name
+        // and can never be selected by an accidental integer.
+        return int.TryParse(raw, out _) ||
+            !Enum.TryParse(raw, ignoreCase: true, out AuthenticationMode mode) ||
+            !Enum.IsDefined(mode)
+            ? throw new InvalidOperationException(
+                $"Authentication:Mode '{raw}' is not a recognized authentication mode. " +
+                "Valid modes are: Entra, GitHub, Anonymous.")
+            : mode;
+    }
+}

--- a/src/RetailPulse.Api/Security/ProviderNeutralAuthentication.cs
+++ b/src/RetailPulse.Api/Security/ProviderNeutralAuthentication.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RetailPulse.Api.Auth;
+
+namespace RetailPulse.Api.Security;
+
+/// <summary>
+/// Provider-neutral authentication factory boundary (Sprint 0 foundation).
+///
+/// This is the single entry point <c>Program.cs</c> calls to wire authentication. It resolves
+/// the configured <see cref="AuthenticationMode"/> and dispatches to a mode-specific wiring
+/// path:
+/// <list type="bullet">
+///   <item><see cref="AuthenticationMode.Entra"/> → the existing, unchanged Entra security
+///     boundary (<see cref="AuthenticationSetup.AddRetailPulseAuthentication"/>). Security
+///     semantics are identical to before this foundation existed.</item>
+///   <item><see cref="AuthenticationMode.GitHub"/> / <see cref="AuthenticationMode.Anonymous"/>
+///     → a deliberate fail-closed startup error. These modes are declared but NOT implemented in
+///     this sprint; selecting one throws before any authentication scheme is registered, so the
+///     app can never fall through to Entra, Development, or anonymous access.</item>
+/// </list>
+/// The boundary is intentionally thin: later sprints add a case per provider here without
+/// reworking the Entra path or the authorization policy.
+/// </summary>
+public static class ProviderNeutralAuthentication
+{
+    /// <summary>
+    /// Resolves the configured authentication mode and registers the matching authentication
+    /// stack. Returns the resolved <see cref="EntraAuthOptions"/> so the caller can wire the
+    /// authorization policy (only the Entra path returns; other modes throw).
+    /// </summary>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the configured mode is recognized but not implemented in this sprint
+    /// (GitHub, Anonymous). This is a fail-closed startup error by design.
+    /// </exception>
+    public static EntraAuthOptions AddProviderNeutralAuthentication(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        AuthenticationMode mode = AuthenticationModeOptions.Resolve(configuration, environment);
+
+        switch (mode)
+        {
+            case AuthenticationMode.Entra:
+                // Register the resolved mode for observability/diagnostics, then wire the
+                // existing Entra boundary exactly as before — no security-semantic change.
+                services.AddSingleton(new AuthenticationModeOptions { Mode = mode });
+                EntraAuthOptions options = services.AddRetailPulseAuthentication(configuration, environment);
+
+                // Normalized principal seam for future providers. Registered (not dead) so the
+                // Entra claims → normalized-identity mapping is exercised and testable today.
+                services.AddSingleton<IPrincipalNormalizer>(new EntraPrincipalNormalizer(options));
+                return options;
+
+            case AuthenticationMode.GitHub:
+            case AuthenticationMode.Anonymous:
+                throw new NotSupportedException(
+                    $"Authentication mode '{mode}' is not implemented in this sprint " +
+                    "(Sprint 0: provider-neutral authentication foundation). Only 'Entra' is currently " +
+                    "supported. GitHub and Anonymous are opt-in capabilities delivered in later sprints and " +
+                    "are never enabled in production. This is a deliberate fail-closed startup error — " +
+                    "authentication does not fall through to Entra, Development, or Anonymous.");
+
+            default:
+                // Unreachable: AuthenticationModeOptions.Resolve only returns defined members.
+                throw new InvalidOperationException(
+                    $"Unhandled authentication mode '{mode}'. This is a bug in the authentication factory.");
+        }
+    }
+}

--- a/src/RetailPulse.Api/appsettings.Production.json
+++ b/src/RetailPulse.Api/appsettings.Production.json
@@ -64,6 +64,15 @@
     ]
   },
 
+  // ---- Authentication provider mode ------------------------------------
+  // Production is EXPLICITLY PINNED to Entra — it does not merely inherit a default.
+  // The API fails closed if this is missing or set to an unknown mode, and the
+  // GitHub/Anonymous modes fail startup (they are never enabled in production). The
+  // azd postprovision hook re-asserts Authentication__Mode=Entra at deploy time.
+  "Authentication": {
+    "Mode": "Entra"
+  },
+
   // ---- Security / Auth --------------------------------------------------
   // Real Entra bearer auth is enforced in Production (no DevelopmentAuthHandler).
   // The default authorization policy requires an authenticated user, the

--- a/src/RetailPulse.Api/appsettings.json
+++ b/src/RetailPulse.Api/appsettings.json
@@ -70,6 +70,17 @@
     ]
   },
 
+  // ---- Authentication provider mode ------------------------------------
+  // Provider-neutral selector for the authentication boundary. Only "Entra" is
+  // implemented today; it routes to the tenant-scoped Microsoft Entra JWT boundary
+  // below. "GitHub" and "Anonymous" are declared for later sprints and FAIL STARTUP
+  // if selected now (they never fall through to Entra/dev/anonymous). Resolution is
+  // deterministic: outside Development a missing mode fails closed; in Development a
+  // missing mode defaults to Entra so the local demo runs without extra config.
+  "Authentication": {
+    "Mode": "Entra"
+  },
+
   // ---- Security / Auth --------------------------------------------------
   // In Development the app uses a built-in DevelopmentAuthHandler (stamps a
   // fixed oid claim plus the RetailPulse.User role + access_as_user scope), so

--- a/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+
+namespace RetailPulse.Tests.Deployment;
+
+/// <summary>
+/// Static deployment-contract guardrails for the provider-neutral authentication foundation.
+/// These only read repo files — they never invoke azd or touch Azure.
+///
+/// They prove that the LIVE deployment path is explicitly pinned to the Entra authentication
+/// mode and can never silently select GitHub or Anonymous:
+/// <list type="bullet">
+///   <item>Both azd postprovision hooks set <c>Authentication__Mode=Entra</c> on the API.</item>
+///   <item>Neither hook ever sets the API mode to GitHub or Anonymous.</item>
+///   <item>The committed <c>appsettings.Production.json</c> pins <c>Authentication:Mode = Entra</c>.</item>
+/// </list>
+/// </summary>
+public sealed class ProviderNeutralDeploymentContractTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Theory]
+    [InlineData("postprovision.ps1")]
+    [InlineData("postprovision.sh")]
+    public void PostprovisionHook_PinsApiAuthenticationModeToEntra(string hookFile)
+    {
+        string script = File.ReadAllText(Path.Combine(RepoRoot, "azd-hooks", hookFile));
+
+        script.Should().Contain("Authentication__Mode=Entra",
+            $"{hookFile} must explicitly pin the API to the Entra authentication mode (not merely default to it)");
+    }
+
+    [Theory]
+    [InlineData("postprovision.ps1")]
+    [InlineData("postprovision.sh")]
+    public void PostprovisionHook_NeverSelectsGitHubOrAnonymousMode(string hookFile)
+    {
+        string script = File.ReadAllText(Path.Combine(RepoRoot, "azd-hooks", hookFile));
+
+        script.Should().NotContain("Authentication__Mode=Anonymous",
+            $"{hookFile} must never deploy the API in Anonymous authentication mode");
+        script.Should().NotContain("Authentication__Mode=GitHub",
+            $"{hookFile} must never deploy the API in GitHub authentication mode");
+    }
+
+    [Fact]
+    public void ProductionAppSettings_PinsAuthenticationModeToEntra()
+    {
+        string json = File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "RetailPulse.Api", "appsettings.Production.json"));
+
+        json.Should().MatchRegex(
+            "\"Authentication\"\\s*:\\s*\\{[^}]*\"Mode\"\\s*:\\s*\"Entra\"",
+            "appsettings.Production.json must explicitly pin Authentication:Mode to Entra");
+        json.Should().NotContain("\"Mode\": \"Anonymous\"");
+        json.Should().NotContain("\"Mode\": \"GitHub\"");
+    }
+
+    [Fact]
+    public void BaseAppSettings_DeclareEntraAuthenticationMode()
+    {
+        string json = File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "RetailPulse.Api", "appsettings.json"));
+
+        json.Should().MatchRegex(
+            "\"Authentication\"\\s*:\\s*\\{[^}]*\"Mode\"\\s*:\\s*\"Entra\"",
+            "the base appsettings.json must declare a deterministic Entra authentication mode");
+    }
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "RetailPulse.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate repo root (RetailPulse.slnx) walking up from " + AppContext.BaseDirectory);
+    }
+}

--- a/tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs
+++ b/tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs
@@ -1,0 +1,248 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Security;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Contract tests for the provider-neutral authentication foundation (Sprint 0):
+/// <see cref="AuthenticationModeOptions.Resolve"/> and the
+/// <see cref="ProviderNeutralAuthentication.AddProviderNeutralAuthentication"/> factory boundary.
+///
+/// These prove the deterministic, fail-closed selection rules:
+/// <list type="bullet">
+///   <item>Explicit <c>Entra</c> (any casing) resolves and wires the existing Entra boundary.</item>
+///   <item>GitHub/Anonymous resolve as known modes but the factory fails startup
+///     ("not implemented in this sprint") and never falls through to Entra/dev/anonymous.</item>
+///   <item>Unknown/malformed/numeric modes fail startup.</item>
+///   <item>Production with a missing mode fails closed; Development defaults to Entra.</item>
+/// </list>
+/// </summary>
+public sealed class AuthenticationModeTests
+{
+    private const string TenantId = "11111111-1111-1111-1111-111111111111";
+    private const string ClientId = "33333333-3333-3333-3333-333333333333";
+
+    private static IConfiguration Config(params (string Key, string? Value)[] entries)
+    {
+        Dictionary<string, string?> dict = entries.ToDictionary(e => e.Key, e => e.Value);
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+
+    private static IConfiguration EntraConfig(string? mode)
+    {
+        var entries = new List<(string, string?)>
+        {
+            ("MicrosoftEntra:TenantId", TenantId),
+            ("MicrosoftEntra:ClientId", ClientId),
+        };
+        if (mode is not null)
+        {
+            entries.Add(("Authentication:Mode", mode));
+        }
+
+        return Config([.. entries]);
+    }
+
+    private static IHostEnvironment Env(string name) => new TestHostEnvironment { EnvironmentName = name };
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "RetailPulse.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+
+    // ── Resolve: explicit known modes ─────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Entra", AuthenticationMode.Entra)]
+    [InlineData("entra", AuthenticationMode.Entra)]
+    [InlineData("ENTRA", AuthenticationMode.Entra)]
+    [InlineData("GitHub", AuthenticationMode.GitHub)]
+    [InlineData("github", AuthenticationMode.GitHub)]
+    [InlineData("Anonymous", AuthenticationMode.Anonymous)]
+    [InlineData("anonymous", AuthenticationMode.Anonymous)]
+    public void Resolve_ExplicitKnownMode_IsHonouredCaseInsensitively(string raw, AuthenticationMode expected)
+    {
+        IConfiguration config = Config(("Authentication:Mode", raw));
+
+        AuthenticationMode mode = AuthenticationModeOptions.Resolve(config, Env("Production"));
+
+        mode.Should().Be(expected);
+    }
+
+    // ── Resolve: missing mode is environment-dependent ────────────────────────
+
+    [Fact]
+    public void Resolve_MissingMode_InDevelopment_DefaultsToEntra()
+    {
+        AuthenticationMode mode = AuthenticationModeOptions.Resolve(Config(), Env("Development"));
+
+        mode.Should().Be(AuthenticationMode.Entra);
+    }
+
+    [Theory]
+    [InlineData("Production")]
+    [InlineData("Staging")]
+    [InlineData("ProductionLike")]
+    public void Resolve_MissingMode_OutsideDevelopment_FailsClosed(string environment)
+    {
+        Action act = () => AuthenticationModeOptions.Resolve(Config(), Env(environment));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Authentication:Mode is not configured*fails closed*");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_BlankMode_OutsideDevelopment_FailsClosed(string? raw)
+    {
+        IConfiguration config = raw is null ? Config() : Config(("Authentication:Mode", raw));
+
+        Action act = () => AuthenticationModeOptions.Resolve(config, Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not configured*");
+    }
+
+    // ── Resolve: unknown / malformed / numeric modes fail ─────────────────────
+
+    [Theory]
+    [InlineData("Foo")]
+    [InlineData("Ldap")]
+    [InlineData("En tra")]
+    [InlineData("Entra ")] // trailing space is trimmed → still Entra, so NOT here
+    public void Resolve_UnknownMode_FailsClosed(string raw)
+    {
+        // "Entra " trims to a valid mode, so only assert failure for genuinely unknown values.
+        if (raw.Trim().Equals("Entra", StringComparison.OrdinalIgnoreCase))
+        {
+            AuthenticationModeOptions.Resolve(Config(("Authentication:Mode", raw)), Env("Production"))
+                .Should().Be(AuthenticationMode.Entra);
+            return;
+        }
+
+        Action act = () => AuthenticationModeOptions.Resolve(Config(("Authentication:Mode", raw)), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not a recognized authentication mode*");
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("2")]
+    public void Resolve_NumericMode_IsRejected(string raw)
+    {
+        // A bare integer must never select a mode — modes are documented names only.
+        Action act = () => AuthenticationModeOptions.Resolve(Config(("Authentication:Mode", raw)), Env("Development"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not a recognized authentication mode*");
+    }
+
+    // ── Factory boundary: Entra wires the existing stack ──────────────────────
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_Entra_WiresEntraStackAndNormalizer()
+    {
+        var services = new ServiceCollection();
+
+        EntraAuthOptions options = services.AddProviderNeutralAuthentication(
+            EntraConfig("Entra"), Env("Production"));
+
+        options.Should().NotBeNull();
+        options.RequireAuth.Should().BeTrue("Production must run real Entra auth");
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetService<EntraAuthOptions>().Should().NotBeNull();
+        provider.GetService<AuthenticationModeOptions>()!.Mode.Should().Be(AuthenticationMode.Entra);
+
+        IPrincipalNormalizer normalizer = provider.GetRequiredService<IPrincipalNormalizer>();
+        normalizer.Should().BeOfType<EntraPrincipalNormalizer>();
+        normalizer.Mode.Should().Be(AuthenticationMode.Entra);
+    }
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_Entra_MissingModeInDevelopment_DefaultsToEntra()
+    {
+        var services = new ServiceCollection();
+
+        EntraAuthOptions options = services.AddProviderNeutralAuthentication(
+            Config(), Env("Development"));
+
+        options.Should().NotBeNull();
+        services.BuildServiceProvider().GetService<IPrincipalNormalizer>().Should().NotBeNull();
+    }
+
+    // ── Factory boundary: unimplemented modes fail closed, no fall-through ─────
+
+    [Theory]
+    [InlineData("GitHub")]
+    [InlineData("Anonymous")]
+    public void AddProviderNeutralAuthentication_UnimplementedMode_FailsStartup(string mode)
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddProviderNeutralAuthentication(EntraConfig(mode), Env("Development"));
+
+        act.Should().Throw<NotSupportedException>()
+            .WithMessage("*not implemented in this sprint*");
+    }
+
+    [Theory]
+    [InlineData("GitHub")]
+    [InlineData("Anonymous")]
+    public void AddProviderNeutralAuthentication_UnimplementedMode_DoesNotWireAnyAuth(string mode)
+    {
+        var services = new ServiceCollection();
+
+        try
+        {
+            services.AddProviderNeutralAuthentication(EntraConfig(mode), Env("Production"));
+        }
+        catch (NotSupportedException)
+        {
+            // expected — the boundary fails closed
+        }
+
+        // Nothing auth-related may be registered: no fall-through to the Entra boundary,
+        // no authentication scheme, no options singletons.
+        services.Should().NotContain(d => d.ServiceType == typeof(EntraAuthOptions),
+            "an unimplemented mode must never register the Entra options");
+        services.Should().NotContain(d => d.ServiceType == typeof(IPrincipalNormalizer),
+            "an unimplemented mode must never register a principal normalizer");
+        services.Should().NotContain(d => d.ServiceType == typeof(AuthenticationModeOptions),
+            "an unimplemented mode must not register a resolved mode");
+        services.Should().NotContain(
+            d => d.ServiceType.FullName == "Microsoft.AspNetCore.Authentication.IAuthenticationSchemeProvider",
+            "an unimplemented mode must never register an authentication scheme");
+    }
+
+    [Theory]
+    [InlineData("Nope")]
+    [InlineData("2")]
+    public void AddProviderNeutralAuthentication_MalformedMode_FailsStartup(string mode)
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddProviderNeutralAuthentication(EntraConfig(mode), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_ProductionMissingMode_FailsStartup()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddProviderNeutralAuthentication(EntraConfig(mode: null), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not configured*");
+    }
+}

--- a/tests/RetailPulse.Tests/Security/NormalizedPrincipalTests.cs
+++ b/tests/RetailPulse.Tests/Security/NormalizedPrincipalTests.cs
@@ -1,0 +1,99 @@
+using System.Security.Claims;
+using FluentAssertions;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Security;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Tests for the provider-neutral <see cref="NormalizedPrincipal"/> and the
+/// <see cref="EntraPrincipalNormalizer"/> claim mapping. These prove the normalized identity
+/// model is populated correctly from Entra claims without changing the authorization contract.
+/// </summary>
+public sealed class NormalizedPrincipalTests
+{
+    private const string Oid = "44444444-4444-4444-4444-444444444444";
+
+    private static readonly EntraPrincipalNormalizer Normalizer =
+        new(new EntraAuthOptions { TenantId = "t", ClientId = "c" });
+
+    private static ClaimsPrincipal Principal(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, authenticationType: "Test"));
+
+    [Fact]
+    public void Normalize_MapsProviderSubjectDisplayRolesAndScopes()
+    {
+        ClaimsPrincipal principal = Principal(
+            new Claim("oid", Oid),
+            new Claim("name", "Ada Lovelace"),
+            new Claim("roles", "RetailPulse.User"),
+            new Claim("scp", "access_as_user Files.Read"));
+
+        NormalizedPrincipal normalized = Normalizer.Normalize(principal);
+
+        normalized.Provider.Should().Be("Entra");
+        normalized.Subject.Should().Be(Oid, "the immutable oid is the stable subject");
+        normalized.DisplayName.Should().Be("Ada Lovelace");
+        normalized.Roles.Should().Contain("RetailPulse.User");
+        normalized.Scopes.Should().Contain("access_as_user");
+        normalized.Scopes.Should().Contain("Files.Read");
+    }
+
+    [Fact]
+    public void Normalize_UsesMsSchemaObjectIdentifier_ForSubject()
+    {
+        ClaimsPrincipal principal = Principal(
+            new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", Oid));
+
+        NormalizedPrincipal normalized = Normalizer.Normalize(principal);
+
+        normalized.Subject.Should().Be(Oid);
+    }
+
+    [Fact]
+    public void Normalize_UsesLongSchemaScopeClaim()
+    {
+        ClaimsPrincipal principal = Principal(
+            new Claim("oid", Oid),
+            new Claim("http://schemas.microsoft.com/identity/claims/scope", "access_as_user"));
+
+        NormalizedPrincipal normalized = Normalizer.Normalize(principal);
+
+        normalized.Scopes.Should().ContainSingle().Which.Should().Be("access_as_user");
+    }
+
+    [Fact]
+    public void Normalize_NoIdentityClaims_SubjectFallsBackToAnonymous()
+    {
+        NormalizedPrincipal normalized = Normalizer.Normalize(Principal());
+
+        normalized.Subject.Should().Be(UserIdentity.AnonymousUserId);
+        normalized.DisplayName.Should().BeNull();
+        normalized.Roles.Should().BeEmpty();
+        normalized.Scopes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Normalize_DeduplicatesRolesAcrossClaimTypes()
+    {
+        ClaimsPrincipal principal = Principal(
+            new Claim("oid", Oid),
+            new Claim("roles", "RetailPulse.User"),
+            new Claim(ClaimTypes.Role, "RetailPulse.User"));
+
+        NormalizedPrincipal normalized = Normalizer.Normalize(principal);
+
+        normalized.Roles.Should().ContainSingle().Which.Should().Be("RetailPulse.User");
+    }
+
+    [Fact]
+    public void Normalizer_ReportsEntraMode() => Normalizer.Mode.Should().Be(AuthenticationMode.Entra);
+
+    [Fact]
+    public void Normalize_NullPrincipal_Throws()
+    {
+        Action act = () => Normalizer.Normalize(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/RetailPulse.Tests/Security/NormalizedPrincipalTests.cs
+++ b/tests/RetailPulse.Tests/Security/NormalizedPrincipalTests.cs
@@ -63,14 +63,12 @@ public sealed class NormalizedPrincipalTests
     }
 
     [Fact]
-    public void Normalize_NoIdentityClaims_SubjectFallsBackToAnonymous()
+    public void Normalize_NoImmutableIdentityClaim_FailsClosed()
     {
-        NormalizedPrincipal normalized = Normalizer.Normalize(Principal());
+        Action act = () => Normalizer.Normalize(Principal());
 
-        normalized.Subject.Should().Be(UserIdentity.AnonymousUserId);
-        normalized.DisplayName.Should().BeNull();
-        normalized.Roles.Should().BeEmpty();
-        normalized.Scopes.Should().BeEmpty();
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*immutable object identifier*");
     }
 
     [Fact]


### PR DESCRIPTION
## Sprint 0: provider-neutral authentication foundation

Foundation only — **no live behavior change**. This introduces a configurable,
provider-neutral authentication mode contract and routes the existing Microsoft
Entra implementation through an explicit `Entra` mode **without changing its
security semantics**. Live production stays Entra-only and fail-closed.

Epic: #27 · Closes #28

### What this delivers

- **Mode contract** — `AuthenticationMode` enum (`Entra`, `GitHub`, `Anonymous`)
  and a deterministic, fail-closed `AuthenticationModeOptions.Resolve` reading
  `Authentication:Mode`. Never auto-detects a provider.
- **Factory boundary** — `ProviderNeutralAuthentication.AddProviderNeutralAuthentication`,
  the single seam `Program.cs` calls. `Entra` routes to the unchanged
  `AddRetailPulseAuthentication`; `GitHub`/`Anonymous` throw at startup
  (**not implemented in this sprint**) before any scheme is registered — no
  fall-through to Entra/Development/anonymous.
- **Normalized principal** — `NormalizedPrincipal`, `IPrincipalNormalizer`,
  `EntraPrincipalNormalizer` (registered and tested). Does not weaken the
  `RetailPulse.User` + `access_as_user` gate.
- **Explicit Entra pins** — `appsettings.json`, `appsettings.Production.json`,
  and both azd `postprovision` hooks pin `Authentication__Mode=Entra` (Production
  does not merely default).
- **Docs** — ADR-005, `docs/authentication-matrix.md`, and updates to
  `authentication-entra.md`, `security.md`, `deployment-azd.md`.

### Fail-closed guarantees

- Missing mode outside Development → startup failure (Development defaults to
  `Entra`, documented).
- Unknown string or bare number → startup failure.
- `GitHub`/`Anonymous` selected → startup failure, no fall-through.
- Production pinned to `Entra` in three artifacts; a deployment contract test
  proves the hooks and Production config never emit `GitHub`/`Anonymous`.

### Tests

- `Security/AuthenticationModeTests.cs` — resolution matrix + factory boundary.
- `Security/NormalizedPrincipalTests.cs` — Entra claim mapping.
- `Deployment/ProviderNeutralDeploymentContractTests.cs` — Entra pins in hooks +
  Production config.
- Existing `EntraAuthenticationTests` / `EndpointAuthorizationCoverageTests` stay
  green (proves semantic identity).

### Verification (local)

- `az bicep build infra/main.bicep` — clean
- `dotnet format --verify-no-changes` — clean
- `dotnet build RetailPulse.slnx -c Release` — 0 warnings, 0 errors
- `dotnet test` — 2225 passed (43 new)
- `npm ci` + `npm run build` + `vitest run` — 357 frontend tests pass

### Out of scope (later sprints)

GitHub and Anonymous provider implementations. No Azure/Entra writes, no
deployment, no production config change except the behavior-preserving
`Authentication__Mode=Entra` pin. **Do not merge/deploy without squad review.**
