### PR TITLE
Sprint 1: secure Anonymous authentication mode (#30)

### DIFF
--- a/docs/adr/005-provider-neutral-authentication.md
+++ b/docs/adr/005-provider-neutral-authentication.md
@@ -180,7 +180,7 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 ### Server-minted session identity (no trusted client header)
 
 - Identity is never taken from a caller-supplied user id. A single, narrowly
-  scoped, per-IP rate-limited bootstrap endpoint
+  scoped, globally rate-limited bootstrap endpoint
   (`POST /api/auth/anonymous/session`) mints a fresh, cryptographically random
   per-session subject (`anon-<base64url>`) SERVER-SIDE.
 - The credential is a compact, short-lived (default 15 min) **HS256 session JWT**
@@ -206,45 +206,91 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 - Sessions are isolated by their random subject; no identity state is shared
   across sessions.
 
-### Read-only by policy (single source of truth)
+### Deny-by-default capability allowlist (single source of truth)
 
-- `AnonymousCapabilityPolicy` is data, not UI hiding: a small allowlist of
-  read-only non-GET routes; every other non-GET verb/route is denied by default.
-  A newly added mutation endpoint is therefore denied to anonymous callers unless
-  it is explicitly added to the allowlist.
-- The chat tool set is filtered so write-capable tools (today: `RequestApproval`)
-  are never registered for an anonymous principal — the model cannot invoke a
-  write path.
+- `AnonymousCapabilityPolicy` is data, not UI hiding, and it is **deny-by-default
+  over every (method, route)** — there is no read/GET shortcut. The allowlist is
+  exactly: the unauthenticated bootstrap, authenticated `POST /api/chat`, and the
+  `/hubs/telemetry` + `/hubs/streaming` hubs (plus `OPTIONS` preflight). Everything
+  else — all observability/admin/export/memory/cards/approvals/guardrail-log routes,
+  every broad GET, and every **alternate LLM/orchestrator route**
+  (`/api/chat/stream`, `/api/council/*`, message-extension, scorecard, escalation) —
+  returns `403`. A newly added endpoint is denied to anonymous callers unless it is
+  explicitly allowlisted, and a runtime endpoint-graph test enumerates the compiled
+  route table to prove it.
+- Read-only data (e.g. charts) is reached **through the filtered chat tool path**,
+  not a direct operator endpoint, so subject-scoping and the output/budget controls
+  always apply.
+- Because only the single `AgentExecutionPipeline` behind `POST /api/chat` is
+  reachable, **all model use is accounted through one metered chokepoint** — there is
+  no alternate billable route or orchestrator to escape the output-token cap, the
+  cost/token metering, or the write-capable-tool filter.
+- The chat tool set is filtered so write-capable tools (today: `RequestApproval`,
+  `RememberPreference`, `SaveMemory`) are never registered for an anonymous
+  principal — the model cannot invoke a write path.
+
+### Provider-aware identity, disabled memory and cache
+
+- Identity is resolved per provider by `UserIdentity.Resolve`: **Anonymous → the
+  immutable server-minted `sub`; Entra → the immutable `oid`.** A request-body
+  `objectId` is **never** honoured for any authenticated principal, closing the
+  cross-session spoof/conflation gap (previously the resolver could key an
+  authenticated principal to a spoofable body value).
+- **Memory is disabled for Anonymous** — no recall, write, or extraction — which
+  eliminates stored cross-prompt injection across anonymous sessions in Sprint 1.
+- The **response cache is disabled for Anonymous** (both read and write), so two
+  subjects issuing an identical prompt always execute independently and can never
+  share a reply.
+- **Hub session ownership (Finding 6):** for an anonymous caller `JoinSession` binds
+  and verifies the session id against the caller's immutable subject via a
+  replica-local `ISessionOwnershipRegistry`; an anonymous attacker cannot join
+  another subject's telemetry/stream group even with a known session id, and card
+  groups are refused. Entra/dev hub behaviour is unchanged.
 
 ### Billable-use safeguards
 
-- `AnonymousGuardMiddleware` centrally enforces: read-only (403), request-size
-  bound (413), per-subject and per-IP minute limits (429), a per-request timeout
-  (504), and a global daily request/token/cost **circuit breaker** (503,
-  fail-closed).
+- `AnonymousGuardMiddleware` centrally enforces: the deny-by-default route allowlist
+  (403), request-size bound (413 — set before the body is read **and** via a
+  length-counting pre-read, so a chunked/unknown-length body without
+  `Content-Length` cannot bypass it), per-subject and per-IP minute limits (429), a
+  per-request timeout (504), and a global daily request/token/cost **circuit
+  breaker** (503, fail-closed). History length is bounded per-message and in
+  aggregate by `ChatRequestValidator` (400 before the model).
+- **ACA proxy / X-Forwarded-For:** behind the Container Apps ingress the connection
+  remote IP is the proxy's, not the client's, and `X-Forwarded-For` is **not**
+  trusted (forgeable; no cryptographically verifiable client-IP header). The per-IP
+  limit therefore collapses to a global bucket; bootstrap is deliberately a single
+  **global** conservative window and the **primary** control is the per-subject
+  limit applied after bootstrap.
 - Accounting is truthful: a request slot is charged **at admission — before the
   cache is consulted** — so cache hits cannot bypass the request ceiling; token
   and cost are metered by an `ICostTracker` decorator (`AnonymousBudgetCostTracker`)
   where cache hits cost zero. Output tokens are capped for anonymous chat.
-- **Replica-local limitation (disclosed):** the ceilings are enforced in
-  replica-local memory. Hosted Anonymous is therefore pinned to `maxReplicas=1`
+- **Replica-local limitation (disclosed):** the ceilings, rate-limit windows, and
+  the hub session-ownership registry are enforced in replica-local memory. Hosted
+  Anonymous is therefore pinned to `maxReplicas=1`
   (rationale comment in `infra/modules/container-apps.bicep`) and the ceilings are
-  conservative; counters reset on restart. This is explicitly **NOT** equivalent
-  to authenticated production.
+  conservative; **all of these counters/bindings reset on restart or replica
+  replacement.** This is explicitly **NOT** equivalent to authenticated production.
 
 ### Sprint 1 threat model additions
 
 | Threat | Mitigation |
 |--------|------------|
-| Spoofed subject via a client header/body | Identity is the signed token subject minted server-side; the guard and normalizer never read a client-supplied id. |
+| Spoofed subject via a client header/body | Identity is the signed token subject minted server-side; `UserIdentity.Resolve` is provider-aware and never honours a request-body `objectId` for an authenticated principal. |
 | Token replay after expiry | Strict short TTL + `ValidateLifetime`; no refresh token; the replay window is bounded by the TTL. |
 | Query token smuggled onto a REST path | `?access_token` is honored only on `/hubs/*`; a REST query token yields no `Authorization` header → 401. |
 | Cross-provider (e.g. Entra) token used for anonymous access | The anonymous policy requires `provider=Anonymous` → 403. |
 | Forged/tampered token | HS256 signature validated against the configured key; wrong signature/issuer/audience → 401. |
-| Oversized request exhausts resources | Request-size bound → 413 before work begins. |
+| Oversized request exhausts resources (incl. chunked/unknown-length) | Request-size bound → 413, enforced before the body is read and via a length-counting pre-read. |
+| Unbounded conversation history | Per-message and aggregate history bounds → 400 before the model. |
 | Cache used to bypass the request budget | The request slot is charged at admission, before the cache; the breaker still trips. |
-| Anonymous visitors exhaust the model budget | Per-subject/per-IP limits + daily request/token/cost breaker (fail-closed), conservative and single-replica-pinned when hosted. |
-| Write/mutation via an anonymous session | Read-only allowlist (403) + write-capable tools stripped from the anonymous tool set. |
+| Cross-subject reply leakage via the response cache | The response cache is disabled (read + write) for Anonymous; identical prompts from two subjects execute independently. |
+| Stored cross-prompt injection via memory | Memory (recall/write/extraction) is disabled for Anonymous in Sprint 1. |
+| Cross-subject telemetry/stream subscription on a hub | `JoinSession` binds/verifies the session to the caller's immutable subject (Finding 6); a different subject is rejected. |
+| Model budget escaped via an alternate route/orchestrator | All alternate LLM routes (`/api/chat/stream`, `/api/council/*`, message-extension) are removed from the anonymous surface; only the single metered `POST /api/chat` pipeline is reachable. |
+| Anonymous visitors exhaust the model budget | Per-subject/global limits + daily request/token/cost breaker (fail-closed), conservative and single-replica-pinned when hosted. |
+| Write/mutation via an anonymous session | Deny-by-default allowlist (403) + write-capable tools stripped from the anonymous tool set. |
 
 ### Sprint 1 files
 
@@ -252,15 +298,29 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
   session-token service, capability policy, usage budget + cost tracker, rate
   limiter.
 - `src/RetailPulse.Api/Security/AnonymousAuthenticationSetup.cs` — scheme + policy.
-- `src/RetailPulse.Api/Middleware/AnonymousGuardMiddleware.cs` — central guard.
+- `src/RetailPulse.Api/Middleware/AnonymousGuardMiddleware.cs` — central guard
+  (deny-by-default allowlist, chunked-safe size bound, limits, breaker).
 - `src/RetailPulse.Api/Endpoints/AnonymousAuthEndpoints.cs` — bootstrap endpoint.
+- `src/RetailPulse.Api/Auth/UserIdentity.cs` — provider-aware, spoof-proof identity
+  resolution (Anonymous `sub` / Entra `oid`; body `objectId` never trusted).
+- `src/RetailPulse.Api/Hubs/SessionOwnershipRegistry.cs` — replica-local hub
+  session→subject ownership binding (Finding 6); consulted by `TelemetryHub` /
+  `StreamingHub`.
+- `src/RetailPulse.Api/Validation/ChatRequestValidator.cs` — history count / per-entry
+  / aggregate bounds.
 - `src/RetailPulse.Api/Auth/AnonymousPrincipalNormalizer.cs`,
-  `Auth/IAnonymousChatPolicy.cs` — normalized principal + tool filter/output cap.
+  `Auth/IAnonymousChatPolicy.cs` — normalized principal + tool filter/output cap +
+  cache/memory-disabled flags.
 - `src/RetailPulse.Api/appsettings.Anonymous.example.json` — a non-live template
   (loaded by no environment; contains no secret).
 - Tests: `tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs`
-  (integration + threat), `Security/AnonymousCapabilityTests.cs` (unit), extended
-  `Security/RateLimitingConfigTests.cs` and
+  (integration + threat, incl. deny-by-default route inventory and chunked-oversized),
+  `Security/AnonymousChatEndpointThreatTests.cs` (REAL `POST /api/chat` endpoint:
+  body-spoof ignored, session isolation, cache-disabled, history bounds),
+  `Security/AnonymousHubOwnershipTests.cs` (hub cross-subject join denied),
+  `Security/AnonymousCapabilityTests.cs` (unit), `Security/UserIdentityTests.cs`,
+  `Security/EndpointAuthorizationCoverageTests.cs` (real route-graph deny-by-default
+  incl. bootstrap + hubs), extended `Security/RateLimitingConfigTests.cs` and
   `Deployment/ProviderNeutralDeploymentContractTests.cs`.
 
 ## Alternatives rejected

--- a/docs/adr/005-provider-neutral-authentication.md
+++ b/docs/adr/005-provider-neutral-authentication.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted (Sprint 0 — foundation only; no live behavior change)
+Accepted (Sprint 0 — foundation only; no live behavior change).
+Extended by the **Sprint 1 addendum** below (Anonymous mode implemented; still
+opt-in, fail-closed, and never deployed — Production stays Entra).
 
 ## Context
 
@@ -80,14 +82,17 @@ Three pieces, all additive:
    - `Entra` → registers the resolved mode for diagnostics, calls the unchanged
      `AddRetailPulseAuthentication`, registers the `IPrincipalNormalizer`, and
      returns `EntraAuthOptions` for the caller to wire the authorization policy;
-   - `GitHub` / `Anonymous` → throws `NotSupportedException` **before any
-     authentication scheme is registered**, so the app can never fall through to
-     Entra, Development, or anonymous access.
+   - `Anonymous` → wires the anonymous session scheme, the constrained
+     authorization policy, and all billable-use guardrails internally, then
+     returns `null` (implemented in Sprint 1 — see the addendum below);
+   - `GitHub` → throws `NotSupportedException` **before any authentication scheme
+     is registered**, so the app can never fall through to Entra, Development, or
+     anonymous access.
 
 This is a deliberate two-layer split: the resolver classifies *unknown/malformed*
-input as a fail-closed error, while the factory classifies *known-but-
-unimplemented* modes (GitHub, Anonymous) as a distinct fail-closed error. The two
-failure classes carry different, precise messages.
+input as a fail-closed error, while the factory classifies a *known-but-
+unimplemented* mode (GitHub) as a distinct fail-closed error. The two failure
+classes carry different, precise messages.
 
 ### Normalized identity and claims model
 
@@ -152,6 +157,112 @@ The three explicit pins are belt-and-suspenders:
 - REST + hub enforcement, `?access_token` hub-only rule, health-only anonymous
   invariant, and Production fail-closed configuration.
 
+## Sprint 1 addendum: Anonymous mode (implemented)
+
+Sprint 1 implements the `Anonymous` mode dispatched by the factory above. It is
+additive, opt-in, and fail-closed; the live/deployed configuration stays `Entra`
+and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode is
+**not deployed** this sprint. Child issue #30, epic #27.
+
+### Explicit activation and fail-closed hosted opt-in
+
+- `Authentication:Mode=Anonymous` is the only switch; no auto-detection/fallback.
+- **Development** may enable it with an ephemeral, process-local HMAC signing key
+  (generated once per process). Sessions do not survive a restart — this is
+  documented, intentional dev behavior, never a hosted fallback.
+- **Any hosted (non-Development) Anonymous deployment** additionally requires a
+  SECOND explicit opt-in, `Anonymous:AllowHosted=true`, PLUS a complete validated
+  guardrail set: a strong configured signing key (≥ 256-bit) and positive daily
+  request/token/cost ceilings. Missing/malformed/unsafe values throw at startup
+  (`AnonymousAuthOptions.FromConfiguration` / `Validate`), so a misconfigured
+  hosted deploy never serves traffic.
+
+### Server-minted session identity (no trusted client header)
+
+- Identity is never taken from a caller-supplied user id. A single, narrowly
+  scoped, per-IP rate-limited bootstrap endpoint
+  (`POST /api/auth/anonymous/session`) mints a fresh, cryptographically random
+  per-session subject (`anon-<base64url>`) SERVER-SIDE.
+- The credential is a compact, short-lived (default 15 min) **HS256 session JWT**
+  with issuer, audience, `provider=Anonymous`, subject, role
+  (`RetailPulse.Anonymous`), scope (`chat_limited`), strict expiry, and a random
+  `jti` — **no PII and no refresh token**. The client re-bootstraps when the TTL
+  elapses, which bounds the replay window to the TTL.
+- The same token is usable as a REST `Authorization: Bearer` and as a SignalR
+  `?access_token` (query token honored **only** on `/hubs/*`). Key rotation is a
+  built-in seam (`AnonymousSigningKeyProvider.ValidationKeys`). The signing key is
+  a secret and is never committed.
+
+### Authorization and normalized principal
+
+- A dedicated authorization policy (registered as both default and fallback)
+  requires an authenticated user, the anonymous role, the anonymous scope, and
+  `provider==Anonymous`. An Entra or any cross-provider token can therefore never
+  satisfy the anonymous policy (authenticated-but-unauthorized → 403).
+- `AnonymousPrincipalNormalizer` projects the token to `provider=Anonymous`, the
+  immutable random subject, and the constrained role/scope — the same
+  `IPrincipalNormalizer` seam Entra uses.
+- Only `/health`, `/alive`, and the bootstrap endpoint are unauthenticated.
+- Sessions are isolated by their random subject; no identity state is shared
+  across sessions.
+
+### Read-only by policy (single source of truth)
+
+- `AnonymousCapabilityPolicy` is data, not UI hiding: a small allowlist of
+  read-only non-GET routes; every other non-GET verb/route is denied by default.
+  A newly added mutation endpoint is therefore denied to anonymous callers unless
+  it is explicitly added to the allowlist.
+- The chat tool set is filtered so write-capable tools (today: `RequestApproval`)
+  are never registered for an anonymous principal — the model cannot invoke a
+  write path.
+
+### Billable-use safeguards
+
+- `AnonymousGuardMiddleware` centrally enforces: read-only (403), request-size
+  bound (413), per-subject and per-IP minute limits (429), a per-request timeout
+  (504), and a global daily request/token/cost **circuit breaker** (503,
+  fail-closed).
+- Accounting is truthful: a request slot is charged **at admission — before the
+  cache is consulted** — so cache hits cannot bypass the request ceiling; token
+  and cost are metered by an `ICostTracker` decorator (`AnonymousBudgetCostTracker`)
+  where cache hits cost zero. Output tokens are capped for anonymous chat.
+- **Replica-local limitation (disclosed):** the ceilings are enforced in
+  replica-local memory. Hosted Anonymous is therefore pinned to `maxReplicas=1`
+  (rationale comment in `infra/modules/container-apps.bicep`) and the ceilings are
+  conservative; counters reset on restart. This is explicitly **NOT** equivalent
+  to authenticated production.
+
+### Sprint 1 threat model additions
+
+| Threat | Mitigation |
+|--------|------------|
+| Spoofed subject via a client header/body | Identity is the signed token subject minted server-side; the guard and normalizer never read a client-supplied id. |
+| Token replay after expiry | Strict short TTL + `ValidateLifetime`; no refresh token; the replay window is bounded by the TTL. |
+| Query token smuggled onto a REST path | `?access_token` is honored only on `/hubs/*`; a REST query token yields no `Authorization` header → 401. |
+| Cross-provider (e.g. Entra) token used for anonymous access | The anonymous policy requires `provider=Anonymous` → 403. |
+| Forged/tampered token | HS256 signature validated against the configured key; wrong signature/issuer/audience → 401. |
+| Oversized request exhausts resources | Request-size bound → 413 before work begins. |
+| Cache used to bypass the request budget | The request slot is charged at admission, before the cache; the breaker still trips. |
+| Anonymous visitors exhaust the model budget | Per-subject/per-IP limits + daily request/token/cost breaker (fail-closed), conservative and single-replica-pinned when hosted. |
+| Write/mutation via an anonymous session | Read-only allowlist (403) + write-capable tools stripped from the anonymous tool set. |
+
+### Sprint 1 files
+
+- `src/RetailPulse.Api/Security/Anonymous/*` — options, signing-key provider,
+  session-token service, capability policy, usage budget + cost tracker, rate
+  limiter.
+- `src/RetailPulse.Api/Security/AnonymousAuthenticationSetup.cs` — scheme + policy.
+- `src/RetailPulse.Api/Middleware/AnonymousGuardMiddleware.cs` — central guard.
+- `src/RetailPulse.Api/Endpoints/AnonymousAuthEndpoints.cs` — bootstrap endpoint.
+- `src/RetailPulse.Api/Auth/AnonymousPrincipalNormalizer.cs`,
+  `Auth/IAnonymousChatPolicy.cs` — normalized principal + tool filter/output cap.
+- `src/RetailPulse.Api/appsettings.Anonymous.example.json` — a non-live template
+  (loaded by no environment; contains no secret).
+- Tests: `tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs`
+  (integration + threat), `Security/AnonymousCapabilityTests.cs` (unit), extended
+  `Security/RateLimitingConfigTests.cs` and
+  `Deployment/ProviderNeutralDeploymentContractTests.cs`.
+
 ## Alternatives rejected
 
 - **SWA-only authentication (Static Web Apps Easy Auth / `.auth`).** Rejected.
@@ -203,8 +314,10 @@ The three explicit pins are belt-and-suspenders:
 1. Authentication never auto-detects a provider. The mode is always explicit
    outside Development.
 2. Outside Development, a missing mode is a startup failure, never a default.
-3. GitHub and Anonymous fail startup until a later sprint implements them; they
-   never fall through to another provider.
+3. GitHub fails startup until a later sprint implements it; it never falls
+   through to another provider. Anonymous is implemented but opt-in and never
+   deployed — a hosted Anonymous deploy fails startup without the second explicit
+   opt-in and complete guardrail configuration.
 4. Production is pinned to `Entra` in base config, Production config, and the azd
    hooks, and a deployment contract test proves those artifacts cannot silently
    select GitHub or Anonymous.
@@ -216,9 +329,9 @@ The three explicit pins are belt-and-suspenders:
 - **Sprint 0 (this ADR):** provider-neutral foundation — mode contract, factory
   boundary routing Entra unchanged, normalized principal, Production Entra pins,
   fail-closed tests. No live behavior change.
-- **Sprint 1:** Anonymous provider with explicit local/hosted opt-in, isolated
-  identities and sessions, disabled write-capable tools, and billable-use
-  ceilings. Production stays Entra.
+- **Sprint 1 (implemented — see addendum above):** Anonymous provider with
+  explicit local/hosted opt-in, isolated identities and sessions, disabled
+  write-capable tools, and billable-use ceilings. Production stays Entra.
 - **Sprint 2:** GitHub provider through a backend confidential OAuth flow,
   short-lived Retail Pulse session tokens, and user/organization allowlists.
   Production stays Entra.

--- a/docs/adr/005-provider-neutral-authentication.md
+++ b/docs/adr/005-provider-neutral-authentication.md
@@ -209,15 +209,23 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 ### Deny-by-default capability allowlist (single source of truth)
 
 - `AnonymousCapabilityPolicy` is data, not UI hiding, and it is **deny-by-default
-  over every (method, route)** — there is no read/GET shortcut. The allowlist is
-  exactly: the unauthenticated bootstrap, authenticated `POST /api/chat`, and the
-  `/hubs/telemetry` + `/hubs/streaming` hubs (plus `OPTIONS` preflight). Everything
+  over every (method, route)** — there is no read/GET shortcut. For Sprint 1 the
+  allowlist is reduced to exactly **two routes**: the unauthenticated bootstrap and
+  authenticated `POST /api/chat` (plus `OPTIONS` preflight). Everything
   else — all observability/admin/export/memory/cards/approvals/guardrail-log routes,
-  every broad GET, and every **alternate LLM/orchestrator route**
+  every broad GET, **both SignalR hubs** (`/hubs/telemetry`, `/hubs/streaming` — at
+  connection and negotiate), and every **alternate LLM/orchestrator route**
   (`/api/chat/stream`, `/api/council/*`, message-extension, scorecard, escalation) —
   returns `403`. A newly added endpoint is denied to anonymous callers unless it is
   explicitly allowlisted, and a runtime endpoint-graph test enumerates the compiled
   route table to prove it.
+- **The hubs are removed from the anonymous surface (Sprint 1 scope reduction).**
+  Anonymous sessions get **no real-time telemetry or token streaming**; a valid
+  anonymous token is denied `403` on both hubs by the guard, and the Sprint 3
+  frontend does not start the hubs in anonymous mode. This retires the whole class of
+  hub exposures (global `Clients.All` broadcast reach and cross-subject group
+  namespace collisions) without touching the Entra hub telemetry path. Entra hub
+  behaviour is unchanged.
 - Read-only data (e.g. charts) is reached **through the filtered chat tool path**,
   not a direct operator endpoint, so subject-scoping and the output/budget controls
   always apply.
@@ -228,6 +236,23 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 - The chat tool set is filtered so write-capable tools (today: `RequestApproval`,
   `RememberPreference`, `SaveMemory`) are never registered for an anonymous
   principal — the model cannot invoke a write path.
+- **Chat-internal intent hard-stops (not reachable by tool filtering).** Two in-process
+  paths do not go through the AI tool set, so the write-tool filter alone cannot stop
+  them; the endpoint therefore refuses them by the router's own classification, before
+  specialist selection/execution:
+  - **Memory management** — the `MemoryManagementAgent` calls
+    `IConversationMemory.StoreAsync`/`ForgetAsync` **directly** (no tools). An anonymous
+    turn classified as `AgentIntent.MemoryManagement` (e.g. `remember that ...`,
+    `forget everything`) returns a standard safe refusal — the agent never runs, no
+    model is called, and zero memory rows are written.
+  - **Consensus council / portfolio health** — the council interception convenes
+    `IConsensusCouncil` (a fan-out of model calls) and returns **early**, which would
+    bypass the single accounted budget/audit/guardrail path. An anonymous turn
+    classified as `AgentIntent.PortfolioHealth` is refused before the council is
+    convened, so `ConveneAsync` is never called. The council interception is the only
+    in-process alternate orchestrator reachable from `POST /api/chat`; the scorecard
+    and escalation orchestrators are not registered as specialist agents and are
+    reachable only via their own `/api` routes, which are already `403`.
 
 ### Provider-aware identity, disabled memory and cache
 
@@ -241,11 +266,11 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 - The **response cache is disabled for Anonymous** (both read and write), so two
   subjects issuing an identical prompt always execute independently and can never
   share a reply.
-- **Hub session ownership (Finding 6):** for an anonymous caller `JoinSession` binds
-  and verifies the session id against the caller's immutable subject via a
-  replica-local `ISessionOwnershipRegistry`; an anonymous attacker cannot join
-  another subject's telemetry/stream group even with a known session id, and card
-  groups are refused. Entra/dev hub behaviour is unchanged.
+- **Hubs are not part of the anonymous surface (Sprint 1).** The former anonymous hub
+  session-ownership binding is moot because a valid anonymous token is denied `403` on
+  both hubs before any hub method runs. This removes the cross-subject
+  telemetry/stream subscription risk entirely rather than mitigating it inside the hub.
+  Entra/dev hub behaviour is unchanged.
 
 ### Billable-use safeguards
 
@@ -258,19 +283,21 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
   aggregate by `ChatRequestValidator` (400 before the model).
 - **ACA proxy / X-Forwarded-For:** behind the Container Apps ingress the connection
   remote IP is the proxy's, not the client's, and `X-Forwarded-For` is **not**
-  trusted (forgeable; no cryptographically verifiable client-IP header). The per-IP
-  limit therefore collapses to a global bucket; bootstrap is deliberately a single
-  **global** conservative window and the **primary** control is the per-subject
-  limit applied after bootstrap.
+  trusted (forgeable; no cryptographically verifiable client-IP header). The bootstrap
+  limiter is therefore a per-replica **global** fixed window (config key
+  `Anonymous:Bootstrap:GlobalPerMinute`, conservative default `5`; the legacy
+  `Anonymous:Bootstrap:PerIpPerMinute` key is still honoured as a
+  backward-compatible fallback), and the **primary** post-bootstrap control is the
+  per-subject limit.
 - Accounting is truthful: a request slot is charged **at admission — before the
   cache is consulted** — so cache hits cannot bypass the request ceiling; token
   and cost are metered by an `ICostTracker` decorator (`AnonymousBudgetCostTracker`)
   where cache hits cost zero. Output tokens are capped for anonymous chat.
-- **Replica-local limitation (disclosed):** the ceilings, rate-limit windows, and
-  the hub session-ownership registry are enforced in replica-local memory. Hosted
+- **Replica-local limitation (disclosed):** the ceilings and rate-limit windows are
+  enforced in replica-local memory. Hosted
   Anonymous is therefore pinned to `maxReplicas=1`
   (rationale comment in `infra/modules/container-apps.bicep`) and the ceilings are
-  conservative; **all of these counters/bindings reset on restart or replica
+  conservative; **all of these counters reset on restart or replica
   replacement.** This is explicitly **NOT** equivalent to authenticated production.
 
 ### Sprint 1 threat model additions
@@ -287,8 +314,10 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 | Cache used to bypass the request budget | The request slot is charged at admission, before the cache; the breaker still trips. |
 | Cross-subject reply leakage via the response cache | The response cache is disabled (read + write) for Anonymous; identical prompts from two subjects execute independently. |
 | Stored cross-prompt injection via memory | Memory (recall/write/extraction) is disabled for Anonymous in Sprint 1. |
-| Cross-subject telemetry/stream subscription on a hub | `JoinSession` binds/verifies the session to the caller's immutable subject (Finding 6); a different subject is rejected. |
+| Cross-subject telemetry/stream subscription on a hub | The SignalR hubs are removed from the anonymous surface — a valid anonymous token is denied `403` on both hubs (connection + negotiate), so no anonymous caller reaches a hub group at all. Entra hub behaviour is unchanged. |
 | Model budget escaped via an alternate route/orchestrator | All alternate LLM routes (`/api/chat/stream`, `/api/council/*`, message-extension) are removed from the anonymous surface; only the single metered `POST /api/chat` pipeline is reachable. |
+| Direct memory write via the memory-management agent (no tool involved) | An anonymous turn classified as `AgentIntent.MemoryManagement` is refused before the agent runs — no `StoreAsync`/`ForgetAsync`, no model call, zero memory rows. |
+| Council fan-out that skips the metered path | An anonymous turn classified as `AgentIntent.PortfolioHealth` is refused before the council interception — `IConsensusCouncil.ConveneAsync` is never called, so there is no unaccounted model fan-out. |
 | Anonymous visitors exhaust the model budget | Per-subject/global limits + daily request/token/cost breaker (fail-closed), conservative and single-replica-pinned when hosted. |
 | Write/mutation via an anonymous session | Deny-by-default allowlist (403) + write-capable tools stripped from the anonymous tool set. |
 
@@ -303,9 +332,12 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 - `src/RetailPulse.Api/Endpoints/AnonymousAuthEndpoints.cs` — bootstrap endpoint.
 - `src/RetailPulse.Api/Auth/UserIdentity.cs` — provider-aware, spoof-proof identity
   resolution (Anonymous `sub` / Entra `oid`; body `objectId` never trusted).
+- `src/RetailPulse.Api/Security/Anonymous/AnonymousChatRestrictions.cs` — intent-level
+  refusals (memory-management, council) applied in `POST /api/chat` before specialist
+  selection and before the council interception.
 - `src/RetailPulse.Api/Hubs/SessionOwnershipRegistry.cs` — replica-local hub
-  session→subject ownership binding (Finding 6); consulted by `TelemetryHub` /
-  `StreamingHub`.
+  session→subject ownership binding, consulted by `TelemetryHub` / `StreamingHub`
+  (retained for the Entra hub path; anonymous callers never reach the hubs).
 - `src/RetailPulse.Api/Validation/ChatRequestValidator.cs` — history count / per-entry
   / aggregate bounds.
 - `src/RetailPulse.Api/Auth/AnonymousPrincipalNormalizer.cs`,
@@ -314,13 +346,19 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 - `src/RetailPulse.Api/appsettings.Anonymous.example.json` — a non-live template
   (loaded by no environment; contains no secret).
 - Tests: `tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs`
-  (integration + threat, incl. deny-by-default route inventory and chunked-oversized),
+  (integration + threat, incl. deny-by-default route inventory, chunked-oversized, and
+  a valid anonymous token → `403` on both hubs at connection + negotiate),
   `Security/AnonymousChatEndpointThreatTests.cs` (REAL `POST /api/chat` endpoint:
   body-spoof ignored, session isolation, cache-disabled, history bounds),
-  `Security/AnonymousHubOwnershipTests.cs` (hub cross-subject join denied),
-  `Security/AnonymousCapabilityTests.cs` (unit), `Security/UserIdentityTests.cs`,
-  `Security/EndpointAuthorizationCoverageTests.cs` (real route-graph deny-by-default
-  incl. bootstrap + hubs), extended `Security/RateLimitingConfigTests.cs` and
+  `Security/AnonymousChatInternalBypassTests.cs` (REAL endpoint: memory-management
+  refusal with zero memory mutation, council refusal with zero `ConveneAsync`, single
+  accounted pipeline with truthful cost/audit),
+  `Security/AnonymousHubOwnershipTests.cs` (Entra hub behaviour unchanged by the
+  anonymous scope reduction),
+  `Security/AnonymousCapabilityTests.cs` (unit — hubs denied), `Security/UserIdentityTests.cs`,
+  `Security/EndpointAuthorizationCoverageTests.cs` (real route-graph deny-by-default —
+  anonymous surface is bootstrap + `POST /api/chat` only, both hubs denied), extended
+  `Security/RateLimitingConfigTests.cs` and
   `Deployment/ProviderNeutralDeploymentContractTests.cs`.
 
 ## Alternatives rejected

--- a/docs/authentication-matrix.md
+++ b/docs/authentication-matrix.md
@@ -15,7 +15,7 @@ resolver is deterministic and never auto-detects a provider.
 |------|-----------------------|------------|
 | `Entra` | Implemented (unchanged) | Supported and pinned |
 | `GitHub` | Declared, not implemented — fails startup | Never enabled |
-| `Anonymous` | Implemented (Sprint 1) — opt-in, fail-closed, never deployed | Never enabled (Entra pinned) |
+| `Anonymous` | Implemented (Sprint 1) — opt-in, fail-closed, not deployed by default (hosted only with `Anonymous:AllowHosted=true`) | Never enabled (Entra pinned) |
 
 ## Mode resolution matrix
 
@@ -46,27 +46,42 @@ Behavior for the `Entra` mode is identical to the pre-foundation implementation.
 
 ## Runtime authorization matrix (Anonymous mode)
 
-Anonymous mode is an **opt-in, fail-closed** capability (never deployed). Identity is a
-server-minted, short-lived session token — never a client-supplied header. The single
-unauthenticated surface besides health is the bootstrap endpoint.
+Anonymous mode is an **opt-in, fail-closed** capability that is **not deployed by
+default** (hosted only behind an explicit `Anonymous:AllowHosted=true` opt-in).
+Identity is a server-minted, short-lived session token — never a client-supplied
+header or body value. The surface is **deny-by-default**: the only reachable routes
+are the unauthenticated bootstrap, authenticated `POST /api/chat`, and the two
+SignalR hubs. There is **no blanket GET allowance** — every other route is `403`.
 
 | Request | Credential | Expected result |
 |---------|-----------|-----------------|
 | `POST /api/auth/anonymous/session` (bootstrap) | none | 200 — mints a short-lived session token (random subject, `provider=Anonymous`, role `RetailPulse.Anonymous`, scope `chat_limited`, no PII, no refresh) |
-| `POST /api/auth/anonymous/session` (bootstrap) | none, over per-IP limit | 429 |
-| Read-only REST (e.g. `GET /api/scorecard`) | valid anonymous session token | 200 |
+| `POST /api/auth/anonymous/session` (bootstrap) | none, over the global bootstrap limit | 429 |
+| `POST /api/chat` (within limits) | valid anonymous session token | 200 — the single allowlisted chat capability, output-token-capped, memory + response-cache disabled |
+| Any broad GET / observability / admin / export / memory / cards / approvals / guardrail-log route (e.g. `GET /api/scorecard`, `GET /api/sessions`, `GET /api/audit`, `GET /api/memory`) | valid anonymous session token | 403 — not on the allowlist (deny-by-default). Read-only data is reached through the filtered chat tool path, not a direct operator endpoint |
+| Alternate LLM / orchestrator routes (`POST /api/chat/stream`, `POST /api/council/convene`) | valid anonymous session token | 403 — removed from the anonymous surface so all model use is accounted through `POST /api/chat` |
 | Protected REST/hub | no token | 401 |
 | Protected REST/hub | malformed / expired / wrong issuer / wrong audience / wrong signature token | 401 |
 | Protected REST/hub | valid-signature token with `provider != Anonymous` (cross-provider) | 403 — the anonymous policy requires `provider=Anonymous` |
-| `/hubs/*` | valid anonymous token via `?access_token` | connects |
+| `/hubs/telemetry`, `/hubs/streaming` | valid anonymous token via `?access_token` | connects |
+| Hub `JoinSession` for a session owned by a **different** subject | valid anonymous token | rejected (`HubException`) — hub groups are namespaced to the caller's immutable subject (Finding 6). Entra behaviour unchanged |
+| Hub `JoinCard` (cards/approvals) | valid anonymous token | rejected — not part of the anonymous surface |
 | REST endpoint | anonymous token via `?access_token` query string only | 401 (query token honored only on `/hubs/*`) |
-| Mutation endpoint / write verb not on the read-only allowlist | valid anonymous token | 403 — Anonymous is read-only, enforced centrally |
+| Chat body carrying a spoofed `user.objectId` | valid anonymous token | ignored — identity is the immutable token `sub`; a body `objectId` is never honoured for an authenticated principal |
 | Chat tool invocation of a write-capable tool (e.g. `RequestApproval`) | valid anonymous token | Tool is not registered for the anonymous principal — never invoked |
-| Read-only chat/query within limits | valid anonymous token | 200, output-token-capped |
-| Read-only chat/query over per-subject or per-IP minute limit | valid anonymous token | 429 |
-| Read-only chat/query after the daily request/token/cost ceiling trips | valid anonymous token | 503 — circuit breaker, fail-closed (cache hits still consume the request slot) |
-| Oversized request body | valid anonymous token | 413 |
+| `POST /api/chat` over per-subject or per-IP minute limit | valid anonymous token | 429 |
+| `POST /api/chat` after the daily request/token/cost ceiling trips | valid anonymous token | 503 — circuit breaker, fail-closed (cache hits still consume the request slot) |
+| Oversized request body (including chunked / unknown-length without `Content-Length`) | valid anonymous token | 413 — enforced before the body is read and via a length-counting pre-read |
+| History over the per-message / aggregate bound | valid anonymous token | 400 — rejected by validation before the model |
 | `/health`, `/alive` | none | 200 |
+
+> **Scope & reset limitation.** The rate-limit windows, daily ceilings, and the hub
+> session-ownership registry are **replica-local, in-memory**. Hosted Anonymous is
+> therefore pinned to `maxReplicas=1`, and all of these counters/bindings **reset on
+> restart or replica replacement**. Behind the ACA ingress the connection IP is the
+> proxy's, not the client's, and `X-Forwarded-For` is not trusted — so the per-IP
+> limit is effectively global and the **primary** control is the per-subject limit
+> applied after bootstrap.
 
 ## Environment behavior
 

--- a/docs/authentication-matrix.md
+++ b/docs/authentication-matrix.md
@@ -49,23 +49,30 @@ Behavior for the `Entra` mode is identical to the pre-foundation implementation.
 Anonymous mode is an **opt-in, fail-closed** capability that is **not deployed by
 default** (hosted only behind an explicit `Anonymous:AllowHosted=true` opt-in).
 Identity is a server-minted, short-lived session token — never a client-supplied
-header or body value. The surface is **deny-by-default**: the only reachable routes
-are the unauthenticated bootstrap, authenticated `POST /api/chat`, and the two
-SignalR hubs. There is **no blanket GET allowance** — every other route is `403`.
+header or body value. The surface is **deny-by-default** and, for Sprint 1, reduced
+to exactly **two routes**: the unauthenticated bootstrap and the authenticated
+`POST /api/chat`. **The SignalR hubs are NOT part of the anonymous surface** — a
+valid anonymous token is denied `403` on both the telemetry and streaming hubs, at
+both the connection and negotiate endpoints. Anonymous sessions therefore have **no
+real-time telemetry or token streaming**; the Sprint 3 frontend does not start the
+hubs in anonymous mode. There is **no blanket GET allowance** — every other route is
+`403`.
 
 | Request | Credential | Expected result |
 |---------|-----------|-----------------|
 | `POST /api/auth/anonymous/session` (bootstrap) | none | 200 — mints a short-lived session token (random subject, `provider=Anonymous`, role `RetailPulse.Anonymous`, scope `chat_limited`, no PII, no refresh) |
 | `POST /api/auth/anonymous/session` (bootstrap) | none, over the global bootstrap limit | 429 |
 | `POST /api/chat` (within limits) | valid anonymous session token | 200 — the single allowlisted chat capability, output-token-capped, memory + response-cache disabled |
+| `POST /api/chat` classified as memory management (e.g. `remember that ...`, `forget everything`) | valid anonymous session token | 200 — standard safe refusal returned **before** the direct-write `MemoryManagementAgent` runs; no `StoreAsync`/`ForgetAsync`, no model call, no memory row written |
+| `POST /api/chat` classified as portfolio health / council | valid anonymous session token | 200 — standard safe refusal returned **before** the consensus-council interception; `IConsensusCouncil.ConveneAsync` is never called, so no council model calls and no accounting bypass |
 | Any broad GET / observability / admin / export / memory / cards / approvals / guardrail-log route (e.g. `GET /api/scorecard`, `GET /api/sessions`, `GET /api/audit`, `GET /api/memory`) | valid anonymous session token | 403 — not on the allowlist (deny-by-default). Read-only data is reached through the filtered chat tool path, not a direct operator endpoint |
 | Alternate LLM / orchestrator routes (`POST /api/chat/stream`, `POST /api/council/convene`) | valid anonymous session token | 403 — removed from the anonymous surface so all model use is accounted through `POST /api/chat` |
+| `/hubs/telemetry`, `/hubs/streaming` — connection (`GET ?access_token=`) | valid anonymous token | **403** — the hubs are not on the anonymous allowlist; the deny-by-default guard blocks the request before the hub runs |
+| `/hubs/telemetry/negotiate`, `/hubs/streaming/negotiate` — negotiate (`POST`) | valid anonymous token | **403** — negotiate is denied on both hubs, same as the connection endpoint |
 | Protected REST/hub | no token | 401 |
 | Protected REST/hub | malformed / expired / wrong issuer / wrong audience / wrong signature token | 401 |
 | Protected REST/hub | valid-signature token with `provider != Anonymous` (cross-provider) | 403 — the anonymous policy requires `provider=Anonymous` |
-| `/hubs/telemetry`, `/hubs/streaming` | valid anonymous token via `?access_token` | connects |
-| Hub `JoinSession` for a session owned by a **different** subject | valid anonymous token | rejected (`HubException`) — hub groups are namespaced to the caller's immutable subject (Finding 6). Entra behaviour unchanged |
-| Hub `JoinCard` (cards/approvals) | valid anonymous token | rejected — not part of the anonymous surface |
+| Hub behaviour for **Entra** callers | valid Entra token | unchanged — the anonymous scope reduction does not alter the Entra real-time surface |
 | REST endpoint | anonymous token via `?access_token` query string only | 401 (query token honored only on `/hubs/*`) |
 | Chat body carrying a spoofed `user.objectId` | valid anonymous token | ignored — identity is the immutable token `sub`; a body `objectId` is never honoured for an authenticated principal |
 | Chat tool invocation of a write-capable tool (e.g. `RequestApproval`) | valid anonymous token | Tool is not registered for the anonymous principal — never invoked |
@@ -75,13 +82,15 @@ SignalR hubs. There is **no blanket GET allowance** — every other route is `40
 | History over the per-message / aggregate bound | valid anonymous token | 400 — rejected by validation before the model |
 | `/health`, `/alive` | none | 200 |
 
-> **Scope & reset limitation.** The rate-limit windows, daily ceilings, and the hub
-> session-ownership registry are **replica-local, in-memory**. Hosted Anonymous is
-> therefore pinned to `maxReplicas=1`, and all of these counters/bindings **reset on
-> restart or replica replacement**. Behind the ACA ingress the connection IP is the
-> proxy's, not the client's, and `X-Forwarded-For` is not trusted — so the per-IP
-> limit is effectively global and the **primary** control is the per-subject limit
-> applied after bootstrap.
+> **Scope & reset limitation.** The rate-limit windows and daily ceilings are
+> **replica-local, in-memory**. Hosted Anonymous is therefore pinned to
+> `maxReplicas=1`, and all of these counters **reset on restart or replica
+> replacement**. Behind the ACA ingress the connection IP is the proxy's, not the
+> client's, and `X-Forwarded-For` is not trusted — so the **bootstrap limiter is a
+> per-replica global window** (config key `Anonymous:Bootstrap:GlobalPerMinute`,
+> conservative default `5`; the legacy `Anonymous:Bootstrap:PerIpPerMinute` key is
+> still honoured as a backward-compatible fallback), and the **primary** post-bootstrap
+> control is the per-subject chat limit.
 
 ## Environment behavior
 
@@ -118,9 +127,11 @@ running without configuration. It never applies outside Development.
 | Mode resolution (all rows above) | `tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs` |
 | Entra wiring + GitHub fail closed at the factory; Anonymous factory wiring | `tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs` |
 | Entra success / 401 / 403 / hubs | `tests/RetailPulse.Tests/Security/EntraAuthenticationTests.cs` |
-| Anonymous bootstrap, token validation, read-only 403, budget/rate breakers, isolation, threat cases | `tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs` |
-| Anonymous options fail-closed validation, token claims (no PII), capability policy, normalizer | `tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs` |
-| REST + both hubs remain protected | `tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs` |
+| Anonymous bootstrap, token validation, read-only 403, **both hubs 403 (connect + negotiate)**, budget/rate breakers, isolation, threat cases | `tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs` |
+| Anonymous options fail-closed validation, token claims (no PII), capability policy (hubs denied), normalizer | `tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs` |
+| Chat-internal bypasses closed: memory-management refusal (zero memory mutation), council refusal (zero `ConveneAsync`), single accounted pipeline with truthful cost/audit | `tests/RetailPulse.Tests/Security/AnonymousChatInternalBypassTests.cs` |
+| Endpoint graph policy: anonymous surface is bootstrap + `POST /api/chat` only; both hubs denied; REST + hubs carry authorization metadata | `tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs` |
+| Entra hub behaviour unchanged by the anonymous scope reduction | `tests/RetailPulse.Tests/Security/AnonymousHubOwnershipTests.cs` |
 | Normalized principal mapping | `tests/RetailPulse.Tests/Security/NormalizedPrincipalTests.cs` |
 | Production / hooks pinned to Entra, never GitHub/Anonymous; single-replica pin | `tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs` |
 

--- a/docs/authentication-matrix.md
+++ b/docs/authentication-matrix.md
@@ -15,7 +15,7 @@ resolver is deterministic and never auto-detects a provider.
 |------|-----------------------|------------|
 | `Entra` | Implemented (unchanged) | Supported and pinned |
 | `GitHub` | Declared, not implemented — fails startup | Never enabled |
-| `Anonymous` | Declared, not implemented — fails startup | Never enabled |
+| `Anonymous` | Implemented (Sprint 1) — opt-in, fail-closed, never deployed | Never enabled (Entra pinned) |
 
 ## Mode resolution matrix
 
@@ -23,7 +23,8 @@ resolver is deterministic and never auto-detects a provider.
 |-----------------------------|-------------|---------|
 | `Entra` (any case) | any | Resolves to `Entra`; wires the existing Entra boundary |
 | `GitHub` (any case) | any | Resolves, then the factory throws `NotSupportedException` — not implemented this sprint |
-| `Anonymous` (any case) | any | Resolves, then the factory throws `NotSupportedException` — not implemented this sprint |
+| `Anonymous` (any case) | Development | Resolves; wires the Anonymous boundary with an ephemeral process-local signing key (sessions die on restart). No hosted guardrails required. |
+| `Anonymous` (any case) | Production (or any non-Development) | Resolves; requires `Anonymous:AllowHosted=true` **plus** a strong signing key (≥ 256-bit) **plus** positive daily request/token/cost ceilings, or startup fails closed |
 | missing / blank | Development | Defaults to `Entra` (documented Development-only default) |
 | missing / blank | Production (or any non-Development) | Startup fails — mode must be pinned explicitly, fails closed |
 | unknown string (for example `Okta`) | any | Startup fails — not a recognized mode |
@@ -43,6 +44,30 @@ Behavior for the `Entra` mode is identical to the pre-foundation implementation.
 | REST endpoint | token via `?access_token` query string only | 401 (query token is honored only on `/hubs/*`) |
 | `/health`, `/alive` | none | 200 (anonymous by design — health-only invariant) |
 
+## Runtime authorization matrix (Anonymous mode)
+
+Anonymous mode is an **opt-in, fail-closed** capability (never deployed). Identity is a
+server-minted, short-lived session token — never a client-supplied header. The single
+unauthenticated surface besides health is the bootstrap endpoint.
+
+| Request | Credential | Expected result |
+|---------|-----------|-----------------|
+| `POST /api/auth/anonymous/session` (bootstrap) | none | 200 — mints a short-lived session token (random subject, `provider=Anonymous`, role `RetailPulse.Anonymous`, scope `chat_limited`, no PII, no refresh) |
+| `POST /api/auth/anonymous/session` (bootstrap) | none, over per-IP limit | 429 |
+| Read-only REST (e.g. `GET /api/scorecard`) | valid anonymous session token | 200 |
+| Protected REST/hub | no token | 401 |
+| Protected REST/hub | malformed / expired / wrong issuer / wrong audience / wrong signature token | 401 |
+| Protected REST/hub | valid-signature token with `provider != Anonymous` (cross-provider) | 403 — the anonymous policy requires `provider=Anonymous` |
+| `/hubs/*` | valid anonymous token via `?access_token` | connects |
+| REST endpoint | anonymous token via `?access_token` query string only | 401 (query token honored only on `/hubs/*`) |
+| Mutation endpoint / write verb not on the read-only allowlist | valid anonymous token | 403 — Anonymous is read-only, enforced centrally |
+| Chat tool invocation of a write-capable tool (e.g. `RequestApproval`) | valid anonymous token | Tool is not registered for the anonymous principal — never invoked |
+| Read-only chat/query within limits | valid anonymous token | 200, output-token-capped |
+| Read-only chat/query over per-subject or per-IP minute limit | valid anonymous token | 429 |
+| Read-only chat/query after the daily request/token/cost ceiling trips | valid anonymous token | 503 — circuit breaker, fail-closed (cache hits still consume the request slot) |
+| Oversized request body | valid anonymous token | 413 |
+| `/health`, `/alive` | none | 200 |
+
 ## Environment behavior
 
 | Environment | Mode source | Auth handler |
@@ -61,19 +86,28 @@ running without configuration. It never applies outside Development.
 - Production is pinned to `Entra` in three independent artifacts (base config,
   Production config, azd hooks). A deployment contract test proves those
   artifacts never emit `GitHub` or `Anonymous`.
-- GitHub and Anonymous are opt-in capabilities for later sprints and are never
-  enabled in production.
+- GitHub is an opt-in capability for a later sprint and is never enabled in
+  production.
+- Anonymous is implemented but **opt-in and never deployed**: any hosted
+  (non-Development) Anonymous deployment fails startup unless a second explicit
+  opt-in (`Anonymous:AllowHosted=true`) and a complete, validated guardrail set
+  (strong signing key + positive daily request/token/cost ceilings) are present.
+  Hosted Anonymous is pinned to a single replica (`maxReplicas=1`) because the
+  billable-use ceilings are replica-local; it is **not** equivalent to
+  authenticated production.
 
 ## Coverage
 
 | Matrix area | Test |
 |-------------|------|
 | Mode resolution (all rows above) | `tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs` |
-| Entra wiring + GitHub/Anonymous fail closed at the factory | `tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs` |
+| Entra wiring + GitHub fail closed at the factory; Anonymous factory wiring | `tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs` |
 | Entra success / 401 / 403 / hubs | `tests/RetailPulse.Tests/Security/EntraAuthenticationTests.cs` |
+| Anonymous bootstrap, token validation, read-only 403, budget/rate breakers, isolation, threat cases | `tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs` |
+| Anonymous options fail-closed validation, token claims (no PII), capability policy, normalizer | `tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs` |
 | REST + both hubs remain protected | `tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs` |
 | Normalized principal mapping | `tests/RetailPulse.Tests/Security/NormalizedPrincipalTests.cs` |
-| Production / hooks pinned to Entra, never GitHub/Anonymous | `tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs` |
+| Production / hooks pinned to Entra, never GitHub/Anonymous; single-replica pin | `tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs` |
 
 See [ADR-005](adr/005-provider-neutral-authentication.md) for the design and
 threat model, and [Entra authentication](authentication-entra.md) for the

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -356,6 +356,20 @@ built-in rate limiter. Acceptable for a throwaway demo; do **not** use this post
 anything with real data or cost exposure. Set `Security__RequireAuth=true` (and wire an
 identity provider) for non-demo environments.
 
+> **Anonymous mode is a safer alternative to this posture, but is not deployed.**
+> Sprint 1 adds a first-class, fail-closed `Authentication:Mode=Anonymous` provider
+> (server-minted short-lived session tokens, read-only enforcement, per-subject/per-IP
+> rate limits, and a daily request/token/cost circuit breaker) — see
+> [security.md → Anonymous mode](security.md#anonymous-mode-opt-in-never-deployed) and
+> [ADR-005](adr/005-provider-neutral-authentication.md). Unlike `Security__RequireAuth=false`,
+> it does not leave the model surface unauthenticated. It is **not** enabled by any
+> deployment artifact this sprint: `appsettings.Production.json`, the Bicep, and the azd
+> postprovision hooks all remain pinned to `Entra`, and a deployment-contract test asserts
+> the hooks never configure Anonymous guardrails. A hosted Anonymous enable would be a
+> deliberate, separate decision requiring `Anonymous:AllowHosted=true`, a strong signing
+> key, positive daily ceilings, and — because the ceilings are replica-local — a single
+> replica (`maxReplicas=1`). It is not equivalent to authenticated production.
+
 ### Frontend → API routing and SignalR
 
 The postprovision hook idempotently links the ACA API as the Static Web App backend,

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -244,6 +244,16 @@ All three Container Apps use `minReplicas: 0` / `maxReplicas: 1`. Consequences:
   (proactive alerts) only run while a replica is live. The SQLite stores
   (cost, audit, memory, approvals, alerts) live in the replica's local temp
   directory and reset the same way — there is **no** durable volume (see below).
+- **Anonymous mode (if opted-in) is replica-local too:** Anonymous mode is
+  **not deployed by default** and is permitted hosted only behind the explicit
+  `Anonymous:AllowHosted=true` opt-in. When enabled, its daily request/token/cost
+  **ceilings**, its **rate-limit windows** (including the global bootstrap window),
+  and the **hub session-ownership registry** are all held in replica-local memory
+  and **reset on restart or replica replacement**. This is exactly why hosted
+  Anonymous requires `maxReplicas: 1` (a single writer/counter owner) and ships with
+  conservative limits — it is explicitly not equivalent to authenticated production.
+  See [ADR-005](adr/005-provider-neutral-authentication.md) and the
+  [authentication matrix](authentication-matrix.md).
 - **SignalR:** the Teams Bot holds a persistent SignalR connection to the API telemetry
   hub, and the frontend connects to `/hubs/telemetry` and `/hubs/streaming`. An active
   SignalR/WebSocket connection keeps the API replica warm; once all clients disconnect

--- a/docs/security.md
+++ b/docs/security.md
@@ -70,9 +70,12 @@ The active identity provider is chosen through the `Authentication:Mode`
 configuration key (`Authentication__Mode`). Resolution is deterministic and
 fails closed — it never auto-detects a provider:
 
-- `Entra` (the only implemented mode) routes to the unchanged Entra boundary.
-- `GitHub` and `Anonymous` are declared but not implemented in this sprint;
-  selecting either fails startup and never falls through to another provider.
+- `Entra` (the production mode) routes to the unchanged Entra boundary.
+- `Anonymous` is implemented (Sprint 1) as an **opt-in, fail-closed, never
+  deployed** capability — see [Anonymous mode](#anonymous-mode-opt-in-never-deployed)
+  below.
+- `GitHub` is declared but not implemented in this sprint; selecting it fails
+  startup and never falls through to another provider.
 - A missing mode defaults to `Entra` **only in Development**. Outside
   Development a missing, unknown, or malformed mode fails startup.
 
@@ -80,6 +83,39 @@ Production pins `Authentication__Mode=Entra` explicitly in
 `appsettings.Production.json` and the azd postprovision hooks. See
 [ADR-005](adr/005-provider-neutral-authentication.md) and the
 [authentication matrix](authentication-matrix.md).
+
+### Anonymous mode (opt-in, never deployed)
+
+Anonymous mode lets a future self-serve frontend (Sprint 3) reach the read-only
+chat/query surface without an identity provider. It is additive and fail-closed;
+**live deployment artifacts stay Entra** and are proven so by deployment-contract
+tests. It is not deployed this sprint.
+
+- **Two-key hosted activation.** `Authentication:Mode=Anonymous` enables it;
+  Development may run with an ephemeral process-local signing key (sessions die on
+  restart). Any hosted/non-Development Anonymous deployment additionally requires
+  `Anonymous:AllowHosted=true` **and** a strong signing key (≥ 256-bit) **and**
+  positive daily request/token/cost ceilings, or startup fails closed.
+- **Server-minted identity.** A per-IP rate-limited bootstrap endpoint
+  (`POST /api/auth/anonymous/session`) issues a short-lived (default 15 min) HS256
+  session token with a cryptographically random subject, `provider=Anonymous`,
+  role `RetailPulse.Anonymous`, scope `chat_limited`, strict expiry, no PII, and
+  no refresh token. It works as a REST bearer and a SignalR `?access_token`
+  (query token honored only on `/hubs/*`). The signing key is a secret, never
+  committed.
+- **Constrained authorization.** A dedicated policy requires
+  `provider=Anonymous` + the anonymous role + scope, so Entra/cross-provider
+  tokens can never satisfy it. Only health and the bootstrap endpoint are
+  unauthenticated.
+- **Read-only + billable-use safeguards.** `AnonymousGuardMiddleware` centrally
+  enforces read-only (403), request size (413), per-subject/per-IP minute limits
+  (429), a per-request timeout, and a daily request/token/cost circuit breaker
+  (503, fail-closed). Request slots are charged before the cache so cache hits
+  cannot bypass the ceiling; output tokens are capped; write-capable chat tools
+  are stripped from the anonymous tool set.
+- **Limitation.** Ceilings are replica-local, so hosted Anonymous is pinned to
+  `maxReplicas=1` with conservative limits and is **not** equivalent to
+  authenticated production; counters reset on restart.
 
 ### Development
 - `DevelopmentAuthHandler` bypasses all authentication

--- a/docs/security.md
+++ b/docs/security.md
@@ -88,17 +88,21 @@ Production pins `Authentication__Mode=Entra` explicitly in
 ### Anonymous mode (opt-in, fail-closed)
 
 Anonymous mode lets a future self-serve frontend (Sprint 3) reach a **single
-chat capability** — authenticated `POST /api/chat` plus the two SignalR hubs that
-carry that chat's telemetry/streaming — without an identity provider. It is
-additive and fail-closed. Hosted Anonymous **is permitted only behind an explicit
+chat capability** — authenticated `POST /api/chat` — without an identity provider.
+It is additive and fail-closed. In Sprint 1 the **SignalR hubs are NOT part of the
+anonymous surface**: anonymous sessions have no real-time telemetry or token
+streaming, and a valid anonymous token is denied `403` on both hubs. Hosted
+Anonymous **is permitted only behind an explicit
 opt-in** (`Anonymous:AllowHosted=true`); by default it is never deployed, and the
 **live deployment artifacts stay Entra**, proven so by deployment-contract tests.
 It is not deployed this sprint.
 
 - **Smallest useful surface (deny-by-default).** The anonymous surface is exactly
-  three things: the unauthenticated bootstrap, authenticated `POST /api/chat`, and
-  the `/hubs/telemetry` + `/hubs/streaming` hubs. **Every other (method, route) is
-  `403`** — there is **no blanket GET allowance**. Observability, admin, export,
+  **two routes**: the unauthenticated bootstrap and authenticated `POST /api/chat`.
+  **Every other (method, route) is
+  `403`** — there is **no blanket GET allowance**, and **both SignalR hubs
+  (`/hubs/telemetry`, `/hubs/streaming`) are denied** at connection and negotiate.
+  Observability, admin, export,
   memory, cards, approvals, guardrail logs, `/api/chat/stream`, council, scorecard,
   escalation and the message-extension endpoints are all forbidden. Read-only data
   (e.g. charts) is reached **through the filtered chat tool path**, never a direct
@@ -139,21 +143,30 @@ It is not deployed this sprint.
   cap and the write-capable-tool filter apply to the whole anonymous surface; there
   is no alternate orchestrator or billable route to escape them. History length is
   bounded per-message and in aggregate (validation `400` before the model).
-- **Hub session ownership (Finding 6).** For an anonymous caller a hub `JoinSession`
-  binds/verifies the session against the caller's immutable subject, so an anonymous
-  attacker cannot subscribe to another subject's telemetry/stream even with a known
-  session id. Card/approval hub groups are refused for Anonymous. Entra hub
-  behaviour is unchanged.
-- **ACA proxy / per-IP limitation.** Behind the Azure Container Apps ingress the
-  connection remote IP is the **proxy's**, not the client's, and `X-Forwarded-For`
+- **Chat-internal intent hard-stops.** Two in-process paths do not use the AI tool
+  set, so the write-tool filter cannot reach them; the endpoint refuses them by the
+  router's own classification, before specialist selection: a memory-management turn
+  (the `MemoryManagementAgent` calls `StoreAsync`/`ForgetAsync` directly) returns a
+  safe refusal with **no memory write and no model call**, and a portfolio-health turn
+  is refused **before the consensus-council interception**, so `ConveneAsync` is never
+  called and no unaccounted council model fan-out occurs.
+- **Hubs are not part of the anonymous surface.** A valid anonymous token is denied
+  `403` on both hubs (connection + negotiate), so no anonymous caller reaches a hub
+  group at all — this retires the global-broadcast and cross-subject group-collision
+  risk without touching the Entra hub telemetry path. **Entra hub behaviour is
+  unchanged.**
+- **ACA proxy / bootstrap limiter.** Behind the Azure Container Apps ingress the
+  connection remote IP is the proxy's, not the client's, and `X-Forwarded-For`
   is **not** trusted (it is forgeable and ACA gives no cryptographically verifiable
-  client-IP header). Per-IP limits therefore collapse to a global bucket in
-  practice; bootstrap is intentionally a single **global** conservative window and
-  the **primary** abuse control is the **per-subject** limit applied after bootstrap.
-- **Limitation.** Ceilings, rate-limit windows, and the hub session-ownership
-  registry are **replica-local, in-memory**, so hosted Anonymous is pinned to
+  client-IP header). The bootstrap limiter is therefore a per-replica **global**
+  window (config key `Anonymous:Bootstrap:GlobalPerMinute`, conservative default `5`;
+  the legacy `Anonymous:Bootstrap:PerIpPerMinute` key is still honoured as a
+  backward-compatible fallback), and the **primary** abuse control is the
+  **per-subject** limit applied after bootstrap.
+- **Limitation.** Ceilings and rate-limit windows are **replica-local, in-memory**,
+  so hosted Anonymous is pinned to
   `maxReplicas=1` with conservative limits and is **not** equivalent to
-  authenticated production; **all of these counters/bindings reset on restart or
+  authenticated production; **all of these counters reset on restart or
   replica replacement**.
 
 ### Development

--- a/docs/security.md
+++ b/docs/security.md
@@ -71,9 +71,10 @@ configuration key (`Authentication__Mode`). Resolution is deterministic and
 fails closed — it never auto-detects a provider:
 
 - `Entra` (the production mode) routes to the unchanged Entra boundary.
-- `Anonymous` is implemented (Sprint 1) as an **opt-in, fail-closed, never
-  deployed** capability — see [Anonymous mode](#anonymous-mode-opt-in-never-deployed)
-  below.
+- `Anonymous` is implemented (Sprint 1) as an **opt-in, fail-closed** capability
+  that is **not deployed by default** (hosted only behind an explicit
+  `Anonymous:AllowHosted=true` opt-in) — see
+  [Anonymous mode](#anonymous-mode-opt-in-fail-closed) below.
 - `GitHub` is declared but not implemented in this sprint; selecting it fails
   startup and never falls through to another provider.
 - A missing mode defaults to `Entra` **only in Development**. Outside
@@ -84,38 +85,76 @@ Production pins `Authentication__Mode=Entra` explicitly in
 [ADR-005](adr/005-provider-neutral-authentication.md) and the
 [authentication matrix](authentication-matrix.md).
 
-### Anonymous mode (opt-in, never deployed)
+### Anonymous mode (opt-in, fail-closed)
 
-Anonymous mode lets a future self-serve frontend (Sprint 3) reach the read-only
-chat/query surface without an identity provider. It is additive and fail-closed;
-**live deployment artifacts stay Entra** and are proven so by deployment-contract
-tests. It is not deployed this sprint.
+Anonymous mode lets a future self-serve frontend (Sprint 3) reach a **single
+chat capability** — authenticated `POST /api/chat` plus the two SignalR hubs that
+carry that chat's telemetry/streaming — without an identity provider. It is
+additive and fail-closed. Hosted Anonymous **is permitted only behind an explicit
+opt-in** (`Anonymous:AllowHosted=true`); by default it is never deployed, and the
+**live deployment artifacts stay Entra**, proven so by deployment-contract tests.
+It is not deployed this sprint.
 
+- **Smallest useful surface (deny-by-default).** The anonymous surface is exactly
+  three things: the unauthenticated bootstrap, authenticated `POST /api/chat`, and
+  the `/hubs/telemetry` + `/hubs/streaming` hubs. **Every other (method, route) is
+  `403`** — there is **no blanket GET allowance**. Observability, admin, export,
+  memory, cards, approvals, guardrail logs, `/api/chat/stream`, council, scorecard,
+  escalation and the message-extension endpoints are all forbidden. Read-only data
+  (e.g. charts) is reached **through the filtered chat tool path**, never a direct
+  operator endpoint. A runtime endpoint-graph test enumerates every mapped route and
+  proves deny-by-default.
 - **Two-key hosted activation.** `Authentication:Mode=Anonymous` enables it;
   Development may run with an ephemeral process-local signing key (sessions die on
   restart). Any hosted/non-Development Anonymous deployment additionally requires
   `Anonymous:AllowHosted=true` **and** a strong signing key (≥ 256-bit) **and**
   positive daily request/token/cost ceilings, or startup fails closed.
-- **Server-minted identity.** A per-IP rate-limited bootstrap endpoint
+- **Server-minted identity.** A bootstrap endpoint
   (`POST /api/auth/anonymous/session`) issues a short-lived (default 15 min) HS256
   session token with a cryptographically random subject, `provider=Anonymous`,
   role `RetailPulse.Anonymous`, scope `chat_limited`, strict expiry, no PII, and
   no refresh token. It works as a REST bearer and a SignalR `?access_token`
   (query token honored only on `/hubs/*`). The signing key is a secret, never
-  committed.
+  committed. Bootstrap is throttled by a **single global conservative** rate limit
+  (see the ACA/proxy note below), not per-client-IP.
+- **Provider-aware, spoof-proof identity.** Identity is resolved per provider:
+  Anonymous → the immutable server-minted `sub`; Entra → the immutable `oid`. A
+  request-body `objectId` is **never** honoured for any authenticated principal, so
+  two anonymous sessions cannot be conflated or spoofed. **Memory is disabled for
+  Anonymous** (no read, write, or extraction) to eliminate stored cross-prompt
+  injection, and the **response cache is disabled for Anonymous** so identical
+  prompts from different subjects can never share a reply.
 - **Constrained authorization.** A dedicated policy requires
   `provider=Anonymous` + the anonymous role + scope, so Entra/cross-provider
   tokens can never satisfy it. Only health and the bootstrap endpoint are
   unauthenticated.
-- **Read-only + billable-use safeguards.** `AnonymousGuardMiddleware` centrally
-  enforces read-only (403), request size (413), per-subject/per-IP minute limits
-  (429), a per-request timeout, and a daily request/token/cost circuit breaker
-  (503, fail-closed). Request slots are charged before the cache so cache hits
-  cannot bypass the ceiling; output tokens are capped; write-capable chat tools
-  are stripped from the anonymous tool set.
-- **Limitation.** Ceilings are replica-local, so hosted Anonymous is pinned to
+- **Central enforcement + billable-use safeguards.** `AnonymousGuardMiddleware`
+  centrally enforces the deny-by-default allowlist (403), request size (413 —
+  enforced before the body is read and via a length-counting pre-read, so a
+  chunked/unknown-length body without `Content-Length` cannot bypass it),
+  per-subject/per-IP minute limits (429), a per-request timeout, and a daily
+  request/token/cost circuit breaker (503, fail-closed). Request slots are charged
+  before the cache so cache hits cannot bypass the ceiling. Because only the single
+  `AgentExecutionPipeline` behind `POST /api/chat` is reachable, the output-token
+  cap and the write-capable-tool filter apply to the whole anonymous surface; there
+  is no alternate orchestrator or billable route to escape them. History length is
+  bounded per-message and in aggregate (validation `400` before the model).
+- **Hub session ownership (Finding 6).** For an anonymous caller a hub `JoinSession`
+  binds/verifies the session against the caller's immutable subject, so an anonymous
+  attacker cannot subscribe to another subject's telemetry/stream even with a known
+  session id. Card/approval hub groups are refused for Anonymous. Entra hub
+  behaviour is unchanged.
+- **ACA proxy / per-IP limitation.** Behind the Azure Container Apps ingress the
+  connection remote IP is the **proxy's**, not the client's, and `X-Forwarded-For`
+  is **not** trusted (it is forgeable and ACA gives no cryptographically verifiable
+  client-IP header). Per-IP limits therefore collapse to a global bucket in
+  practice; bootstrap is intentionally a single **global** conservative window and
+  the **primary** abuse control is the **per-subject** limit applied after bootstrap.
+- **Limitation.** Ceilings, rate-limit windows, and the hub session-ownership
+  registry are **replica-local, in-memory**, so hosted Anonymous is pinned to
   `maxReplicas=1` with conservative limits and is **not** equivalent to
-  authenticated production; counters reset on restart.
+  authenticated production; **all of these counters/bindings reset on restart or
+  replica replacement**.
 
 ### Development
 - `DevelopmentAuthHandler` bypasses all authentication

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -49,6 +49,13 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       // replacement, new revisions, or scale-to-zero. maxReplicas: 1 keeps a single
       // SQLite writer; see docs/deployment-azd.md for the policy-compatible durable
       // options under evaluation.
+      //
+      // maxReplicas: 1 is ALSO a hard requirement for the (non-Production) Anonymous
+      // authentication mode: its billable-use circuit breaker (daily request/token/cost
+      // ceilings) is replica-local in-memory state, so exact global enforcement only
+      // holds with a single replica. This live deployment stays Authentication:Mode=Entra;
+      // the constraint is documented here so a future Anonymous demo deployment cannot
+      // scale out and silently bypass the ceilings. See docs/adr/005 and docs/security.md.
       scale: {
         minReplicas: 0
         maxReplicas: 1

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -52,8 +52,10 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       //
       // maxReplicas: 1 is ALSO a hard requirement for the (non-Production) Anonymous
       // authentication mode: its billable-use circuit breaker (daily request/token/cost
-      // ceilings) is replica-local in-memory state, so exact global enforcement only
-      // holds with a single replica. This live deployment stays Authentication:Mode=Entra;
+      // ceilings), its rate-limit windows (including the global bootstrap limiter), and
+      // its hub session-ownership registry are all replica-local in-memory state, so exact
+      // global enforcement only holds with a single replica (and all of it resets on
+      // restart or replica replacement). This live deployment stays Authentication:Mode=Entra;
       // the constraint is documented here so a future Anonymous demo deployment cannot
       // scale out and silently bypass the ceilings. See docs/adr/005 and docs/security.md.
       scale: {

--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.AI;
+using RetailPulse.Api.Auth;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Middleware;
 using RetailPulse.Api.Telemetry;
@@ -26,6 +27,7 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
     private readonly ILogger<AgentExecutionPipeline> _logger;
     private readonly RetailPulseMetrics? _metrics;
     private readonly StreamingProgressFeature _streamingFeature;
+    private readonly IAnonymousChatPolicy? _anonymousChatPolicy;
 
     private static readonly JsonSerializerOptions _caseInsensitiveOptions = new() { PropertyNameCaseInsensitive = true };
 
@@ -45,7 +47,8 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         StreamingProgressFeature? streamingFeature,
         IConfiguration configuration,
         ILogger<AgentExecutionPipeline> logger,
-        RetailPulseMetrics? metrics = null)
+        RetailPulseMetrics? metrics = null,
+        IAnonymousChatPolicy? anonymousChatPolicy = null)
     {
         _chatClient = chatClient;
         _hubContext = hubContext;
@@ -54,6 +57,7 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         _configuration = configuration;
         _logger = logger;
         _metrics = metrics;
+        _anonymousChatPolicy = anonymousChatPolicy;
     }
 
     /// <summary>
@@ -85,8 +89,9 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         var chatOptions = new ChatOptions
         {
             Temperature = context.Temperature,
-            Tools = [.. context.Tools.Select(t => t is AIFunction fn ? new TimedAIFunction(fn) : t)]
+            Tools = [.. _anonymousChatPolicy.ApplyToolFilter(context.Tools).Select(t => t is AIFunction fn ? new TimedAIFunction(fn) : t)]
         };
+        _anonymousChatPolicy.ApplyOutputCap(chatOptions);
 
         string systemPrompt = BuildSystemPromptWithPrefetch(context.SystemPrompt, context.PrefetchedData);
         List<ChatMessage> messages = BuildMessages(systemPrompt, request);
@@ -256,13 +261,15 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
 
         // Wrap tools with instrumentation for real-time per-tool progress events
         var instrumentedToolMiddleware = new InstrumentedToolMiddleware(_hubContext);
-        IReadOnlyList<AITool> instrumentedTools = instrumentedToolMiddleware.WrapTools(context.Tools, sessionId);
+        IEnumerable<AITool> allowedTools = _anonymousChatPolicy.ApplyToolFilter(context.Tools);
+        IReadOnlyList<AITool> instrumentedTools = instrumentedToolMiddleware.WrapTools(allowedTools, sessionId);
 
         var chatOptions = new ChatOptions
         {
             Temperature = context.Temperature,
             Tools = [.. instrumentedTools]
         };
+        _anonymousChatPolicy.ApplyOutputCap(chatOptions);
 
         string systemPrompt = BuildSystemPromptWithPrefetch(context.SystemPrompt, context.PrefetchedData);
         List<ChatMessage> messages = BuildMessages(systemPrompt, request);

--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
@@ -27,7 +27,7 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
     private readonly ILogger<AgentExecutionPipeline> _logger;
     private readonly RetailPulseMetrics? _metrics;
     private readonly StreamingProgressFeature _streamingFeature;
-    private readonly IAnonymousChatPolicy? _anonymousChatPolicy;
+    private readonly IAnonymousChatPolicy _anonymousChatPolicy;
 
     private static readonly JsonSerializerOptions _caseInsensitiveOptions = new() { PropertyNameCaseInsensitive = true };
 
@@ -47,8 +47,8 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         StreamingProgressFeature? streamingFeature,
         IConfiguration configuration,
         ILogger<AgentExecutionPipeline> logger,
-        RetailPulseMetrics? metrics = null,
-        IAnonymousChatPolicy? anonymousChatPolicy = null)
+        RetailPulseMetrics? metrics,
+        IAnonymousChatPolicy anonymousChatPolicy)
     {
         _chatClient = chatClient;
         _hubContext = hubContext;
@@ -57,12 +57,15 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         _configuration = configuration;
         _logger = logger;
         _metrics = metrics;
-        _anonymousChatPolicy = anonymousChatPolicy;
+        _anonymousChatPolicy = anonymousChatPolicy
+            ?? throw new ArgumentNullException(nameof(anonymousChatPolicy));
     }
 
     /// <summary>
     /// Simplified constructor for backward compatibility (tests and legacy code).
-    /// Streaming progress is disabled when using this constructor.
+    /// Streaming progress is disabled when using this constructor, and the provider-neutral
+    /// <see cref="NoOpAnonymousChatPolicy"/> is applied (no Anonymous tool-stripping or output cap).
+    /// Production DI must use the primary constructor and supply the resolved policy explicitly.
     /// </summary>
     public AgentExecutionPipeline(
         IChatClient chatClient,
@@ -70,7 +73,7 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         IConfiguration configuration,
         ILogger<AgentExecutionPipeline> logger,
         RetailPulseMetrics? metrics = null)
-        : this(chatClient, hubContext, null, null, configuration, logger, metrics)
+        : this(chatClient, hubContext, null, null, configuration, logger, metrics, NoOpAnonymousChatPolicy.Instance)
     {
     }
 

--- a/src/RetailPulse.Api/Agents/RetailPulseAgent.cs
+++ b/src/RetailPulse.Api/Agents/RetailPulseAgent.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using RetailPulse.Api.Agents.Specialists;
+using RetailPulse.Api.Auth;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Models;
 using RetailPulse.Contracts;
@@ -40,7 +41,9 @@ public class RetailPulseAgent
             streamingHubContext,
             streamingFeature,
             configuration,
-            pipelineLogger);
+            pipelineLogger,
+            metrics: null,
+            anonymousChatPolicy: NoOpAnonymousChatPolicy.Instance);
         _generalAgent = new GeneralAgent(_pipeline, agentDef, tools);
     }
 

--- a/src/RetailPulse.Api/Agents/RoutingServiceExtensions.cs
+++ b/src/RetailPulse.Api/Agents/RoutingServiceExtensions.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using RetailPulse.Api.Agents.Routing;
 using RetailPulse.Api.Agents.Specialists;
 using RetailPulse.Api.Alerts;
+using RetailPulse.Api.Auth;
 using RetailPulse.Api.Caching;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Models;
@@ -47,6 +49,14 @@ public static class RoutingServiceExtensions
         // Register the scoped streaming progress feature
         services.AddScoped<StreamingProgressFeature>();
 
+        // Guarantee an IAnonymousChatPolicy is always resolvable wherever the pipeline is composed.
+        // Anonymous mode registers the real AnonymousChatPolicy earlier (see
+        // ProviderNeutralAuthentication.AddAnonymousMode), so this TryAdd is a no-op there and the
+        // constrained policy wins. In Entra/Development the provider-neutral no-op is used. This
+        // makes the pipeline's non-optional policy dependency satisfiable in every composition —
+        // an omitted policy is a startup resolution failure, never a silent null runtime bypass.
+        services.TryAddSingleton<IAnonymousChatPolicy, NoOpAnonymousChatPolicy>();
+
         // Register the shared execution pipeline
         services.AddScoped<IAgentExecutionPipeline>(sp =>
         {
@@ -57,7 +67,8 @@ public static class RoutingServiceExtensions
             IConfiguration configuration = sp.GetRequiredService<IConfiguration>();
             ILogger<AgentExecutionPipeline> logger = sp.GetRequiredService<ILogger<AgentExecutionPipeline>>();
             RetailPulseMetrics? metrics = sp.GetService<RetailPulseMetrics>();
-            return new AgentExecutionPipeline(chatClient, hubContext, streamingHubContext, streamingFeature, configuration, logger, metrics);
+            IAnonymousChatPolicy anonymousChatPolicy = sp.GetRequiredService<IAnonymousChatPolicy>();
+            return new AgentExecutionPipeline(chatClient, hubContext, streamingHubContext, streamingFeature, configuration, logger, metrics, anonymousChatPolicy);
         });
 
         // Register GeneralAgent as ISpecialistAgent

--- a/src/RetailPulse.Api/Auth/AnonymousPrincipalNormalizer.cs
+++ b/src/RetailPulse.Api/Auth/AnonymousPrincipalNormalizer.cs
@@ -1,0 +1,61 @@
+using System.Security.Claims;
+using Microsoft.IdentityModel.JsonWebTokens;
+using RetailPulse.Api.Security;
+using RetailPulse.Api.Security.Anonymous;
+
+namespace RetailPulse.Api.Auth;
+
+/// <summary>
+/// Maps a validated anonymous session <see cref="ClaimsPrincipal"/> onto the provider-neutral
+/// <see cref="NormalizedPrincipal"/>.
+///
+/// The subject comes exclusively from the server-signed token's <c>sub</c> claim — the immutable,
+/// cryptographically random per-session id minted by <see cref="AnonymousSessionTokenService"/>.
+/// A caller-supplied user id (request body or header) is NEVER used as identity, so anonymous
+/// sessions cannot spoof or collide with one another. Roles and scopes are pinned to the
+/// constrained anonymous set and provider is always <c>Anonymous</c>.
+/// </summary>
+public sealed class AnonymousPrincipalNormalizer : IPrincipalNormalizer
+{
+    public AuthenticationMode Mode => AuthenticationMode.Anonymous;
+
+    public NormalizedPrincipal Normalize(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        string? subject =
+            principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            throw new InvalidOperationException(
+                "Cannot normalize an anonymous principal without a server-issued subject claim.");
+        }
+
+        // Defense in depth: the token must carry the anonymous provider stamp. A token from any
+        // other provider must never normalize as Anonymous.
+        string? provider = principal.FindFirst(AnonymousCapabilityPolicy.ProviderClaimType)?.Value;
+        if (!string.Equals(provider, AnonymousCapabilityPolicy.ProviderName, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Cannot normalize a principal whose provider claim is not 'Anonymous'.");
+        }
+
+        string[] roles = [.. principal.FindAll("roles").Select(c => c.Value)
+            .Concat(principal.FindAll(ClaimTypes.Role).Select(c => c.Value))
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Distinct(StringComparer.Ordinal)];
+
+        string[] scopes = [.. principal.FindAll("scp").Select(c => c.Value)
+            .SelectMany(v => v.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Distinct(StringComparer.Ordinal)];
+
+        return new NormalizedPrincipal(
+            Provider: AnonymousCapabilityPolicy.ProviderName,
+            Subject: subject,
+            DisplayName: null,
+            Roles: roles,
+            Scopes: scopes);
+    }
+}

--- a/src/RetailPulse.Api/Auth/IAnonymousChatPolicy.cs
+++ b/src/RetailPulse.Api/Auth/IAnonymousChatPolicy.cs
@@ -75,6 +75,31 @@ public sealed class AnonymousChatPolicy : IAnonymousChatPolicy
 }
 
 /// <summary>
+/// Provider-neutral no-op chat policy. Registered as the default <see cref="IAnonymousChatPolicy"/>
+/// in every non-Anonymous composition (Entra/Development) so the execution pipeline can take a
+/// non-optional policy dependency without any mode having to special-case a null. It is a strict
+/// passthrough: it never claims to apply to a request, never disables cache or memory, never strips
+/// a tool, and never caps output tokens. This makes Anonymous constraints opt-in via
+/// <see cref="AnonymousChatPolicy"/> while guaranteeing every DI composition supplies a policy —
+/// omission becomes a compile/resolution failure rather than a silently-null runtime bypass.
+/// </summary>
+public sealed class NoOpAnonymousChatPolicy : IAnonymousChatPolicy
+{
+    /// <summary>Shared stateless instance for convenience constructors and tests.</summary>
+    public static readonly NoOpAnonymousChatPolicy Instance = new();
+
+    public bool AppliesToCurrentRequest => false;
+
+    public bool CacheDisabled => false;
+
+    public bool MemoryDisabled => false;
+
+    public IEnumerable<AITool> FilterTools(IEnumerable<AITool> tools) => tools;
+
+    public int? MaxOutputTokens => null;
+}
+
+/// <summary>
 /// Null-safe helpers so the execution pipeline can apply the anonymous policy uniformly whether or
 /// not one is registered. When the policy is null (non-Anonymous modes) tools pass through
 /// unchanged and no output cap is applied.

--- a/src/RetailPulse.Api/Auth/IAnonymousChatPolicy.cs
+++ b/src/RetailPulse.Api/Auth/IAnonymousChatPolicy.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.AI;
+using RetailPulse.Api.Security.Anonymous;
+
+namespace RetailPulse.Api.Auth;
+
+/// <summary>
+/// Applies Anonymous-mode constraints to a chat/agent execution: it strips write-capable tools so
+/// the model can never invoke a mutation, and it caps model output tokens. It is consulted by the
+/// <c>AgentExecutionPipeline</c> at every point where the tool set and chat options are assembled.
+///
+/// The decision is made from the CURRENT request principal (resolved via
+/// <see cref="IHttpContextAccessor"/>): only an authenticated Anonymous session is constrained.
+/// Any other principal (Entra) is unaffected — this is a strict narrowing that never grants
+/// anything. When no policy is registered (non-Anonymous modes) the pipeline treats tools/options
+/// as passthrough.
+/// </summary>
+public interface IAnonymousChatPolicy
+{
+    /// <summary>True when the current request is an authenticated anonymous session.</summary>
+    bool AppliesToCurrentRequest { get; }
+
+    /// <summary>
+    /// Returns the tool set the current principal may use. For anonymous sessions the
+    /// write-capable tools are removed; for everyone else the input set is returned unchanged.
+    /// </summary>
+    IEnumerable<AITool> FilterTools(IEnumerable<AITool> tools);
+
+    /// <summary>Model output-token cap for the current principal, or null for no anonymous cap.</summary>
+    int? MaxOutputTokens { get; }
+}
+
+/// <summary>
+/// Active Anonymous chat policy. Registered only when <c>Authentication:Mode=Anonymous</c>.
+/// </summary>
+public sealed class AnonymousChatPolicy : IAnonymousChatPolicy
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly AnonymousAuthOptions _options;
+
+    public AnonymousChatPolicy(IHttpContextAccessor httpContextAccessor, AnonymousAuthOptions options)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _options = options;
+    }
+
+    public bool AppliesToCurrentRequest =>
+        AnonymousCapabilityPolicy.IsAnonymousPrincipal(_httpContextAccessor.HttpContext?.User);
+
+    public IEnumerable<AITool> FilterTools(IEnumerable<AITool> tools) =>
+        !AppliesToCurrentRequest
+            ? tools
+            : tools.Where(t =>
+                !(t is AIFunction fn && AnonymousCapabilityPolicy.WriteCapableToolNames.Contains(fn.Name)));
+
+    public int? MaxOutputTokens => AppliesToCurrentRequest ? _options.MaxOutputTokens : null;
+}
+
+/// <summary>
+/// Null-safe helpers so the execution pipeline can apply the anonymous policy uniformly whether or
+/// not one is registered. When the policy is null (non-Anonymous modes) tools pass through
+/// unchanged and no output cap is applied.
+/// </summary>
+public static class AnonymousChatPolicyExtensions
+{
+    public static IEnumerable<AITool> ApplyToolFilter(this IAnonymousChatPolicy? policy, IEnumerable<AITool> tools) =>
+        policy is null ? tools : policy.FilterTools(tools);
+
+    public static void ApplyOutputCap(this IAnonymousChatPolicy? policy, ChatOptions options)
+    {
+        int? cap = policy?.MaxOutputTokens;
+        if (cap is int max && (options.MaxOutputTokens is null || options.MaxOutputTokens > max))
+        {
+            options.MaxOutputTokens = max;
+        }
+    }
+}

--- a/src/RetailPulse.Api/Auth/IAnonymousChatPolicy.cs
+++ b/src/RetailPulse.Api/Auth/IAnonymousChatPolicy.cs
@@ -20,6 +20,21 @@ public interface IAnonymousChatPolicy
     bool AppliesToCurrentRequest { get; }
 
     /// <summary>
+    /// True when the response cache must be bypassed for the current request. Anonymous sessions
+    /// disable the cache entirely (both read and write) so identical prompts from two different
+    /// subjects always execute independently and no reply is ever shared across subjects — the
+    /// shared cache key excluded the subject, so disabling is the fail-safe choice for Sprint 1.
+    /// </summary>
+    bool CacheDisabled { get; }
+
+    /// <summary>
+    /// True when conversation memory (recall + extraction) must be disabled for the current
+    /// request. Anonymous sessions disable memory entirely in Sprint 1 to eliminate any stored
+    /// cross-prompt injection surface; there is no durable, accountable identity to key it to.
+    /// </summary>
+    bool MemoryDisabled { get; }
+
+    /// <summary>
     /// Returns the tool set the current principal may use. For anonymous sessions the
     /// write-capable tools are removed; for everyone else the input set is returned unchanged.
     /// </summary>
@@ -46,6 +61,10 @@ public sealed class AnonymousChatPolicy : IAnonymousChatPolicy
     public bool AppliesToCurrentRequest =>
         AnonymousCapabilityPolicy.IsAnonymousPrincipal(_httpContextAccessor.HttpContext?.User);
 
+    public bool CacheDisabled => AppliesToCurrentRequest;
+
+    public bool MemoryDisabled => AppliesToCurrentRequest;
+
     public IEnumerable<AITool> FilterTools(IEnumerable<AITool> tools) =>
         !AppliesToCurrentRequest
             ? tools
@@ -64,6 +83,12 @@ public static class AnonymousChatPolicyExtensions
 {
     public static IEnumerable<AITool> ApplyToolFilter(this IAnonymousChatPolicy? policy, IEnumerable<AITool> tools) =>
         policy is null ? tools : policy.FilterTools(tools);
+
+    /// <summary>True when the cache must be bypassed for the current request (Anonymous). Null-safe.</summary>
+    public static bool IsCacheDisabled(this IAnonymousChatPolicy? policy) => policy?.CacheDisabled ?? false;
+
+    /// <summary>True when conversation memory must be disabled for the current request (Anonymous). Null-safe.</summary>
+    public static bool IsMemoryDisabled(this IAnonymousChatPolicy? policy) => policy?.MemoryDisabled ?? false;
 
     public static void ApplyOutputCap(this IAnonymousChatPolicy? policy, ChatOptions options)
     {

--- a/src/RetailPulse.Api/Auth/UserIdentity.cs
+++ b/src/RetailPulse.Api/Auth/UserIdentity.cs
@@ -1,9 +1,11 @@
 using System.Security.Claims;
+using Microsoft.IdentityModel.JsonWebTokens;
+using RetailPulse.Api.Security.Anonymous;
 
 namespace RetailPulse.Api.Auth;
 
 /// <summary>
-/// Centralised user-identifier resolution so write paths (chat → agents)
+/// Centralised, provider-aware user-identifier resolution so write paths (chat → agents)
 /// and read paths (memory endpoint, etc.) converge on the same value.
 ///
 /// History (Costco, 2026-06-04): the Memory Panel showed "0 memories" even
@@ -14,22 +16,56 @@ namespace RetailPulse.Api.Auth;
 /// — which the dev-mode auth handler stamps with the zero GUID. Writes landed
 /// under "anonymous"; reads queried under "00000000-…". Use this helper from
 /// every endpoint that needs a userId so the two sides cannot drift again.
+///
+/// Sprint 1 hardening (Costco, 2026-08-06): identity is now resolved per authentication
+/// provider and a request-body objectId is NEVER honoured for an authenticated principal
+/// (it was previously accepted as a fallback whenever no <c>oid</c> claim was present, which
+/// let an authenticated Anonymous token — which carries <c>sub</c> but no <c>oid</c> — be
+/// keyed to a spoofable body value or collapse to a shared "anonymous" bucket). Resolution:
+/// <list type="bullet">
+///   <item><b>Anonymous</b> provider → the immutable, server-minted session <c>sub</c>.</item>
+///   <item><b>Entra</b> (and any other authenticated principal) → the immutable <c>oid</c>.</item>
+///   <item>An authenticated principal with neither never falls back to the request body.</item>
+///   <item>Only a truly unauthenticated caller may supply a body objectId as a last resort.</item>
+/// </list>
 /// </summary>
 public static class UserIdentity
 {
     public const string AnonymousUserId = "anonymous";
 
     /// <summary>
-    /// Resolves the canonical userId for memory/audit purposes.
-    /// Priority: authenticated "oid" claim (either short or MS schema form) →
-    /// explicit body value (fallback only when no claim) → "anonymous".
-    /// Claims are trusted first to prevent request-body spoofing attacks.
+    /// Resolves the canonical userId for memory/audit purposes in a provider-aware, spoof-proof
+    /// way. Priority: Anonymous session <c>sub</c> → authenticated <c>oid</c> (short or MS schema
+    /// form) → (only when the caller is NOT authenticated) an explicit body value → "anonymous".
+    /// A request-body objectId is never trusted for an authenticated principal.
     /// </summary>
     public static string Resolve(ClaimsPrincipal? principal, string? bodyObjectId = null)
     {
+        // Anonymous provider: identity is the immutable, cryptographically random session subject
+        // minted server-side. A request-body objectId is never honoured for it.
+        if (AnonymousCapabilityPolicy.IsAnonymousPrincipal(principal))
+        {
+            string? sub = principal!.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+                ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            return !string.IsNullOrWhiteSpace(sub) ? sub : AnonymousUserId;
+        }
+
+        // Entra / default: the immutable object identifier (short or MS-schema form).
         string? oid = principal?.FindFirst("oid")?.Value
             ?? principal?.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value;
+        if (!string.IsNullOrWhiteSpace(oid))
+        {
+            return oid;
+        }
 
-        return !string.IsNullOrWhiteSpace(oid) ? oid : !string.IsNullOrWhiteSpace(bodyObjectId) ? bodyObjectId : AnonymousUserId;
+        // No provider subject and no oid. An authenticated principal must NEVER be keyed to a
+        // spoofable request-body value — fail closed to "anonymous" instead.
+        if (principal?.Identity is { IsAuthenticated: true })
+        {
+            return AnonymousUserId;
+        }
+
+        // Unauthenticated caller (e.g. no auth configured): body value permitted as a last resort.
+        return !string.IsNullOrWhiteSpace(bodyObjectId) ? bodyObjectId : AnonymousUserId;
     }
 }

--- a/src/RetailPulse.Api/Endpoints/AnonymousAuthEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/AnonymousAuthEndpoints.cs
@@ -1,0 +1,42 @@
+using RetailPulse.Api.Security;
+using RetailPulse.Api.Security.Anonymous;
+
+namespace RetailPulse.Api.Endpoints;
+
+/// <summary>
+/// The single, narrowly-scoped unauthenticated surface of Anonymous mode: a bootstrap endpoint
+/// that mints a short-lived anonymous session credential for a future frontend (Sprint 3).
+///
+/// It creates a cryptographically random per-session subject SERVER-SIDE (never from a client
+/// header or body) and returns a signed, short-TTL Retail Pulse session token usable both as a
+/// REST <c>Authorization: Bearer</c> and as a SignalR <c>?access_token</c>. It is rate-limited
+/// per-IP, exposes no other anonymous API, carries no PII, and issues no refresh token — the
+/// client re-bootstraps when the token expires, which bounds the replay window to the TTL.
+/// Mapped only when <c>Authentication:Mode=Anonymous</c>.
+/// </summary>
+public static class AnonymousAuthEndpoints
+{
+    public const string BootstrapRateLimitPolicy = "anonymous-bootstrap";
+
+    public static WebApplication MapAnonymousAuthEndpoints(this WebApplication app)
+    {
+        app.MapPost(AnonymousCapabilityPolicy.BootstrapRoute,
+            (IAnonymousSessionTokenService tokenService) =>
+            {
+                AnonymousSession session = tokenService.CreateSession();
+                return Results.Ok(new
+                {
+                    token = session.Token,
+                    tokenType = "Bearer",
+                    expiresInSeconds = session.ExpiresInSeconds,
+                    subject = session.Subject,
+                });
+            })
+            .AllowAnonymous()
+            .RequireRateLimiting(BootstrapRateLimitPolicy)
+            .WithName("AnonymousSessionBootstrap")
+            .WithTags("Authentication");
+
+        return app;
+    }
+}

--- a/src/RetailPulse.Api/Endpoints/AnonymousAuthEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/AnonymousAuthEndpoints.cs
@@ -9,10 +9,11 @@ namespace RetailPulse.Api.Endpoints;
 ///
 /// It creates a cryptographically random per-session subject SERVER-SIDE (never from a client
 /// header or body) and returns a signed, short-TTL Retail Pulse session token usable both as a
-/// REST <c>Authorization: Bearer</c> and as a SignalR <c>?access_token</c>. It is rate-limited
-/// per-IP, exposes no other anonymous API, carries no PII, and issues no refresh token — the
-/// client re-bootstraps when the token expires, which bounds the replay window to the TTL.
-/// Mapped only when <c>Authentication:Mode=Anonymous</c>.
+/// REST <c>Authorization: Bearer</c> and as a SignalR <c>?access_token</c>. Session minting is
+/// rate-limited by a single global conservative window (client IP is not trustworthy behind the
+/// ACA ingress proxy, and X-Forwarded-For is not honoured), exposes no other anonymous API,
+/// carries no PII, and issues no refresh token — the client re-bootstraps when the token expires,
+/// which bounds the replay window to the TTL. Mapped only when <c>Authentication:Mode=Anonymous</c>.
 /// </summary>
 public static class AnonymousAuthEndpoints
 {

--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -30,7 +30,7 @@ public static class ChatEndpoints
     public static WebApplication MapChatEndpoints(this WebApplication app, AgentDefinition agentDef)
     {
         // Chat endpoint — routes through guardrails → cache → multi-agent router with memory and tracing
-        app.MapPost("/api/chat", async (HttpContext httpContext, ChatRequest request, IAgentRouter router, IEnumerable<ISpecialistAgent> specialists, ConversationMemoryMiddleware memoryMiddleware, InMemoryTraceCollector traceCollector, GuardrailsMiddleware guardrails, IResponseCache responseCache, ICostTracker costTracker, IAuditLog auditLog, ConversationExporter conversationExporter, ITenantProvider tenantProvider, RagContextProvider ragProvider, MemoryExtractionChannel memoryChannel, IHubContext<TelemetryHub> hubContext, ILogger<Program> logger, CancellationToken clientCt, IConsensusCouncil? council = null) =>
+        app.MapPost("/api/chat", async (HttpContext httpContext, ChatRequest request, IAgentRouter router, IEnumerable<ISpecialistAgent> specialists, ConversationMemoryMiddleware memoryMiddleware, InMemoryTraceCollector traceCollector, GuardrailsMiddleware guardrails, IResponseCache responseCache, ICostTracker costTracker, IAuditLog auditLog, ConversationExporter conversationExporter, ITenantProvider tenantProvider, RagContextProvider ragProvider, MemoryExtractionChannel memoryChannel, IHubContext<TelemetryHub> hubContext, ILogger<Program> logger, CancellationToken clientCt, IAnonymousChatPolicy? anonymousChatPolicy = null, ISessionOwnershipRegistry? sessionOwnership = null, IConsensusCouncil? council = null) =>
         {
             // Input validation — fail fast before expensive LLM pipeline
             ValidationResult validation = ChatRequestValidator.Validate(request);
@@ -54,6 +54,24 @@ public static class ChatEndpoints
             {
                 string sessionId = request.SessionId ?? Guid.NewGuid().ToString("N");
                 string userId = UserIdentity.Resolve(httpContext.User, request.User?.ObjectId);
+
+                // Anonymous narrowing (resolved from the validated token, never a client flag):
+                //  • cache is disabled entirely (Finding 7 — the shared key excluded the subject);
+                //  • conversation memory recall + extraction are disabled (Finding 2 — no durable,
+                //    accountable identity, so no stored cross-prompt injection surface).
+                bool anonymous = anonymousChatPolicy?.AppliesToCurrentRequest == true;
+                bool cacheDisabled = anonymousChatPolicy.IsCacheDisabled();
+                bool memoryDisabled = anonymousChatPolicy.IsMemoryDisabled();
+
+                // Bind the session to this anonymous subject BEFORE any telemetry flows to its group.
+                // If the client-supplied id is already owned by a DIFFERENT subject, mint a fresh id
+                // for this turn so this subject's telemetry can never be delivered to another subject's
+                // hub group (the reverse of the JoinSession leak — Finding 6).
+                if (anonymous && sessionOwnership is not null && !sessionOwnership.TryBind(sessionId, userId))
+                {
+                    sessionId = Guid.NewGuid().ToString("N");
+                    sessionOwnership.TryBind(sessionId, userId);
+                }
                 // Normalise request.User so downstream agents resolve the same userId
                 // (MemoryManagementAgent reads request.User?.ObjectId — without this
                 // it would diverge from the /api/memory read path under dev auth).
@@ -77,7 +95,7 @@ public static class ChatEndpoints
                 }
 
                 // ── Cache: check for cached response ─────────────────────────────
-                if (CacheHelpers.IsCacheable(request.Message))
+                if (!cacheDisabled && CacheHelpers.IsCacheable(request.Message))
                 {
                     string cacheKey = CacheHelpers.BuildCacheKey("pre-route", request.Message);
                     CachedResponse? cached = await responseCache.GetAsync(cacheKey, ct);
@@ -225,12 +243,14 @@ public static class ChatEndpoints
 
                 // ── Enrich: now load context relevant to the routed agent ────────
 
-                // Memory recall with tracing
+                // Memory recall with tracing — skipped entirely for Anonymous (memory disabled).
                 string? memoryContext = null;
                 using (Activity? memoryRecallActivity = AgentTelemetry.StartMemoryRecall(userId))
                 {
                     DateTimeOffset memoryStart = DateTimeOffset.UtcNow;
-                    memoryContext = await memoryMiddleware.BuildMemoryContextAsync(userId, request.Message, ct);
+                    memoryContext = memoryDisabled
+                        ? null
+                        : await memoryMiddleware.BuildMemoryContextAsync(userId, request.Message, ct);
                     DateTimeOffset memoryEnd = DateTimeOffset.UtcNow;
                     double memoryDurationMs = (memoryEnd - memoryStart).TotalMilliseconds;
 
@@ -315,7 +335,10 @@ public static class ChatEndpoints
                             null,
                             (long)verdict.TotalDuration.TotalMilliseconds);
 
-                        await memoryMiddleware.ExtractAndStoreAsync(userId, enrichedRequest.Message, councilReply, ct);
+                        if (!memoryDisabled)
+                        {
+                            await memoryMiddleware.ExtractAndStoreAsync(userId, enrichedRequest.Message, councilReply, ct);
+                        }
 
                         // Auto-create a Voting card from the council verdict
                         IAdaptiveCardState cardState = app.Services.GetRequiredService<IAdaptiveCardState>();
@@ -427,8 +450,9 @@ public static class ChatEndpoints
                     }
                 }
 
-                // Memory store via bounded channel (background service processes)
-                if (decision.Intent != AgentIntent.MemoryManagement)
+                // Memory store via bounded channel (background service processes) — never for
+                // Anonymous (memory disabled: no accountable identity to key extraction to).
+                if (!memoryDisabled && decision.Intent != AgentIntent.MemoryManagement)
                 {
                     memoryChannel.TryWrite(new MemoryWorkItem(
                         userId,
@@ -502,7 +526,7 @@ public static class ChatEndpoints
                 response = response with { Routing = isErrorResponse ? null : routingInfo };
 
                 // ── Cache: store response for deterministic queries ──────────────
-                if (CacheHelpers.IsCacheable(request.Message))
+                if (!cacheDisabled && CacheHelpers.IsCacheable(request.Message))
                 {
                     string cacheKey = CacheHelpers.BuildCacheKey("pre-route", request.Message);
                     await responseCache.SetAsync(cacheKey,

--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -11,6 +11,7 @@ using RetailPulse.Api.Models;
 using RetailPulse.Api.Observability;
 using RetailPulse.Api.Prefetch;
 using RetailPulse.Api.Rag;
+using RetailPulse.Api.Security.Anonymous;
 using RetailPulse.Api.Tracing;
 using RetailPulse.Api.Validation;
 using RetailPulse.Contracts;
@@ -189,6 +190,50 @@ public static class ChatEndpoints
                             ["router.intent"] = decision.Intent,
                             ["router.confidence"] = decision.Confidence.ToString("F2", CultureInfo.InvariantCulture)
                         }));
+                }
+
+                // ── Anonymous intent hard-stops (before specialist selection / execution) ──
+                // These close two chat-internal bypasses that the anonymous write-tool filter and
+                // the cache/memory-disabled narrowing cannot reach, because they do not go through
+                // the tool set at all:
+                //
+                //  1) Memory management — the MemoryManagementAgent calls StoreAsync/ForgetAsync
+                //     DIRECTLY (no AI tools), so tool filtering never sees it. Refuse now so that
+                //     agent never runs: no model call, and zero memory rows are written.
+                //  2) Consensus council (portfolio health) — the council interception below fans out
+                //     multiple model calls via IConsensusCouncil and returns EARLY, bypassing the
+                //     single accounted budget/audit/guardrail path. Refuse now so the council is
+                //     never convened for an anonymous session.
+                //
+                // The council interception is the ONLY in-process alternate orchestrator reachable
+                // from POST /api/chat; the scorecard/escalation orchestrators are not registered as
+                // ISpecialistAgent and are reachable only via their own /api routes (all 403 for
+                // anonymous). Both refusals are deterministic (no model) — they cannot be defeated by
+                // a crafted keyword prompt because they fire on the router's own classification.
+                if (anonymous && AnonymousChatRestrictions.IsMemoryManagementIntent(decision))
+                {
+                    logger.LogInformation(
+                        "Anonymous memory-management request refused (no store/forget, no model) for session {SessionId}",
+                        sessionId);
+                    return Results.Ok(new ChatResponse(
+                        AnonymousChatRestrictions.MemoryRefusalMessage,
+                        sessionId,
+                        [],
+                        null,
+                        0));
+                }
+
+                if (anonymous && AnonymousChatRestrictions.IsCouncilIntent(decision))
+                {
+                    logger.LogInformation(
+                        "Anonymous portfolio-health/council request refused (no council model calls) for session {SessionId}",
+                        sessionId);
+                    return Results.Ok(new ChatResponse(
+                        AnonymousChatRestrictions.CouncilRefusalMessage,
+                        sessionId,
+                        [],
+                        null,
+                        0));
                 }
 
                 // Agent selection with tracing

--- a/src/RetailPulse.Api/Hubs/SessionOwnershipRegistry.cs
+++ b/src/RetailPulse.Api/Hubs/SessionOwnershipRegistry.cs
@@ -1,0 +1,69 @@
+using System.Collections.Concurrent;
+
+namespace RetailPulse.Api.Hubs;
+
+/// <summary>
+/// Binds a chat <c>sessionId</c> to the immutable subject that owns it, so a SignalR hub can refuse
+/// to subscribe a caller to another subject's session group.
+///
+/// Root cause (Sprint 1 review, Finding 6): <c>Hub.JoinSession(sessionId)</c> added the caller to
+/// the group named by an arbitrary, caller-supplied session id. An anonymous attacker who knew or
+/// guessed a victim's session id could join that group and receive the victim's streamed tokens and
+/// telemetry. This registry records the owner at chat time and lets the hub verify the caller owns
+/// (or may claim) the session before joining.
+///
+/// <para><b>Scope.</b> Ownership binding is consulted only for Anonymous principals; Entra/dev hub
+/// semantics are unchanged. Storage is replica-local in-memory (consistent with the other Anonymous
+/// guardrails; hosted Anonymous runs at <c>maxReplicas=1</c>) and bounded to avoid unbounded growth.</para>
+/// </summary>
+public interface ISessionOwnershipRegistry
+{
+    /// <summary>
+    /// Binds <paramref name="sessionId"/> to <paramref name="subject"/> and returns true when the
+    /// caller now owns it — either because it was previously unowned (now claimed) or was already
+    /// owned by this same subject. Returns false when the session is owned by a DIFFERENT subject.
+    /// </summary>
+    bool TryBind(string sessionId, string subject);
+
+    /// <summary>Returns the owning subject for a session, or null when unowned. For diagnostics/tests.</summary>
+    string? OwnerOf(string sessionId);
+}
+
+/// <inheritdoc />
+public sealed class SessionOwnershipRegistry : ISessionOwnershipRegistry
+{
+    private const int _maxEntries = 20_000;
+
+    private readonly ConcurrentDictionary<string, string> _owners = new(StringComparer.Ordinal);
+
+    public bool TryBind(string sessionId, string subject)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) || string.IsNullOrWhiteSpace(subject))
+        {
+            return false;
+        }
+
+        EvictIfNeeded();
+
+        string owner = _owners.GetOrAdd(sessionId, subject);
+        return string.Equals(owner, subject, StringComparison.Ordinal);
+    }
+
+    public string? OwnerOf(string sessionId) =>
+        _owners.TryGetValue(sessionId, out string? owner) ? owner : null;
+
+    private void EvictIfNeeded()
+    {
+        if (_owners.Count < _maxEntries)
+        {
+            return;
+        }
+
+        // Replica-local, bounded: drop a batch of arbitrary entries when the cap is reached. A
+        // dropped entry simply means the next claim re-binds ownership; it never widens access.
+        foreach (string key in _owners.Keys.Take(_maxEntries / 10))
+        {
+            _owners.TryRemove(key, out _);
+        }
+    }
+}

--- a/src/RetailPulse.Api/Hubs/StreamingHub.cs
+++ b/src/RetailPulse.Api/Hubs/StreamingHub.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.SignalR;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Security.Anonymous;
 
 namespace RetailPulse.Api.Hubs;
 
@@ -9,6 +11,13 @@ namespace RetailPulse.Api.Hubs;
 /// </summary>
 public class StreamingHub : Hub
 {
+    private readonly ISessionOwnershipRegistry _ownership;
+
+    public StreamingHub(ISessionOwnershipRegistry ownership)
+    {
+        _ownership = ownership;
+    }
+
     public override async Task OnConnectedAsync()
     {
         await Clients.Caller.SendAsync("Connected", "Connected to Retail Pulse streaming");
@@ -17,11 +26,19 @@ public class StreamingHub : Hub
 
     /// <summary>
     /// Subscribes the caller to streaming events for a specific chat session.
+    ///
+    /// For an Anonymous caller the session is bound to the caller's immutable subject: the caller may
+    /// only join a session it owns (or an as-yet-unclaimed one). This blocks an anonymous attacker
+    /// from subscribing to another subject's streamed tokens with a known/guessed session id
+    /// (Finding 6). Entra/dev callers are unchanged.
     /// </summary>
     public Task JoinSession(string sessionId)
     {
         return string.IsNullOrWhiteSpace(sessionId)
             ? Task.CompletedTask
+            : AnonymousCapabilityPolicy.IsAnonymousPrincipal(Context.User)
+            && !_ownership.TryBind(sessionId, UserIdentity.Resolve(Context.User))
+            ? throw new HubException("Not authorized to join this session.")
             : Groups.AddToGroupAsync(Context.ConnectionId, $"stream:{sessionId}");
     }
 

--- a/src/RetailPulse.Api/Hubs/TelemetryHub.cs
+++ b/src/RetailPulse.Api/Hubs/TelemetryHub.cs
@@ -1,9 +1,18 @@
 using Microsoft.AspNetCore.SignalR;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Security.Anonymous;
 
 namespace RetailPulse.Api.Hubs;
 
 public class TelemetryHub : Hub
 {
+    private readonly ISessionOwnershipRegistry _ownership;
+
+    public TelemetryHub(ISessionOwnershipRegistry ownership)
+    {
+        _ownership = ownership;
+    }
+
     public override async Task OnConnectedAsync()
     {
         await Clients.Caller.SendAsync("Connected", "Connected to Retail Pulse telemetry stream");
@@ -13,8 +22,21 @@ public class TelemetryHub : Hub
     /// <summary>
     /// Subscribes the caller to spans for a specific chat session.
     /// Used to scope telemetry per session instead of broadcasting to all clients.
+    ///
+    /// For an Anonymous caller the session is bound to the caller's immutable subject: the caller may
+    /// only join a session it owns (or an as-yet-unclaimed one). This blocks an anonymous attacker
+    /// from subscribing to another subject's telemetry with a known/guessed session id (Finding 6).
+    /// Entra/dev callers are unchanged.
     /// </summary>
-    public Task JoinSession(string sessionId) => string.IsNullOrWhiteSpace(sessionId) ? Task.CompletedTask : Groups.AddToGroupAsync(Context.ConnectionId, sessionId);
+    public Task JoinSession(string sessionId)
+    {
+        return string.IsNullOrWhiteSpace(sessionId)
+            ? Task.CompletedTask
+            : AnonymousCapabilityPolicy.IsAnonymousPrincipal(Context.User)
+            && !_ownership.TryBind(sessionId, UserIdentity.Resolve(Context.User))
+            ? throw new HubException("Not authorized to join this session.")
+            : Groups.AddToGroupAsync(Context.ConnectionId, sessionId);
+    }
 
     /// <summary>
     /// Removes the caller from a session group.
@@ -24,8 +46,18 @@ public class TelemetryHub : Hub
     /// <summary>
     /// Subscribes the caller to card events for a specific card.
     /// Used for per-card SignalR groups so card actions are scoped.
+    ///
+    /// Cards/approvals are not part of the Anonymous surface, so an Anonymous caller is refused here
+    /// (deny-by-default) — it cannot subscribe to another subject's card events.
     /// </summary>
-    public Task JoinCard(string cardId) => string.IsNullOrWhiteSpace(cardId) ? Task.CompletedTask : Groups.AddToGroupAsync(Context.ConnectionId, $"card:{cardId}");
+    public Task JoinCard(string cardId)
+    {
+        return string.IsNullOrWhiteSpace(cardId)
+            ? Task.CompletedTask
+            : AnonymousCapabilityPolicy.IsAnonymousPrincipal(Context.User)
+            ? throw new HubException("Card events are not available in Anonymous mode.")
+            : Groups.AddToGroupAsync(Context.ConnectionId, $"card:{cardId}");
+    }
 
     /// <summary>
     /// Removes the caller from a card group.

--- a/src/RetailPulse.Api/Middleware/AnonymousGuardMiddleware.cs
+++ b/src/RetailPulse.Api/Middleware/AnonymousGuardMiddleware.cs
@@ -1,4 +1,6 @@
+using System.Buffers;
 using System.Net;
+using Microsoft.AspNetCore.Http.Features;
 using RetailPulse.Api.Security.Anonymous;
 
 namespace RetailPulse.Api.Middleware;
@@ -9,10 +11,13 @@ namespace RetailPulse.Api.Middleware;
 /// anonymous principal is available. It enforces — server-side, from the token, never from UI or a
 /// client header — that an anonymous session may only:
 /// <list type="bullet">
-///   <item>reach read-only routes (GET/HEAD/OPTIONS or the explicit read-only-POST allowlist);
-///     every other verb/route is a mutation and gets <c>403</c>;</item>
-///   <item>send bodies within the configured size bound (<c>413</c> otherwise);</item>
-///   <item>call model routes within per-subject and per-IP minute limits (<c>429</c>) and within
+///   <item>reach the explicit <see cref="AnonymousCapabilityPolicy"/> allowlist (deny-by-default):
+///     every (method, route) that is not the bootstrap, <c>POST /api/chat</c>, or an allowed hub
+///     gets <c>403</c>. There is NO read/GET shortcut;</item>
+///   <item>send bodies within the configured size bound (<c>413</c> otherwise) — enforced before the
+///     body is read and via a length-counting pre-read, so a chunked/unknown-length body that omits
+///     <c>Content-Length</c> cannot bypass the cap;</item>
+///   <item>call the model route within per-subject and per-IP minute limits (<c>429</c>) and within
 ///     the global daily request/token/cost circuit breaker (<c>503</c> when tripped).</item>
 /// </list>
 /// A request slot is charged at admission — before the cache is consulted downstream — so cache
@@ -50,16 +55,26 @@ public sealed class AnonymousGuardMiddleware : IMiddleware
         string method = context.Request.Method;
         string path = context.Request.Path.Value ?? string.Empty;
 
-        // 1) Read-only enforcement — deny any mutation not on the explicit allowlist.
-        if (AnonymousCapabilityPolicy.IsBlockedMutation(method, path))
+        // 1) Deny-by-default authorization — reject any (method, route) not on the explicit
+        //    anonymous allowlist (bootstrap, POST /api/chat, or an allowed hub). There is no
+        //    read/GET shortcut: observability/admin/export/memory/cards/approvals/etc. are 403.
+        if (AnonymousCapabilityPolicy.IsBlocked(method, path))
         {
             await WriteProblem(context, HttpStatusCode.Forbidden,
-                "anonymous_read_only",
-                "This operation is not available in Anonymous mode. Anonymous sessions are read-only.");
+                "anonymous_forbidden",
+                "This operation is not available in Anonymous mode.");
             return;
         }
 
-        // 2) Request-size bound.
+        // 2) Request-size bound. Set the Kestrel per-request max BEFORE the body is read so a
+        //    chunked / unknown-length body (no Content-Length) is capped during the read, then also
+        //    reject early when a declared Content-Length already exceeds the limit.
+        IHttpMaxRequestBodySizeFeature? sizeFeature = context.Features.Get<IHttpMaxRequestBodySizeFeature>();
+        if (sizeFeature is { IsReadOnly: false })
+        {
+            sizeFeature.MaxRequestBodySize = _options.MaxRequestBytes;
+        }
+
         if (context.Request.ContentLength is long len && len > _options.MaxRequestBytes)
         {
             await WriteProblem(context, HttpStatusCode.RequestEntityTooLarge,
@@ -68,9 +83,20 @@ public sealed class AnonymousGuardMiddleware : IMiddleware
             return;
         }
 
-        bool isModelRoute = IsBudgetedModelRoute(method, path);
+        bool isModelRoute = AnonymousCapabilityPolicy.IsBudgetedModelRoute(method, path);
         if (isModelRoute)
         {
+            // Length-counting pre-read: catches a chunked/unknown-length body that omits
+            // Content-Length (the ContentLength check above cannot see it). Deterministic under the
+            // test server as well as Kestrel. Rejects with 413 before any model work is scheduled.
+            if (await ExceedsBodyLimitAsync(context, _options.MaxRequestBytes))
+            {
+                await WriteProblem(context, HttpStatusCode.RequestEntityTooLarge,
+                    "anonymous_request_too_large",
+                    $"Request body exceeds the anonymous limit of {_options.MaxRequestBytes} bytes.");
+                return;
+            }
+
             string subject = context.User.FindFirst(Microsoft.IdentityModel.JsonWebTokens.JwtRegisteredClaimNames.Sub)?.Value
                 ?? context.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
                 ?? "unknown";
@@ -122,19 +148,42 @@ public sealed class AnonymousGuardMiddleware : IMiddleware
         }
     }
 
-    private static bool IsBudgetedModelRoute(string method, string path)
+    /// <summary>
+    /// Reads the request body through a length counter and returns true as soon as it exceeds
+    /// <paramref name="maxBytes"/>. Buffering is enabled first and the stream is rewound afterwards
+    /// so downstream model binding re-reads the same body. This is the deterministic defense against
+    /// a chunked / unknown-length body that omits <c>Content-Length</c>.
+    /// </summary>
+    private static async Task<bool> ExceedsBodyLimitAsync(HttpContext context, long maxBytes)
     {
-        if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method) || HttpMethods.IsOptions(method))
+        context.Request.EnableBuffering();
+        Stream body = context.Request.Body;
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(8192);
+        long total = 0;
+        bool exceeded = false;
+        try
         {
-            return false;
+            int read;
+            while ((read = await body.ReadAsync(buffer.AsMemory(0, buffer.Length), context.RequestAborted)) > 0)
+            {
+                total += read;
+                if (total > maxBytes)
+                {
+                    exceeded = true;
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            if (body.CanSeek)
+            {
+                body.Position = 0;
+            }
         }
 
-        string normalized = path.Length > 1 ? path.TrimEnd('/') : path;
-
-        // Every anonymous-allowed non-GET route EXCEPT the bootstrap reaches real work/models and
-        // is charged against the budget + chat limits. Bootstrap has its own per-IP limiter.
-        return AnonymousCapabilityPolicy.AnonymousReadableNonGetRoutes.Contains(normalized)
-            && !string.Equals(normalized, AnonymousCapabilityPolicy.BootstrapRoute, StringComparison.OrdinalIgnoreCase);
+        return exceeded;
     }
 
     private static async Task WriteProblem(HttpContext context, HttpStatusCode status, string code, string detail)

--- a/src/RetailPulse.Api/Middleware/AnonymousGuardMiddleware.cs
+++ b/src/RetailPulse.Api/Middleware/AnonymousGuardMiddleware.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using RetailPulse.Api.Security.Anonymous;
+
+namespace RetailPulse.Api.Middleware;
+
+/// <summary>
+/// The single, central enforcement point for Anonymous-mode request restrictions. Registered only
+/// when <c>Authentication:Mode=Anonymous</c>, after authentication/authorization so the validated
+/// anonymous principal is available. It enforces — server-side, from the token, never from UI or a
+/// client header — that an anonymous session may only:
+/// <list type="bullet">
+///   <item>reach read-only routes (GET/HEAD/OPTIONS or the explicit read-only-POST allowlist);
+///     every other verb/route is a mutation and gets <c>403</c>;</item>
+///   <item>send bodies within the configured size bound (<c>413</c> otherwise);</item>
+///   <item>call model routes within per-subject and per-IP minute limits (<c>429</c>) and within
+///     the global daily request/token/cost circuit breaker (<c>503</c> when tripped).</item>
+/// </list>
+/// A request slot is charged at admission — before the cache is consulted downstream — so cache
+/// hits cannot bypass the request ceiling. A per-request timeout is also applied.
+/// </summary>
+public sealed class AnonymousGuardMiddleware : IMiddleware
+{
+    private readonly AnonymousAuthOptions _options;
+    private readonly AnonymousRateLimiter _rateLimiter;
+    private readonly AnonymousUsageBudget _budget;
+    private readonly ILogger<AnonymousGuardMiddleware> _logger;
+
+    public AnonymousGuardMiddleware(
+        AnonymousAuthOptions options,
+        AnonymousRateLimiter rateLimiter,
+        AnonymousUsageBudget budget,
+        ILogger<AnonymousGuardMiddleware> logger)
+    {
+        _options = options;
+        _rateLimiter = rateLimiter;
+        _budget = budget;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        // Only authenticated anonymous sessions are constrained here. Unauthenticated requests are
+        // handled by the authorization policy (AllowAnonymous only on health + bootstrap).
+        if (!AnonymousCapabilityPolicy.IsAnonymousPrincipal(context.User))
+        {
+            await next(context);
+            return;
+        }
+
+        string method = context.Request.Method;
+        string path = context.Request.Path.Value ?? string.Empty;
+
+        // 1) Read-only enforcement — deny any mutation not on the explicit allowlist.
+        if (AnonymousCapabilityPolicy.IsBlockedMutation(method, path))
+        {
+            await WriteProblem(context, HttpStatusCode.Forbidden,
+                "anonymous_read_only",
+                "This operation is not available in Anonymous mode. Anonymous sessions are read-only.");
+            return;
+        }
+
+        // 2) Request-size bound.
+        if (context.Request.ContentLength is long len && len > _options.MaxRequestBytes)
+        {
+            await WriteProblem(context, HttpStatusCode.RequestEntityTooLarge,
+                "anonymous_request_too_large",
+                $"Request body exceeds the anonymous limit of {_options.MaxRequestBytes} bytes.");
+            return;
+        }
+
+        bool isModelRoute = IsBudgetedModelRoute(method, path);
+        if (isModelRoute)
+        {
+            string subject = context.User.FindFirst(Microsoft.IdentityModel.JsonWebTokens.JwtRegisteredClaimNames.Sub)?.Value
+                ?? context.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                ?? "unknown";
+            string ip = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+            // 3) Per-subject and per-IP minute limits.
+            if (!_rateLimiter.TryAcquire($"chat:sub:{subject}", _options.ChatPerSubjectPerMinute) ||
+                !_rateLimiter.TryAcquire($"chat:ip:{ip}", _options.ChatPerIpPerMinute))
+            {
+                await WriteProblem(context, HttpStatusCode.TooManyRequests,
+                    "anonymous_rate_limited",
+                    "Anonymous request rate limit exceeded. Please retry shortly.");
+                return;
+            }
+
+            // 4) Global daily circuit breaker — charge a request slot up-front so cache hits
+            //    downstream still consume the request ceiling and cannot bypass it.
+            if (!_budget.TryBeginRequest(out string? denyReason))
+            {
+                _logger.LogWarning("Anonymous daily budget denied a request: {Reason}", denyReason);
+                await WriteProblem(context, HttpStatusCode.ServiceUnavailable,
+                    "anonymous_budget_exhausted",
+                    denyReason ?? "The anonymous daily budget has been exhausted. Please try again later.");
+                return;
+            }
+        }
+
+        // 5) Per-request timeout for anonymous callers.
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(_options.RequestTimeoutSeconds));
+        CancellationToken original = context.RequestAborted;
+        context.RequestAborted = timeoutCts.Token;
+        try
+        {
+            await next(context);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !original.IsCancellationRequested)
+        {
+            if (!context.Response.HasStarted)
+            {
+                await WriteProblem(context, HttpStatusCode.GatewayTimeout,
+                    "anonymous_request_timeout",
+                    $"The request exceeded the anonymous timeout of {_options.RequestTimeoutSeconds} seconds.");
+            }
+        }
+        finally
+        {
+            context.RequestAborted = original;
+        }
+    }
+
+    private static bool IsBudgetedModelRoute(string method, string path)
+    {
+        if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method) || HttpMethods.IsOptions(method))
+        {
+            return false;
+        }
+
+        string normalized = path.Length > 1 ? path.TrimEnd('/') : path;
+
+        // Every anonymous-allowed non-GET route EXCEPT the bootstrap reaches real work/models and
+        // is charged against the budget + chat limits. Bootstrap has its own per-IP limiter.
+        return AnonymousCapabilityPolicy.AnonymousReadableNonGetRoutes.Contains(normalized)
+            && !string.Equals(normalized, AnonymousCapabilityPolicy.BootstrapRoute, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task WriteProblem(HttpContext context, HttpStatusCode status, string code, string detail)
+    {
+        context.Response.StatusCode = (int)status;
+        context.Response.ContentType = "application/problem+json";
+        await context.Response.WriteAsJsonAsync(new
+        {
+            type = $"https://retail-pulse/errors/{code}",
+            title = code,
+            status = (int)status,
+            detail,
+        });
+    }
+}

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -96,6 +96,12 @@ builder.Services.AddOpenTelemetry()
 builder.Services.AddSignalR()
     .AddJsonProtocol(options => options.PayloadSerializerOptions.PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase);
 
+// Session-ownership registry — binds a chat sessionId to its owning subject so the hubs can refuse
+// a caller that tries to join another subject's session group (Finding 6). Consulted only for
+// Anonymous callers; Entra/dev hub behavior is unchanged. Registered in all modes because the hubs
+// take it via constructor injection.
+builder.Services.AddSingleton<ISessionOwnershipRegistry, SessionOwnershipRegistry>();
+
 // ── CORS — split policies for Development vs Production ─────────────────
 // Development includes known local origins plus explicitly configured deployed
 // origins. This keeps the fixed synthetic demo identity while allowing the SWA
@@ -182,15 +188,27 @@ builder.Services.AddRateLimiter(options =>
         opt.QueueLimit = 0;
     });
 
-    // Per-IP limiter for the unauthenticated Anonymous bootstrap endpoint. Always registered so
-    // the limiter graph is stable and testable; only used when Authentication:Mode=Anonymous maps
-    // the bootstrap route. Partitioning by remote IP throttles session minting per client.
-    options.AddPolicy("anonymous-bootstrap", httpContext =>
+    // Rate limiter for the unauthenticated Anonymous bootstrap endpoint. Always registered so the
+    // limiter graph is stable and testable; only used when Authentication:Mode=Anonymous maps the
+    // bootstrap route.
+    //
+    // IMPORTANT (ACA ingress reality): when hosted behind Azure Container Apps, every request
+    // arrives from the ingress/proxy, so HttpContext.Connection.RemoteIpAddress is the proxy's IP,
+    // NOT the client's — a per-IP partition would therefore collapse to a single global bucket
+    // anyway. We do NOT trust X-Forwarded-For to recover the client IP: ACA does not give us a
+    // cryptographically verifiable client-IP header, and an attacker can forge XFF to shard around a
+    // per-IP limit. So bootstrap is intentionally a single GLOBAL, conservative fixed window — it
+    // caps total anonymous session minting per minute for the whole replica and cannot be bypassed
+    // by header spoofing. Fine-grained abuse control is enforced AFTER bootstrap by the per-subject
+    // (immutable, server-minted sub) limits in AnonymousGuardMiddleware, which is the primary
+    // control. Note: this window is replica-local; hosted Anonymous runs at maxReplicas=1.
+    options.AddPolicy("anonymous-bootstrap", _ =>
         RateLimitPartition.GetFixedWindowLimiter(
-            partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            partitionKey: "anonymous-bootstrap-global",
             factory: _ => new FixedWindowRateLimiterOptions
             {
-                PermitLimit = builder.Configuration.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 5),
+                PermitLimit = builder.Configuration.GetValue("Anonymous:Bootstrap:GlobalPerMinute",
+                    builder.Configuration.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 30)),
                 Window = TimeSpan.FromMinutes(1),
                 QueueLimit = 0,
             }));

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -202,13 +202,17 @@ builder.Services.AddRateLimiter(options =>
     // by header spoofing. Fine-grained abuse control is enforced AFTER bootstrap by the per-subject
     // (immutable, server-minted sub) limits in AnonymousGuardMiddleware, which is the primary
     // control. Note: this window is replica-local; hosted Anonymous runs at maxReplicas=1.
+    //
+    // Config key: Anonymous:Bootstrap:GlobalPerMinute (conservative default 5). The legacy
+    // Anonymous:Bootstrap:PerIpPerMinute key is still honoured as a fallback for backward
+    // compatibility — it was never actually per-IP behind ACA, hence the rename.
     options.AddPolicy("anonymous-bootstrap", _ =>
         RateLimitPartition.GetFixedWindowLimiter(
             partitionKey: "anonymous-bootstrap-global",
             factory: _ => new FixedWindowRateLimiterOptions
             {
                 PermitLimit = builder.Configuration.GetValue("Anonymous:Bootstrap:GlobalPerMinute",
-                    builder.Configuration.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 30)),
+                    builder.Configuration.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 5)),
                 Window = TimeSpan.FromMinutes(1),
                 QueueLimit = 0,
             }));

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -134,11 +134,20 @@ builder.Services.AddCors(options =>
 // honours the access_token query param only for /hubs, and requires the app role + API
 // scope on every protected endpoint and hub. Development uses the synthetic handler. The
 // default policy is never permissive — no RequireAssertion(_ => true) when auth is on.
-// GitHub/Anonymous modes are declared but fail startup ("not implemented in this sprint") and
-// never fall through to Entra/Development/anonymous; a missing mode fails closed outside Development.
-EntraAuthOptions entraAuthOptions =
+// GitHub mode is declared but fails startup ("not implemented in this sprint"); a missing mode
+// fails closed outside Development. Anonymous mode (Sprint 1) wires its own constrained session
+// scheme + guardrails internally and returns null (see AddAnonymousMode); it never falls through
+// to Entra/Development and, in a hosted environment, requires a second explicit opt-in.
+AuthenticationMode resolvedAuthMode =
+    AuthenticationModeOptions.Resolve(builder.Configuration, builder.Environment);
+bool anonymousAuthMode = resolvedAuthMode == AuthenticationMode.Anonymous;
+
+EntraAuthOptions? entraAuthOptions =
     builder.Services.AddProviderNeutralAuthentication(builder.Configuration, builder.Environment);
-builder.Services.AddRetailPulseAuthorization(entraAuthOptions);
+if (entraAuthOptions is not null)
+{
+    builder.Services.AddRetailPulseAuthorization(entraAuthOptions);
+}
 
 // ── Rate Limiting ───────────────────────────────────────────────────────
 builder.Services.AddRateLimiter(options =>
@@ -172,6 +181,19 @@ builder.Services.AddRateLimiter(options =>
         opt.Window = TimeSpan.FromMinutes(1);
         opt.QueueLimit = 0;
     });
+
+    // Per-IP limiter for the unauthenticated Anonymous bootstrap endpoint. Always registered so
+    // the limiter graph is stable and testable; only used when Authentication:Mode=Anonymous maps
+    // the bootstrap route. Partitioning by remote IP throttles session minting per client.
+    options.AddPolicy("anonymous-bootstrap", httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = builder.Configuration.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 5),
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+            }));
 });
 
 // ── API Versioning ──────────────────────────────────────────────────────
@@ -554,6 +576,18 @@ builder.Services.AddSingleton(sp => new DurableCostTracker(
     sp.GetRequiredService<IOptions<ObservabilityOptions>>(),
     sp.GetRequiredService<IConfiguration>()));
 builder.Services.AddSingleton<ICostTracker>(sp => sp.GetRequiredService<DurableCostTracker>());
+
+// Anonymous mode: decorate the cost tracker so every recorded usage event is also counted
+// against the anonymous daily token/cost circuit breaker. The decorator delegates unchanged to
+// the durable tracker (audit/export/telemetry intact) and feeds the SAME numbers to the budget —
+// cache hits arrive as zero-token events and therefore never advance the token/cost ceilings.
+if (anonymousAuthMode)
+{
+    builder.Services.AddSingleton<ICostTracker>(sp => new RetailPulse.Api.Security.Anonymous.AnonymousBudgetCostTracker(
+        sp.GetRequiredService<DurableCostTracker>(),
+        sp.GetRequiredService<RetailPulse.Api.Security.Anonymous.AnonymousUsageBudget>(),
+        sp.GetRequiredService<IConfiguration>()));
+}
 string auditDbPath = Path.Combine(dataDirectory, "audit.db");
 builder.Services.AddSingleton(_ => new DurableAuditLog(auditDbPath));
 builder.Services.AddSingleton<IAuditLog>(sp => sp.GetRequiredService<DurableAuditLog>());
@@ -933,6 +967,15 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.UseRateLimiter();
 
+// Anonymous mode central enforcement: read-only restriction (block mutations), request-size
+// bound, per-subject/per-IP chat limits, the daily billable-use circuit breaker, and a per-request
+// timeout. Runs after authorization so the validated anonymous principal is available; no-op for
+// any non-anonymous principal. Registered only when Authentication:Mode=Anonymous.
+if (anonymousAuthMode)
+{
+    app.UseMiddleware<AnonymousGuardMiddleware>();
+}
+
 app.MapDefaultEndpoints();
 
 if (app.Environment.IsDevelopment())
@@ -977,5 +1020,13 @@ app.MapMarginEndpoints();
 app.MapDeadLetterEndpoints();
 app.MapMemoryEndpoints();
 app.MapCacheEndpoints();
+
+// Anonymous mode: map the single unauthenticated bootstrap endpoint that mints short-lived
+// session tokens for a future frontend (Sprint 3). Mapped only when Authentication:Mode=Anonymous
+// so it exposes no anonymous surface in Entra deployments.
+if (anonymousAuthMode)
+{
+    app.MapAnonymousAuthEndpoints();
+}
 
 app.Run();

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousAuthOptions.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousAuthOptions.cs
@@ -47,7 +47,10 @@ public sealed class AnonymousAuthOptions
     public int RequestTimeoutSeconds { get; init; } = 60;
 
     // ── Rate limits ──────────────────────────────────────────────────────────
-    public int BootstrapPerIpPerMinute { get; init; } = 5;
+    // Bootstrap is a single GLOBAL fixed window (not per-IP): behind ACA the client IP is the
+    // proxy's and X-Forwarded-For is forgeable, so a per-IP partition would collapse to one bucket
+    // anyway. Conservative default 5/min per replica. The legacy per-IP key is still honoured.
+    public int BootstrapGlobalPerMinute { get; init; } = 5;
     public int ChatPerSubjectPerMinute { get; init; } = 5;
     public int ChatPerIpPerMinute { get; init; } = 10;
 
@@ -107,7 +110,8 @@ public sealed class AnonymousAuthOptions
             MaxOutputTokens = section.GetValue("MaxOutputTokens", 512),
             MaxRequestBytes = section.GetValue("MaxRequestBytes", 16 * 1024),
             RequestTimeoutSeconds = section.GetValue("RequestTimeoutSeconds", 60),
-            BootstrapPerIpPerMinute = section.GetValue("Bootstrap:PerIpPerMinute", 5),
+            BootstrapGlobalPerMinute = section.GetValue("Bootstrap:GlobalPerMinute",
+                section.GetValue("Bootstrap:PerIpPerMinute", 5)),
             ChatPerSubjectPerMinute = section.GetValue("Chat:PerSubjectPerMinute", 5),
             ChatPerIpPerMinute = section.GetValue("Chat:PerIpPerMinute", 10),
             DailyMaxRequests = section.GetValue("Limits:DailyMaxRequests", 500),
@@ -127,7 +131,7 @@ public sealed class AnonymousAuthOptions
         RequireInRange(MaxOutputTokens, 1, 4096, "Anonymous:MaxOutputTokens");
         RequireInRange(MaxRequestBytes, 256, 1_000_000, "Anonymous:MaxRequestBytes");
         RequireInRange(RequestTimeoutSeconds, 1, 120, "Anonymous:RequestTimeoutSeconds");
-        RequirePositive(BootstrapPerIpPerMinute, "Anonymous:Bootstrap:PerIpPerMinute");
+        RequirePositive(BootstrapGlobalPerMinute, "Anonymous:Bootstrap:GlobalPerMinute");
         RequirePositive(ChatPerSubjectPerMinute, "Anonymous:Chat:PerSubjectPerMinute");
         RequirePositive(ChatPerIpPerMinute, "Anonymous:Chat:PerIpPerMinute");
 

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousAuthOptions.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousAuthOptions.cs
@@ -1,0 +1,199 @@
+using System.Text;
+using Microsoft.Extensions.Hosting;
+
+namespace RetailPulse.Api.Security.Anonymous;
+
+/// <summary>
+/// Resolved, validated configuration for the Anonymous authentication mode.
+///
+/// Anonymous mode reaches billable models, so it is fail-closed by construction:
+/// <list type="bullet">
+///   <item>It only runs when <c>Authentication:Mode=Anonymous</c> is set explicitly (resolved by
+///     <see cref="AuthenticationModeOptions"/>; no auto-detection).</item>
+///   <item>Any hosted (non-Development) deployment additionally requires a SECOND explicit opt-in,
+///     <c>Anonymous:AllowHosted=true</c>, PLUS a complete, validated guardrail configuration —
+///     a strong signing key and positive daily request/token/cost ceilings. A missing, malformed,
+///     or unsafe value throws at startup so a misconfigured hosted deploy never serves traffic.</item>
+///   <item>Development may run without <c>AllowHosted</c> and without a configured signing key
+///     (an ephemeral process-local key is generated — sessions die on restart).</item>
+/// </list>
+/// The signing key is a SECRET and is never committed; it is supplied at runtime via
+/// <c>Anonymous__SigningKey</c> or a secret store.
+/// </summary>
+public sealed class AnonymousAuthOptions
+{
+    public const string SectionName = "Anonymous";
+
+    // ── Session token ────────────────────────────────────────────────────────
+    public string Issuer { get; init; } = "retail-pulse-anonymous";
+    public string Audience { get; init; } = "retail-pulse-api";
+
+    /// <summary>Short-lived session token TTL. Bounded to keep the replay window small.</summary>
+    public int SessionTokenTtlSeconds { get; init; } = 900;
+
+    /// <summary>HMAC signing key (secret). Required in hosted mode; ephemeral in Development.</summary>
+    public string? SigningKey { get; init; }
+
+    public string Role { get; init; } = AnonymousCapabilityPolicy.DefaultRole;
+    public string Scope { get; init; } = AnonymousCapabilityPolicy.DefaultScope;
+
+    /// <summary>Hard cap on model output tokens for anonymous chat.</summary>
+    public int MaxOutputTokens { get; init; } = 512;
+
+    /// <summary>Max accepted request body size (bytes) for anonymous callers.</summary>
+    public int MaxRequestBytes { get; init; } = 16 * 1024;
+
+    /// <summary>Per-request pipeline timeout (seconds) for anonymous callers.</summary>
+    public int RequestTimeoutSeconds { get; init; } = 60;
+
+    // ── Rate limits ──────────────────────────────────────────────────────────
+    public int BootstrapPerIpPerMinute { get; init; } = 5;
+    public int ChatPerSubjectPerMinute { get; init; } = 5;
+    public int ChatPerIpPerMinute { get; init; } = 10;
+
+    // ── Hosted global daily ceilings (billable-use circuit breaker) ───────────
+    public int DailyMaxRequests { get; init; } = 500;
+    public long DailyMaxTokens { get; init; } = 200_000;
+    public decimal DailyMaxCostUsd { get; init; } = 5.00m;
+
+    /// <summary>True once the hosted opt-in and guardrails have been validated and enforced.</summary>
+    public bool AllowHosted { get; init; }
+
+    /// <summary>
+    /// True when this process must enforce the hosted guardrails (hosted deploy, or an explicit
+    /// <c>AllowHosted=true</c> even in Development). Drives the circuit breaker and replica pinning.
+    /// </summary>
+    public bool HostedGuardrailsEnforced { get; init; }
+
+    /// <summary>True when the signing key was supplied via configuration (not ephemerally generated).</summary>
+    public bool HasConfiguredSigningKey => !string.IsNullOrWhiteSpace(SigningKey) && !IsPlaceholder(SigningKey);
+
+    /// <summary>
+    /// Resolves and validates options from configuration. Throws at startup for any missing,
+    /// malformed, or unsafe value that would make a hosted Anonymous deployment unsafe.
+    /// </summary>
+    public static AnonymousAuthOptions FromConfiguration(IConfiguration configuration, IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        IConfigurationSection section = configuration.GetSection(SectionName);
+        bool isDevelopment = environment.IsDevelopment();
+        bool allowHosted = section.GetValue("AllowHosted", false);
+
+        // Any non-Development environment is "hosted" and MUST carry the second explicit opt-in.
+        bool hosted = !isDevelopment;
+        if (hosted && !allowHosted)
+        {
+            throw new InvalidOperationException(
+                $"Anonymous authentication is enabled in the '{environment.EnvironmentName}' environment but " +
+                "Anonymous:AllowHosted is not true. A hosted/non-Development Anonymous deployment requires a " +
+                "SECOND explicit opt-in (Anonymous__AllowHosted=true) plus complete guardrail configuration. " +
+                "This fails closed by design — Anonymous mode reaches billable models.");
+        }
+
+        // Enforce the full guardrail set whenever hosting is in play (a hosted deploy, or an
+        // explicit AllowHosted=true even locally). Development without AllowHosted stays lenient.
+        bool enforce = hosted || allowHosted;
+
+        var options = new AnonymousAuthOptions
+        {
+            Issuer = Clean(section["Issuer"]) ?? "retail-pulse-anonymous",
+            Audience = Clean(section["Audience"]) ?? "retail-pulse-api",
+            SessionTokenTtlSeconds = section.GetValue("SessionTokenTtlSeconds", 900),
+            SigningKey = Clean(section["SigningKey"]),
+            Role = Clean(section["Role"]) ?? AnonymousCapabilityPolicy.DefaultRole,
+            Scope = Clean(section["Scope"]) ?? AnonymousCapabilityPolicy.DefaultScope,
+            MaxOutputTokens = section.GetValue("MaxOutputTokens", 512),
+            MaxRequestBytes = section.GetValue("MaxRequestBytes", 16 * 1024),
+            RequestTimeoutSeconds = section.GetValue("RequestTimeoutSeconds", 60),
+            BootstrapPerIpPerMinute = section.GetValue("Bootstrap:PerIpPerMinute", 5),
+            ChatPerSubjectPerMinute = section.GetValue("Chat:PerSubjectPerMinute", 5),
+            ChatPerIpPerMinute = section.GetValue("Chat:PerIpPerMinute", 10),
+            DailyMaxRequests = section.GetValue("Limits:DailyMaxRequests", 500),
+            DailyMaxTokens = section.GetValue("Limits:DailyMaxTokens", 200_000L),
+            DailyMaxCostUsd = section.GetValue("Limits:DailyMaxCostUsd", 5.00m),
+            AllowHosted = allowHosted,
+            HostedGuardrailsEnforced = enforce,
+        };
+
+        options.Validate(enforce, environment.EnvironmentName);
+        return options;
+    }
+
+    private void Validate(bool enforce, string environmentName)
+    {
+        RequireInRange(SessionTokenTtlSeconds, 30, 3600, "Anonymous:SessionTokenTtlSeconds");
+        RequireInRange(MaxOutputTokens, 1, 4096, "Anonymous:MaxOutputTokens");
+        RequireInRange(MaxRequestBytes, 256, 1_000_000, "Anonymous:MaxRequestBytes");
+        RequireInRange(RequestTimeoutSeconds, 1, 120, "Anonymous:RequestTimeoutSeconds");
+        RequirePositive(BootstrapPerIpPerMinute, "Anonymous:Bootstrap:PerIpPerMinute");
+        RequirePositive(ChatPerSubjectPerMinute, "Anonymous:Chat:PerSubjectPerMinute");
+        RequirePositive(ChatPerIpPerMinute, "Anonymous:Chat:PerIpPerMinute");
+
+        if (string.IsNullOrWhiteSpace(Issuer) || string.IsNullOrWhiteSpace(Audience))
+        {
+            throw new InvalidOperationException(
+                "Anonymous:Issuer and Anonymous:Audience are required so session tokens can be validated.");
+        }
+
+        if (!enforce)
+        {
+            return; // Development without AllowHosted: ephemeral key + lenient ceilings are allowed.
+        }
+
+        // Hosted guardrails — every one of these is mandatory and must be safe.
+        if (!HasConfiguredSigningKey)
+        {
+            throw new InvalidOperationException(
+                $"Anonymous:SigningKey is required for a hosted Anonymous deployment ('{environmentName}'). " +
+                "Supply a strong secret via Anonymous__SigningKey or a secret store — never commit it. " +
+                "An ephemeral key is only permitted in Development.");
+        }
+
+        if (Encoding.UTF8.GetByteCount(SigningKey!) < 32)
+        {
+            throw new InvalidOperationException(
+                "Anonymous:SigningKey must be at least 32 bytes (256-bit) for HMAC-SHA256 signing.");
+        }
+
+        RequirePositive(DailyMaxRequests, "Anonymous:Limits:DailyMaxRequests");
+        RequirePositive(DailyMaxTokens, "Anonymous:Limits:DailyMaxTokens");
+        if (DailyMaxCostUsd <= 0m)
+        {
+            throw new InvalidOperationException(
+                "Anonymous:Limits:DailyMaxCostUsd must be greater than zero for a hosted Anonymous deployment. " +
+                "Missing or non-positive billable-use ceilings fail closed.");
+        }
+    }
+
+    private static void RequirePositive(long value, string name)
+    {
+        if (value <= 0)
+        {
+            throw new InvalidOperationException($"{name} must be greater than zero (was {value}).");
+        }
+    }
+
+    private static void RequireInRange(int value, int min, int max, string name)
+    {
+        if (value < min || value > max)
+        {
+            throw new InvalidOperationException($"{name} must be between {min} and {max} (was {value}).");
+        }
+    }
+
+    private static bool IsPlaceholder(string? value) =>
+        !string.IsNullOrWhiteSpace(value) && (value.Contains('<') || value.Contains('>'));
+
+    private static string? Clean(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        string trimmed = value.Trim();
+        return IsPlaceholder(trimmed) ? null : trimmed;
+    }
+}

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousBudgetCostTracker.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousBudgetCostTracker.cs
@@ -1,0 +1,49 @@
+using RetailPulse.Api.Observability;
+using RetailPulse.Contracts.Observability;
+
+namespace RetailPulse.Api.Security.Anonymous;
+
+/// <summary>
+/// Decorates the real <see cref="ICostTracker"/> so every recorded usage event is also counted
+/// against the anonymous daily <see cref="AnonymousUsageBudget"/>.
+///
+/// It delegates unchanged to the inner tracker (audit/export/telemetry stay intact) and, in
+/// addition, feeds the budget the SAME numbers the cost tracker sees — token totals and the
+/// pricing-table cost. Cache hits arrive as zero-token, cache-flagged events, so they add nothing
+/// to the token/cost ceilings here, exactly as the pricing table computes zero cost for them. This
+/// keeps budget accounting truthful and impossible to inflate or bypass.
+/// </summary>
+public sealed class AnonymousBudgetCostTracker : ICostTracker
+{
+    private readonly ICostTracker _inner;
+    private readonly AnonymousUsageBudget _budget;
+    private readonly TokenPricing _pricing;
+
+    public AnonymousBudgetCostTracker(ICostTracker inner, AnonymousUsageBudget budget, IConfiguration configuration)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _budget = budget ?? throw new ArgumentNullException(nameof(budget));
+        _pricing = TokenPricing.FromConfiguration(configuration);
+    }
+
+    public async Task TrackUsageAsync(UsageEvent usage, CancellationToken ct = default)
+    {
+        await _inner.TrackUsageAsync(usage, ct);
+
+        // CacheHit events and zero-token events contribute nothing (pricing returns 0), so a
+        // cache hit advances neither the token nor the cost ceiling — only the request ceiling,
+        // which is charged up-front at request admission by the guard middleware.
+        long tokens = usage.CacheHit ? 0 : usage.InputTokens + usage.OutputTokens;
+        decimal cost = _pricing.Calculate(usage);
+        _budget.RecordUsage(tokens, cost);
+    }
+
+    public Task<CostSummary> GetSummaryAsync(CostPeriod period, CancellationToken ct = default) =>
+        _inner.GetSummaryAsync(period, ct);
+
+    public Task<IReadOnlyList<AgentCostBreakdown>> GetByAgentAsync(CostPeriod period, CancellationToken ct = default) =>
+        _inner.GetByAgentAsync(period, ct);
+
+    public Task<CostTrend> GetTrendAsync(int days = 7, CancellationToken ct = default) =>
+        _inner.GetTrendAsync(days, ct);
+}

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousCapabilityPolicy.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousCapabilityPolicy.cs
@@ -1,0 +1,89 @@
+using System.Security.Claims;
+
+namespace RetailPulse.Api.Security.Anonymous;
+
+/// <summary>
+/// Central, single-source definition of what an Anonymous-mode principal may and may not do.
+///
+/// This is deliberately data — a named policy, not fragile per-endpoint or UI-level hiding — so
+/// the read-only guard, the chat tool filter, and the tests all reason about the same lists. If a
+/// new mutation endpoint or write-capable tool is added, it is denied to anonymous callers by
+/// DEFAULT (deny-by-default on non-GET verbs), and only an explicit addition to
+/// <see cref="AnonymousReadableNonGetRoutes"/> can widen the anonymous surface.
+/// </summary>
+public static class AnonymousCapabilityPolicy
+{
+    /// <summary>The normalized provider name stamped on every anonymous principal.</summary>
+    public const string ProviderName = "Anonymous";
+
+    /// <summary>Claim type that records the issuing provider on the session token.</summary>
+    public const string ProviderClaimType = "provider";
+
+    /// <summary>Constrained app role every anonymous session carries (never RetailPulse.User).</summary>
+    public const string DefaultRole = "RetailPulse.Anonymous";
+
+    /// <summary>Constrained delegated scope every anonymous session carries.</summary>
+    public const string DefaultScope = "chat_limited";
+
+    /// <summary>Route of the single unauthenticated anonymous bootstrap endpoint.</summary>
+    public const string BootstrapRoute = "/api/auth/anonymous/session";
+
+    /// <summary>
+    /// Tool method names that mutate state (create approvals/actions, write memory, etc.). These
+    /// are stripped from the tool set exposed to an anonymous principal so the model can never
+    /// invoke a write path. Matched against <c>AIFunction.Name</c> (the CLR method name).
+    /// </summary>
+    public static readonly IReadOnlySet<string> WriteCapableToolNames =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Creates an approval-gate request and awaits a human action — a write.
+            "RequestApproval",
+        };
+
+    /// <summary>
+    /// The ONLY non-GET routes an anonymous principal may reach. Everything else that is not a
+    /// GET/HEAD/OPTIONS is a mutation and is denied. These are read-only query/chat endpoints that
+    /// happen to use POST for a request body. The bootstrap route is unauthenticated (handled by
+    /// AllowAnonymous) and is included for completeness/robustness.
+    /// </summary>
+    public static readonly IReadOnlySet<string> AnonymousReadableNonGetRoutes =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            BootstrapRoute,
+            "/api/chat",
+            "/api/chat/stream",
+            "/api/council/convene",
+            "/api/knowledge/search",
+            "/api/message-extension/query",
+            "/api/scorecard",
+            "/api/escalate",
+        };
+
+    /// <summary>
+    /// True when the principal is an authenticated Anonymous-provider session (used by the guard
+    /// and tool filter to decide whether the read-only / write-tool restrictions apply). Identity
+    /// is taken from the validated token's <c>provider</c> claim — never a client header.
+    /// </summary>
+    public static bool IsAnonymousPrincipal(ClaimsPrincipal? principal) =>
+        principal?.Identity is { IsAuthenticated: true }
+        && string.Equals(
+            principal.FindFirst(ProviderClaimType)?.Value,
+            ProviderName,
+            StringComparison.Ordinal);
+
+    /// <summary>
+    /// True when a request with the given HTTP method and path is a mutation that must be denied
+    /// to anonymous callers. GET/HEAD/OPTIONS are always read-safe; any other verb is a mutation
+    /// unless the exact path is on the read-only allowlist.
+    /// </summary>
+    public static bool IsBlockedMutation(string method, string path)
+    {
+        if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method) || HttpMethods.IsOptions(method))
+        {
+            return false;
+        }
+
+        string normalized = path.Length > 1 ? path.TrimEnd('/') : path;
+        return !AnonymousReadableNonGetRoutes.Contains(normalized);
+    }
+}

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousCapabilityPolicy.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousCapabilityPolicy.cs
@@ -6,10 +6,15 @@ namespace RetailPulse.Api.Security.Anonymous;
 /// Central, single-source definition of what an Anonymous-mode principal may and may not do.
 ///
 /// This is deliberately data — a named policy, not fragile per-endpoint or UI-level hiding — so
-/// the read-only guard, the chat tool filter, and the tests all reason about the same lists. If a
-/// new mutation endpoint or write-capable tool is added, it is denied to anonymous callers by
-/// DEFAULT (deny-by-default on non-GET verbs), and only an explicit addition to
-/// <see cref="AnonymousReadableNonGetRoutes"/> can widen the anonymous surface.
+/// the deny-by-default guard, the chat tool filter, and the tests all reason about the same
+/// allowlist. There is NO verb shortcut: a request is denied unless its exact (method, route) is
+/// on the closed <see cref="AllowedRoutes"/> allowlist (or one of the two allowed hubs). The
+/// entire anonymous surface is therefore: the unauthenticated bootstrap, the authenticated
+/// <c>POST /api/chat</c>, and the telemetry/streaming hubs that chat turn needs. Every other
+/// mapped endpoint — observability, admin, export, memory, cards, approvals, guardrail logs, and
+/// all broad GET reads — is denied (403). Read-only charts/data are reached through the filtered
+/// chat tool path, never a direct operator endpoint. Widening the surface requires an explicit
+/// addition here, reviewed against the runtime inventory tests.
 /// </summary>
 public static class AnonymousCapabilityPolicy
 {
@@ -28,6 +33,15 @@ public static class AnonymousCapabilityPolicy
     /// <summary>Route of the single unauthenticated anonymous bootstrap endpoint.</summary>
     public const string BootstrapRoute = "/api/auth/anonymous/session";
 
+    /// <summary>The single authenticated REST capability of an anonymous session.</summary>
+    public const string ChatRoute = "/api/chat";
+
+    /// <summary>Telemetry hub root — the anonymous chat UI subscribes to per-session spans here.</summary>
+    public const string TelemetryHubRoute = "/hubs/telemetry";
+
+    /// <summary>Streaming hub root — progressive token delivery for the anonymous chat turn.</summary>
+    public const string StreamingHubRoute = "/hubs/streaming";
+
     /// <summary>
     /// Tool method names that mutate state (create approvals/actions, write memory, etc.). These
     /// are stripped from the tool set exposed to an anonymous principal so the model can never
@@ -38,26 +52,29 @@ public static class AnonymousCapabilityPolicy
         {
             // Creates an approval-gate request and awaits a human action — a write.
             "RequestApproval",
+            // Persists cross-prompt memory — disabled for Anonymous to eliminate stored injection.
+            "RememberPreference",
+            "SaveMemory",
         };
 
     /// <summary>
-    /// The ONLY non-GET routes an anonymous principal may reach. Everything else that is not a
-    /// GET/HEAD/OPTIONS is a mutation and is denied. These are read-only query/chat endpoints that
-    /// happen to use POST for a request body. The bootstrap route is unauthenticated (handled by
-    /// AllowAnonymous) and is included for completeness/robustness.
+    /// The EXACT (method, route) pairs an authenticated anonymous principal may reach. This is a
+    /// closed allowlist — there is NO GET verb shortcut. Any request whose (method, path) is not
+    /// matched here (or a hub route, see <see cref="IsHubRoute"/>) is denied by default. Deliberately
+    /// minimal: the smallest useful surface is the authenticated chat POST plus the bootstrap
+    /// (which is unauthenticated via AllowAnonymous and therefore never reaches the guard, but is
+    /// listed for completeness). Read-only charts/data are served through the filtered chat tool
+    /// path, never through direct operator/observability endpoints.
     /// </summary>
-    public static readonly IReadOnlySet<string> AnonymousReadableNonGetRoutes =
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    private static readonly IReadOnlySet<(string Method, string Route)> _allowedRoutes =
+        new HashSet<(string, string)>
         {
-            BootstrapRoute,
-            "/api/chat",
-            "/api/chat/stream",
-            "/api/council/convene",
-            "/api/knowledge/search",
-            "/api/message-extension/query",
-            "/api/scorecard",
-            "/api/escalate",
+            ("POST", BootstrapRoute),
+            ("POST", ChatRoute),
         };
+
+    /// <summary>The two SignalR hub roots an anonymous chat session needs for telemetry/streaming.</summary>
+    private static readonly string[] _allowedHubRoutes = [TelemetryHubRoute, StreamingHubRoute];
 
     /// <summary>
     /// True when the principal is an authenticated Anonymous-provider session (used by the guard
@@ -72,18 +89,59 @@ public static class AnonymousCapabilityPolicy
             StringComparison.Ordinal);
 
     /// <summary>
-    /// True when a request with the given HTTP method and path is a mutation that must be denied
-    /// to anonymous callers. GET/HEAD/OPTIONS are always read-safe; any other verb is a mutation
-    /// unless the exact path is on the read-only allowlist.
+    /// True when the request targets one of the two allowed SignalR hubs. SignalR uses GET
+    /// (WebSocket upgrade / long-poll receive) and POST (negotiate / long-poll send) under the hub
+    /// path, so both verbs are permitted on the hub prefixes; cross-subject isolation for hub
+    /// groups is enforced separately in the hub itself (session-ownership binding).
     /// </summary>
-    public static bool IsBlockedMutation(string method, string path)
+    public static bool IsHubRoute(string method, string path)
     {
-        if (HttpMethods.IsGet(method) || HttpMethods.IsHead(method) || HttpMethods.IsOptions(method))
+        if (!HttpMethods.IsGet(method) && !HttpMethods.IsPost(method) && !HttpMethods.IsOptions(method))
         {
             return false;
         }
 
-        string normalized = path.Length > 1 ? path.TrimEnd('/') : path;
-        return !AnonymousReadableNonGetRoutes.Contains(normalized);
+        string normalized = Normalize(path);
+        foreach (string hub in _allowedHubRoutes)
+        {
+            if (normalized.Equals(hub, StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith(hub + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
+
+    /// <summary>
+    /// Deny-by-default authorization for an anonymous principal: returns true ONLY when the exact
+    /// (method, path) is on the closed allowlist or is an allowed hub route. Everything else —
+    /// including every GET to observability/admin/export/memory/cards/approvals/guardrail-log
+    /// endpoints — is denied (the guard returns 403).
+    /// </summary>
+    public static bool IsAllowed(string method, string path)
+    {
+        // CORS preflight carries no credentials/body and mutates nothing.
+        return HttpMethods.IsOptions(method)
+            || IsHubRoute(method, path)
+            || _allowedRoutes.Contains((method.ToUpperInvariant(), Normalize(path)));
+    }
+
+    /// <summary>
+    /// True when the request must be denied (403) for an anonymous principal — the negation of
+    /// <see cref="IsAllowed"/>. A request is blocked unless it is explicitly allowlisted.
+    /// </summary>
+    public static bool IsBlocked(string method, string path) => !IsAllowed(method, path);
+
+    /// <summary>
+    /// True when the request reaches the single billable model path (<c>POST /api/chat</c>) and
+    /// must be metered against the per-subject/per-IP limits and the daily budget. No other
+    /// anonymous-reachable route calls a model.
+    /// </summary>
+    public static bool IsBudgetedModelRoute(string method, string path) =>
+        HttpMethods.IsPost(method)
+        && string.Equals(Normalize(path), ChatRoute, StringComparison.OrdinalIgnoreCase);
+
+    private static string Normalize(string path) => path.Length > 1 ? path.TrimEnd('/') : path;
 }

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousCapabilityPolicy.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousCapabilityPolicy.cs
@@ -8,13 +8,21 @@ namespace RetailPulse.Api.Security.Anonymous;
 /// This is deliberately data — a named policy, not fragile per-endpoint or UI-level hiding — so
 /// the deny-by-default guard, the chat tool filter, and the tests all reason about the same
 /// allowlist. There is NO verb shortcut: a request is denied unless its exact (method, route) is
-/// on the closed <see cref="AllowedRoutes"/> allowlist (or one of the two allowed hubs). The
-/// entire anonymous surface is therefore: the unauthenticated bootstrap, the authenticated
-/// <c>POST /api/chat</c>, and the telemetry/streaming hubs that chat turn needs. Every other
-/// mapped endpoint — observability, admin, export, memory, cards, approvals, guardrail logs, and
-/// all broad GET reads — is denied (403). Read-only charts/data are reached through the filtered
-/// chat tool path, never a direct operator endpoint. Widening the surface requires an explicit
-/// addition here, reviewed against the runtime inventory tests.
+/// on the closed <see cref="_allowedRoutes"/> allowlist. The entire anonymous surface is exactly
+/// TWO routes: the unauthenticated bootstrap <c>POST /api/auth/anonymous/session</c> and the
+/// authenticated <c>POST /api/chat</c>.
+///
+/// Sprint 1 mandate: the SignalR hubs (<c>/hubs/telemetry</c>, <c>/hubs/streaming</c>) are NOT part
+/// of the anonymous surface. An anonymous session gets no real-time telemetry or token streaming —
+/// a valid anonymous token is denied (403) on both hub negotiate and connection endpoints. Removing
+/// the hubs eliminates the Clients.All / global-broadcast and hub group-namespace collision exposure
+/// entirely, without refactoring the shared (Entra) telemetry pipeline. The Sprint 3 anonymous
+/// frontend simply does not start the hubs.
+///
+/// Every other mapped endpoint — observability, admin, export, memory, cards, approvals, guardrail
+/// logs, all broad GET reads, and every hub route — is denied (403). Read-only charts/data are
+/// reached through the filtered chat tool path, never a direct operator endpoint. Widening the
+/// surface requires an explicit addition here, reviewed against the runtime inventory tests.
 /// </summary>
 public static class AnonymousCapabilityPolicy
 {
@@ -36,12 +44,6 @@ public static class AnonymousCapabilityPolicy
     /// <summary>The single authenticated REST capability of an anonymous session.</summary>
     public const string ChatRoute = "/api/chat";
 
-    /// <summary>Telemetry hub root — the anonymous chat UI subscribes to per-session spans here.</summary>
-    public const string TelemetryHubRoute = "/hubs/telemetry";
-
-    /// <summary>Streaming hub root — progressive token delivery for the anonymous chat turn.</summary>
-    public const string StreamingHubRoute = "/hubs/streaming";
-
     /// <summary>
     /// Tool method names that mutate state (create approvals/actions, write memory, etc.). These
     /// are stripped from the tool set exposed to an anonymous principal so the model can never
@@ -59,12 +61,12 @@ public static class AnonymousCapabilityPolicy
 
     /// <summary>
     /// The EXACT (method, route) pairs an authenticated anonymous principal may reach. This is a
-    /// closed allowlist — there is NO GET verb shortcut. Any request whose (method, path) is not
-    /// matched here (or a hub route, see <see cref="IsHubRoute"/>) is denied by default. Deliberately
-    /// minimal: the smallest useful surface is the authenticated chat POST plus the bootstrap
-    /// (which is unauthenticated via AllowAnonymous and therefore never reaches the guard, but is
-    /// listed for completeness). Read-only charts/data are served through the filtered chat tool
-    /// path, never through direct operator/observability endpoints.
+    /// closed allowlist — there is NO GET verb shortcut and NO hub route. Any request whose
+    /// (method, path) is not matched here is denied by default. The anonymous surface is exactly two
+    /// routes: the authenticated chat POST plus the bootstrap (which is unauthenticated via
+    /// AllowAnonymous and therefore never reaches the guard, but is listed for completeness).
+    /// Read-only charts/data are served through the filtered chat tool path, never through direct
+    /// operator/observability endpoints; real-time telemetry/streaming hubs are not exposed.
     /// </summary>
     private static readonly IReadOnlySet<(string Method, string Route)> _allowedRoutes =
         new HashSet<(string, string)>
@@ -72,9 +74,6 @@ public static class AnonymousCapabilityPolicy
             ("POST", BootstrapRoute),
             ("POST", ChatRoute),
         };
-
-    /// <summary>The two SignalR hub roots an anonymous chat session needs for telemetry/streaming.</summary>
-    private static readonly string[] _allowedHubRoutes = [TelemetryHubRoute, StreamingHubRoute];
 
     /// <summary>
     /// True when the principal is an authenticated Anonymous-provider session (used by the guard
@@ -89,42 +88,15 @@ public static class AnonymousCapabilityPolicy
             StringComparison.Ordinal);
 
     /// <summary>
-    /// True when the request targets one of the two allowed SignalR hubs. SignalR uses GET
-    /// (WebSocket upgrade / long-poll receive) and POST (negotiate / long-poll send) under the hub
-    /// path, so both verbs are permitted on the hub prefixes; cross-subject isolation for hub
-    /// groups is enforced separately in the hub itself (session-ownership binding).
-    /// </summary>
-    public static bool IsHubRoute(string method, string path)
-    {
-        if (!HttpMethods.IsGet(method) && !HttpMethods.IsPost(method) && !HttpMethods.IsOptions(method))
-        {
-            return false;
-        }
-
-        string normalized = Normalize(path);
-        foreach (string hub in _allowedHubRoutes)
-        {
-            if (normalized.Equals(hub, StringComparison.OrdinalIgnoreCase)
-                || normalized.StartsWith(hub + "/", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
     /// Deny-by-default authorization for an anonymous principal: returns true ONLY when the exact
-    /// (method, path) is on the closed allowlist or is an allowed hub route. Everything else —
-    /// including every GET to observability/admin/export/memory/cards/approvals/guardrail-log
-    /// endpoints — is denied (the guard returns 403).
+    /// (method, path) is on the closed allowlist. Everything else — including every hub route and
+    /// every GET to observability/admin/export/memory/cards/approvals/guardrail-log endpoints — is
+    /// denied (the guard returns 403).
     /// </summary>
     public static bool IsAllowed(string method, string path)
     {
         // CORS preflight carries no credentials/body and mutates nothing.
         return HttpMethods.IsOptions(method)
-            || IsHubRoute(method, path)
             || _allowedRoutes.Contains((method.ToUpperInvariant(), Normalize(path)));
     }
 

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousChatRestrictions.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousChatRestrictions.cs
@@ -1,0 +1,61 @@
+using RetailPulse.Contracts.Routing;
+
+namespace RetailPulse.Api.Security.Anonymous;
+
+/// <summary>
+/// Intent-level restrictions applied to an Anonymous-mode <c>POST /api/chat</c> turn, enforced in
+/// the endpoint BEFORE specialist selection/execution and BEFORE any alternate in-process
+/// orchestrator (the consensus council) is convened.
+///
+/// These close two chat-internal bypasses that tool filtering alone cannot:
+/// <list type="bullet">
+///   <item><b>Memory management</b> — the <c>MemoryManagementAgent</c> calls
+///     <c>IConversationMemory.StoreAsync</c>/<c>ForgetAsync</c> DIRECTLY (it uses no AI tools), so
+///     the anonymous write-tool filter never sees it. If the router classifies a prompt (e.g.
+///     "remember that ...") as <see cref="AgentIntent.MemoryManagement"/>, the endpoint returns a
+///     standard safe refusal so that agent never runs — no model call, no memory row written.</item>
+///   <item><b>Consensus council / portfolio health</b> — the council interception convenes
+///     <c>IConsensusCouncil</c>, which fans out multiple model calls and returns EARLY, bypassing
+///     the single accounted budget/audit/guardrail path. For an anonymous session the endpoint
+///     refuses before the council is convened, so no council model call is ever made.</item>
+/// </list>
+/// Both are hard refusals (deterministic, no model), independent of and in addition to the
+/// tool-filter and cache/memory-disabled narrowing already applied to the retained single
+/// <c>AgentExecutionPipeline</c> model path.
+/// </summary>
+public static class AnonymousChatRestrictions
+{
+    /// <summary>Standard safe refusal returned when an anonymous turn is classified as memory management.</summary>
+    public const string MemoryRefusalMessage =
+        "Saving or clearing remembered preferences isn't available in anonymous mode. " +
+        "Your session keeps no durable memory between conversations. " +
+        "You can still ask about demand, promotions, supply, margins, competitive and field insights.";
+
+    /// <summary>Standard safe refusal returned when an anonymous turn would convene the portfolio-health council.</summary>
+    public const string CouncilRefusalMessage =
+        "The multi-agent Portfolio Health Council isn't available in anonymous mode. " +
+        "Ask a single-topic question — for example demand, promotions, supply, margins, " +
+        "competitive or field insights — and a specialist will answer.";
+
+    /// <summary>
+    /// True when the routing decision targets memory management (the direct-write
+    /// <c>MemoryManagementAgent</c>), by primary intent or any detected multi-intent.
+    /// </summary>
+    public static bool IsMemoryManagementIntent(RoutingDecision decision) =>
+        MatchesIntent(decision, AgentIntent.MemoryManagement);
+
+    /// <summary>
+    /// True when the routing decision would trigger the consensus-council interception
+    /// (portfolio health), by primary intent or any detected multi-intent. Mirrors the council
+    /// interception's own trigger so the refusal fires on exactly the same condition.
+    /// </summary>
+    public static bool IsCouncilIntent(RoutingDecision decision) =>
+        MatchesIntent(decision, AgentIntent.PortfolioHealth);
+
+    private static bool MatchesIntent(RoutingDecision decision, string intent)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        return string.Equals(decision.Intent, intent, StringComparison.OrdinalIgnoreCase)
+            || decision.DetectedIntents?.Any(i => string.Equals(i, intent, StringComparison.OrdinalIgnoreCase)) == true;
+    }
+}

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousRateLimiter.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousRateLimiter.cs
@@ -1,0 +1,85 @@
+using System.Collections.Concurrent;
+
+namespace RetailPulse.Api.Security.Anonymous;
+
+/// <summary>
+/// Compact, thread-safe, in-memory fixed-window rate limiter keyed by an arbitrary string
+/// (per-subject or per-IP). Used by the anonymous guard for chat limits that need a key the
+/// ASP.NET rate limiter partitions cannot easily express (the validated token subject). Windows
+/// are one minute; stale buckets are swept opportunistically to bound memory.
+///
+/// Replica-local like the rest of the anonymous guardrails — acceptable because hosted Anonymous
+/// runs at <c>maxReplicas=1</c>.
+/// </summary>
+public sealed class AnonymousRateLimiter
+{
+    private sealed class Window
+    {
+        public long WindowTicks;
+        public int Count;
+    }
+
+    private readonly ConcurrentDictionary<string, Window> _windows = new(StringComparer.Ordinal);
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _window = TimeSpan.FromMinutes(1);
+    private long _lastSweepTicks;
+
+    public AnonymousRateLimiter(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Returns true when a request under <paramref name="key"/> is within
+    /// <paramref name="permitPerMinute"/> for the current one-minute window; false when the limit
+    /// is exceeded (fail-closed).
+    /// </summary>
+    public bool TryAcquire(string key, int permitPerMinute)
+    {
+        long nowTicks = _timeProvider.GetUtcNow().UtcDateTime.Ticks;
+        long windowTicks = nowTicks - (nowTicks % _window.Ticks);
+
+        MaybeSweep(nowTicks);
+
+        Window window = _windows.GetOrAdd(key, _ => new Window { WindowTicks = windowTicks });
+        lock (window)
+        {
+            if (window.WindowTicks != windowTicks)
+            {
+                window.WindowTicks = windowTicks;
+                window.Count = 0;
+            }
+
+            if (window.Count >= permitPerMinute)
+            {
+                return false;
+            }
+
+            window.Count++;
+            return true;
+        }
+    }
+
+    private void MaybeSweep(long nowTicks)
+    {
+        long last = Interlocked.Read(ref _lastSweepTicks);
+        if (nowTicks - last < _window.Ticks)
+        {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _lastSweepTicks, nowTicks, last) != last)
+        {
+            return;
+        }
+
+        long cutoff = nowTicks - (2 * _window.Ticks);
+        foreach (KeyValuePair<string, Window> entry in _windows)
+        {
+            if (Volatile.Read(ref entry.Value.WindowTicks) < cutoff)
+            {
+                _windows.TryRemove(entry.Key, out _);
+            }
+        }
+    }
+}

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousSessionTokenService.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousSessionTokenService.cs
@@ -1,0 +1,83 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace RetailPulse.Api.Security.Anonymous;
+
+/// <summary>Result of minting an anonymous session credential.</summary>
+/// <param name="Token">The signed, short-lived bearer/access token.</param>
+/// <param name="Subject">The cryptographically random, immutable per-session subject.</param>
+/// <param name="ExpiresInSeconds">Seconds until the token expires.</param>
+public readonly record struct AnonymousSession(string Token, string Subject, int ExpiresInSeconds);
+
+/// <summary>
+/// Issues short-lived, server-signed anonymous session tokens.
+///
+/// Identity is minted by the SERVER, never taken from a client header: each call produces a fresh,
+/// cryptographically random subject. The token is a compact HS256 JWT carrying only non-PII claims
+/// (subject, provider, constrained role/scope, issuer/audience, strict expiry, random jti). There
+/// is no refresh token — the client re-bootstraps when the short TTL elapses, which bounds replay.
+/// </summary>
+public interface IAnonymousSessionTokenService
+{
+    /// <summary>Creates a new anonymous session with a fresh random subject and a signed token.</summary>
+    AnonymousSession CreateSession();
+}
+
+/// <inheritdoc />
+public sealed class AnonymousSessionTokenService : IAnonymousSessionTokenService
+{
+    private readonly AnonymousAuthOptions _options;
+    private readonly AnonymousSigningKeyProvider _keyProvider;
+    private readonly TimeProvider _timeProvider;
+    private readonly JsonWebTokenHandler _handler = new();
+
+    public AnonymousSessionTokenService(
+        AnonymousAuthOptions options,
+        AnonymousSigningKeyProvider keyProvider,
+        TimeProvider? timeProvider = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _keyProvider = keyProvider ?? throw new ArgumentNullException(nameof(keyProvider));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public AnonymousSession CreateSession()
+    {
+        string subject = NewSubject();
+        DateTime now = _timeProvider.GetUtcNow().UtcDateTime;
+        DateTime expires = now.AddSeconds(_options.SessionTokenTtlSeconds);
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _options.Issuer,
+            Audience = _options.Audience,
+            IssuedAt = now,
+            NotBefore = now,
+            Expires = expires,
+            Subject = new ClaimsIdentity(
+            [
+                new Claim(JwtRegisteredClaimNames.Sub, subject),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+                new Claim(AnonymousCapabilityPolicy.ProviderClaimType, AnonymousCapabilityPolicy.ProviderName),
+                new Claim("roles", _options.Role),
+                new Claim("scp", _options.Scope),
+            ]),
+            SigningCredentials = new SigningCredentials(
+                _keyProvider.Key,
+                SecurityAlgorithms.HmacSha256),
+        };
+
+        string token = _handler.CreateToken(descriptor);
+        return new AnonymousSession(token, subject, _options.SessionTokenTtlSeconds);
+    }
+
+    /// <summary>16 random bytes, base64url-encoded, no PII. Immutable for the session lifetime.</summary>
+    private static string NewSubject()
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        RandomNumberGenerator.Fill(bytes);
+        return "anon-" + Base64UrlEncoder.Encode(bytes.ToArray());
+    }
+}

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousSigningKeyProvider.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousSigningKeyProvider.cs
@@ -1,0 +1,52 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace RetailPulse.Api.Security.Anonymous;
+
+/// <summary>
+/// Provides the symmetric HMAC key used to sign and validate anonymous session tokens.
+///
+/// Key resolution is fail-closed and environment-aware:
+/// <list type="bullet">
+///   <item>When <see cref="AnonymousAuthOptions.HasConfiguredSigningKey"/> is true, the configured
+///     secret is used (required in hosted mode; validated to be ≥ 256-bit by the options).</item>
+///   <item>Otherwise (Development only — hosted mode already failed startup) a cryptographically
+///     random 256-bit key is generated ONCE per process. It is never persisted, so all anonymous
+///     sessions are invalidated when the process restarts. This is documented, intentional dev
+///     behavior, not a fallback that can leak into a hosted deployment.</item>
+/// </list>
+/// A single instance is registered as a singleton so the ephemeral key is stable within a process.
+/// </summary>
+public sealed class AnonymousSigningKeyProvider
+{
+    /// <summary>True when the key was generated ephemerally (Development, no configured secret).</summary>
+    public bool IsEphemeral { get; }
+
+    public AnonymousSigningKeyProvider(AnonymousAuthOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.HasConfiguredSigningKey)
+        {
+            Key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(options.SigningKey!))
+            {
+                KeyId = "anon-configured",
+            };
+            IsEphemeral = false;
+        }
+        else
+        {
+            // Development-only: a fresh 256-bit key per process. Sessions do not survive a restart.
+            byte[] material = RandomNumberGenerator.GetBytes(32);
+            Key = new SymmetricSecurityKey(material) { KeyId = "anon-ephemeral" };
+            IsEphemeral = true;
+        }
+    }
+
+    /// <summary>The active signing key for token creation and validation.</summary>
+    public SymmetricSecurityKey Key { get; }
+
+    /// <summary>All keys accepted for validation. Kept as a seam for future key rotation.</summary>
+    public IEnumerable<SecurityKey> ValidationKeys => [Key];
+}

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousUsageBudget.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousUsageBudget.cs
@@ -1,0 +1,154 @@
+namespace RetailPulse.Api.Security.Anonymous;
+
+/// <summary>Point-in-time view of the anonymous daily budget, for telemetry and tests.</summary>
+public readonly record struct AnonymousBudgetSnapshot(
+    DateOnly Day,
+    int Requests,
+    int MaxRequests,
+    long Tokens,
+    long MaxTokens,
+    decimal CostUsd,
+    decimal MaxCostUsd,
+    bool BreakerTripped,
+    string? TripReason);
+
+/// <summary>
+/// Fail-closed daily circuit breaker for anonymous billable use.
+///
+/// Anonymous mode has no per-user accountability, so it MUST have a hard global ceiling. This
+/// tracks the current UTC day's request count, cumulative model tokens, and estimated cost, and
+/// trips a breaker the moment any ceiling is exceeded — after which every new request is denied
+/// until the counters reset at UTC midnight.
+///
+/// <para><b>Truthful accounting.</b> A request slot is consumed at request admission
+/// (<see cref="TryBeginRequest"/>), BEFORE the cache is consulted, so a cache hit cannot bypass
+/// the request ceiling. Token/cost accumulation (<see cref="RecordUsage"/>) is driven by the real
+/// <c>ICostTracker</c> usage stream, where cache hits correctly contribute zero tokens and zero
+/// cost. Usage is never fabricated.</para>
+///
+/// <para><b>Replica-local.</b> Counters live in process memory. Distributed exact enforcement is
+/// not possible with the current replica-local storage, so hosted Anonymous is pinned to
+/// <c>maxReplicas=1</c> and the ceilings are set conservatively. This is explicitly NOT equivalent
+/// to authenticated production; counters also reset on restart.</para>
+/// </summary>
+public sealed class AnonymousUsageBudget
+{
+    private readonly AnonymousAuthOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly Lock _gate = new();
+
+    private DateOnly _day;
+    private int _requests;
+    private long _tokens;
+    private decimal _costUsd;
+    private bool _tripped;
+    private string? _tripReason;
+
+    /// <summary>
+    /// When false (Development without hosted guardrails), the breaker is advisory only and never
+    /// denies — but still counts, so tests and telemetry are meaningful.
+    /// </summary>
+    public bool Enforced { get; }
+
+    public AnonymousUsageBudget(AnonymousAuthOptions options, TimeProvider? timeProvider = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        Enforced = options.HostedGuardrailsEnforced;
+        _day = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
+    }
+
+    /// <summary>
+    /// Attempts to admit one request. Consumes a request slot when admitted. Returns false
+    /// (fail-closed) when the breaker is tripped or the daily request ceiling is reached. In
+    /// non-enforced Development mode it always admits but still increments the counter.
+    /// </summary>
+    public bool TryBeginRequest(out string? denyReason)
+    {
+        lock (_gate)
+        {
+            RollDayIfNeeded();
+
+            if (_tripped)
+            {
+                denyReason = _tripReason ?? "Anonymous daily budget exhausted.";
+                _requests++;
+                return !Enforced;
+            }
+
+            if (_requests >= _options.DailyMaxRequests)
+            {
+                Trip($"Anonymous daily request ceiling reached ({_options.DailyMaxRequests}).");
+                denyReason = _tripReason;
+                _requests++;
+                return !Enforced;
+            }
+
+            _requests++;
+            denyReason = null;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Records real model usage (tokens and estimated cost) against the daily budget. Cache hits
+    /// arrive here as zero tokens/zero cost and therefore never advance the token/cost ceilings.
+    /// Trips the breaker when the token or cost ceiling is exceeded.
+    /// </summary>
+    public void RecordUsage(long tokens, decimal costUsd)
+    {
+        if (tokens <= 0 && costUsd <= 0m)
+        {
+            return;
+        }
+
+        lock (_gate)
+        {
+            RollDayIfNeeded();
+            _tokens += Math.Max(0, tokens);
+            _costUsd += Math.Max(0m, costUsd);
+
+            if (!_tripped && _tokens >= _options.DailyMaxTokens)
+            {
+                Trip($"Anonymous daily token ceiling reached ({_options.DailyMaxTokens}).");
+            }
+            else if (!_tripped && _costUsd >= _options.DailyMaxCostUsd)
+            {
+                Trip($"Anonymous daily cost ceiling reached (${_options.DailyMaxCostUsd}).");
+            }
+        }
+    }
+
+    public AnonymousBudgetSnapshot Snapshot()
+    {
+        lock (_gate)
+        {
+            RollDayIfNeeded();
+            return new AnonymousBudgetSnapshot(
+                _day, _requests, _options.DailyMaxRequests,
+                _tokens, _options.DailyMaxTokens,
+                _costUsd, _options.DailyMaxCostUsd,
+                _tripped, _tripReason);
+        }
+    }
+
+    private void RollDayIfNeeded()
+    {
+        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
+        if (today != _day)
+        {
+            _day = today;
+            _requests = 0;
+            _tokens = 0;
+            _costUsd = 0m;
+            _tripped = false;
+            _tripReason = null;
+        }
+    }
+
+    private void Trip(string reason)
+    {
+        _tripped = true;
+        _tripReason = reason;
+    }
+}

--- a/src/RetailPulse.Api/Security/AnonymousAuthenticationSetup.cs
+++ b/src/RetailPulse.Api/Security/AnonymousAuthenticationSetup.cs
@@ -1,0 +1,141 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Security.Anonymous;
+
+namespace RetailPulse.Api.Security;
+
+/// <summary>
+/// Authentication + authorization wiring for the Anonymous mode.
+///
+/// Mirrors the Entra boundary's shape (a single JwtBearer scheme, a strong default AND fallback
+/// authorization policy, hub-only <c>?access_token</c> mapping) but validates the app's OWN
+/// short-lived session tokens with the local HMAC signing key instead of Entra. The policy is
+/// deliberately narrow and non-degrading:
+/// <list type="bullet">
+///   <item>an authenticated user is always required;</item>
+///   <item>the constrained anonymous role and scope are required;</item>
+///   <item>the token's <c>provider</c> claim must equal <c>Anonymous</c>, so an Entra or any
+///     cross-provider token can never satisfy the anonymous policy.</item>
+/// </list>
+/// Only <c>/health</c>, <c>/alive</c>, and the bootstrap endpoint opt out with AllowAnonymous.
+/// </summary>
+public static class AnonymousAuthenticationSetup
+{
+    public const string AnonymousPolicy = "RetailPulseAnonymous";
+    private const string _hubPathPrefix = "/hubs";
+
+    /// <summary>
+    /// Registers the anonymous session services, the JwtBearer scheme that validates the app's
+    /// own session tokens, and the constrained authorization policy (as both default and
+    /// fallback). Called by the provider-neutral factory for the Anonymous mode.
+    /// </summary>
+    public static void AddAnonymousAuthentication(
+        this IServiceCollection services,
+        AnonymousAuthOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        services.AddSingleton(options);
+        var keyProvider = new AnonymousSigningKeyProvider(options);
+        services.AddSingleton(keyProvider);
+        services.AddSingleton<IAnonymousSessionTokenService, AnonymousSessionTokenService>();
+        services.AddSingleton<IPrincipalNormalizer, AnonymousPrincipalNormalizer>();
+
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, jwt => ConfigureJwtBearer(jwt, keyProvider, options));
+
+        services.AddAuthorization(authz =>
+        {
+            AuthorizationPolicy policy = BuildAnonymousPolicy(options);
+            authz.AddPolicy(AnonymousPolicy, policy);
+            authz.DefaultPolicy = policy;
+            authz.FallbackPolicy = policy;
+        });
+    }
+
+    /// <summary>
+    /// Builds the constrained anonymous authorization policy: authenticated + anonymous role +
+    /// anonymous scope + provider==Anonymous. Exposed for tests.
+    /// </summary>
+    public static AuthorizationPolicy BuildAnonymousPolicy(AnonymousAuthOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return new AuthorizationPolicyBuilder()
+            .RequireAuthenticatedUser()
+            .RequireRole(options.Role)
+            .RequireAssertion(ctx => HasScope(ctx.User, options.Scope))
+            .RequireAssertion(ctx => string.Equals(
+                ctx.User.FindFirst(AnonymousCapabilityPolicy.ProviderClaimType)?.Value,
+                AnonymousCapabilityPolicy.ProviderName,
+                StringComparison.Ordinal))
+            .Build();
+    }
+
+    private static void ConfigureJwtBearer(
+        JwtBearerOptions jwt,
+        AnonymousSigningKeyProvider keyProvider,
+        AnonymousAuthOptions options)
+    {
+        jwt.MapInboundClaims = false;
+        jwt.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuers = [options.Issuer],
+            ValidateAudience = true,
+            ValidAudiences = [options.Audience],
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeys = keyProvider.ValidationKeys,
+            ValidAlgorithms = [SecurityAlgorithms.HmacSha256],
+            ClockSkew = TimeSpan.FromSeconds(30),
+            RoleClaimType = "roles",
+            NameClaimType = JwtRegisteredClaimNames.Sub,
+        };
+
+        jwt.Events = new JwtBearerEvents
+        {
+            OnMessageReceived = context =>
+            {
+                // WebSocket handshakes cannot set Authorization; SignalR passes ?access_token=.
+                // Honour it ONLY for /hubs so REST endpoints keep header-only tokens (a query
+                // token on a REST path is therefore ignored and the request is rejected).
+                if (context.HttpContext.Request.Path.StartsWithSegments(_hubPathPrefix))
+                {
+                    string? queryToken = context.Request.Query["access_token"];
+                    if (!string.IsNullOrEmpty(queryToken))
+                    {
+                        context.Token = queryToken;
+                    }
+                }
+
+                return Task.CompletedTask;
+            },
+        };
+    }
+
+    private static bool HasScope(ClaimsPrincipal principal, string requiredScope)
+    {
+        if (string.IsNullOrWhiteSpace(requiredScope))
+        {
+            return true;
+        }
+
+        foreach (Claim claim in principal.FindAll("scp"))
+        {
+            foreach (string scope in claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (string.Equals(scope, requiredScope, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/RetailPulse.Api/Security/ProviderNeutralAuthentication.cs
+++ b/src/RetailPulse.Api/Security/ProviderNeutralAuthentication.cs
@@ -2,11 +2,13 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using RetailPulse.Api.Auth;
+using RetailPulse.Api.Middleware;
+using RetailPulse.Api.Security.Anonymous;
 
 namespace RetailPulse.Api.Security;
 
 /// <summary>
-/// Provider-neutral authentication factory boundary (Sprint 0 foundation).
+/// Provider-neutral authentication factory boundary.
 ///
 /// This is the single entry point <c>Program.cs</c> calls to wire authentication. It resolves
 /// the configured <see cref="AuthenticationMode"/> and dispatches to a mode-specific wiring
@@ -14,11 +16,17 @@ namespace RetailPulse.Api.Security;
 /// <list type="bullet">
 ///   <item><see cref="AuthenticationMode.Entra"/> → the existing, unchanged Entra security
 ///     boundary (<see cref="AuthenticationSetup.AddRetailPulseAuthentication"/>). Security
-///     semantics are identical to before this foundation existed.</item>
-///   <item><see cref="AuthenticationMode.GitHub"/> / <see cref="AuthenticationMode.Anonymous"/>
-///     → a deliberate fail-closed startup error. These modes are declared but NOT implemented in
-///     this sprint; selecting one throws before any authentication scheme is registered, so the
-///     app can never fall through to Entra, Development, or anonymous access.</item>
+///     semantics are identical to before this foundation existed; it returns the resolved
+///     <see cref="EntraAuthOptions"/> so the caller wires the Entra authorization policy.</item>
+///   <item><see cref="AuthenticationMode.Anonymous"/> → the Sprint 1 Anonymous boundary. It wires
+///     the anonymous session scheme, the constrained authorization policy, and all billable-use
+///     guardrails INTERNALLY, then returns <c>null</c> (the caller must not layer the Entra policy
+///     on top). A hosted deployment must additionally pass the second explicit opt-in and complete
+///     guardrail configuration, or startup fails closed (see <see cref="AnonymousAuthOptions"/>).</item>
+///   <item><see cref="AuthenticationMode.GitHub"/> → a deliberate fail-closed startup error. This
+///     mode is declared but NOT implemented in this sprint; selecting it throws before any
+///     authentication scheme is registered, so the app can never fall through to Entra,
+///     Development, or anonymous access.</item>
 /// </list>
 /// The boundary is intentionally thin: later sprints add a case per provider here without
 /// reworking the Entra path or the authorization policy.
@@ -27,14 +35,15 @@ public static class ProviderNeutralAuthentication
 {
     /// <summary>
     /// Resolves the configured authentication mode and registers the matching authentication
-    /// stack. Returns the resolved <see cref="EntraAuthOptions"/> so the caller can wire the
-    /// authorization policy (only the Entra path returns; other modes throw).
+    /// stack. Returns the resolved <see cref="EntraAuthOptions"/> for the Entra path so the
+    /// caller can wire the authorization policy; returns <c>null</c> for the Anonymous path,
+    /// which wires its own authorization internally. GitHub throws.
     /// </summary>
     /// <exception cref="NotSupportedException">
-    /// Thrown when the configured mode is recognized but not implemented in this sprint
-    /// (GitHub, Anonymous). This is a fail-closed startup error by design.
+    /// Thrown when the configured mode is recognized but not implemented in this sprint (GitHub).
+    /// This is a fail-closed startup error by design.
     /// </exception>
-    public static EntraAuthOptions AddProviderNeutralAuthentication(
+    public static EntraAuthOptions? AddProviderNeutralAuthentication(
         this IServiceCollection services,
         IConfiguration configuration,
         IHostEnvironment environment)
@@ -54,13 +63,15 @@ public static class ProviderNeutralAuthentication
                 services.AddSingleton<IPrincipalNormalizer>(new EntraPrincipalNormalizer(options));
                 return options;
 
-            case AuthenticationMode.GitHub:
             case AuthenticationMode.Anonymous:
+                services.AddSingleton(new AuthenticationModeOptions { Mode = mode });
+                AddAnonymousMode(services, configuration, environment);
+                return null;
+            case AuthenticationMode.GitHub:
                 throw new NotSupportedException(
-                    $"Authentication mode '{mode}' is not implemented in this sprint " +
-                    "(Sprint 0: provider-neutral authentication foundation). Only 'Entra' is currently " +
-                    "supported. GitHub and Anonymous are opt-in capabilities delivered in later sprints and " +
-                    "are never enabled in production. This is a deliberate fail-closed startup error — " +
+                    $"Authentication mode '{mode}' is not implemented in this sprint. Only 'Entra' and " +
+                    "'Anonymous' are currently supported. GitHub is an opt-in capability delivered in a later " +
+                    "sprint and is never enabled in production. This is a deliberate fail-closed startup error — " +
                     "authentication does not fall through to Entra, Development, or Anonymous.");
 
             default:
@@ -68,5 +79,32 @@ public static class ProviderNeutralAuthentication
                 throw new InvalidOperationException(
                     $"Unhandled authentication mode '{mode}'. This is a bug in the authentication factory.");
         }
+    }
+
+    /// <summary>
+    /// Wires the Anonymous authentication scheme, the constrained authorization policy, and every
+    /// billable-use guardrail. Resolution is fail-closed: a hosted (non-Development) environment
+    /// throws here unless <c>Anonymous:AllowHosted=true</c> AND a strong signing key AND positive
+    /// daily request/token/cost ceilings are supplied.
+    /// </summary>
+    private static void AddAnonymousMode(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        var options = AnonymousAuthOptions.FromConfiguration(configuration, environment);
+
+        // Session scheme + constrained authz policy (default + fallback) + token service +
+        // signing key provider + anonymous principal normalizer.
+        services.AddAnonymousAuthentication(options);
+
+        // The chat tool filter + output cap decide from the current request principal.
+        services.AddHttpContextAccessor();
+        services.AddSingleton<IAnonymousChatPolicy, AnonymousChatPolicy>();
+
+        // Billable-use guardrails: per-subject/per-IP minute limits + global daily circuit breaker.
+        services.AddSingleton<AnonymousRateLimiter>();
+        services.AddSingleton<AnonymousUsageBudget>();
+        services.AddSingleton<AnonymousGuardMiddleware>();
     }
 }

--- a/src/RetailPulse.Api/Validation/ChatRequestValidator.cs
+++ b/src/RetailPulse.Api/Validation/ChatRequestValidator.cs
@@ -11,6 +11,19 @@ public static partial class ChatRequestValidator
 {
     public const int MaxMessageLength = 4000;
 
+    /// <summary>Maximum number of prior conversation turns accepted with a chat request.</summary>
+    public const int MaxHistoryMessages = 50;
+
+    /// <summary>Maximum characters allowed in any single history entry's content.</summary>
+    public const int MaxHistoryMessageLength = 4000;
+
+    /// <summary>
+    /// Maximum combined characters across all history entries. Bounds the total prompt a caller can
+    /// assemble from the history array (a rough proxy for token count) independent of the per-entry
+    /// and count caps, so an attacker cannot smuggle a huge context past the model.
+    /// </summary>
+    public const int MaxAggregateHistoryChars = 100_000;
+
     // SessionId must be alphanumeric/hyphens, 1-64 chars (GUID-like formats)
     [GeneratedRegex(@"^[a-zA-Z0-9\-]{1,64}$")]
     private static partial Regex SessionIdPattern();
@@ -39,6 +52,33 @@ public static partial class ChatRequestValidator
         if (request.SessionId is not null && !SessionIdPattern().IsMatch(request.SessionId))
         {
             errors["sessionId"] = ["Field 'sessionId' must be 1-64 alphanumeric characters or hyphens."];
+        }
+
+        // History bounds — count, per-entry size, and aggregate size are all bounded BEFORE the
+        // model runs so an oversized or padded history array is rejected with 400, not billed.
+        if (request.History is { Count: > 0 } history)
+        {
+            if (history.Count > MaxHistoryMessages)
+            {
+                errors["history"] = [$"Field 'history' must not exceed {MaxHistoryMessages} messages. Received: {history.Count}."];
+            }
+
+            long aggregate = 0;
+            for (int i = 0; i < history.Count; i++)
+            {
+                int contentLength = history[i]?.Content?.Length ?? 0;
+                aggregate += contentLength;
+
+                if (contentLength > MaxHistoryMessageLength)
+                {
+                    errors[$"history[{i}]"] = [$"History message content must not exceed {MaxHistoryMessageLength} characters. Received: {contentLength}."];
+                }
+            }
+
+            if (aggregate > MaxAggregateHistoryChars)
+            {
+                errors["history.aggregate"] = [$"Combined history content must not exceed {MaxAggregateHistoryChars} characters. Received: {aggregate}."];
+            }
         }
 
         return new ValidationResult(errors.Count == 0, errors);

--- a/src/RetailPulse.Api/appsettings.Anonymous.example.json
+++ b/src/RetailPulse.Api/appsettings.Anonymous.example.json
@@ -58,9 +58,12 @@
     "MaxRequestBytes": 16384,
     "RequestTimeoutSeconds": 60,
 
-    // Per-IP minute limit for the unauthenticated bootstrap endpoint.
+    // GLOBAL per-minute cap on the unauthenticated bootstrap endpoint (session-token minting).
+    // Behind Azure Container Apps the client IP is the proxy's and X-Forwarded-For is forgeable,
+    // so this is a single global fixed window per replica, NOT per-IP. Conservative default: 5.
+    // The legacy key "PerIpPerMinute" is still read as a fallback for backward compatibility.
     "Bootstrap": {
-      "PerIpPerMinute": 5
+      "GlobalPerMinute": 5
     },
 
     // Per-subject and per-IP minute limits for anonymous chat/model routes.

--- a/src/RetailPulse.Api/appsettings.Anonymous.example.json
+++ b/src/RetailPulse.Api/appsettings.Anonymous.example.json
@@ -1,0 +1,81 @@
+{
+  // ===========================================================================
+  // Anonymous authentication mode — EXAMPLE / TEMPLATE (NON-LIVE)
+  // ===========================================================================
+  // This file documents the configuration schema for the Sprint 1 Anonymous
+  // authentication mode. It is NOT loaded by the app (only appsettings.json and
+  // appsettings.{Environment}.json are). Copy the values you need into real
+  // configuration (environment variables / secret store) to run Anonymous mode.
+  //
+  // Anonymous mode is a constrained, read-only, rate/token/cost-capped session
+  // mode for a future public demo. It is NEVER used in Production — every
+  // committed deployment artifact keeps Authentication:Mode=Entra.
+  //
+  // FAIL-CLOSED CONTRACT:
+  //   * Authentication:Mode=Anonymous enables it (no auto-detection/fallback).
+  //   * Development MAY run with AllowHosted=false and NO signing key — an
+  //     ephemeral process-local key is generated and ALL sessions die on restart.
+  //   * ANY hosted (non-Development) environment additionally requires:
+  //       - Anonymous:AllowHosted=true  (a SECOND explicit opt-in), AND
+  //       - Anonymous:SigningKey        (a strong >=32-byte SECRET, never committed), AND
+  //       - positive Anonymous:Limits daily request/token/cost ceilings.
+  //     Missing/malformed/unsafe values throw at startup.
+  //   * Hosted Anonymous MUST run at maxReplicas=1 (the daily circuit breaker is
+  //     replica-local; it is NOT equivalent to authenticated production and its
+  //     counters reset on restart).
+  // ===========================================================================
+  "Authentication": {
+    // Set to "Anonymous" ONLY in a dedicated demo configuration — never in a
+    // committed Production artifact.
+    "Mode": "Anonymous"
+  },
+
+  "Anonymous": {
+    // Second explicit opt-in. MUST be true for any hosted (non-Development) run.
+    "AllowHosted": true,
+
+    // HMAC-SHA256 signing key for the short-lived session tokens. SECRET — supply
+    // via Anonymous__SigningKey or a secret store. NEVER commit a real key. Must
+    // be at least 32 bytes (256-bit) in hosted mode.
+    "SigningKey": "<set-via-secret-store-min-32-bytes>",
+
+    // Token issuer/audience — validated on every request. Anonymous tokens are
+    // rejected if either does not match.
+    "Issuer": "retail-pulse-anonymous",
+    "Audience": "retail-pulse-api",
+
+    // Short session TTL (seconds). Bounds the replay window. 30..3600.
+    "SessionTokenTtlSeconds": 900,
+
+    // Constrained principal — never RetailPulse.User / access_as_user.
+    "Role": "RetailPulse.Anonymous",
+    "Scope": "chat_limited",
+
+    // Model output-token cap for anonymous chat. 1..4096.
+    "MaxOutputTokens": 512,
+
+    // Request-body size bound (bytes) and per-request timeout (seconds).
+    "MaxRequestBytes": 16384,
+    "RequestTimeoutSeconds": 60,
+
+    // Per-IP minute limit for the unauthenticated bootstrap endpoint.
+    "Bootstrap": {
+      "PerIpPerMinute": 5
+    },
+
+    // Per-subject and per-IP minute limits for anonymous chat/model routes.
+    "Chat": {
+      "PerSubjectPerMinute": 5,
+      "PerIpPerMinute": 10
+    },
+
+    // Global daily billable-use ceilings. When any is exceeded a fail-closed
+    // circuit breaker trips and all further anonymous requests are refused until
+    // UTC midnight. All three MUST be > 0 in hosted mode. Keep them CONSERVATIVE.
+    "Limits": {
+      "DailyMaxRequests": 500,
+      "DailyMaxTokens": 200000,
+      "DailyMaxCostUsd": 5.00
+    }
+  }
+}

--- a/src/RetailPulse.Api/appsettings.json
+++ b/src/RetailPulse.Api/appsettings.json
@@ -71,12 +71,17 @@
   },
 
   // ---- Authentication provider mode ------------------------------------
-  // Provider-neutral selector for the authentication boundary. Only "Entra" is
-  // implemented today; it routes to the tenant-scoped Microsoft Entra JWT boundary
-  // below. "GitHub" and "Anonymous" are declared for later sprints and FAIL STARTUP
-  // if selected now (they never fall through to Entra/dev/anonymous). Resolution is
-  // deterministic: outside Development a missing mode fails closed; in Development a
-  // missing mode defaults to Entra so the local demo runs without extra config.
+  // Provider-neutral selector for the authentication boundary. "Entra" (the live
+  // value here and in every committed deployment artifact) routes to the tenant-scoped
+  // Microsoft Entra JWT boundary below. "Anonymous" (Sprint 1) is IMPLEMENTED but is a
+  // constrained, read-only, rate/token/cost-capped session mode intended for a future
+  // public demo — it is NEVER enabled in Production and, in any hosted environment,
+  // additionally requires a second explicit opt-in (Anonymous:AllowHosted=true) plus a
+  // strong signing key and daily ceilings or startup fails closed. See
+  // appsettings.Anonymous.example.json for the (non-live) template. "GitHub" is declared
+  // for a later sprint and FAILS STARTUP if selected. Resolution is deterministic:
+  // outside Development a missing mode fails closed; in Development a missing mode
+  // defaults to Entra so the local demo runs without extra config.
   "Authentication": {
     "Mode": "Entra"
   },

--- a/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
@@ -66,6 +66,62 @@ public sealed class ProviderNeutralDeploymentContractTests
             "the base appsettings.json must declare a deterministic Entra authentication mode");
     }
 
+    [Fact]
+    public void BaseAppSettings_NeverSelectsAnonymousOrGitHubMode()
+    {
+        string json = File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "RetailPulse.Api", "appsettings.json"));
+
+        json.Should().NotContain("\"Mode\": \"Anonymous\"",
+            "the live base appsettings.json must never select Anonymous mode");
+        json.Should().NotContain("\"Mode\": \"GitHub\"",
+            "the live base appsettings.json must never select GitHub mode");
+    }
+
+    [Theory]
+    [InlineData("postprovision.ps1")]
+    [InlineData("postprovision.sh")]
+    public void PostprovisionHook_NeverConfiguresAnonymousGuardrails(string hookFile)
+    {
+        string script = File.ReadAllText(Path.Combine(RepoRoot, "azd-hooks", hookFile));
+
+        // The live deployment is Entra-only, so it must never carry the Anonymous hosted
+        // opt-in or a signing key — configuring these would imply an Anonymous deployment.
+        script.Should().NotContain("Anonymous__AllowHosted",
+            $"{hookFile} must never enable hosted Anonymous mode");
+        script.Should().NotContain("Anonymous__SigningKey",
+            $"{hookFile} must never carry an Anonymous signing key");
+    }
+
+    [Fact]
+    public void ContainerAppsBicep_PinsApiToSingleReplica()
+    {
+        // maxReplicas: 1 is required for the single SQLite writer AND for the (non-Production)
+        // Anonymous mode's replica-local billable-use circuit breaker. This proves the live
+        // artifact cannot scale the API out.
+        string bicep = File.ReadAllText(Path.Combine(
+            RepoRoot, "infra", "modules", "container-apps.bicep"));
+
+        bicep.Should().MatchRegex(
+            "maxReplicas\\s*:\\s*1",
+            "the API container app must pin maxReplicas to 1");
+    }
+
+    [Fact]
+    public void ExampleAnonymousConfig_IsNotLoadedByAnyEnvironment()
+    {
+        // The Anonymous example/template MUST NOT be a real environment overlay. Only
+        // appsettings.json and appsettings.{Environment}.json are auto-loaded; the example
+        // is deliberately named appsettings.Anonymous.example.json (note ".example.") so it
+        // can never be picked up by ASPNETCORE_ENVIRONMENT=Anonymous.
+        string apiDir = Path.Combine(RepoRoot, "src", "RetailPulse.Api");
+
+        File.Exists(Path.Combine(apiDir, "appsettings.Anonymous.json"))
+            .Should().BeFalse("a live appsettings.Anonymous.json overlay must not exist");
+        File.Exists(Path.Combine(apiDir, "appsettings.Anonymous.example.json"))
+            .Should().BeTrue("the non-live Anonymous template should be committed for documentation");
+    }
+
     private static string FindRepoRoot()
     {
         DirectoryInfo? dir = new(AppContext.BaseDirectory);

--- a/tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs
@@ -66,14 +66,14 @@ public sealed class AnonymousAuthenticationTests
     }
 
     [Fact]
-    public async Task Bootstrap_IsRateLimitedPerIp()
+    public async Task Bootstrap_IsRateLimitedGlobally()
     {
         using TestFixture fx = CreateServer(bootstrapPerIp: 2);
 
         (await fx.Client.PostAsync("/api/auth/anonymous/session", null)).StatusCode.Should().Be(HttpStatusCode.OK);
         (await fx.Client.PostAsync("/api/auth/anonymous/session", null)).StatusCode.Should().Be(HttpStatusCode.OK);
         (await fx.Client.PostAsync("/api/auth/anonymous/session", null)).StatusCode
-            .Should().Be(HttpStatusCode.TooManyRequests, "the 3rd bootstrap in the window exceeds the per-IP limit");
+            .Should().Be(HttpStatusCode.TooManyRequests, "the 3rd bootstrap in the window exceeds the global limit");
     }
 
     // ── token validation / threat cases ───────────────────────────────────────
@@ -137,16 +137,51 @@ public sealed class AnonymousAuthenticationTests
     // ── valid anonymous access ─────────────────────────────────────────────────
 
     [Fact]
-    public async Task ValidToken_ReachesReadRestAndHub()
+    public async Task ValidToken_ReachesChatAndHub()
     {
         using TestFixture fx = CreateServer();
         string token = Token(subject: "anon-ok");
 
-        (await Get(fx, "/api/scorecard", token)).StatusCode.Should().Be(HttpStatusCode.OK);
+        // POST /api/chat is the single allowlisted authenticated REST capability.
+        (await PostChatRaw(fx, token)).StatusCode.Should().Be(HttpStatusCode.OK);
 
         // Hub: the token is supplied via ?access_token (WebSocket handshakes cannot set headers).
         HttpResponseMessage hub = await fx.Client.GetAsync($"/hubs/telemetry?access_token={token}");
         hub.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ── deny-by-default: the broad GET/observability/admin surface is 403 ───────
+
+    [Theory]
+    [InlineData("GET", "/api/scorecard")]
+    [InlineData("GET", "/api/sessions")]
+    [InlineData("GET", "/api/audit")]
+    [InlineData("GET", "/api/traces")]
+    [InlineData("GET", "/api/dead-letter")]
+    [InlineData("GET", "/api/cards")]
+    [InlineData("GET", "/api/approvals")]
+    [InlineData("GET", "/api/memory")]
+    [InlineData("GET", "/api/export/session/abc")]
+    [InlineData("GET", "/api/guardrails/logs")]
+    [InlineData("POST", "/api/chat/stream")]
+    [InlineData("POST", "/api/council/convene")]
+    [InlineData("GET", "/api/council/agents")]
+    [InlineData("POST", "/api/messages")]
+    public async Task NonAllowlistedRoutes_AreForbidden_ForAnonymous(string method, string path)
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token(subject: "anon-deny");
+
+        var req = new HttpRequestMessage(new HttpMethod(method), path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (method == "POST")
+        {
+            req.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+        }
+
+        HttpResponseMessage resp = await fx.Client.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            $"'{method} {path}' is not on the anonymous allowlist — deny-by-default applies before routing");
     }
 
     [Fact]
@@ -241,6 +276,24 @@ public sealed class AnonymousAuthenticationTests
 
         HttpResponseMessage resp = await fx.Client.SendAsync(req);
         resp.StatusCode.Should().Be(HttpStatusCode.RequestEntityTooLarge);
+    }
+
+    [Fact]
+    public async Task ChunkedOversizedRequest_Returns413_WithoutContentLength()
+    {
+        using TestFixture fx = CreateServer(maxRequestBytes: 256);
+        string token = Token(subject: "anon-chunked");
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/api/chat");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Content = new StringContent(new string('x', 2000), Encoding.UTF8, "application/json");
+        // Force chunked transfer so no Content-Length header is sent — the ContentLength check
+        // cannot see the size; the length-counting pre-read must still reject it.
+        req.Headers.TransferEncodingChunked = true;
+
+        HttpResponseMessage resp = await fx.Client.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.RequestEntityTooLarge,
+            "a chunked/unknown-length oversized body must be capped during the read");
     }
 
     // ── health stays anonymous ─────────────────────────────────────────────────
@@ -343,16 +396,19 @@ public sealed class AnonymousAuthenticationTests
                     // Wire the full anonymous stack (scheme + policy + guardrail services).
                     services.AddProviderNeutralAuthentication(config, context.HostingEnvironment);
 
-                    // Rate limiter with the anonymous-bootstrap per-IP policy (mirrors Program.cs).
+                    // Global conservative bootstrap limiter — mirrors Program.cs. Behind ACA the
+                    // client IP is not trustworthy (proxy IP / forgeable XFF), so bootstrap is a
+                    // single global window; per-subject limits take over after bootstrap.
                     services.AddRateLimiter(rl =>
                     {
                         rl.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
-                        rl.AddPolicy("anonymous-bootstrap", httpContext =>
+                        rl.AddPolicy("anonymous-bootstrap", _ =>
                             System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
-                                partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                                partitionKey: "anonymous-bootstrap-global",
                                 factory: _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
                                 {
-                                    PermitLimit = config.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 5),
+                                    PermitLimit = config.GetValue("Anonymous:Bootstrap:GlobalPerMinute",
+                                        config.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 30)),
                                     Window = TimeSpan.FromMinutes(1),
                                     QueueLimit = 0,
                                 }));

--- a/tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs
@@ -137,7 +137,7 @@ public sealed class AnonymousAuthenticationTests
     // ── valid anonymous access ─────────────────────────────────────────────────
 
     [Fact]
-    public async Task ValidToken_ReachesChatAndHub()
+    public async Task ValidToken_ReachesChat_ButBothHubsAreForbidden()
     {
         using TestFixture fx = CreateServer();
         string token = Token(subject: "anon-ok");
@@ -145,9 +145,24 @@ public sealed class AnonymousAuthenticationTests
         // POST /api/chat is the single allowlisted authenticated REST capability.
         (await PostChatRaw(fx, token)).StatusCode.Should().Be(HttpStatusCode.OK);
 
-        // Hub: the token is supplied via ?access_token (WebSocket handshakes cannot set headers).
-        HttpResponseMessage hub = await fx.Client.GetAsync($"/hubs/telemetry?access_token={token}");
-        hub.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Sprint 1: the SignalR hubs are NOT part of the anonymous surface. A VALID anonymous token
+        // is authenticated and satisfies the authorization policy, but the deny-by-default guard
+        // blocks the hub before the endpoint runs — 403 on both connection (GET, ?access_token) and
+        // negotiate (POST), for both telemetry and streaming. Anonymous gets no real-time telemetry.
+        foreach (string hub in new[] { "/hubs/telemetry", "/hubs/streaming" })
+        {
+            HttpResponseMessage connect = await fx.Client.GetAsync($"{hub}?access_token={token}");
+            connect.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+                $"a valid anonymous token must be denied on the {hub} connection endpoint");
+
+            var negotiate = new HttpRequestMessage(HttpMethod.Post, $"{hub}/negotiate?access_token={token}")
+            {
+                Content = new StringContent(string.Empty),
+            };
+            HttpResponseMessage neg = await fx.Client.SendAsync(negotiate);
+            neg.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+                $"a valid anonymous token must be denied on the {hub} negotiate endpoint");
+        }
     }
 
     // ── deny-by-default: the broad GET/observability/admin surface is 403 ───────
@@ -408,7 +423,7 @@ public sealed class AnonymousAuthenticationTests
                                 factory: _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
                                 {
                                     PermitLimit = config.GetValue("Anonymous:Bootstrap:GlobalPerMinute",
-                                        config.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 30)),
+                                        config.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 5)),
                                     Window = TimeSpan.FromMinutes(1),
                                     QueueLimit = 0,
                                 }));
@@ -453,8 +468,16 @@ public sealed class AnonymousAuthenticationTests
                         endpoints.MapPost("/api/approvals/{id}/respond", static (string id) => Results.Ok(new { id }))
                             .RequireAuthorization();
 
-                        // Hub stand-in (query-token path).
+                        // Hub stand-ins (query-token path). Both the connection (GET) and negotiate
+                        // (POST) endpoints for BOTH hubs require authorization but are NOT on the
+                        // anonymous allowlist, so the guard denies a valid anonymous token with 403.
                         endpoints.MapGet("/hubs/telemetry", static () => Results.Ok(new { hub = "telemetry" }))
+                            .RequireAuthorization();
+                        endpoints.MapPost("/hubs/telemetry/negotiate", static () => Results.Ok(new { negotiated = true }))
+                            .RequireAuthorization();
+                        endpoints.MapGet("/hubs/streaming", static () => Results.Ok(new { hub = "streaming" }))
+                            .RequireAuthorization();
+                        endpoints.MapPost("/hubs/streaming/negotiate", static () => Results.Ok(new { negotiated = true }))
                             .RequireAuthorization();
 
                         endpoints.MapGet("/health", static () => Results.Ok(new { status = "ok" })).AllowAnonymous();

--- a/tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs
@@ -1,0 +1,446 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Api.Middleware;
+using RetailPulse.Api.Security;
+using RetailPulse.Api.Security.Anonymous;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// End-to-end HTTP contract + threat tests for the Sprint 1 Anonymous authentication boundary.
+///
+/// A minimal in-process <see cref="TestServer"/> wires the EXACT anonymous stack the API uses
+/// (<see cref="ProviderNeutralAuthentication.AddProviderNeutralAuthentication"/> in Anonymous mode
+/// → session JwtBearer scheme + constrained policy + <see cref="AnonymousGuardMiddleware"/>), with
+/// a configured signing key so tests can mint their own session tokens offline. It proves:
+/// <list type="bullet">
+///   <item>bootstrap issues a token and is per-IP rate-limited;</item>
+///   <item>malformed / expired / wrong-issuer / wrong-audience / wrong-signature / wrong-provider
+///     tokens are rejected;</item>
+///   <item>a valid anonymous token reaches read REST and the hub (query token);</item>
+///   <item>distinct sessions are isolated and identity comes from the token, not a spoof header;</item>
+///   <item>mutation routes are 403 for anonymous;</item>
+///   <item>the daily request circuit breaker fails closed (cache cannot bypass it);</item>
+///   <item>oversized requests and REST query-tokens are rejected.</item>
+/// </list>
+/// </summary>
+public sealed class AnonymousAuthenticationTests
+{
+    private const string Issuer = "retail-pulse-anonymous";
+    private const string Audience = "retail-pulse-api";
+    private const string SigningKeyText = "anon-integration-test-signing-key-0123456789";
+    private static readonly SymmetricSecurityKey SigningKey = new(Encoding.UTF8.GetBytes(SigningKeyText));
+    private static readonly SymmetricSecurityKey WrongKey = new(Encoding.UTF8.GetBytes("a-totally-different-wrong-signing-key-999999"));
+
+    // ── bootstrap ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Bootstrap_IssuesUsableSessionToken()
+    {
+        using TestFixture fx = CreateServer();
+
+        HttpResponseMessage resp = await fx.Client.PostAsync("/api/auth/anonymous/session", null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        BootstrapBody body = await resp.Content.ReadFromJsonAsync<BootstrapBody>() ?? new();
+        body.Token.Should().NotBeNullOrWhiteSpace();
+        body.Subject.Should().StartWith("anon-");
+        body.TokenType.Should().Be("Bearer");
+        body.ExpiresInSeconds.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Bootstrap_IsRateLimitedPerIp()
+    {
+        using TestFixture fx = CreateServer(bootstrapPerIp: 2);
+
+        (await fx.Client.PostAsync("/api/auth/anonymous/session", null)).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await fx.Client.PostAsync("/api/auth/anonymous/session", null)).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await fx.Client.PostAsync("/api/auth/anonymous/session", null)).StatusCode
+            .Should().Be(HttpStatusCode.TooManyRequests, "the 3rd bootstrap in the window exceeds the per-IP limit");
+    }
+
+    // ── token validation / threat cases ───────────────────────────────────────
+
+    [Fact]
+    public async Task AnonymousRestWithoutToken_Returns401()
+    {
+        using TestFixture fx = CreateServer();
+        (await fx.Client.GetAsync("/api/scorecard")).StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task MalformedToken_Returns401()
+    {
+        using TestFixture fx = CreateServer();
+        (await Get(fx, "/api/scorecard", "not-a-jwt")).StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ExpiredToken_Returns401()
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token(subject: "anon-exp", expires: DateTime.UtcNow.AddMinutes(-5), notBefore: DateTime.UtcNow.AddMinutes(-10));
+        (await Get(fx, "/api/scorecard", token)).StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task WrongIssuer_Returns401()
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token(subject: "anon-i", issuer: "https://evil.example/");
+        (await Get(fx, "/api/scorecard", token)).StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task WrongAudience_Returns401()
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token(subject: "anon-a", audience: "some-other-api");
+        (await Get(fx, "/api/scorecard", token)).StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task WrongSignature_Returns401()
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token(subject: "anon-s", key: WrongKey);
+        (await Get(fx, "/api/scorecard", token)).StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CrossProviderToken_IsRejected()
+    {
+        using TestFixture fx = CreateServer();
+        // Correctly signed for issuer/audience but stamped provider=Entra — the constrained
+        // anonymous policy must refuse it (authenticated but not authorized → 403).
+        string token = Token(subject: "anon-x", provider: "Entra");
+        (await Get(fx, "/api/scorecard", token)).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── valid anonymous access ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ValidToken_ReachesReadRestAndHub()
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token(subject: "anon-ok");
+
+        (await Get(fx, "/api/scorecard", token)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Hub: the token is supplied via ?access_token (WebSocket handshakes cannot set headers).
+        HttpResponseMessage hub = await fx.Client.GetAsync($"/hubs/telemetry?access_token={token}");
+        hub.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RestQueryToken_IsIgnored_Returns401()
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token(subject: "anon-q");
+        // A REST endpoint must NOT accept ?access_token (only /hubs may). No Authorization header
+        // means the request is unauthenticated → 401.
+        HttpResponseMessage resp = await fx.Client.GetAsync($"/api/scorecard?access_token={token}");
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task IdentityComesFromToken_NotSpoofHeader()
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token(subject: "anon-real");
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/api/chat");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Add("X-User-Id", "anon-attacker");
+        req.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage resp = await fx.Client.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        WhoAmI body = await resp.Content.ReadFromJsonAsync<WhoAmI>() ?? new();
+        body.Subject.Should().Be("anon-real", "identity must come from the signed token subject, never a header");
+    }
+
+    [Fact]
+    public async Task DistinctSessions_AreIsolated()
+    {
+        using TestFixture fx = CreateServer();
+        string a = Token(subject: "anon-A");
+        string b = Token(subject: "anon-B");
+
+        WhoAmI ra = await PostChat(fx, a);
+        WhoAmI rb = await PostChat(fx, b);
+
+        ra.Subject.Should().Be("anon-A");
+        rb.Subject.Should().Be("anon-B");
+        ra.Subject.Should().NotBe(rb.Subject);
+    }
+
+    // ── mutation surface disabled ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("DELETE", "/api/memory/42")]
+    [InlineData("POST", "/api/approvals/7/respond")]
+    public async Task MutationRoutes_Return403_ForAnonymous(string method, string path)
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token(subject: "anon-m");
+
+        var req = new HttpRequestMessage(new HttpMethod(method), path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (method == "POST")
+        {
+            req.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+        }
+
+        HttpResponseMessage resp = await fx.Client.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden, "anonymous mode is read-only");
+    }
+
+    // ── billable-use circuit breaker ───────────────────────────────────────────
+
+    [Fact]
+    public async Task DailyRequestCeiling_FailsClosed()
+    {
+        using TestFixture fx = CreateServer(dailyRequests: 2);
+        string token = Token(subject: "anon-budget");
+
+        (await PostChatRaw(fx, token)).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await PostChatRaw(fx, token)).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await PostChatRaw(fx, token)).StatusCode
+            .Should().Be(HttpStatusCode.ServiceUnavailable, "the daily request circuit breaker trips (fail-closed)");
+    }
+
+    // ── request-size bound ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task OversizedRequest_Returns413()
+    {
+        using TestFixture fx = CreateServer(maxRequestBytes: 256);
+        string token = Token(subject: "anon-big");
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/api/chat");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Content = new StringContent(new string('x', 2000), Encoding.UTF8, "application/json");
+
+        HttpResponseMessage resp = await fx.Client.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.RequestEntityTooLarge);
+    }
+
+    // ── health stays anonymous ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Health_IsAnonymous()
+    {
+        using TestFixture fx = CreateServer();
+        (await fx.Client.GetAsync("/health")).StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private static async Task<HttpResponseMessage> Get(TestFixture fx, string path, string token)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await fx.Client.SendAsync(req);
+    }
+
+    private static async Task<HttpResponseMessage> PostChatRaw(TestFixture fx, string token)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/api/chat");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+        return await fx.Client.SendAsync(req);
+    }
+
+    private static async Task<WhoAmI> PostChat(TestFixture fx, string token)
+    {
+        HttpResponseMessage resp = await PostChatRaw(fx, token);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await resp.Content.ReadFromJsonAsync<WhoAmI>() ?? new();
+    }
+
+    private static string Token(
+        string subject,
+        string? issuer = null,
+        string? audience = null,
+        string provider = "Anonymous",
+        DateTime? expires = null,
+        DateTime? notBefore = null,
+        SymmetricSecurityKey? key = null)
+    {
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, subject),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+            new("provider", provider),
+            new("roles", "RetailPulse.Anonymous"),
+            new("scp", "chat_limited"),
+        };
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = issuer ?? Issuer,
+            Audience = audience ?? Audience,
+            Subject = new ClaimsIdentity(claims),
+            NotBefore = notBefore ?? DateTime.UtcNow.AddMinutes(-1),
+            Expires = expires ?? DateTime.UtcNow.AddMinutes(10),
+            SigningCredentials = new SigningCredentials(key ?? SigningKey, SecurityAlgorithms.HmacSha256),
+        };
+
+        var handler = new JsonWebTokenHandler { SetDefaultTimesOnTokenCreation = false };
+        return handler.CreateToken(descriptor);
+    }
+
+    private static TestFixture CreateServer(
+        int bootstrapPerIp = 50,
+        int dailyRequests = 500,
+        int maxRequestBytes = 16384)
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Authentication:Mode"] = "Anonymous",
+                ["Anonymous:AllowHosted"] = "true",
+                ["Anonymous:SigningKey"] = SigningKeyText,
+                ["Anonymous:Issuer"] = Issuer,
+                ["Anonymous:Audience"] = Audience,
+                ["Anonymous:MaxRequestBytes"] = maxRequestBytes.ToString(),
+                ["Anonymous:Bootstrap:PerIpPerMinute"] = bootstrapPerIp.ToString(),
+                ["Anonymous:Chat:PerSubjectPerMinute"] = "100",
+                ["Anonymous:Chat:PerIpPerMinute"] = "100",
+                ["Anonymous:Limits:DailyMaxRequests"] = dailyRequests.ToString(),
+                ["Anonymous:Limits:DailyMaxTokens"] = "1000000",
+                ["Anonymous:Limits:DailyMaxCostUsd"] = "100",
+            })
+            .Build();
+
+        IHostBuilder builder = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices((context, services) =>
+                {
+                    services.AddRouting();
+                    services.AddLogging();
+
+                    // Wire the full anonymous stack (scheme + policy + guardrail services).
+                    services.AddProviderNeutralAuthentication(config, context.HostingEnvironment);
+
+                    // Rate limiter with the anonymous-bootstrap per-IP policy (mirrors Program.cs).
+                    services.AddRateLimiter(rl =>
+                    {
+                        rl.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+                        rl.AddPolicy("anonymous-bootstrap", httpContext =>
+                            System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
+                                partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                                factory: _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+                                {
+                                    PermitLimit = config.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 5),
+                                    Window = TimeSpan.FromMinutes(1),
+                                    QueueLimit = 0,
+                                }));
+                    });
+                });
+                webHost.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseAuthentication();
+                    app.UseAuthorization();
+                    app.UseRateLimiter();
+                    app.UseMiddleware<AnonymousGuardMiddleware>();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        // Unauthenticated bootstrap (per-IP rate-limited).
+                        endpoints.MapPost(AnonymousCapabilityPolicy.BootstrapRoute,
+                            (IAnonymousSessionTokenService svc) =>
+                            {
+                                AnonymousSession s = svc.CreateSession();
+                                return Results.Ok(new
+                                {
+                                    token = s.Token,
+                                    tokenType = "Bearer",
+                                    expiresInSeconds = s.ExpiresInSeconds,
+                                    subject = s.Subject,
+                                });
+                            })
+                            .AllowAnonymous()
+                            .RequireRateLimiting("anonymous-bootstrap");
+
+                        // Read-only chat/query stand-ins — echo the token subject to prove identity
+                        // provenance and isolation.
+                        endpoints.MapPost("/api/chat", (HttpContext ctx) =>
+                            Results.Ok(new { subject = ctx.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value }))
+                            .RequireAuthorization();
+                        endpoints.MapGet("/api/scorecard", static () => Results.Ok(new { data = "read" }))
+                            .RequireAuthorization();
+
+                        // Mutation stand-ins — must be blocked by the guard for anonymous callers.
+                        endpoints.MapDelete("/api/memory/{id}", static (string id) => Results.Ok(new { deleted = id }))
+                            .RequireAuthorization();
+                        endpoints.MapPost("/api/approvals/{id}/respond", static (string id) => Results.Ok(new { id }))
+                            .RequireAuthorization();
+
+                        // Hub stand-in (query-token path).
+                        endpoints.MapGet("/hubs/telemetry", static () => Results.Ok(new { hub = "telemetry" }))
+                            .RequireAuthorization();
+
+                        endpoints.MapGet("/health", static () => Results.Ok(new { status = "ok" })).AllowAnonymous();
+                    });
+                });
+            });
+
+        IHost host = builder.Build();
+        host.Start();
+        return new TestFixture(host);
+    }
+
+    private sealed class BootstrapBody
+    {
+        public string? Token { get; set; }
+        public string? Subject { get; set; }
+        public string? TokenType { get; set; }
+        public int ExpiresInSeconds { get; set; }
+    }
+
+    private sealed class WhoAmI
+    {
+        public string? Subject { get; set; }
+    }
+
+    private sealed class TestFixture : IDisposable
+    {
+        private readonly IHost _host;
+
+        public TestFixture(IHost host)
+        {
+            _host = host;
+            Client = host.GetTestClient();
+        }
+
+        public HttpClient Client { get; }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _host.StopAsync().GetAwaiter().GetResult();
+            _host.Dispose();
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs
@@ -171,6 +171,12 @@ public sealed class AnonymousCapabilityTests
     [InlineData("GET", "/api/approvals")]
     [InlineData("GET", "/api/info")]
     [InlineData("GET", "/api/chat")]
+    // Sprint 1: the SignalR hubs are NOT part of the anonymous surface — connection and negotiate,
+    // both telemetry and streaming, are denied. Anonymous sessions get no real-time telemetry.
+    [InlineData("GET", "/hubs/telemetry")]
+    [InlineData("POST", "/hubs/telemetry/negotiate")]
+    [InlineData("GET", "/hubs/streaming")]
+    [InlineData("POST", "/hubs/streaming/negotiate")]
     public void CapabilityPolicy_DeniesEverythingOutsideAllowlist(string method, string path)
     {
         AnonymousCapabilityPolicy.IsBlocked(method, path).Should().BeTrue();
@@ -178,14 +184,11 @@ public sealed class AnonymousCapabilityTests
     }
 
     [Theory]
-    // The entire authenticated + bootstrap surface: chat POST, bootstrap POST, the two hubs, preflight.
+    // The entire authenticated + bootstrap surface is exactly two routes plus CORS preflight.
+    // No hub route is reachable in Anonymous mode.
     [InlineData("POST", "/api/chat")]
     [InlineData("POST", "/api/auth/anonymous/session")]
     [InlineData("OPTIONS", "/api/chat")]
-    [InlineData("GET", "/hubs/telemetry")]
-    [InlineData("POST", "/hubs/telemetry/negotiate")]
-    [InlineData("GET", "/hubs/streaming")]
-    [InlineData("POST", "/hubs/streaming/negotiate")]
     public void CapabilityPolicy_AllowsOnlyTheMinimalSurface(string method, string path)
     {
         AnonymousCapabilityPolicy.IsAllowed(method, path).Should().BeTrue();

--- a/tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs
@@ -146,20 +146,60 @@ public sealed class AnonymousCapabilityTests
         act.Should().Throw<InvalidOperationException>().WithMessage("*not 'Anonymous'*");
     }
 
-    // ── Capability policy: read-only enforcement ──────────────────────────────
+    // ── Capability policy: deny-by-default allowlist ──────────────────────────
 
     [Theory]
-    [InlineData("POST", "/api/approvals/7/respond", true)]
-    [InlineData("DELETE", "/api/memory/42", true)]
-    [InlineData("POST", "/api/cards", true)]
-    [InlineData("PUT", "/api/guardrails/config", true)]
-    [InlineData("POST", "/api/admin/cache/invalidate", true)]
-    [InlineData("POST", "/api/chat", false)]
+    // Mutations / admin / observability / memory / cards / approvals / guardrail logs — all denied.
+    [InlineData("POST", "/api/approvals/7/respond")]
+    [InlineData("DELETE", "/api/memory/42")]
+    [InlineData("POST", "/api/cards")]
+    [InlineData("PUT", "/api/guardrails/config")]
+    [InlineData("POST", "/api/admin/cache/invalidate")]
+    // Alternate billable LLM paths + broad GET reads removed from the Anonymous surface — denied.
+    [InlineData("POST", "/api/chat/stream")]
+    [InlineData("POST", "/api/knowledge/search")]
+    [InlineData("POST", "/api/council/convene")]
+    [InlineData("POST", "/api/escalate")]
+    [InlineData("GET", "/api/scorecard")]
+    [InlineData("GET", "/api/margin/anything")]
+    [InlineData("GET", "/api/sessions")]
+    [InlineData("GET", "/api/audit")]
+    [InlineData("GET", "/api/traces")]
+    [InlineData("GET", "/api/dead-letter")]
+    [InlineData("GET", "/api/memory")]
+    [InlineData("GET", "/api/cards")]
+    [InlineData("GET", "/api/approvals")]
+    [InlineData("GET", "/api/info")]
+    [InlineData("GET", "/api/chat")]
+    public void CapabilityPolicy_DeniesEverythingOutsideAllowlist(string method, string path)
+    {
+        AnonymousCapabilityPolicy.IsBlocked(method, path).Should().BeTrue();
+        AnonymousCapabilityPolicy.IsAllowed(method, path).Should().BeFalse();
+    }
+
+    [Theory]
+    // The entire authenticated + bootstrap surface: chat POST, bootstrap POST, the two hubs, preflight.
+    [InlineData("POST", "/api/chat")]
+    [InlineData("POST", "/api/auth/anonymous/session")]
+    [InlineData("OPTIONS", "/api/chat")]
+    [InlineData("GET", "/hubs/telemetry")]
+    [InlineData("POST", "/hubs/telemetry/negotiate")]
+    [InlineData("GET", "/hubs/streaming")]
+    [InlineData("POST", "/hubs/streaming/negotiate")]
+    public void CapabilityPolicy_AllowsOnlyTheMinimalSurface(string method, string path)
+    {
+        AnonymousCapabilityPolicy.IsAllowed(method, path).Should().BeTrue();
+        AnonymousCapabilityPolicy.IsBlocked(method, path).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("POST", "/api/chat", true)]
+    [InlineData("GET", "/hubs/telemetry", false)]
+    [InlineData("POST", "/api/auth/anonymous/session", false)]
+    [InlineData("OPTIONS", "/api/chat", false)]
     [InlineData("POST", "/api/chat/stream", false)]
-    [InlineData("POST", "/api/knowledge/search", false)]
-    [InlineData("GET", "/api/scorecard", false)]
-    [InlineData("GET", "/api/margin/anything", false)]
-    public void CapabilityPolicy_BlocksMutations_AllowsReads(string method, string path, bool blocked) => AnonymousCapabilityPolicy.IsBlockedMutation(method, path).Should().Be(blocked);
+    public void CapabilityPolicy_OnlyChatPostIsBudgeted(string method, string path, bool budgeted)
+        => AnonymousCapabilityPolicy.IsBudgetedModelRoute(method, path).Should().Be(budgeted);
 
     // ── Tool filter: write-capable tools removed for anonymous ─────────────────
 

--- a/tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs
@@ -1,0 +1,296 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Security.Anonymous;
+using RetailPulse.Contracts.Observability;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Unit tests for the Anonymous-mode capability building blocks: fail-closed option validation,
+/// the server-signed session token, the normalized principal, the read-only/write-tool policy,
+/// and the billable-use circuit breaker. These are the safeguards a security reviewer must be
+/// able to see enforced without standing up an HTTP host.
+/// </summary>
+public sealed class AnonymousCapabilityTests
+{
+    private const string HostedKey = "unit-test-signing-key-0123456789ABCDEF-32b";
+
+    private static IHostEnvironment Env(string name) => new TestEnv { EnvironmentName = name };
+
+    private static IConfiguration Config(params (string, string?)[] entries) =>
+        new ConfigurationBuilder().AddInMemoryCollection(entries.ToDictionary(e => e.Item1, e => e.Item2)).Build();
+
+    // ── Options: fail-closed hosted validation ────────────────────────────────
+
+    [Fact]
+    public void Options_Development_AllowsEphemeralKeyAndLenientLimits()
+    {
+        var options = AnonymousAuthOptions.FromConfiguration(
+            Config(("Authentication:Mode", "Anonymous")), Env("Development"));
+        options.HostedGuardrailsEnforced.Should().BeFalse();
+        options.HasConfiguredSigningKey.Should().BeFalse("Development generates an ephemeral key");
+    }
+
+    [Fact]
+    public void Options_HostedWithoutAllowHosted_Throws()
+    {
+        Action act = () => AnonymousAuthOptions.FromConfiguration(
+            Config(("Authentication:Mode", "Anonymous")), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*AllowHosted*");
+    }
+
+    [Fact]
+    public void Options_HostedWithShortKey_Throws()
+    {
+        Action act = () => AnonymousAuthOptions.FromConfiguration(
+            Config(
+                ("Authentication:Mode", "Anonymous"),
+                ("Anonymous:AllowHosted", "true"),
+                ("Anonymous:SigningKey", "too-short"),
+                ("Anonymous:Limits:DailyMaxRequests", "10"),
+                ("Anonymous:Limits:DailyMaxTokens", "1000"),
+                ("Anonymous:Limits:DailyMaxCostUsd", "1")),
+            Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*at least 32 bytes*");
+    }
+
+    [Fact]
+    public void Options_HostedWithZeroCostCeiling_Throws()
+    {
+        Action act = () => AnonymousAuthOptions.FromConfiguration(
+            Config(
+                ("Authentication:Mode", "Anonymous"),
+                ("Anonymous:AllowHosted", "true"),
+                ("Anonymous:SigningKey", HostedKey),
+                ("Anonymous:Limits:DailyMaxRequests", "10"),
+                ("Anonymous:Limits:DailyMaxTokens", "1000"),
+                ("Anonymous:Limits:DailyMaxCostUsd", "0")),
+            Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*DailyMaxCostUsd*");
+    }
+
+    [Fact]
+    public void Options_HostedFullyConfigured_Succeeds()
+    {
+        AnonymousAuthOptions options = HostedOptions();
+
+        options.HostedGuardrailsEnforced.Should().BeTrue();
+        options.HasConfiguredSigningKey.Should().BeTrue();
+        options.Role.Should().Be("RetailPulse.Anonymous");
+        options.Scope.Should().Be("chat_limited");
+    }
+
+    // ── Session token: server-minted identity, no PII, short expiry ────────────
+
+    [Fact]
+    public void TokenService_MintsRandomSubject_WithConstrainedClaims()
+    {
+        AnonymousAuthOptions options = HostedOptions();
+        var keyProvider = new AnonymousSigningKeyProvider(options);
+        var svc = new AnonymousSessionTokenService(options, keyProvider);
+
+        AnonymousSession a = svc.CreateSession();
+        AnonymousSession b = svc.CreateSession();
+
+        a.Subject.Should().StartWith("anon-");
+        a.Subject.Should().NotBe(b.Subject, "each session gets a fresh random subject");
+        a.ExpiresInSeconds.Should().Be(options.SessionTokenTtlSeconds);
+
+        var handler = new JsonWebTokenHandler();
+        JsonWebToken jwt = handler.ReadJsonWebToken(a.Token);
+        jwt.GetClaim("provider").Value.Should().Be("Anonymous");
+        jwt.GetClaim("roles").Value.Should().Be("RetailPulse.Anonymous");
+        jwt.GetClaim("scp").Value.Should().Be("chat_limited");
+        jwt.Subject.Should().Be(a.Subject);
+        jwt.Claims.Should().NotContain(c => c.Type == "name" || c.Type == "email" || c.Type == "preferred_username",
+            "anonymous tokens must carry no PII");
+    }
+
+    // ── Principal normalizer: subject from token, provider pinned ──────────────
+
+    [Fact]
+    public void Normalizer_ProjectsProviderSubjectRolesScopes()
+    {
+        ClaimsPrincipal principal = AnonymousPrincipal("anon-abc", role: "RetailPulse.Anonymous", scope: "chat_limited");
+        var normalizer = new AnonymousPrincipalNormalizer();
+
+        NormalizedPrincipal np = normalizer.Normalize(principal);
+
+        np.Provider.Should().Be("Anonymous");
+        np.Subject.Should().Be("anon-abc");
+        np.Roles.Should().Contain("RetailPulse.Anonymous");
+        np.Scopes.Should().Contain("chat_limited");
+        np.DisplayName.Should().BeNull("anonymous principals expose no display name");
+    }
+
+    [Fact]
+    public void Normalizer_RejectsNonAnonymousProvider()
+    {
+        var identity = new ClaimsIdentity("test");
+        identity.AddClaim(new Claim(JwtRegisteredClaimNames.Sub, "anon-x"));
+        identity.AddClaim(new Claim("provider", "Entra"));
+        var principal = new ClaimsPrincipal(identity);
+
+        Action act = () => new AnonymousPrincipalNormalizer().Normalize(principal);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not 'Anonymous'*");
+    }
+
+    // ── Capability policy: read-only enforcement ──────────────────────────────
+
+    [Theory]
+    [InlineData("POST", "/api/approvals/7/respond", true)]
+    [InlineData("DELETE", "/api/memory/42", true)]
+    [InlineData("POST", "/api/cards", true)]
+    [InlineData("PUT", "/api/guardrails/config", true)]
+    [InlineData("POST", "/api/admin/cache/invalidate", true)]
+    [InlineData("POST", "/api/chat", false)]
+    [InlineData("POST", "/api/chat/stream", false)]
+    [InlineData("POST", "/api/knowledge/search", false)]
+    [InlineData("GET", "/api/scorecard", false)]
+    [InlineData("GET", "/api/margin/anything", false)]
+    public void CapabilityPolicy_BlocksMutations_AllowsReads(string method, string path, bool blocked) => AnonymousCapabilityPolicy.IsBlockedMutation(method, path).Should().Be(blocked);
+
+    // ── Tool filter: write-capable tools removed for anonymous ─────────────────
+
+    [Fact]
+    public void ToolFilter_DropsWriteTools_ForAnonymousPrincipal()
+    {
+        AITool approval = AIFunctionFactory.Create(() => "approved", "RequestApproval");
+        AITool readOnly = AIFunctionFactory.Create(() => "chart", "GenerateChart");
+        var accessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext { User = AnonymousPrincipal("anon-1") }
+        };
+        var policy = new AnonymousChatPolicy(accessor, HostedOptions());
+
+        AITool[] filtered = [.. policy.FilterTools([approval, readOnly])];
+
+        filtered.Should().ContainSingle().Which.Should().BeSameAs(readOnly);
+        policy.MaxOutputTokens.Should().Be(HostedOptions().MaxOutputTokens);
+    }
+
+    [Fact]
+    public void ToolFilter_IsPassthrough_ForNonAnonymousPrincipal()
+    {
+        AITool approval = AIFunctionFactory.Create(() => "approved", "RequestApproval");
+        var accessor = new HttpContextAccessor { HttpContext = new DefaultHttpContext() }; // unauthenticated
+        var policy = new AnonymousChatPolicy(accessor, HostedOptions());
+
+        AITool[] filtered = [.. policy.FilterTools([approval])];
+
+        filtered.Should().ContainSingle().Which.Should().BeSameAs(approval);
+        policy.MaxOutputTokens.Should().BeNull();
+    }
+
+    // ── Circuit breaker: request/token/cost ceilings, cache-truthful ───────────
+
+    [Fact]
+    public void Budget_TripsWhenRequestCeilingReached_FailClosed()
+    {
+        AnonymousUsageBudget budget = new(HostedOptions(dailyRequests: 2));
+
+        budget.TryBeginRequest(out _).Should().BeTrue();
+        budget.TryBeginRequest(out _).Should().BeTrue();
+        budget.TryBeginRequest(out string? reason).Should().BeFalse("the 3rd request exceeds the daily ceiling");
+        reason.Should().Contain("request ceiling");
+    }
+
+    [Fact]
+    public void Budget_TripsWhenTokenCeilingReached()
+    {
+        AnonymousUsageBudget budget = new(HostedOptions(dailyTokens: 100));
+
+        budget.TryBeginRequest(out _).Should().BeTrue();
+        budget.RecordUsage(tokens: 150, costUsd: 0m);
+
+        budget.TryBeginRequest(out string? reason).Should().BeFalse();
+        reason.Should().Contain("token ceiling");
+    }
+
+    [Fact]
+    public void Budget_CacheHitDoesNotAdvanceTokenOrCostCeiling()
+    {
+        AnonymousAuthOptions options = HostedOptions(dailyTokens: 100, dailyCost: 100m);
+        AnonymousUsageBudget budget = new(options);
+        var tracker = new AnonymousBudgetCostTracker(new NullCostTracker(), budget, Config());
+
+        // A cache hit is recorded truthfully as zero tokens / cache-flagged: it must not advance
+        // the token or cost ceiling. The request slot is charged elsewhere (guard middleware).
+        tracker.TrackUsageAsync(new UsageEvent("cache", "cache", 0, 0, null, DateTime.UtcNow, CacheHit: true))
+            .GetAwaiter().GetResult();
+
+        AnonymousBudgetSnapshot snap = budget.Snapshot();
+        snap.Tokens.Should().Be(0);
+        snap.CostUsd.Should().Be(0m);
+        snap.BreakerTripped.Should().BeFalse();
+    }
+
+    // ── Rate limiter: fixed-window per key ─────────────────────────────────────
+
+    [Fact]
+    public void RateLimiter_DeniesBeyondPermitInWindow()
+    {
+        var limiter = new AnonymousRateLimiter();
+
+        limiter.TryAcquire("k", 2).Should().BeTrue();
+        limiter.TryAcquire("k", 2).Should().BeTrue();
+        limiter.TryAcquire("k", 2).Should().BeFalse();
+        limiter.TryAcquire("other", 2).Should().BeTrue("a different key has its own window");
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private static AnonymousAuthOptions HostedOptions(
+        int dailyRequests = 500, long dailyTokens = 200_000, decimal dailyCost = 5.00m) =>
+        AnonymousAuthOptions.FromConfiguration(
+            Config(
+                ("Authentication:Mode", "Anonymous"),
+                ("Anonymous:AllowHosted", "true"),
+                ("Anonymous:SigningKey", HostedKey),
+                ("Anonymous:Limits:DailyMaxRequests", dailyRequests.ToString()),
+                ("Anonymous:Limits:DailyMaxTokens", dailyTokens.ToString()),
+                ("Anonymous:Limits:DailyMaxCostUsd", dailyCost.ToString(System.Globalization.CultureInfo.InvariantCulture))),
+            Env("Production"));
+
+    private static ClaimsPrincipal AnonymousPrincipal(
+        string subject, string role = "RetailPulse.Anonymous", string scope = "chat_limited")
+    {
+        var identity = new ClaimsIdentity("anonymous-session");
+        identity.AddClaim(new Claim(JwtRegisteredClaimNames.Sub, subject));
+        identity.AddClaim(new Claim("provider", "Anonymous"));
+        identity.AddClaim(new Claim("roles", role));
+        identity.AddClaim(new Claim("scp", scope));
+        return new ClaimsPrincipal(identity);
+    }
+
+    private sealed class TestEnv : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "RetailPulse.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+
+    private sealed class NullCostTracker : ICostTracker
+    {
+        public Task TrackUsageAsync(UsageEvent usage, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<CostSummary> GetSummaryAsync(CostPeriod period, CancellationToken ct = default) =>
+            Task.FromResult(new CostSummary(0, 0m, 0, period));
+        public Task<IReadOnlyList<AgentCostBreakdown>> GetByAgentAsync(CostPeriod period, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<AgentCostBreakdown>>([]);
+        public Task<CostTrend> GetTrendAsync(int days = 7, CancellationToken ct = default) =>
+            Task.FromResult(new CostTrend([]));
+    }
+}

--- a/tests/RetailPulse.Tests/Security/AnonymousChatEndpointThreatTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousChatEndpointThreatTests.cs
@@ -1,0 +1,333 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using RetailPulse.Api.Agents;
+using RetailPulse.Api.Caching;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Api.Guardrails;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Memory;
+using RetailPulse.Api.Middleware;
+using RetailPulse.Api.Models;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Rag;
+using RetailPulse.Api.Security;
+using RetailPulse.Api.Security.Anonymous;
+using RetailPulse.Api.Tracing;
+using RetailPulse.Api.Validation;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Caching;
+using RetailPulse.Contracts.Consensus;
+using RetailPulse.Contracts.Guardrails;
+using RetailPulse.Contracts.Memory;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Rag;
+using RetailPulse.Contracts.Routing;
+using ChatRequest = RetailPulse.Contracts.ChatRequest;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Threat regression tests that drive the REAL <see cref="ChatEndpoints.MapChatEndpoints"/> delegate
+/// (not a stand-in echo) end-to-end through the anonymous stack in an in-process
+/// <see cref="TestServer"/>. Router, specialists, memory, cost/audit and the LLM are faked at their
+/// boundaries so no Azure credentials are required, but the endpoint's own identity resolution,
+/// cache/memory gating, session-ownership binding and validation all run as in production.
+///
+/// It proves, at the endpoint level:
+/// <list type="bullet">
+///   <item><b>Finding 2</b> — a request-body <c>objectId</c> is ignored; identity is the token
+///     subject, and two sessions are isolated;</item>
+///   <item><b>Finding 7</b> — the response cache is disabled for anonymous, so identical prompts
+///     from two subjects execute independently and never share a reply.</item>
+/// </list>
+/// </summary>
+public sealed class AnonymousChatEndpointThreatTests
+{
+    private const string Issuer = "retail-pulse-anonymous";
+    private const string Audience = "retail-pulse-api";
+    private const string SigningKeyText = "anon-chat-endpoint-test-signing-key-0123456789";
+    private static readonly SymmetricSecurityKey SigningKey = new(Encoding.UTF8.GetBytes(SigningKeyText));
+
+    [Fact]
+    public async Task BodyObjectId_IsIgnored_IdentityComesFromTokenSubject()
+    {
+        using ChatFixture fx = CreateServer();
+        string token = Token("anon-real");
+
+        // The body carries a spoofed objectId; the real endpoint must resolve identity from the
+        // signed token subject and normalise request.User.ObjectId to it before the agent runs.
+        EchoResult result = await PostChat(fx, token, new ChatRequest(
+            "hello", SessionId: "sess-1", User: new UserContext("anon-attacker", "Mallory", "m@x")));
+
+        result.Reply.Should().Be("anon-real", "identity must be the token subject, never the body objectId");
+    }
+
+    [Fact]
+    public async Task TwoSessions_AreIsolated_EachSeesOnlyItsOwnSubject()
+    {
+        using ChatFixture fx = CreateServer();
+
+        EchoResult a = await PostChat(fx, Token("anon-A"), new ChatRequest("hi", SessionId: "s-a"));
+        EchoResult b = await PostChat(fx, Token("anon-B"), new ChatRequest("hi", SessionId: "s-b"));
+
+        a.Reply.Should().Be("anon-A");
+        b.Reply.Should().Be("anon-B");
+        a.Reply.Should().NotBe(b.Reply);
+    }
+
+    [Fact]
+    public async Task Cache_IsDisabled_ForAnonymous_IdenticalPromptsExecuteIndependently()
+    {
+        using ChatFixture fx = CreateServer();
+
+        // A deterministic, cacheable prompt. If the cache were active (subject-blind key), the second
+        // subject would receive the first subject's cached reply. With the cache disabled for
+        // anonymous, the agent runs for BOTH and each sees only its own subject.
+        const string prompt = "How many stores do we have?";
+        CacheHelpers.IsCacheable(prompt).Should().BeTrue("the test relies on a cacheable prompt");
+
+        EchoResult a = await PostChat(fx, Token("anon-1"), new ChatRequest(prompt, SessionId: "c-1"));
+        EchoResult b = await PostChat(fx, Token("anon-2"), new ChatRequest(prompt, SessionId: "c-2"));
+
+        a.Reply.Should().Be("anon-1");
+        b.Reply.Should().Be("anon-2", "the second subject must not receive the first subject's cached reply");
+        fx.AgentInvocations.Should().Be(2, "the cache is disabled for anonymous — both requests reach the agent");
+    }
+
+    [Fact]
+    public async Task HistoryBounds_AreRejected_BeforeModel_With400()
+    {
+        using ChatFixture fx = CreateServer();
+        var oversizedHistory = Enumerable.Range(0, ChatRequestValidator.MaxHistoryMessages + 5)
+            .Select(i => new ChatHistoryMessage("user", $"m{i}"))
+            .ToList();
+
+        HttpResponseMessage resp = await PostChatRaw(fx, Token("anon-hist"),
+            new ChatRequest("hi", SessionId: "h-1", History: oversizedHistory));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest, "history count over the bound is rejected pre-model");
+        fx.AgentInvocations.Should().Be(0, "validation must fail closed before the agent runs");
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private static async Task<HttpResponseMessage> PostChatRaw(ChatFixture fx, string token, ChatRequest body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/api/chat");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Content = JsonContent.Create(body);
+        return await fx.Client.SendAsync(req);
+    }
+
+    private static async Task<EchoResult> PostChat(ChatFixture fx, string token, ChatRequest body)
+    {
+        HttpResponseMessage resp = await PostChatRaw(fx, token, body);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await resp.Content.ReadFromJsonAsync<EchoResult>() ?? new();
+    }
+
+    private static string Token(string subject)
+    {
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, subject),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+            new("provider", "Anonymous"),
+            new("roles", "RetailPulse.Anonymous"),
+            new("scp", "chat_limited"),
+        };
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = Audience,
+            Subject = new ClaimsIdentity(claims),
+            NotBefore = DateTime.UtcNow.AddMinutes(-1),
+            Expires = DateTime.UtcNow.AddMinutes(10),
+            SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.HmacSha256),
+        };
+
+        var handler = new JsonWebTokenHandler { SetDefaultTimesOnTokenCreation = false };
+        return handler.CreateToken(descriptor);
+    }
+
+    private static ChatFixture CreateServer()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Authentication:Mode"] = "Anonymous",
+                ["Anonymous:AllowHosted"] = "true",
+                ["Anonymous:SigningKey"] = SigningKeyText,
+                ["Anonymous:Issuer"] = Issuer,
+                ["Anonymous:Audience"] = Audience,
+                ["Anonymous:MaxRequestBytes"] = "16384",
+                ["Anonymous:Chat:PerSubjectPerMinute"] = "100",
+                ["Anonymous:Chat:PerIpPerMinute"] = "100",
+                ["Anonymous:Limits:DailyMaxRequests"] = "500",
+                ["Anonymous:Limits:DailyMaxTokens"] = "1000000",
+                ["Anonymous:Limits:DailyMaxCostUsd"] = "100",
+            })
+            .Build();
+
+        WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Configuration.AddConfiguration(config);
+        builder.Services.AddLogging();
+        builder.Services.AddRouting();
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddSignalR();
+
+        // Full anonymous stack: scheme + constrained policy + guard services + IAnonymousChatPolicy.
+        builder.Services.AddProviderNeutralAuthentication(config, builder.Environment);
+
+        // Session-ownership registry (consulted by the endpoint + hubs).
+        builder.Services.AddSingleton<ISessionOwnershipRegistry, SessionOwnershipRegistry>();
+
+        // Real, in-memory pipeline collaborators.
+        builder.Services.AddSingleton<InMemoryResponseCache>();
+        builder.Services.AddSingleton<IResponseCache>(sp => sp.GetRequiredService<InMemoryResponseCache>());
+        builder.Services.AddSingleton<InMemoryKnowledgeBase>();
+        builder.Services.AddSingleton<IKnowledgeBase>(sp => sp.GetRequiredService<InMemoryKnowledgeBase>());
+        builder.Services.AddSingleton<RagContextProvider>();
+        builder.Services.AddSingleton<InMemorySuspiciousRequestLog>();
+        builder.Services.AddSingleton<ISuspiciousRequestLog>(sp => sp.GetRequiredService<InMemorySuspiciousRequestLog>());
+        builder.Services.AddSingleton<GuardrailsConfig>();
+        builder.Services.AddScoped<GuardrailsMiddleware>();
+        builder.Services.AddSingleton<InMemoryTraceCollector>();
+        builder.Services.Configure<ObservabilityOptions>(_ => { });
+        builder.Services.AddSingleton<ConversationExporter>();
+        builder.Services.AddSingleton<MemoryExtractionChannel>();
+        builder.Services.AddSingleton<MemoryExtractionService>();
+        builder.Services.AddSingleton<ConversationMemoryMiddleware>();
+
+        // Streaming collaborators are only needed so the (blocked-for-anonymous) /api/chat/stream
+        // route can have its metadata inferred at startup; the route itself is never reachable here.
+        builder.Services.AddScoped<StreamingMiddleware>();
+        builder.Services.AddScoped<StreamingProgressFeature>();
+
+        // Faked boundaries (LLM + memory are never reached for anonymous; cost/audit/tenant are no-ops).
+        builder.Services.AddSingleton(new Mock<IChatClient>().Object);
+        builder.Services.AddSingleton(new Mock<IConversationMemory>().Object);
+        builder.Services.AddSingleton(new Mock<IConsensusCouncil>().Object);
+
+        var cost = new Mock<ICostTracker>();
+        cost.Setup(c => c.TrackUsageAsync(It.IsAny<UsageEvent>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        builder.Services.AddSingleton(cost.Object);
+
+        var audit = new Mock<IAuditLog>();
+        audit.Setup(a => a.LogAsync(It.IsAny<AuditEntry>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        builder.Services.AddSingleton(audit.Object);
+
+        var tenant = new Mock<ITenantProvider>();
+        tenant.Setup(t => t.GetTenant()).Returns(new TenantConfiguration());
+        builder.Services.AddSingleton(tenant.Object);
+
+        var counter = new AgentCounter();
+        builder.Services.AddSingleton(counter);
+        builder.Services.AddSingleton<IAgentRouter, FakeRouter>();
+        builder.Services.AddSingleton<ISpecialistAgent>(sp => new EchoSpecialist(sp.GetRequiredService<AgentCounter>()));
+
+        WebApplication app = builder.Build();
+        app.UseRouting();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseMiddleware<AnonymousGuardMiddleware>();
+        app.MapChatEndpoints(new AgentDefinition { Name = "test" });
+
+        app.StartAsync().GetAwaiter().GetResult();
+        return new ChatFixture(app, counter);
+    }
+
+    private sealed class EchoResult
+    {
+        public string? Reply { get; set; }
+        public string? SessionId { get; set; }
+    }
+
+    private sealed class AgentCounter
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+        public void Increment() => Interlocked.Increment(ref _count);
+    }
+
+    /// <summary>Routes everything to the "general" specialist.</summary>
+    private sealed class FakeRouter : IAgentRouter
+    {
+        public Task<RoutingDecision> RouteAsync(
+            string message,
+            IReadOnlyList<ChatHistoryMessage>? conversationHistory,
+            UserContext? user,
+            string? tenantId,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RoutingDecision("general", AgentIntent.General, 0.9, [AgentIntent.General]));
+    }
+
+    /// <summary>Echoes the resolved userId (request.User.ObjectId, normalised by the endpoint).</summary>
+    private sealed class EchoSpecialist : ISpecialistAgent
+    {
+        private readonly AgentCounter _counter;
+        public EchoSpecialist(AgentCounter counter)
+        {
+            _counter = counter;
+        }
+
+        public string Key => "general";
+        public string DisplayName => "General";
+        public string Model => "gpt-test";
+        public IReadOnlyList<string> SupportedIntents => [AgentIntent.General];
+
+        public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+        {
+            _counter.Increment();
+            string subject = request.User?.ObjectId ?? "(none)";
+            return Task.FromResult(new ChatResponse(
+                subject,
+                request.SessionId ?? "s",
+                [new AgentSpan("agent.general.response", "response", "done", 1, DateTimeOffset.UtcNow, request.SessionId)],
+                Charts: null,
+                TotalDurationMs: 1,
+                TokenUsage: new TokenUsage(1, 1, 2)));
+        }
+    }
+
+    private sealed class ChatFixture : IDisposable
+    {
+        private readonly WebApplication _app;
+        private readonly AgentCounter _counter;
+
+        public ChatFixture(WebApplication app, AgentCounter counter)
+        {
+            _app = app;
+            _counter = counter;
+            Client = app.GetTestClient();
+        }
+
+        public HttpClient Client { get; }
+
+        public int AgentInvocations => _counter.Count;
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _app.StopAsync().GetAwaiter().GetResult();
+            ((IDisposable)_app).Dispose();
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Security/AnonymousChatInternalBypassTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousChatInternalBypassTests.cs
@@ -1,0 +1,439 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using RetailPulse.Api.Agents;
+using RetailPulse.Api.Agents.Specialists;
+using RetailPulse.Api.Caching;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Api.Guardrails;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Memory;
+using RetailPulse.Api.Middleware;
+using RetailPulse.Api.Models;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Rag;
+using RetailPulse.Api.Security;
+using RetailPulse.Api.Security.Anonymous;
+using RetailPulse.Api.Tracing;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Caching;
+using RetailPulse.Contracts.Consensus;
+using RetailPulse.Contracts.Guardrails;
+using RetailPulse.Contracts.Memory;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Rag;
+using RetailPulse.Contracts.Routing;
+using ChatRequest = RetailPulse.Contracts.ChatRequest;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Chat-internal bypass regression tests that drive the REAL
+/// <see cref="ChatEndpoints.MapChatEndpoints"/> delegate end-to-end through the anonymous stack in
+/// an in-process <see cref="TestServer"/>. Unlike tool-filter unit tests, these prove the two
+/// bypasses that tool filtering can NEVER reach are closed at the endpoint:
+///
+/// <list type="bullet">
+///   <item><b>Blocker 1 — memory management.</b> The real <see cref="MemoryManagementAgent"/> calls
+///     <c>IConversationMemory.StoreAsync</c>/<c>ForgetAsync</c> DIRECTLY (no AI tools). A
+///     <c>remember that ...</c> / <c>forget everything</c> prompt classified as
+///     <see cref="AgentIntent.MemoryManagement"/> must be refused BEFORE the agent runs — proven by
+///     a spy memory that records zero mutations and a specialist-invocation counter of zero.</item>
+///   <item><b>Blocker 2 — consensus council.</b> A <c>council/health</c> prompt must be refused
+///     BEFORE the council interception, so <see cref="IConsensusCouncil.ConveneAsync"/> is never
+///     called — no council model calls, and no early-return that would skip the single accounted
+///     budget/audit path.</item>
+///   <item><b>Blocker 3 — truthful accounting.</b> An allowed single-topic chat reaches exactly one
+///     accounted <c>AgentExecutionPipeline</c> path: the cost tracker and audit log each record the
+///     turn once, with the specialist's real token totals. Refusals are deterministic (no model) and
+///     record NO cost/audit — nothing is fabricated.</item>
+/// </list>
+/// Router, specialists, memory, council, cost and audit are faked at their boundaries so no Azure
+/// credentials are needed, but the endpoint's own anonymous gating, refusal logic and accounting all
+/// run exactly as in production.
+/// </summary>
+public sealed class AnonymousChatInternalBypassTests
+{
+    private const string Issuer = "retail-pulse-anonymous";
+    private const string Audience = "retail-pulse-api";
+    private const string SigningKeyText = "anon-chat-bypass-test-signing-key-0123456789";
+    private static readonly SymmetricSecurityKey SigningKey = new(Encoding.UTF8.GetBytes(SigningKeyText));
+
+    // ── Blocker 1: memory management is refused, with zero memory mutation ──────
+
+    [Theory]
+    [InlineData("remember that our flagship store is in Seattle")]
+    [InlineData("please remember this: I prefer weekly reports")]
+    [InlineData("forget everything we discussed")]
+    [InlineData("reset and start fresh")]
+    public async Task Anonymous_MemoryManagementPrompt_IsRefused_WithZeroMemoryMutation(string prompt)
+    {
+        using BypassFixture fx = CreateServer();
+
+        EchoResult result = await PostChat(fx, Token("anon-mem"), new ChatRequest(prompt, SessionId: "m-1"));
+
+        result.Reply.Should().Be(AnonymousChatRestrictions.MemoryRefusalMessage,
+            "an anonymous memory-management turn must return the standard safe refusal");
+
+        // The direct-write agent must never run: no StoreAsync, no ForgetAsync, no rows mutated.
+        fx.Memory.Verify(m => m.StoreAsync(It.IsAny<string>(), It.IsAny<MemoryEntry>(), It.IsAny<CancellationToken>()), Times.Never,
+            "the refusal must fire before the MemoryManagementAgent can store anything");
+        fx.Memory.Verify(m => m.ForgetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never,
+            "the refusal must fire before the MemoryManagementAgent can forget anything");
+        fx.Memory.Verify(m => m.ForgetEntryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        fx.SpecialistInvocations.Should().Be(0, "no specialist (and therefore no model) runs for a refused turn");
+
+        // A refusal is not billable: no cost and no audit entry are fabricated.
+        fx.Cost.Verify(c => c.TrackUsageAsync(It.IsAny<UsageEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+        fx.Audit.Verify(a => a.LogAsync(It.IsAny<AuditEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Blocker 2: council is refused, with zero council model calls ────────────
+
+    [Theory]
+    [InlineData("give me a portfolio health assessment for Contoso")]
+    [InlineData("convene the council on overall brand health")]
+    public async Task Anonymous_CouncilPrompt_IsRefused_WithZeroCouncilCalls(string prompt)
+    {
+        using BypassFixture fx = CreateServer();
+
+        EchoResult result = await PostChat(fx, Token("anon-council"), new ChatRequest(prompt, SessionId: "c-1"));
+
+        result.Reply.Should().Be(AnonymousChatRestrictions.CouncilRefusalMessage,
+            "an anonymous portfolio-health turn must return the standard safe refusal");
+
+        // The council interception must never convene — no fan-out of model calls.
+        fx.Council.Verify(c => c.ConveneAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never,
+            "the refusal must fire before the council interception");
+
+        fx.SpecialistInvocations.Should().Be(0, "no specialist runs for a refused council turn");
+
+        // The early-return council path is the one that historically skipped accounting; a refusal
+        // must likewise not fabricate cost/audit.
+        fx.Cost.Verify(c => c.TrackUsageAsync(It.IsAny<UsageEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+        fx.Audit.Verify(a => a.LogAsync(It.IsAny<AuditEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Blocker 3: allowed chat reaches ONE accounted pipeline, truthfully ──────
+
+    [Fact]
+    public async Task Anonymous_AllowedChat_ReachesSinglePipeline_WithTruthfulBudgetAndAudit()
+    {
+        using BypassFixture fx = CreateServer();
+
+        EchoResult result = await PostChat(fx, Token("anon-ok"), new ChatRequest(
+            "How is demand trending for our top brand?", SessionId: "g-1"));
+
+        result.Reply.Should().Be("anon-ok", "an allowed single-topic chat reaches the general specialist");
+
+        fx.SpecialistInvocations.Should().Be(1, "exactly one accounted AgentExecutionPipeline path runs");
+
+        // Neither the direct-write memory agent nor the council is on the allowed path.
+        fx.Memory.Verify(m => m.StoreAsync(It.IsAny<string>(), It.IsAny<MemoryEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+        fx.Memory.Verify(m => m.ForgetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        fx.Council.Verify(c => c.ConveneAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        // Accounting is truthful: exactly one usage event (with the specialist's real tokens) and
+        // exactly one audit entry — no more, no less.
+        fx.Cost.Verify(c => c.TrackUsageAsync(
+            It.Is<UsageEvent>(u => u.InputTokens == 1 && u.OutputTokens == 1), It.IsAny<CancellationToken>()), Times.Once,
+            "the single model path records its real token usage against the budget");
+        fx.Audit.Verify(a => a.LogAsync(It.IsAny<AuditEntry>(), It.IsAny<CancellationToken>()), Times.Once,
+            "the allowed turn is audited exactly once");
+    }
+
+    [Fact]
+    public async Task Anonymous_DeterministicKeywordPrompts_CannotReachMemoryOrCouncil()
+    {
+        using BypassFixture fx = CreateServer();
+
+        // A crafted prompt cannot defeat the refusals: they fire on the router's own classification,
+        // not on prompt text. Drive both restricted intents and one allowed intent in sequence and
+        // prove the restricted collaborators are never touched.
+        await PostChat(fx, Token("k-1"), new ChatRequest("remember that margins are thin", SessionId: "k-1"));
+        await PostChat(fx, Token("k-2"), new ChatRequest("portfolio health council please", SessionId: "k-2"));
+        await PostChat(fx, Token("k-3"), new ChatRequest("what is our promo plan?", SessionId: "k-3"));
+
+        fx.Memory.Verify(m => m.StoreAsync(It.IsAny<string>(), It.IsAny<MemoryEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+        fx.Memory.Verify(m => m.ForgetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        fx.Council.Verify(c => c.ConveneAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        // Only the single allowed general turn is accounted.
+        fx.SpecialistInvocations.Should().Be(1, "only the allowed general prompt reaches a specialist");
+        fx.Cost.Verify(c => c.TrackUsageAsync(It.IsAny<UsageEvent>(), It.IsAny<CancellationToken>()), Times.Once);
+        fx.Audit.Verify(a => a.LogAsync(It.IsAny<AuditEntry>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private static async Task<EchoResult> PostChat(BypassFixture fx, string token, ChatRequest body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/api/chat");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Content = JsonContent.Create(body);
+        HttpResponseMessage resp = await fx.Client.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await resp.Content.ReadFromJsonAsync<EchoResult>() ?? new();
+    }
+
+    private static string Token(string subject)
+    {
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, subject),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+            new("provider", "Anonymous"),
+            new("roles", "RetailPulse.Anonymous"),
+            new("scp", "chat_limited"),
+        };
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = Audience,
+            Subject = new ClaimsIdentity(claims),
+            NotBefore = DateTime.UtcNow.AddMinutes(-1),
+            Expires = DateTime.UtcNow.AddMinutes(10),
+            SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.HmacSha256),
+        };
+
+        var handler = new JsonWebTokenHandler { SetDefaultTimesOnTokenCreation = false };
+        return handler.CreateToken(descriptor);
+    }
+
+    private static BypassFixture CreateServer()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Authentication:Mode"] = "Anonymous",
+                ["Anonymous:AllowHosted"] = "true",
+                ["Anonymous:SigningKey"] = SigningKeyText,
+                ["Anonymous:Issuer"] = Issuer,
+                ["Anonymous:Audience"] = Audience,
+                ["Anonymous:MaxRequestBytes"] = "16384",
+                ["Anonymous:Chat:PerSubjectPerMinute"] = "100",
+                ["Anonymous:Chat:PerIpPerMinute"] = "100",
+                ["Anonymous:Limits:DailyMaxRequests"] = "500",
+                ["Anonymous:Limits:DailyMaxTokens"] = "1000000",
+                ["Anonymous:Limits:DailyMaxCostUsd"] = "100",
+            })
+            .Build();
+
+        WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Configuration.AddConfiguration(config);
+        builder.Services.AddLogging();
+        builder.Services.AddRouting();
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddSignalR();
+
+        builder.Services.AddProviderNeutralAuthentication(config, builder.Environment);
+        builder.Services.AddSingleton<ISessionOwnershipRegistry, SessionOwnershipRegistry>();
+
+        builder.Services.AddSingleton<InMemoryResponseCache>();
+        builder.Services.AddSingleton<IResponseCache>(sp => sp.GetRequiredService<InMemoryResponseCache>());
+        builder.Services.AddSingleton<InMemoryKnowledgeBase>();
+        builder.Services.AddSingleton<IKnowledgeBase>(sp => sp.GetRequiredService<InMemoryKnowledgeBase>());
+        builder.Services.AddSingleton<RagContextProvider>();
+        builder.Services.AddSingleton<InMemorySuspiciousRequestLog>();
+        builder.Services.AddSingleton<ISuspiciousRequestLog>(sp => sp.GetRequiredService<InMemorySuspiciousRequestLog>());
+        builder.Services.AddSingleton<GuardrailsConfig>();
+        builder.Services.AddScoped<GuardrailsMiddleware>();
+        builder.Services.AddSingleton<InMemoryTraceCollector>();
+        builder.Services.Configure<ObservabilityOptions>(_ => { });
+        builder.Services.AddSingleton<ConversationExporter>();
+        builder.Services.AddSingleton<MemoryExtractionChannel>();
+        builder.Services.AddSingleton<MemoryExtractionService>();
+        builder.Services.AddSingleton<ConversationMemoryMiddleware>();
+        builder.Services.AddScoped<StreamingMiddleware>();
+        builder.Services.AddScoped<StreamingProgressFeature>();
+
+        builder.Services.AddSingleton(new Mock<IChatClient>().Object);
+
+        // Spy memory: if the direct-write MemoryManagementAgent ever ran, these would be hit.
+        var memory = new Mock<IConversationMemory>();
+        memory.Setup(m => m.StoreAsync(It.IsAny<string>(), It.IsAny<MemoryEntry>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        memory.Setup(m => m.ForgetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        memory.Setup(m => m.RecallAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        builder.Services.AddSingleton(memory.Object);
+
+        // Spy council: proves ConveneAsync is never reached for anonymous.
+        var council = new Mock<IConsensusCouncil>();
+        builder.Services.AddSingleton(council.Object);
+
+        var cost = new Mock<ICostTracker>();
+        cost.Setup(c => c.TrackUsageAsync(It.IsAny<UsageEvent>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        builder.Services.AddSingleton(cost.Object);
+
+        var audit = new Mock<IAuditLog>();
+        audit.Setup(a => a.LogAsync(It.IsAny<AuditEntry>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        builder.Services.AddSingleton(audit.Object);
+
+        var tenant = new Mock<ITenantProvider>();
+        tenant.Setup(t => t.GetTenant()).Returns(new TenantConfiguration());
+        builder.Services.AddSingleton(tenant.Object);
+
+        var counter = new SpecialistCounter();
+        builder.Services.AddSingleton(counter);
+        builder.Services.AddSingleton<IAgentRouter, KeywordRouter>();
+
+        // The REAL direct-write memory agent (so a bypass would produce a real StoreAsync/ForgetAsync)
+        // and a general echo specialist for the allowed path.
+        builder.Services.AddSingleton<ISpecialistAgent>(sp => new CountingMemoryAgent(
+            sp.GetRequiredService<IConversationMemory>(),
+            sp.GetRequiredService<ILoggerFactory>().CreateLogger<MemoryManagementAgent>(),
+            sp.GetRequiredService<SpecialistCounter>()));
+        builder.Services.AddSingleton<ISpecialistAgent>(sp => new EchoSpecialist(sp.GetRequiredService<SpecialistCounter>()));
+
+        WebApplication app = builder.Build();
+        app.UseRouting();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseMiddleware<AnonymousGuardMiddleware>();
+        app.MapChatEndpoints(new AgentDefinition { Name = "test" });
+
+        app.StartAsync().GetAwaiter().GetResult();
+        return new BypassFixture(app, counter, memory, council, cost, audit);
+    }
+
+    private sealed class EchoResult
+    {
+        public string? Reply { get; set; }
+        public string? SessionId { get; set; }
+    }
+
+    private sealed class SpecialistCounter
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+        public void Increment() => Interlocked.Increment(ref _count);
+    }
+
+    /// <summary>Deterministic keyword router: memory / council / general by prompt content.</summary>
+    private sealed class KeywordRouter : IAgentRouter
+    {
+        public Task<RoutingDecision> RouteAsync(
+            string message,
+            IReadOnlyList<ChatHistoryMessage>? conversationHistory,
+            UserContext? user,
+            string? tenantId,
+            CancellationToken ct = default)
+        {
+            string lower = (message ?? string.Empty).ToLowerInvariant();
+            RoutingDecision decision =
+                lower.Contains("remember") || lower.Contains("forget") || lower.Contains("reset")
+                    ? new RoutingDecision("memory-management", AgentIntent.MemoryManagement, 0.95, [AgentIntent.MemoryManagement])
+                : lower.Contains("council") || lower.Contains("portfolio health") || lower.Contains("health")
+                    ? new RoutingDecision("portfolio-health", AgentIntent.PortfolioHealth, 0.95, [AgentIntent.PortfolioHealth])
+                : new RoutingDecision("general", AgentIntent.General, 0.9, [AgentIntent.General]);
+            return Task.FromResult(decision);
+        }
+    }
+
+    /// <summary>Real MemoryManagementAgent behaviour, but counts invocations so a bypass is visible.</summary>
+    private sealed class CountingMemoryAgent : ISpecialistAgent
+    {
+        private readonly MemoryManagementAgent _inner;
+        private readonly SpecialistCounter _counter;
+
+        public CountingMemoryAgent(IConversationMemory memory, ILogger<MemoryManagementAgent> logger, SpecialistCounter counter)
+        {
+            _inner = new MemoryManagementAgent(memory, logger);
+            _counter = counter;
+        }
+
+        public string Key => _inner.Key;
+        public string DisplayName => _inner.DisplayName;
+        public string Model => _inner.Model;
+        public IReadOnlyList<string> SupportedIntents => _inner.SupportedIntents;
+
+        public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+        {
+            _counter.Increment();
+            return _inner.HandleAsync(request, ct);
+        }
+    }
+
+    /// <summary>Echoes the resolved userId and records one accounted invocation.</summary>
+    private sealed class EchoSpecialist : ISpecialistAgent
+    {
+        private readonly SpecialistCounter _counter;
+        public EchoSpecialist(SpecialistCounter counter)
+        {
+            _counter = counter;
+        }
+
+        public string Key => "general";
+        public string DisplayName => "General";
+        public string Model => "gpt-test";
+        public IReadOnlyList<string> SupportedIntents => [AgentIntent.General];
+
+        public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+        {
+            _counter.Increment();
+            string subject = request.User?.ObjectId ?? "(none)";
+            return Task.FromResult(new ChatResponse(
+                subject,
+                request.SessionId ?? "s",
+                [new AgentSpan("agent.general.response", "response", "done", 1, DateTimeOffset.UtcNow, request.SessionId)],
+                Charts: null,
+                TotalDurationMs: 1,
+                TokenUsage: new TokenUsage(1, 1, 2)));
+        }
+    }
+
+    private sealed class BypassFixture : IDisposable
+    {
+        private readonly WebApplication _app;
+        private readonly SpecialistCounter _counter;
+
+        public BypassFixture(
+            WebApplication app,
+            SpecialistCounter counter,
+            Mock<IConversationMemory> memory,
+            Mock<IConsensusCouncil> council,
+            Mock<ICostTracker> cost,
+            Mock<IAuditLog> audit)
+        {
+            _app = app;
+            _counter = counter;
+            Memory = memory;
+            Council = council;
+            Cost = cost;
+            Audit = audit;
+            Client = app.GetTestClient();
+        }
+
+        public HttpClient Client { get; }
+        public Mock<IConversationMemory> Memory { get; }
+        public Mock<IConsensusCouncil> Council { get; }
+        public Mock<ICostTracker> Cost { get; }
+        public Mock<IAuditLog> Audit { get; }
+        public int SpecialistInvocations => _counter.Count;
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _app.StopAsync().GetAwaiter().GetResult();
+            ((IDisposable)_app).Dispose();
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Security/AnonymousHubOwnershipTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousHubOwnershipTests.cs
@@ -1,7 +1,6 @@
 using System.Security.Claims;
 using FluentAssertions;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.IdentityModel.JsonWebTokens;
 using Moq;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Security.Anonymous;
@@ -9,24 +8,20 @@ using RetailPulse.Api.Security.Anonymous;
 namespace RetailPulse.Tests.Security;
 
 /// <summary>
-/// Finding 6 — hub session-ownership binding. <c>JoinSession</c> previously added the caller to a
-/// group named by an arbitrary, caller-supplied session id, so an anonymous attacker who knew or
-/// guessed a victim's session id could subscribe to the victim's telemetry / streamed tokens.
+/// Sprint 1 mandated simplification: the SignalR hubs are NO LONGER part of the anonymous surface.
+/// A valid anonymous token is denied (403) on BOTH hubs at both the negotiate and connection
+/// endpoints — proven by the deny-by-default guard in
+/// <see cref="AnonymousAuthenticationTests"/> and by the compiled endpoint-graph policy in
+/// <see cref="EndpointAuthorizationCoverageTests"/>. Because anonymous callers can never reach a
+/// hub method, the former anonymous hub session-ownership expectations are intentionally gone.
 ///
-/// These tests drive the real <see cref="TelemetryHub"/> and <see cref="StreamingHub"/> with two
-/// distinct anonymous principals and prove the second subject cannot join the first subject's
-/// session, while Entra callers keep their unchanged (unbound) behaviour.
+/// What remains here is a guardrail proving the mandate's other half: <b>Entra hub behaviour is
+/// unchanged.</b> An Entra caller keeps its original (unbound) semantics on the real
+/// <see cref="TelemetryHub"/>, so the scope reduction for anonymous did not regress the
+/// authenticated real-time surface.
 /// </summary>
 public sealed class AnonymousHubOwnershipTests
 {
-    private static ClaimsPrincipal Anonymous(string subject) =>
-        new(new ClaimsIdentity(
-            [
-                new Claim(AnonymousCapabilityPolicy.ProviderClaimType, AnonymousCapabilityPolicy.ProviderName),
-                new Claim(JwtRegisteredClaimNames.Sub, subject),
-            ],
-            authenticationType: "AnonymousTest"));
-
     private static ClaimsPrincipal Entra(string oid) =>
         new(new ClaimsIdentity([new Claim("oid", oid)], authenticationType: "EntraTest"));
 
@@ -42,78 +37,14 @@ public sealed class AnonymousHubOwnershipTests
         return (new TelemetryHub(registry) { Context = ctx.Object, Groups = groups.Object }, groups);
     }
 
-    private static (StreamingHub hub, Mock<IGroupManager> groups) NewStreamingHub(
-        ISessionOwnershipRegistry registry, ClaimsPrincipal user, string connectionId)
-    {
-        var groups = new Mock<IGroupManager>();
-        groups.Setup(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-        var ctx = new Mock<HubCallerContext>();
-        ctx.SetupGet(c => c.User).Returns(user);
-        ctx.SetupGet(c => c.ConnectionId).Returns(connectionId);
-        return (new StreamingHub(registry) { Context = ctx.Object, Groups = groups.Object }, groups);
-    }
-
     [Fact]
-    public async Task TelemetryHub_SecondAnonymousSubject_CannotJoinFirstSubjectsSession()
+    public async Task TelemetryHub_EntraCaller_IsUnbound_AndCanJoinAnySession()
     {
         var registry = new SessionOwnershipRegistry();
-        const string sessionId = "victim-session-123";
+        const string sessionId = "some-session";
 
-        (TelemetryHub ownerHub, Mock<IGroupManager> ownerGroups) = NewTelemetryHub(registry, Anonymous("anon-A"), "conn-A");
-        await ownerHub.JoinSession(sessionId);
-        ownerGroups.Verify(g => g.AddToGroupAsync("conn-A", sessionId, It.IsAny<CancellationToken>()), Times.Once);
-
-        (TelemetryHub attackerHub, Mock<IGroupManager> attackerGroups) = NewTelemetryHub(registry, Anonymous("anon-B"), "conn-B");
-        Func<Task> join = () => attackerHub.JoinSession(sessionId);
-
-        await join.Should().ThrowAsync<HubException>("a different anonymous subject must not join another subject's session");
-        attackerGroups.Verify(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task StreamingHub_SecondAnonymousSubject_CannotJoinFirstSubjectsSession()
-    {
-        var registry = new SessionOwnershipRegistry();
-        const string sessionId = "victim-session-456";
-
-        (StreamingHub ownerHub, Mock<IGroupManager> ownerGroups) = NewStreamingHub(registry, Anonymous("anon-A"), "conn-A");
-        await ownerHub.JoinSession(sessionId);
-        ownerGroups.Verify(g => g.AddToGroupAsync("conn-A", $"stream:{sessionId}", It.IsAny<CancellationToken>()), Times.Once);
-
-        (StreamingHub attackerHub, Mock<IGroupManager> attackerGroups) = NewStreamingHub(registry, Anonymous("anon-B"), "conn-B");
-        Func<Task> join = () => attackerHub.JoinSession(sessionId);
-
-        await join.Should().ThrowAsync<HubException>("a different anonymous subject must not join another subject's streamed tokens");
-        attackerGroups.Verify(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task Hub_SameAnonymousSubject_CanRejoinOwnSession()
-    {
-        var registry = new SessionOwnershipRegistry();
-        const string sessionId = "own-session";
-
-        (TelemetryHub hub1, _) = NewTelemetryHub(registry, Anonymous("anon-A"), "conn-A1");
-        await hub1.JoinSession(sessionId);
-
-        (TelemetryHub hub2, Mock<IGroupManager> groups2) = NewTelemetryHub(registry, Anonymous("anon-A"), "conn-A2");
-        await hub2.JoinSession(sessionId);
-        groups2.Verify(g => g.AddToGroupAsync("conn-A2", sessionId, It.IsAny<CancellationToken>()), Times.Once,
-            "the owning subject may rejoin from another connection");
-    }
-
-    [Fact]
-    public async Task Hub_EntraCaller_IsUnbound_AndCanJoinAnySession()
-    {
-        var registry = new SessionOwnershipRegistry();
-        const string sessionId = "anon-owned-session";
-
-        // An anonymous subject claims the session first.
-        (TelemetryHub anonHub, _) = NewTelemetryHub(registry, Anonymous("anon-A"), "conn-A");
-        await anonHub.JoinSession(sessionId);
-
-        // Entra behaviour is unchanged — no ownership binding is enforced.
+        // Entra behaviour is unchanged by the anonymous scope reduction — no ownership binding is
+        // enforced and the caller is added to the requested group as before.
         (TelemetryHub entraHub, Mock<IGroupManager> entraGroups) = NewTelemetryHub(registry, Entra("entra-oid-1"), "conn-E");
         await entraHub.JoinSession(sessionId);
         entraGroups.Verify(g => g.AddToGroupAsync("conn-E", sessionId, It.IsAny<CancellationToken>()), Times.Once,
@@ -121,17 +52,13 @@ public sealed class AnonymousHubOwnershipTests
     }
 
     [Fact]
-    public async Task TelemetryHub_JoinCard_IsForbidden_ForAnonymous_ButAllowedForEntra()
+    public async Task TelemetryHub_EntraCaller_CanJoinCard()
     {
         var registry = new SessionOwnershipRegistry();
 
-        (TelemetryHub anonHub, Mock<IGroupManager> anonGroups) = NewTelemetryHub(registry, Anonymous("anon-A"), "conn-A");
-        Func<Task> anonJoinCard = () => anonHub.JoinCard("card-1");
-        await anonJoinCard.Should().ThrowAsync<HubException>("cards/approvals are not part of the anonymous surface");
-        anonGroups.Verify(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-
         (TelemetryHub entraHub, Mock<IGroupManager> entraGroups) = NewTelemetryHub(registry, Entra("entra-oid-1"), "conn-E");
         await entraHub.JoinCard("card-1");
-        entraGroups.Verify(g => g.AddToGroupAsync("conn-E", "card:card-1", It.IsAny<CancellationToken>()), Times.Once);
+        entraGroups.Verify(g => g.AddToGroupAsync("conn-E", "card:card-1", It.IsAny<CancellationToken>()), Times.Once,
+            "Entra callers retain their original card-subscription semantics");
     }
 }

--- a/tests/RetailPulse.Tests/Security/AnonymousHubOwnershipTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousHubOwnershipTests.cs
@@ -1,0 +1,137 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Moq;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Security.Anonymous;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Finding 6 — hub session-ownership binding. <c>JoinSession</c> previously added the caller to a
+/// group named by an arbitrary, caller-supplied session id, so an anonymous attacker who knew or
+/// guessed a victim's session id could subscribe to the victim's telemetry / streamed tokens.
+///
+/// These tests drive the real <see cref="TelemetryHub"/> and <see cref="StreamingHub"/> with two
+/// distinct anonymous principals and prove the second subject cannot join the first subject's
+/// session, while Entra callers keep their unchanged (unbound) behaviour.
+/// </summary>
+public sealed class AnonymousHubOwnershipTests
+{
+    private static ClaimsPrincipal Anonymous(string subject) =>
+        new(new ClaimsIdentity(
+            [
+                new Claim(AnonymousCapabilityPolicy.ProviderClaimType, AnonymousCapabilityPolicy.ProviderName),
+                new Claim(JwtRegisteredClaimNames.Sub, subject),
+            ],
+            authenticationType: "AnonymousTest"));
+
+    private static ClaimsPrincipal Entra(string oid) =>
+        new(new ClaimsIdentity([new Claim("oid", oid)], authenticationType: "EntraTest"));
+
+    private static (TelemetryHub hub, Mock<IGroupManager> groups) NewTelemetryHub(
+        ISessionOwnershipRegistry registry, ClaimsPrincipal user, string connectionId)
+    {
+        var groups = new Mock<IGroupManager>();
+        groups.Setup(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var ctx = new Mock<HubCallerContext>();
+        ctx.SetupGet(c => c.User).Returns(user);
+        ctx.SetupGet(c => c.ConnectionId).Returns(connectionId);
+        return (new TelemetryHub(registry) { Context = ctx.Object, Groups = groups.Object }, groups);
+    }
+
+    private static (StreamingHub hub, Mock<IGroupManager> groups) NewStreamingHub(
+        ISessionOwnershipRegistry registry, ClaimsPrincipal user, string connectionId)
+    {
+        var groups = new Mock<IGroupManager>();
+        groups.Setup(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var ctx = new Mock<HubCallerContext>();
+        ctx.SetupGet(c => c.User).Returns(user);
+        ctx.SetupGet(c => c.ConnectionId).Returns(connectionId);
+        return (new StreamingHub(registry) { Context = ctx.Object, Groups = groups.Object }, groups);
+    }
+
+    [Fact]
+    public async Task TelemetryHub_SecondAnonymousSubject_CannotJoinFirstSubjectsSession()
+    {
+        var registry = new SessionOwnershipRegistry();
+        const string sessionId = "victim-session-123";
+
+        (TelemetryHub ownerHub, Mock<IGroupManager> ownerGroups) = NewTelemetryHub(registry, Anonymous("anon-A"), "conn-A");
+        await ownerHub.JoinSession(sessionId);
+        ownerGroups.Verify(g => g.AddToGroupAsync("conn-A", sessionId, It.IsAny<CancellationToken>()), Times.Once);
+
+        (TelemetryHub attackerHub, Mock<IGroupManager> attackerGroups) = NewTelemetryHub(registry, Anonymous("anon-B"), "conn-B");
+        Func<Task> join = () => attackerHub.JoinSession(sessionId);
+
+        await join.Should().ThrowAsync<HubException>("a different anonymous subject must not join another subject's session");
+        attackerGroups.Verify(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StreamingHub_SecondAnonymousSubject_CannotJoinFirstSubjectsSession()
+    {
+        var registry = new SessionOwnershipRegistry();
+        const string sessionId = "victim-session-456";
+
+        (StreamingHub ownerHub, Mock<IGroupManager> ownerGroups) = NewStreamingHub(registry, Anonymous("anon-A"), "conn-A");
+        await ownerHub.JoinSession(sessionId);
+        ownerGroups.Verify(g => g.AddToGroupAsync("conn-A", $"stream:{sessionId}", It.IsAny<CancellationToken>()), Times.Once);
+
+        (StreamingHub attackerHub, Mock<IGroupManager> attackerGroups) = NewStreamingHub(registry, Anonymous("anon-B"), "conn-B");
+        Func<Task> join = () => attackerHub.JoinSession(sessionId);
+
+        await join.Should().ThrowAsync<HubException>("a different anonymous subject must not join another subject's streamed tokens");
+        attackerGroups.Verify(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Hub_SameAnonymousSubject_CanRejoinOwnSession()
+    {
+        var registry = new SessionOwnershipRegistry();
+        const string sessionId = "own-session";
+
+        (TelemetryHub hub1, _) = NewTelemetryHub(registry, Anonymous("anon-A"), "conn-A1");
+        await hub1.JoinSession(sessionId);
+
+        (TelemetryHub hub2, Mock<IGroupManager> groups2) = NewTelemetryHub(registry, Anonymous("anon-A"), "conn-A2");
+        await hub2.JoinSession(sessionId);
+        groups2.Verify(g => g.AddToGroupAsync("conn-A2", sessionId, It.IsAny<CancellationToken>()), Times.Once,
+            "the owning subject may rejoin from another connection");
+    }
+
+    [Fact]
+    public async Task Hub_EntraCaller_IsUnbound_AndCanJoinAnySession()
+    {
+        var registry = new SessionOwnershipRegistry();
+        const string sessionId = "anon-owned-session";
+
+        // An anonymous subject claims the session first.
+        (TelemetryHub anonHub, _) = NewTelemetryHub(registry, Anonymous("anon-A"), "conn-A");
+        await anonHub.JoinSession(sessionId);
+
+        // Entra behaviour is unchanged — no ownership binding is enforced.
+        (TelemetryHub entraHub, Mock<IGroupManager> entraGroups) = NewTelemetryHub(registry, Entra("entra-oid-1"), "conn-E");
+        await entraHub.JoinSession(sessionId);
+        entraGroups.Verify(g => g.AddToGroupAsync("conn-E", sessionId, It.IsAny<CancellationToken>()), Times.Once,
+            "Entra callers retain their original hub semantics");
+    }
+
+    [Fact]
+    public async Task TelemetryHub_JoinCard_IsForbidden_ForAnonymous_ButAllowedForEntra()
+    {
+        var registry = new SessionOwnershipRegistry();
+
+        (TelemetryHub anonHub, Mock<IGroupManager> anonGroups) = NewTelemetryHub(registry, Anonymous("anon-A"), "conn-A");
+        Func<Task> anonJoinCard = () => anonHub.JoinCard("card-1");
+        await anonJoinCard.Should().ThrowAsync<HubException>("cards/approvals are not part of the anonymous surface");
+        anonGroups.Verify(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        (TelemetryHub entraHub, Mock<IGroupManager> entraGroups) = NewTelemetryHub(registry, Entra("entra-oid-1"), "conn-E");
+        await entraHub.JoinCard("card-1");
+        entraGroups.Verify(g => g.AddToGroupAsync("conn-E", "card:card-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/RetailPulse.Tests/Security/AnonymousPipelineCompositionTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousPipelineCompositionTests.cs
@@ -1,0 +1,215 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.JsonWebTokens;
+using RetailPulse.Api.Agents;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Models;
+using RetailPulse.Api.Security;
+using RetailPulse.Contracts;
+using ChatRequest = RetailPulse.Contracts.ChatRequest;
+using MeaiChatResponse = Microsoft.Extensions.AI.ChatResponse;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Composition (integration-style) regression for the blocking finding that the DI factory built
+/// the <see cref="AgentExecutionPipeline"/> WITHOUT an <see cref="IAnonymousChatPolicy"/>, so the
+/// write-tool filter and output-token cap never ran at runtime even though the isolated unit tests
+/// on <see cref="AnonymousChatPolicy"/> passed.
+///
+/// Unlike the unit tests that <c>new</c> a policy directly, these resolve
+/// <see cref="IAgentExecutionPipeline"/> through the SAME production registration path
+/// (<see cref="RoutingServiceExtensions.AddAgentRouting"/>, plus
+/// <see cref="ProviderNeutralAuthentication.AddProviderNeutralAuthentication"/> for the Anonymous
+/// composition) and then drive a real execution with a capturing <see cref="IChatClient"/> and real
+/// tools. They assert on the <see cref="ChatOptions"/> the pipeline actually handed to the model —
+/// the exact surface that was silently unconstrained before the fix.
+/// </summary>
+public sealed class AnonymousPipelineCompositionTests
+{
+    private const string SigningKeyText = "anon-pipeline-composition-signing-key-0123456789";
+    private const int ConfiguredCap = 333;
+
+    [Fact]
+    public async Task AnonymousComposition_ResolvesRealPolicy_StripsWriteTools_AndCapsOutput()
+    {
+        var chatClient = new CapturingChatClient();
+        ServiceProvider provider = BuildProvider(chatClient, anonymousMode: true);
+
+        // The production Anonymous wiring must win over the no-op fallback.
+        provider.GetRequiredService<IAnonymousChatPolicy>().Should().BeOfType<AnonymousChatPolicy>(
+            "AddAnonymousMode registers the constrained policy and AddAgentRouting's TryAdd must not override it");
+
+        // Put an authenticated Anonymous principal on the ambient HttpContext the policy reads from.
+        provider.GetRequiredService<IHttpContextAccessor>().HttpContext =
+            new DefaultHttpContext { User = AnonymousPrincipal("anon-subject") };
+
+        await ExecuteAsync(provider);
+
+        chatClient.LastOptions.Should().NotBeNull("the pipeline must have called the model");
+        IReadOnlyList<string> toolNames = ToolNames(chatClient.LastOptions);
+
+        toolNames.Should().NotContain(
+            "RequestApproval",
+            "the write-capable tool must be stripped for an anonymous principal at runtime — the exact bypass this fixes");
+        toolNames.Should().Contain("GetSalesData", "read-only tools remain available to anonymous sessions");
+        chatClient.LastOptions?.MaxOutputTokens.Should().Be(
+            ConfiguredCap, "the configured Anonymous output cap must be applied by the composed pipeline");
+    }
+
+    [Fact]
+    public async Task NonAnonymousComposition_UsesNoOpPolicy_RetainsTools_AndDoesNotCap()
+    {
+        var chatClient = new CapturingChatClient();
+
+        // Entra/Development composition: no Anonymous wiring, so AddAgentRouting's TryAdd supplies
+        // the provider-neutral no-op — never a null dependency.
+        ServiceProvider provider = BuildProvider(chatClient, anonymousMode: false);
+
+        provider.GetRequiredService<IAnonymousChatPolicy>().Should().BeOfType<NoOpAnonymousChatPolicy>(
+            "non-Anonymous modes get the explicit provider-neutral no-op, not a null");
+
+        await ExecuteAsync(provider);
+
+        chatClient.LastOptions.Should().NotBeNull();
+        IReadOnlyList<string> toolNames = ToolNames(chatClient.LastOptions);
+
+        toolNames.Should().Contain("RequestApproval", "the no-op policy never strips tools");
+        toolNames.Should().Contain("GetSalesData");
+        chatClient.LastOptions?.MaxOutputTokens.Should().BeNull("the no-op policy never caps output tokens");
+    }
+
+    // ── composition helpers ─────────────────────────────────────────────────────
+
+    private static ServiceProvider BuildProvider(CapturingChatClient chatClient, bool anonymousMode)
+    {
+        var settings = new Dictionary<string, string?>();
+        if (anonymousMode)
+        {
+            settings["Authentication:Mode"] = "Anonymous";
+            settings["Anonymous:AllowHosted"] = "true";
+            settings["Anonymous:SigningKey"] = SigningKeyText;
+            settings["Anonymous:MaxOutputTokens"] = ConfiguredCap.ToString();
+            settings["Anonymous:Limits:DailyMaxRequests"] = "500";
+            settings["Anonymous:Limits:DailyMaxTokens"] = "1000000";
+            settings["Anonymous:Limits:DailyMaxCostUsd"] = "100";
+        }
+
+        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSignalR();
+        services.AddHttpContextAccessor();
+        services.AddSingleton(config);
+
+        // The capturing model client the composed pipeline will call.
+        services.AddSingleton<IChatClient>(chatClient);
+
+        if (anonymousMode)
+        {
+            // Production Anonymous wiring: registers the real AnonymousChatPolicy (+ options + accessor).
+            services.AddProviderNeutralAuthentication(config, new TestEnv("Production"));
+        }
+
+        // Production pipeline registration. This is the factory that previously omitted the policy.
+        services.AddAgentRouting(
+            promptConfig: RouterOnlyConfig(),
+            generalAgentDef: new AgentDefinition { Name = "General" },
+            foundryEnabled: false,
+            toolsFactory: _ => Tools());
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task ExecuteAsync(ServiceProvider provider)
+    {
+        using IServiceScope scope = provider.CreateScope();
+        IAgentExecutionPipeline pipeline = scope.ServiceProvider.GetRequiredService<IAgentExecutionPipeline>();
+
+        var context = new AgentExecutionContext
+        {
+            AgentName = "General",
+            SystemPrompt = "You are a test agent.",
+            Temperature = 0.5f,
+            ModelName = "gpt-4o",
+            Request = new ChatRequest("What are today's sales?", SessionId: "compose-1"),
+            Tools = Tools(),
+        };
+
+        await pipeline.ExecuteAsync(context);
+    }
+
+    private static IReadOnlyList<AITool> Tools() =>
+    [
+        AIFunctionFactory.Create(() => "approved", "RequestApproval"),
+        AIFunctionFactory.Create(() => "sales", "GetSalesData"),
+    ];
+
+    private static IReadOnlyList<string> ToolNames(ChatOptions? options) =>
+        [.. (options?.Tools ?? []).OfType<AIFunction>().Select(t => t.Name)];
+
+    private static PromptConfiguration RouterOnlyConfig() => new()
+    {
+        Agents = new Dictionary<string, AgentDefinition>
+        {
+            ["router"] = new AgentDefinition { Name = "router", SystemPrompt = "route" },
+        },
+    };
+
+    private static ClaimsPrincipal AnonymousPrincipal(string subject)
+    {
+        var identity = new ClaimsIdentity("anonymous-session");
+        identity.AddClaim(new Claim(JwtRegisteredClaimNames.Sub, subject));
+        identity.AddClaim(new Claim("provider", "Anonymous"));
+        identity.AddClaim(new Claim("roles", "RetailPulse.Anonymous"));
+        identity.AddClaim(new Claim("scp", "chat_limited"));
+        return new ClaimsPrincipal(identity);
+    }
+
+    /// <summary>Records the <see cref="ChatOptions"/> the pipeline handed to the model.</summary>
+    private sealed class CapturingChatClient : IChatClient
+    {
+        public ChatOptions? LastOptions { get; private set; }
+
+        public Task<MeaiChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastOptions = options;
+            return Task.FromResult(new MeaiChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException("Streaming is not exercised by this composition test.");
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestEnv : IHostEnvironment
+    {
+        public TestEnv(string environmentName)
+        {
+            EnvironmentName = environmentName;
+        }
+
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; } = "RetailPulse.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs
+++ b/tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs
@@ -15,8 +15,10 @@ namespace RetailPulse.Tests.Security;
 /// These prove the deterministic, fail-closed selection rules:
 /// <list type="bullet">
 ///   <item>Explicit <c>Entra</c> (any casing) resolves and wires the existing Entra boundary.</item>
-///   <item>GitHub/Anonymous resolve as known modes but the factory fails startup
+///   <item>GitHub resolves as a known mode but the factory fails startup
 ///     ("not implemented in this sprint") and never falls through to Entra/dev/anonymous.</item>
+///   <item>Anonymous (Sprint 1) wires its own constrained session stack; hosted use fails
+///     closed without the second opt-in + signing key + daily ceilings.</item>
 ///   <item>Unknown/malformed/numeric modes fail startup.</item>
 ///   <item>Production with a missing mode fails closed; Development defaults to Entra.</item>
 /// </list>
@@ -153,11 +155,11 @@ public sealed class AuthenticationModeTests
     {
         var services = new ServiceCollection();
 
-        EntraAuthOptions options = services.AddProviderNeutralAuthentication(
+        EntraAuthOptions? options = services.AddProviderNeutralAuthentication(
             EntraConfig("Entra"), Env("Production"));
 
         options.Should().NotBeNull();
-        options.RequireAuth.Should().BeTrue("Production must run real Entra auth");
+        options!.RequireAuth.Should().BeTrue("Production must run real Entra auth");
 
         ServiceProvider provider = services.BuildServiceProvider();
         provider.GetService<EntraAuthOptions>().Should().NotBeNull();
@@ -173,18 +175,17 @@ public sealed class AuthenticationModeTests
     {
         var services = new ServiceCollection();
 
-        EntraAuthOptions options = services.AddProviderNeutralAuthentication(
+        EntraAuthOptions? options = services.AddProviderNeutralAuthentication(
             Config(), Env("Development"));
 
         options.Should().NotBeNull();
         services.BuildServiceProvider().GetService<IPrincipalNormalizer>().Should().NotBeNull();
     }
 
-    // ── Factory boundary: unimplemented modes fail closed, no fall-through ─────
+    // ── Factory boundary: GitHub still fails closed, no fall-through ───────────
 
     [Theory]
     [InlineData("GitHub")]
-    [InlineData("Anonymous")]
     public void AddProviderNeutralAuthentication_UnimplementedMode_FailsStartup(string mode)
     {
         var services = new ServiceCollection();
@@ -197,7 +198,6 @@ public sealed class AuthenticationModeTests
 
     [Theory]
     [InlineData("GitHub")]
-    [InlineData("Anonymous")]
     public void AddProviderNeutralAuthentication_UnimplementedMode_DoesNotWireAnyAuth(string mode)
     {
         var services = new ServiceCollection();
@@ -222,6 +222,94 @@ public sealed class AuthenticationModeTests
         services.Should().NotContain(
             d => d.ServiceType.FullName == "Microsoft.AspNetCore.Authentication.IAuthenticationSchemeProvider",
             "an unimplemented mode must never register an authentication scheme");
+    }
+
+    // ── Factory boundary: Anonymous mode (Sprint 1) ───────────────────────────
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_AnonymousInDevelopment_WiresAnonymousStackAndReturnsNull()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Development may enable Anonymous with just the explicit mode — no AllowHosted, no key.
+        EntraAuthOptions? options = services.AddProviderNeutralAuthentication(
+            Config(("Authentication:Mode", "Anonymous")), Env("Development"));
+
+        // Anonymous wires its own authorization internally, so it returns null (Program.cs must
+        // NOT layer the Entra policy on top).
+        options.Should().BeNull();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetService<AuthenticationModeOptions>()!.Mode.Should().Be(AuthenticationMode.Anonymous);
+
+        // The anonymous principal normalizer and session token service are registered and usable.
+        IPrincipalNormalizer normalizer = provider.GetRequiredService<IPrincipalNormalizer>();
+        normalizer.Mode.Should().Be(AuthenticationMode.Anonymous);
+
+        provider.GetService<Api.Security.Anonymous.IAnonymousSessionTokenService>()
+            .Should().NotBeNull("Development Anonymous mode generates an ephemeral signing key");
+        provider.GetService<Api.Security.Anonymous.AnonymousUsageBudget>()
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_HostedAnonymousWithoutAllowHosted_FailsClosed()
+    {
+        var services = new ServiceCollection();
+
+        // A hosted (non-Development) Anonymous deployment without the SECOND explicit opt-in
+        // must fail startup — no scheme is wired.
+        Action act = () => services.AddProviderNeutralAuthentication(
+            Config(("Authentication:Mode", "Anonymous")), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*AllowHosted*");
+    }
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_HostedAnonymousWithoutSigningKey_FailsClosed()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddProviderNeutralAuthentication(
+            Config(
+                ("Authentication:Mode", "Anonymous"),
+                ("Anonymous:AllowHosted", "true"),
+                ("Anonymous:Limits:DailyMaxRequests", "100"),
+                ("Anonymous:Limits:DailyMaxTokens", "50000"),
+                ("Anonymous:Limits:DailyMaxCostUsd", "2.5")),
+            Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*SigningKey*");
+    }
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_HostedAnonymousFullyConfigured_Wires()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        EntraAuthOptions? options = services.AddProviderNeutralAuthentication(
+            Config(
+                ("Authentication:Mode", "Anonymous"),
+                ("Anonymous:AllowHosted", "true"),
+                ("Anonymous:SigningKey", "this-is-a-32-byte-minimum-signing-key!!"),
+                ("Anonymous:Limits:DailyMaxRequests", "100"),
+                ("Anonymous:Limits:DailyMaxTokens", "50000"),
+                ("Anonymous:Limits:DailyMaxCostUsd", "2.5")),
+            Env("Production"));
+
+        options.Should().BeNull();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        Api.Security.Anonymous.AnonymousAuthOptions resolved =
+            provider.GetRequiredService<Api.Security.Anonymous.AnonymousAuthOptions>();
+        resolved.HostedGuardrailsEnforced.Should().BeTrue();
+        resolved.HasConfiguredSigningKey.Should().BeTrue();
+
+        Api.Security.Anonymous.AnonymousUsageBudget budget =
+            provider.GetRequiredService<Api.Security.Anonymous.AnonymousUsageBudget>();
+        budget.Enforced.Should().BeTrue("hosted Anonymous must enforce the daily circuit breaker");
     }
 
     [Theory]

--- a/tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs
+++ b/tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs
@@ -10,6 +10,7 @@ using RetailPulse.Api.Endpoints;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Models;
 using RetailPulse.Api.Security;
+using RetailPulse.Api.Security.Anonymous;
 
 namespace RetailPulse.Tests.Security;
 
@@ -28,8 +29,13 @@ namespace RetailPulse.Tests.Security;
 /// </summary>
 public sealed class EndpointAuthorizationCoverageTests
 {
-    /// <summary>The ONLY routes allowed to be reachable anonymously.</summary>
-    private static readonly string[] AnonymousAllowlist = ["/health", "/alive"];
+    /// <summary>
+    /// The ONLY routes allowed to be reachable anonymously: health/liveness, plus the Anonymous
+    /// bootstrap endpoint (the single sanctioned unauthenticated <c>/api</c> route, which mints a
+    /// session credential and is AllowAnonymous by design).
+    /// </summary>
+    private static readonly string[] AnonymousAllowlist =
+        ["/health", "/alive", AnonymousCapabilityPolicy.BootstrapRoute];
 
     private static WebApplication BuildRealEndpointGraph()
     {
@@ -96,6 +102,10 @@ public sealed class EndpointAuthorizationCoverageTests
         app.MapDeadLetterEndpoints();
         app.MapMemoryEndpoints();
         app.MapCacheEndpoints();
+
+        // The Anonymous bootstrap endpoint (unauthenticated, AllowAnonymous by design) — mirrors
+        // Program.cs so the coverage walk sees the exact same route graph the app exposes.
+        app.MapAnonymousAuthEndpoints();
 
         return app;
     }
@@ -186,6 +196,63 @@ public sealed class EndpointAuthorizationCoverageTests
         RouteEndpoint offending = ProtectedRoutes(app).Single();
         HasAuthorization(offending).Should().BeFalse(
             "the fixture endpoint intentionally omits RequireAuthorization, and the detector must catch it");
+    }
+
+    [Fact]
+    public async Task AnonymousCapabilityGraph_AllowsOnlyBootstrapChatAndHubs()
+    {
+        await using WebApplication app = BuildRealEndpointGraph();
+
+        // Walk the REAL compiled route table and, for every mapped (method, route) on the protected
+        // surface, ask the production allowlist whether an anonymous principal may reach it. Only the
+        // bootstrap, POST /api/chat, and the two hubs may be reachable; everything else — every broad
+        // GET, observability/admin/export/memory/cards/approvals route, and every alternate LLM path
+        // (/api/chat/stream, /api/council/*) — must be denied.
+        var allowed = new List<string>();
+        foreach (RouteEndpoint e in ProtectedRoutes(app))
+        {
+            string path = e.RoutePattern.RawText ?? string.Empty;
+            IReadOnlyList<string> methods =
+                e.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods ?? ["GET"];
+            foreach (string method in methods)
+            {
+                if (!AnonymousCapabilityPolicy.IsBlocked(method, path))
+                {
+                    allowed.Add($"{method} {path}");
+                }
+            }
+        }
+
+        allowed.Should().OnlyContain(entry =>
+            entry.Contains(AnonymousCapabilityPolicy.BootstrapRoute, StringComparison.OrdinalIgnoreCase)
+            || entry == $"POST {AnonymousCapabilityPolicy.ChatRoute}"
+            || entry.Contains("/hubs/telemetry", StringComparison.OrdinalIgnoreCase)
+            || entry.Contains("/hubs/streaming", StringComparison.OrdinalIgnoreCase),
+            "the anonymous surface is bootstrap + POST /api/chat + the two hubs only. Reachable set: "
+            + string.Join(", ", allowed));
+
+        // Prove the positive capabilities really are present (not a vacuous pass).
+        allowed.Should().Contain(entry => entry == $"POST {AnonymousCapabilityPolicy.ChatRoute}",
+            "POST /api/chat must be reachable for anonymous");
+        allowed.Should().Contain(
+            entry => entry.Contains(AnonymousCapabilityPolicy.BootstrapRoute, StringComparison.OrdinalIgnoreCase),
+            "the bootstrap route must be reachable for anonymous");
+
+        // And prove representative billable / observability / alternate-LLM routes are denied.
+        foreach ((string method, string route) in new[]
+        {
+            ("POST", "/api/chat/stream"),
+            ("POST", "/api/council/convene"),
+            ("GET", "/api/scorecard"),
+            ("GET", "/api/sessions"),
+            ("GET", "/api/memory"),
+            ("GET", "/api/audit"),
+            ("GET", "/api/traces"),
+            ("GET", "/api/dead-letter"),
+        })
+        {
+            AnonymousCapabilityPolicy.IsBlocked(method, route).Should().BeTrue($"{method} {route} must be denied for anonymous");
+        }
     }
 
     /// <summary>

--- a/tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs
+++ b/tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs
@@ -199,15 +199,16 @@ public sealed class EndpointAuthorizationCoverageTests
     }
 
     [Fact]
-    public async Task AnonymousCapabilityGraph_AllowsOnlyBootstrapChatAndHubs()
+    public async Task AnonymousCapabilityGraph_AllowsOnlyBootstrapAndChat()
     {
         await using WebApplication app = BuildRealEndpointGraph();
 
         // Walk the REAL compiled route table and, for every mapped (method, route) on the protected
         // surface, ask the production allowlist whether an anonymous principal may reach it. Only the
-        // bootstrap, POST /api/chat, and the two hubs may be reachable; everything else — every broad
-        // GET, observability/admin/export/memory/cards/approvals route, and every alternate LLM path
-        // (/api/chat/stream, /api/council/*) — must be denied.
+        // bootstrap and POST /api/chat may be reachable; everything else — every broad GET,
+        // observability/admin/export/memory/cards/approvals route, every alternate LLM path
+        // (/api/chat/stream, /api/council/*), AND both SignalR hubs (Sprint 1: no anonymous
+        // real-time telemetry/streaming) — must be denied.
         var allowed = new List<string>();
         foreach (RouteEndpoint e in ProtectedRoutes(app))
         {
@@ -225,10 +226,8 @@ public sealed class EndpointAuthorizationCoverageTests
 
         allowed.Should().OnlyContain(entry =>
             entry.Contains(AnonymousCapabilityPolicy.BootstrapRoute, StringComparison.OrdinalIgnoreCase)
-            || entry == $"POST {AnonymousCapabilityPolicy.ChatRoute}"
-            || entry.Contains("/hubs/telemetry", StringComparison.OrdinalIgnoreCase)
-            || entry.Contains("/hubs/streaming", StringComparison.OrdinalIgnoreCase),
-            "the anonymous surface is bootstrap + POST /api/chat + the two hubs only. Reachable set: "
+            || entry == $"POST {AnonymousCapabilityPolicy.ChatRoute}",
+            "the anonymous surface is bootstrap + POST /api/chat only (no hubs). Reachable set: "
             + string.Join(", ", allowed));
 
         // Prove the positive capabilities really are present (not a vacuous pass).
@@ -238,7 +237,11 @@ public sealed class EndpointAuthorizationCoverageTests
             entry => entry.Contains(AnonymousCapabilityPolicy.BootstrapRoute, StringComparison.OrdinalIgnoreCase),
             "the bootstrap route must be reachable for anonymous");
 
-        // And prove representative billable / observability / alternate-LLM routes are denied.
+        // Prove no hub route is reachable — negotiate (POST) and connection (GET), both hubs.
+        allowed.Should().NotContain(entry => entry.Contains("/hubs/", StringComparison.OrdinalIgnoreCase),
+            "no SignalR hub route may be reachable for anonymous in Sprint 1");
+
+        // And prove representative billable / observability / alternate-LLM / hub routes are denied.
         foreach ((string method, string route) in new[]
         {
             ("POST", "/api/chat/stream"),
@@ -249,6 +252,10 @@ public sealed class EndpointAuthorizationCoverageTests
             ("GET", "/api/audit"),
             ("GET", "/api/traces"),
             ("GET", "/api/dead-letter"),
+            ("GET", "/hubs/telemetry"),
+            ("POST", "/hubs/telemetry/negotiate"),
+            ("GET", "/hubs/streaming"),
+            ("POST", "/hubs/streaming/negotiate"),
         })
         {
             AnonymousCapabilityPolicy.IsBlocked(method, route).Should().BeTrue($"{method} {route} must be denied for anonymous");

--- a/tests/RetailPulse.Tests/Security/RateLimitingConfigTests.cs
+++ b/tests/RetailPulse.Tests/Security/RateLimitingConfigTests.cs
@@ -95,10 +95,13 @@ public class RateLimitingConfigTests
 
     // ── Sprint 1: mode-conditional anonymous bootstrap limiter ─────────────────
     // The "anonymous-bootstrap" policy is NOT one of the four always-on core policies above. It is
-    // a per-IP fixed-window limiter added by Program.cs ONLY when Authentication:Mode=Anonymous, so
-    // the single unauthenticated anonymous surface (the session bootstrap endpoint) cannot be used
-    // to farm session tokens. Its permit limit is driven by Anonymous:Bootstrap:PerIpPerMinute
-    // (default 5) over a 1-minute window. It is asserted separately here so the four-core invariant
+    // a single GLOBAL fixed-window limiter added by Program.cs ONLY when Authentication:Mode=Anonymous,
+    // so the single unauthenticated anonymous surface (the session bootstrap endpoint) cannot be used
+    // to farm session tokens. Behind Azure Container Apps the client IP is the proxy's and
+    // X-Forwarded-For is forgeable, so it is a per-replica GLOBAL window rather than per-IP. Its
+    // permit limit is driven by Anonymous:Bootstrap:GlobalPerMinute (conservative default 5); the
+    // legacy Anonymous:Bootstrap:PerIpPerMinute key is still honoured as a backward-compatible
+    // fallback. It is asserted separately here so the four-core invariant
     // (RateLimitPolicies_ExactlyFourDefined) stays intact.
 
     private const string AnonymousBootstrapPolicy = "anonymous-bootstrap";
@@ -114,7 +117,7 @@ public class RateLimitingConfigTests
     }
 
     [Fact]
-    public async Task AnonymousBootstrapPolicy_UsesConservativePerIpDefault()
+    public async Task AnonymousBootstrapPolicy_UsesConservativeGlobalDefault()
     {
         AnonymousBootstrapDefaultPermitLimit.Should().BePositive();
         AnonymousBootstrapDefaultPermitLimit.Should().BeLessThanOrEqualTo(ExpectedPolicies["strict"].PermitLimit,

--- a/tests/RetailPulse.Tests/Security/RateLimitingConfigTests.cs
+++ b/tests/RetailPulse.Tests/Security/RateLimitingConfigTests.cs
@@ -92,4 +92,34 @@ public class RateLimitingConfigTests
             $"endpoint {endpoint} should map to a valid policy");
         await Task.CompletedTask;
     }
+
+    // ── Sprint 1: mode-conditional anonymous bootstrap limiter ─────────────────
+    // The "anonymous-bootstrap" policy is NOT one of the four always-on core policies above. It is
+    // a per-IP fixed-window limiter added by Program.cs ONLY when Authentication:Mode=Anonymous, so
+    // the single unauthenticated anonymous surface (the session bootstrap endpoint) cannot be used
+    // to farm session tokens. Its permit limit is driven by Anonymous:Bootstrap:PerIpPerMinute
+    // (default 5) over a 1-minute window. It is asserted separately here so the four-core invariant
+    // (RateLimitPolicies_ExactlyFourDefined) stays intact.
+
+    private const string AnonymousBootstrapPolicy = "anonymous-bootstrap";
+    private const int AnonymousBootstrapDefaultPermitLimit = 5;
+    private const int AnonymousBootstrapWindowMinutes = 1;
+
+    [Fact]
+    public async Task AnonymousBootstrapPolicy_IsSeparateFromCorePolicies()
+    {
+        ExpectedPolicies.Keys.Should().NotContain(AnonymousBootstrapPolicy,
+            "the anonymous bootstrap limiter is mode-conditional and not part of the always-on core set");
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task AnonymousBootstrapPolicy_UsesConservativePerIpDefault()
+    {
+        AnonymousBootstrapDefaultPermitLimit.Should().BePositive();
+        AnonymousBootstrapDefaultPermitLimit.Should().BeLessThanOrEqualTo(ExpectedPolicies["strict"].PermitLimit,
+            "bootstrapping a token must be at least as restricted as the strictest core policy");
+        AnonymousBootstrapWindowMinutes.Should().Be(1);
+        await Task.CompletedTask;
+    }
 }


### PR DESCRIPTION
Implements **Sprint 1: secure Anonymous authentication mode** (child of epic #27). Closes #30.

Additive, fail-closed Anonymous mode behind the Sprint 0 provider-neutral factory. **Every committed deployment artifact stays pinned to Entra; Anonymous is not deployed in this sprint.**

## Identity & activation
- `Authentication:Mode=Anonymous` enables it — no auto-detection/fallback. Any hosted (non-Development) run additionally requires `Anonymous:AllowHosted=true` **plus** a strong signing key (≥256-bit) **plus** positive daily request/token/cost ceilings, or startup throws. Development may use an ephemeral process-local key (sessions die on restart).
- Per-IP rate-limited bootstrap endpoint `POST /api/auth/anonymous/session` mints a short-lived (15 min) HS256 session token: random subject, `provider=Anonymous`, role `RetailPulse.Anonymous`, scope `chat_limited`, strict expiry, **no PII, no refresh token**. Works as REST bearer and SignalR `?access_token` (hub-only query token).

## Authorization & isolation
- Dedicated policy (default+fallback) requires `provider=Anonymous` + anonymous role/scope — Entra/cross-provider tokens can never satisfy it. Only health + bootstrap are unauthenticated. Sessions isolated by random subject.

## Billable-use safeguards
- `AnonymousGuardMiddleware` centrally enforces read-only (403), request size (413), per-subject/per-IP minute limits (429), per-request timeout (504), and a global daily request/token/cost **circuit breaker** (503, fail-closed). Request slots charged **before the cache** so cache hits can't bypass the ceiling; cost metered via an `ICostTracker` decorator; output tokens capped.
- **Limitation:** ceilings are replica-local → hosted Anonymous pinned to `maxReplicas=1`; **not** equivalent to authenticated production; counters reset on restart.

## Read-only capability restrictions
- `AnonymousCapabilityPolicy` is the single source of truth: read-only route allowlist (deny-by-default on other non-GET verbs) + write-capable tools (`RequestApproval`) stripped from the anonymous chat tool set.

## Deployment (Entra-pinned)
- `appsettings.json`/`Production`, azd hooks, and Bicep remain Entra. Added non-live `appsettings.Anonymous.example.json` (no secret) + `maxReplicas=1` rationale. Deployment-contract tests prove live artifacts cannot select Anonymous.

## Tests & docs
- Integration + threat tests (bootstrap + rate limit; 401 for malformed/expired/wrong issuer/audience/signature; 403 cross-provider; valid read REST + hub; subject isolation; mutation 403; oversized 413; REST query-token rejected; daily breaker), unit tests, extended rate-limit + deployment-contract tests.
- Updated ADR-005 (Sprint 1 addendum), authentication matrix, `security.md`, `deployment-azd.md`.

## Verification (local)
- `dotnet build -c Release`: 0 warnings / 0 errors
- Backend tests: **2276 passed**
- `dotnet format --verify-no-changes`: clean
- Frontend `npm ci` + `npm run build` + `vitest`: **357 passed**
- `az bicep build infra/main.bicep`: clean

⚠️ Do not merge or deploy — review only.