### PR TITLE
fix: never render blank comparison charts; enforce renderable invariant (#32)

### DIFF
--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
@@ -490,8 +490,16 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
                             {
                                 ChartSpec? chart = JsonSerializer.Deserialize<ChartSpec>(
                                     chartElement.GetRawText(), _caseInsensitiveOptions);
-                                if (chart != null)
-                                    charts.Add(chart);
+                                // Enforce the renderable invariant at the extraction
+                                // boundary too: a chart only enters the response when it
+                                // has at least one finite datapoint, so a stale or
+                                // permissively-shaped tool result can never surface as a
+                                // blank card. Non-finite points / empty series are dropped.
+                                if (Charts.ChartSpecValidator.TryGetRenderable(chart, out ChartSpec? renderable)
+                                    && renderable is not null)
+                                {
+                                    charts.Add(renderable);
+                                }
                             }
                         }
                         catch

--- a/src/RetailPulse.Api/Charts/ChartSpecNormalizer.cs
+++ b/src/RetailPulse.Api/Charts/ChartSpecNormalizer.cs
@@ -276,8 +276,14 @@ internal static class ChartSpecNormalizer
 
     private static ChartSeries? BuildSeries(string legend, string? color, JsonElement seriesObj, List<string> labels)
     {
+        // Accept the value array under any of the keys models realistically use for a
+        // series' numbers: canonical "values"/"data", plus CanvasJS-style "dataPoints"
+        // and the terse "points". Without this, a two-series comparison emitted as
+        // series:[{name, dataPoints:[...]}] binds to zero points and renders blank.
         bool hasValues = seriesObj.TryGetProperty("values", out JsonElement valuesEl)
-            || seriesObj.TryGetProperty("data", out valuesEl);
+            || seriesObj.TryGetProperty("data", out valuesEl)
+            || seriesObj.TryGetProperty("dataPoints", out valuesEl)
+            || seriesObj.TryGetProperty("points", out valuesEl);
         return !hasValues ? null : BuildSeriesFromValues(legend, color, valuesEl, labels);
     }
 
@@ -378,11 +384,14 @@ internal static class ChartSpecNormalizer
     {
         if (e.ValueKind == JsonValueKind.Number)
         {
-            return e.TryGetDouble(out value);
+            return e.TryGetDouble(out value) && double.IsFinite(value);
         }
         if (e.ValueKind == JsonValueKind.String)
         {
-            return double.TryParse(e.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+            // Reject non-finite tokens ("NaN", "Infinity") — they are not bindable and
+            // would otherwise pass double.TryParse and render as an empty/degenerate mark.
+            return double.TryParse(e.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out value)
+                && double.IsFinite(value);
         }
         value = 0;
         return false;

--- a/src/RetailPulse.Api/Charts/ChartSpecValidator.cs
+++ b/src/RetailPulse.Api/Charts/ChartSpecValidator.cs
@@ -1,0 +1,94 @@
+using RetailPulse.Contracts;
+
+namespace RetailPulse.Api.Charts;
+
+/// <summary>
+/// Enforces the single "renderable chart" invariant shared by every boundary that
+/// can emit a <see cref="ChartSpec"/> (the CreateChart tool, the pipeline's
+/// tool-result extraction, and inline prose recovery).
+///
+/// A chart is renderable only when it has a recognized <c>Type</c>, a non-empty
+/// <c>Title</c>, and at least one series carrying at least one finite datapoint.
+/// Series with no legend or no finite points are dropped, and non-finite Y values
+/// (NaN / ±Infinity) are never bindable — so a chart that would render as an empty
+/// card (recognized axes/title but no marks) is rejected here instead of being
+/// promoted downstream. Multi-series charts keep their original category (X) labels
+/// so legend/category alignment is preserved; values are never fabricated.
+/// </summary>
+internal static class ChartSpecValidator
+{
+    private static readonly HashSet<string> _knownChartTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "line", "bar", "groupedBar", "stackedBar", "horizontalBar", "pie", "donut", "gauge", "table",
+    };
+
+    /// <summary>
+    /// True when <paramref name="chart"/> can be reduced to a renderable chart with
+    /// at least one finite datapoint.
+    /// </summary>
+    public static bool IsRenderable(ChartSpec? chart) => TryGetRenderable(chart, out _);
+
+    /// <summary>
+    /// Produces a cleaned chart that contains only legend-bearing series with finite
+    /// datapoints. Returns false (and a null chart) when nothing renderable remains,
+    /// so callers can surface a diagnostic instead of a blank card. Never fabricates
+    /// datapoints or reorders series.
+    /// </summary>
+    public static bool TryGetRenderable(ChartSpec? chart, out ChartSpec? renderable)
+    {
+        renderable = null;
+
+        if (chart is null
+            || string.IsNullOrWhiteSpace(chart.Type)
+            || !_knownChartTypes.Contains(chart.Type)
+            || string.IsNullOrWhiteSpace(chart.Title))
+        {
+            return false;
+        }
+
+        var cleanedSeries = new List<ChartSeries>();
+        bool changed = false;
+
+        foreach (ChartSeries series in chart.Data)
+        {
+            if (series is null || string.IsNullOrWhiteSpace(series.Legend))
+            {
+                changed = true;
+                continue;
+            }
+
+            var finitePoints = new List<ChartDataPoint>(series.Values.Count);
+            foreach (ChartDataPoint point in series.Values)
+            {
+                if (point is not null && double.IsFinite(point.Y))
+                {
+                    finitePoints.Add(point);
+                }
+            }
+
+            if (finitePoints.Count == 0)
+            {
+                changed = true;
+                continue;
+            }
+
+            if (finitePoints.Count != series.Values.Count)
+            {
+                changed = true;
+                cleanedSeries.Add(series with { Values = finitePoints });
+            }
+            else
+            {
+                cleanedSeries.Add(series);
+            }
+        }
+
+        if (cleanedSeries.Count == 0)
+        {
+            return false;
+        }
+
+        renderable = changed ? chart with { Data = cleanedSeries } : chart;
+        return true;
+    }
+}

--- a/src/RetailPulse.Api/Tools/ChartDataTool.cs
+++ b/src/RetailPulse.Api/Tools/ChartDataTool.cs
@@ -21,7 +21,7 @@ public class ChartDataTool
         _logger = logger;
     }
 
-    [Description("Create a chart visualization by providing structured chart data. Provide JSON matching ChartSpec schema. Types: line, bar, groupedBar, pie, donut, horizontalBar, stackedBar, gauge, table.")]
+    [Description("Create a chart visualization by providing structured chart data. Provide JSON matching the ChartSpec schema: {\"type\":\"line|bar|groupedBar|stackedBar|horizontalBar|pie|donut|gauge|table\",\"title\":\"...\",\"xAxisTitle\":\"...\",\"yAxisTitle\":\"...\",\"data\":[{\"legend\":\"Series name\",\"color\":\"#hex\",\"values\":[{\"x\":\"Category\",\"y\":123.4}]}]}. For a multi-series comparison, emit one entry in \"data\" per series, and give every series the same set of \"x\" category labels so they align. Every point needs a finite numeric \"y\". An empty or valueless chart is rejected, not rendered.")]
     public Task<string> CreateChart(
         [Description("JSON string matching the ChartSpec schema")] string chartSpecJson = "")
     {
@@ -39,24 +39,28 @@ public class ChartDataTool
                 return Task.FromResult(JsonSerializer.Serialize(new { error = "Invalid chart specification" }));
             }
 
-            // Strict binding succeeds structurally even when the model used a
-            // non-canonical schema (e.g. top-level series + xAxis), leaving Data empty.
-            // Recover the real series via the normalizer before returning an empty chart.
-            if (spec.Data.Count == 0
-                && ChartSpecNormalizer.TryNormalize(chartSpecJson, out ChartSpec? enriched)
-                && enriched is not null
-                && enriched.Data.Count > 0)
+            // A strictly-valid payload is only usable if it actually has a bindable
+            // datapoint. Prefer it when renderable; otherwise fall back to the normalizer,
+            // which recovers realistic non-canonical schemas (top-level series, Chart.js
+            // labels/series, CanvasJS dataPoints) that bind to empty Data under strict
+            // deserialization. Either way the result must pass the renderable invariant —
+            // an empty/valueless chart is returned as a diagnostic, never as success.
+            if (ChartSpecValidator.IsRenderable(spec))
+            {
+                return Task.FromResult(RenderableSuccessOrError(spec, recovered: false));
+            }
+
+            if (ChartSpecNormalizer.TryNormalize(chartSpecJson, out ChartSpec? enriched)
+                && ChartSpecValidator.IsRenderable(enriched))
             {
                 _logger.LogInformation(
                     "Enriched chart spec from non-canonical schema: {Type} - {Title} with {SeriesCount} series",
-                    enriched.Type, enriched.Title, enriched.Data.Count);
+                    enriched!.Type, enriched.Title, enriched.Data.Count);
 
-                return Task.FromResult(JsonSerializer.Serialize(new { status = "success", chart = enriched, recovered = true }));
+                return Task.FromResult(RenderableSuccessOrError(enriched, recovered: true));
             }
 
-            _logger.LogInformation("Chart created: {Type} - {Title} with {SeriesCount} series", spec.Type, spec.Title, spec.Data.Count);
-
-            return Task.FromResult(JsonSerializer.Serialize(new { status = "success", chart = spec, recovered = false }));
+            return Task.FromResult(NoRenderableDataError());
         }
         catch (JsonException ex)
         {
@@ -80,13 +84,13 @@ public class ChartDataTool
         // The payload may be well-formed but use a non-canonical, model-invented
         // schema (e.g. Chart.js-style data:{labels,series}). Normalize that shape
         // before falling back to truncation repair.
-        if (ChartSpecNormalizer.TryNormalize(cleaned, out ChartSpec? normalized) && normalized is not null)
+        if (ChartSpecNormalizer.TryNormalize(cleaned, out ChartSpec? normalized) && ChartSpecValidator.IsRenderable(normalized))
         {
             _logger.LogInformation(
                 "Normalized non-canonical chart spec: {Type} - {Title} with {SeriesCount} series",
-                normalized.Type, normalized.Title, normalized.Data.Count);
+                normalized!.Type, normalized.Title, normalized.Data.Count);
 
-            return JsonSerializer.Serialize(new { status = "success", chart = normalized, recovered = true });
+            return RenderableSuccessOrError(normalized, recovered: true);
         }
 
         string? repaired = RepairTruncatedJson(cleaned);
@@ -96,13 +100,13 @@ public class ChartDataTool
             {
                 LenientChartSpec? lenient = JsonSerializer.Deserialize<LenientChartSpec>(repaired, _inputOptions);
                 ChartSpec? salvaged = BuildUsableChart(lenient);
-                if (salvaged is not null)
+                if (salvaged is not null && ChartSpecValidator.IsRenderable(salvaged))
                 {
                     _logger.LogInformation(
                         "Recovered truncated chart spec: {Type} - {Title} with {SeriesCount} series",
                         salvaged.Type, salvaged.Title, salvaged.Data.Count);
 
-                    return JsonSerializer.Serialize(new { status = "success", chart = salvaged, recovered = true });
+                    return RenderableSuccessOrError(salvaged, recovered: true);
                 }
             }
             catch (JsonException)
@@ -115,6 +119,42 @@ public class ChartDataTool
         {
             error = "Invalid JSON format",
             message = originalError.Message,
+            recovered = false
+        });
+    }
+
+    /// <summary>
+    /// Serializes a success result only when the chart survives the renderable
+    /// invariant (recognized type + title + at least one finite datapoint), returning
+    /// the cleaned chart. Otherwise returns a structured diagnostic so an empty or
+    /// valueless chart is never emitted as <c>status:"success"</c> and can never
+    /// render as a blank card.
+    /// </summary>
+    private string RenderableSuccessOrError(ChartSpec? chart, bool recovered)
+    {
+        if (ChartSpecValidator.TryGetRenderable(chart, out ChartSpec? renderable) && renderable is not null)
+        {
+            _logger.LogInformation(
+                "Chart created: {Type} - {Title} with {SeriesCount} series (recovered={Recovered})",
+                renderable.Type, renderable.Title, renderable.Data.Count, recovered);
+
+            return JsonSerializer.Serialize(new { status = "success", chart = renderable, recovered });
+        }
+
+        return NoRenderableDataError();
+    }
+
+    private string NoRenderableDataError()
+    {
+        _logger.LogWarning("Chart spec rejected: no renderable data (a recognized type, a title, and at least one finite datapoint are required)");
+
+        return JsonSerializer.Serialize(new
+        {
+            error = "Chart has no renderable data",
+            message = "The chart specification did not contain any bindable series. A renderable chart "
+                + "needs a recognized type, a title, and at least one series with a finite numeric value. "
+                + "Re-issue CreateChart using the canonical schema: data:[{legend, values:[{x, y}]}] with a "
+                + "numeric y per point and a shared x label per category across every series.",
             recovered = false
         });
     }

--- a/src/RetailPulse.Api/prompts.yaml
+++ b/src/RetailPulse.Api/prompts.yaml
@@ -486,6 +486,21 @@ agents:
         ]
       }
       
+      For a multi-series comparison (e.g. two brands across the same regions or weeks),
+      emit ONE entry in "data" per series and give every series the SAME set of "x"
+      category labels so they align. Do NOT invent top-level "categories"/"series" arrays
+      or per-series "dataPoints" — always nest points under each series' "values":
+      {
+        "type": "groupedBar",
+        "title": "Brand A vs Brand B Weekly Depletions by Region",
+        "xAxisTitle": "Region",
+        "yAxisTitle": "Weekly Depletions (cases)",
+        "data": [
+          { "legend": "Brand A", "values": [{ "x": "Northeast", "y": 4200 }, { "x": "Southeast", "y": 3800 }] },
+          { "legend": "Brand B", "values": [{ "x": "Northeast", "y": 3900 }, { "x": "Southeast", "y": 4100 }] }
+        ]
+      }
+      
       ## Brands
       {tenant.brands}
       

--- a/src/RetailPulse.Web/src/__tests__/ChartRenderer.comparison.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChartRenderer.comparison.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FluentProvider, webDarkTheme } from '@fluentui/react-components';
+import type { ChartSpec } from '../types';
+
+// recharts' ResponsiveContainer measures 0x0 under jsdom, so it renders no inner
+// marks. Replace it with a fixed-size wrapper that forwards an explicit
+// width/height to the chart child so real bars/lines/legends are produced and we
+// can assert on actual DOM marks (issue #32 regression: prove the comparison
+// chart contains BOTH brand legends and real marks, not just a chart object).
+vi.mock('recharts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('recharts')>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) =>
+      React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+        width: 800,
+        height: 400,
+      }),
+  };
+});
+
+import ChartRenderer from '../components/ChartRenderer';
+
+beforeAll(() => {
+  if (!(globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver) {
+    class RO {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (globalThis as unknown as { ResizeObserver: typeof RO }).ResizeObserver = RO;
+  }
+});
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<FluentProvider theme={webDarkTheme}>{ui}</FluentProvider>);
+}
+
+// Exact production shape from the P0 report: two brands compared across regions.
+const comparisonSpec = (type: ChartSpec['type']): ChartSpec => ({
+  type,
+  title: 'Coastline Tacos vs Apex Grill: Weekly Depletion Trend Across All Regions',
+  data: [
+    {
+      legend: 'Coastline Tacos',
+      values: [
+        { x: 'West', y: 1200 },
+        { x: 'Central', y: 980 },
+        { x: 'East', y: 1450 },
+      ],
+    },
+    {
+      legend: 'Apex Grill',
+      values: [
+        { x: 'West', y: 1100 },
+        { x: 'Central', y: 1320 },
+        { x: 'East', y: 890 },
+      ],
+    },
+  ],
+});
+
+describe('ChartRenderer two-brand regional comparison (issue #32)', () => {
+  it('renders a grouped bar comparison with both brand legends and real bar marks', () => {
+    const { container } = renderWithProvider(<ChartRenderer charts={[comparisonSpec('groupedBar' as ChartSpec['type'])]} />);
+
+    // Two bar series groups, one per brand.
+    const barSeries = container.querySelectorAll('.recharts-bar');
+    expect(barSeries.length).toBe(2);
+
+    // Actual rendered bar marks (3 regions x 2 brands = 6 rectangles).
+    const barRects = container.querySelectorAll('.recharts-bar-rectangle');
+    expect(barRects.length).toBeGreaterThanOrEqual(6);
+
+    // Both brand legends present.
+    const legendTexts = Array.from(container.querySelectorAll('.recharts-legend-item-text')).map((n) => n.textContent);
+    expect(legendTexts).toContain('Coastline Tacos');
+    expect(legendTexts).toContain('Apex Grill');
+
+    // Regional x categories rendered on the axis.
+    expect(screen.getAllByText('West').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Central').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('East').length).toBeGreaterThan(0);
+  });
+
+  it('renders a line comparison with both brand legends and real line marks', () => {
+    const { container } = renderWithProvider(<ChartRenderer charts={[comparisonSpec('line')]} />);
+
+    const lineSeries = container.querySelectorAll('.recharts-line');
+    expect(lineSeries.length).toBe(2);
+
+    const lineCurves = container.querySelectorAll('.recharts-line-curve');
+    expect(lineCurves.length).toBe(2);
+
+    const legendTexts = Array.from(container.querySelectorAll('.recharts-legend-item-text')).map((n) => n.textContent);
+    expect(legendTexts).toContain('Coastline Tacos');
+    expect(legendTexts).toContain('Apex Grill');
+  });
+
+  it('surfaces a diagnostic (no blank chart) when a comparison series has no finite points', () => {
+    const spec: ChartSpec = {
+      type: 'groupedBar' as ChartSpec['type'],
+      title: 'Coastline Tacos vs Apex Grill: Weekly Depletion Trend Across All Regions',
+      data: [
+        { legend: 'Coastline Tacos', values: [] },
+        { legend: 'Apex Grill', values: [] },
+      ],
+    };
+
+    const { container } = renderWithProvider(<ChartRenderer charts={[spec]} />);
+
+    expect(screen.getByRole('note')).toBeInTheDocument();
+    expect(screen.getByText(/Chart unavailable/i)).toBeInTheDocument();
+    // No chart canvas and no bar marks — the blank card is never emitted.
+    expect(container.querySelector('svg')).toBeNull();
+    expect(container.querySelector('.recharts-bar-rectangle')).toBeNull();
+  });
+
+  it('drops non-finite points but still renders marks for the finite ones', () => {
+    const spec: ChartSpec = {
+      type: 'groupedBar' as ChartSpec['type'],
+      title: 'Coastline Tacos vs Apex Grill: Weekly Depletion Trend Across All Regions',
+      data: [
+        {
+          legend: 'Coastline Tacos',
+          values: [
+            { x: 'West', y: 1200 },
+            { x: 'Central', y: Number.NaN as unknown as number },
+          ],
+        },
+        {
+          legend: 'Apex Grill',
+          values: [
+            { x: 'West', y: 1100 },
+            { x: 'Central', y: 1320 },
+          ],
+        },
+      ],
+    };
+
+    const { container } = renderWithProvider(<ChartRenderer charts={[spec]} />);
+
+    // Chart still renders (at least one finite point present).
+    expect(container.querySelectorAll('.recharts-bar-rectangle').length).toBeGreaterThan(0);
+    const legendTexts = Array.from(container.querySelectorAll('.recharts-legend-item-text')).map((n) => n.textContent);
+    expect(legendTexts).toContain('Coastline Tacos');
+    expect(legendTexts).toContain('Apex Grill');
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/ChartRenderer.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChartRenderer.test.tsx
@@ -88,15 +88,21 @@ describe('ChartRenderer', () => {
     expect(screen.getByText('Fallback')).toBeInTheDocument();
   });
 
-  it('handles empty data array without crashing', () => {
+  it('shows a diagnostic instead of a blank card for an empty data array', () => {
     const spec: ChartSpec = {
       type: 'bar',
       title: 'Empty',
       data: [],
     };
 
-    expect(() => renderWithProvider(<ChartRenderer charts={[spec]} />)).not.toThrow();
-    expect(screen.getByText('Empty')).toBeInTheDocument();
+    const { container } = renderWithProvider(<ChartRenderer charts={[spec]} />);
+
+    // Non-disruptive diagnostic is shown...
+    expect(screen.getByRole('note')).toBeInTheDocument();
+    expect(screen.getByText(/Chart unavailable/i)).toBeInTheDocument();
+    // ...and NO chart canvas / axes are rendered (no blank card).
+    expect(container.querySelector('.recharts-wrapper')).toBeNull();
+    expect(container.querySelector('svg')).toBeNull();
   });
 
   it('renders multiple charts in order', () => {

--- a/src/RetailPulse.Web/src/components/ChartRenderer.tsx
+++ b/src/RetailPulse.Web/src/components/ChartRenderer.tsx
@@ -9,6 +9,7 @@ import {
 import { Card, makeStyles } from '@fluentui/react-components';
 import type { ChartSpec, ChartSeries, ForecastData } from '../types';
 import { ForecastChart } from './forecast';
+import { chartIsRenderable } from './chartBindability';
 
 const BRAND_COLORS = ['#1565C0', '#42A5F5', '#4682B4', '#2E8B57', '#1E88E5', '#64B5F6', '#5F9EA0', '#0D47A1'];
 
@@ -56,6 +57,23 @@ const useStyles = makeStyles({
     alignItems: 'center',
     justifyContent: 'center',
     padding: '20px',
+  },
+  unavailableCard: {
+    marginTop: '12px',
+    padding: '16px 20px',
+    backgroundColor: 'var(--color-surface-alt)',
+    border: '1px dashed var(--color-border-strong)',
+    borderRadius: '12px',
+  },
+  unavailableTitle: {
+    color: 'var(--color-text)',
+    fontSize: '14px',
+    fontWeight: '600',
+    marginBottom: '4px',
+  },
+  unavailableNote: {
+    color: 'var(--color-text-secondary)',
+    fontSize: '12px',
   },
 });
 
@@ -291,6 +309,22 @@ function SingleChart({ spec }: { spec: ChartSpec }) {
   );
 }
 
+// Non-disruptive diagnostic shown instead of an empty chart card when a spec
+// carries no bindable datapoints. Keeps the assistant's prose answer intact and
+// tells the user the visualization couldn't be built — no blank axes, no CSS
+// hiding, no silent drop.
+function ChartUnavailable({ title }: { title?: string }) {
+  const styles = useStyles();
+  return (
+    <div className={styles.unavailableCard} role="note">
+      {title ? <div className={styles.unavailableTitle}>{title}</div> : null}
+      <div className={styles.unavailableNote}>
+        Chart unavailable — the data returned couldn&apos;t be rendered as a chart.
+      </div>
+    </div>
+  );
+}
+
 // Detect forecast-shaped data embedded in a chart spec's metadata
 function isForecastSpec(spec: ChartSpec): spec is ChartSpec & { forecast: ForecastData } {
   return 'forecast' in spec && !!(spec as ChartSpec & { forecast?: ForecastData }).forecast;
@@ -304,13 +338,17 @@ export default function ChartRenderer({ charts, forecastData }: { charts: ChartS
 
   return (
     <>
-      {charts.map((spec, i) =>
-        isForecastSpec(spec) ? (
-          <ForecastChart key={spec.title || `forecast-${i}`} data={spec.forecast} />
-        ) : (
-          <SingleChart key={spec.title || `chart-${i}`} spec={spec} />
-        ),
-      )}
+      {charts.map((spec, i) => {
+        if (isForecastSpec(spec)) {
+          return <ForecastChart key={spec.title || `forecast-${i}`} data={spec.forecast} />;
+        }
+        // Enforce the renderable invariant at the render boundary: a spec with no
+        // bindable datapoints surfaces a diagnostic instead of an empty chart card.
+        if (!chartIsRenderable(spec)) {
+          return <ChartUnavailable key={spec.title || `chart-${i}`} title={spec.title} />;
+        }
+        return <SingleChart key={spec.title || `chart-${i}`} spec={spec} />;
+      })}
     </>
   );
 }

--- a/src/RetailPulse.Web/src/components/chartBindability.ts
+++ b/src/RetailPulse.Web/src/components/chartBindability.ts
@@ -1,0 +1,35 @@
+import type { ChartSpec, ChartSeries } from '../types';
+
+function seriesHasFinitePoint(series: ChartSeries): boolean {
+  return (
+    !!series &&
+    typeof series.legend === 'string' &&
+    series.legend.trim().length > 0 &&
+    Array.isArray(series.values) &&
+    series.values.some((v) => v != null && typeof v.y === 'number' && Number.isFinite(v.y))
+  );
+}
+
+/**
+ * True when a ChartSpec can actually be drawn: a typed spec with a non-empty
+ * title and at least one legend-bearing series carrying a finite datapoint.
+ *
+ * This is the frontend half of the shared renderable-chart invariant. It guards
+ * the actual P0 defect (issue #32): a spec with no bindable datapoints must
+ * surface a diagnostic, never an empty chart card with bare axes and no marks.
+ *
+ * Recognized-type enforcement is owned authoritatively by the backend
+ * `ChartSpecValidator`, which drops unknown types before a chart is ever
+ * emitted. The frontend intentionally stays permissive on the type string so
+ * the renderer's table fallback can still surface a data-bearing spec rather
+ * than hide real data; we only require the type to be a non-empty string.
+ */
+export function chartIsRenderable(spec: ChartSpec | null | undefined): boolean {
+  if (!spec || typeof spec.type !== 'string' || spec.type.trim().length === 0) {
+    return false;
+  }
+  if (typeof spec.title !== 'string' || spec.title.trim().length === 0) {
+    return false;
+  }
+  return Array.isArray(spec.data) && spec.data.some(seriesHasFinitePoint);
+}

--- a/tests/RetailPulse.Tests/ChartDataToolTests.cs
+++ b/tests/RetailPulse.Tests/ChartDataToolTests.cs
@@ -72,16 +72,38 @@ public class ChartDataToolTests
     }
 
     [Fact]
-    public async Task CreateChart_EmptyDataArray_StillSucceeds()
+    public async Task CreateChart_EmptyDataArray_ReturnsError()
     {
+        // Invariant: an empty chart (recognized type + title but no series) is NOT
+        // renderable and must be a structured diagnostic, never status:success — a
+        // success-shaped empty chart is exactly what produced the blank card (issue #32).
         ChartDataTool tool = CreateTool();
         string spec = /*lang=json,strict*/ """{"type":"bar","title":"Empty","data":[]}""";
 
         string result = await tool.CreateChart(spec);
 
         var doc = JsonDocument.Parse(result);
-        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
-        doc.RootElement.GetProperty("chart").GetProperty("Data").GetArrayLength().Should().Be(0);
+        doc.RootElement.TryGetProperty("status", out _).Should().BeFalse(
+            "an empty chart must not be reported as success");
+        doc.RootElement.TryGetProperty("error", out JsonElement err).Should().BeTrue();
+        err.GetString().Should().NotBeNullOrEmpty();
+        doc.RootElement.GetProperty("recovered").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateChart_SeriesWithNoValues_ReturnsError()
+    {
+        // Strict deserialization binds a legend-only series with zero datapoints
+        // (Data.Count == 1) — structurally valid but unrenderable. It must be rejected.
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """{"type":"line","title":"No Points","data":[{"legend":"BrandA","values":[]}]}""";
+
+        string result = await tool.CreateChart(spec);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.TryGetProperty("status", out _).Should().BeFalse();
+        doc.RootElement.TryGetProperty("error", out _).Should().BeTrue(
+            "a series with no finite datapoints is not renderable");
     }
 
     [Theory]
@@ -435,5 +457,211 @@ public class ChartDataToolTests
         values[0].GetProperty("Y").GetDouble().Should().Be(1893.2);
         values[2].GetProperty("X").GetString().Should().Be("Summit Vodka");
         values[2].GetProperty("Y").GetDouble().Should().Be(2296.3);
+    }
+
+    // ---- Issue #32: two-brand / all-regions comparison must bind to two non-empty series ----
+
+    [Fact]
+    public async Task CreateChart_TwoBrandComparison_DataPointsSchema_BindsBothSeries()
+    {
+        // Exact live shape (issue #32): the Demand Forecast Agent emitted the
+        // "Coastline Tacos vs Apex Grill ... Across All Regions" comparison as a
+        // top-level series[] with per-series "dataPoints" and shared top-level
+        // "categories". Strict ChartSpec binding leaves Data empty (no "data" key),
+        // which previously returned success with an empty chart → blank card.
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """
+            {
+                "type": "groupedBar",
+                "title": "Coastline Tacos vs Apex Grill: Weekly Depletion Trend Across All Regions",
+                "xAxisTitle": "Region",
+                "yAxisTitle": "Weekly Depletions (cases)",
+                "categories": ["Northeast", "Southeast", "Midwest", "West", "Southwest"],
+                "series": [
+                    {"name": "Coastline Tacos", "dataPoints": [4200, 3800, 5100, 4700, 3300]},
+                    {"name": "Apex Grill", "dataPoints": [3900, 4100, 4600, 5200, 3000]}
+                ]
+            }
+            """;
+
+        string result = await tool.CreateChart(spec);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+        doc.RootElement.GetProperty("recovered").GetBoolean().Should().BeTrue();
+        JsonElement chart = doc.RootElement.GetProperty("chart");
+        chart.GetProperty("Type").GetString().Should().Be("groupedBar");
+        JsonElement data = chart.GetProperty("Data");
+        data.GetArrayLength().Should().Be(2, "both brands must bind as their own series");
+        data[0].GetProperty("Legend").GetString().Should().Be("Coastline Tacos");
+        data[1].GetProperty("Legend").GetString().Should().Be("Apex Grill");
+        JsonElement s0 = data[0].GetProperty("Values");
+        s0.GetArrayLength().Should().Be(5, "the five regional categories must align to the first series");
+        s0[0].GetProperty("X").GetString().Should().Be("Northeast");
+        s0[0].GetProperty("Y").GetDouble().Should().Be(4200);
+        data[1].GetProperty("Values")[3].GetProperty("X").GetString().Should().Be("West");
+        data[1].GetProperty("Values")[3].GetProperty("Y").GetDouble().Should().Be(5200);
+    }
+
+    [Fact]
+    public async Task ExtractChartSpecs_TwoBrandComparison_FlowsBothSeriesIntoChartsList()
+    {
+        // Cross-boundary: the recovered two-series comparison must land in the real
+        // AgentExecutionPipeline.ExtractChartSpecs Charts list with both legends intact.
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """
+            {
+                "type": "line",
+                "title": "Coastline Tacos vs Apex Grill: Weekly Depletion Trend Across All Regions",
+                "categories": ["Northeast", "Southeast", "Midwest"],
+                "series": [
+                    {"name": "Coastline Tacos", "dataPoints": [4200, 3800, 5100]},
+                    {"name": "Apex Grill", "dataPoints": [3900, 4100, 4600]}
+                ]
+            }
+            """;
+
+        string toolOutput = await tool.CreateChart(spec);
+        var response = new Microsoft.Extensions.AI.ChatResponse(
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("call-cmp-1", toolOutput)]));
+
+        List<ChartSpec> charts = AgentExecutionPipeline.ExtractChartSpecs(response);
+
+        charts.Should().ContainSingle();
+        charts[0].Data.Should().HaveCount(2);
+        charts[0].Data.Select(s => s.Legend).Should().Equal("Coastline Tacos", "Apex Grill");
+        charts[0].Data.Should().OnlyContain(s => s.Values.Count == 3);
+    }
+
+    [Fact]
+    public async Task CreateChart_CanonicalTwoSeriesComparison_Succeeds()
+    {
+        // The canonical schema the tightened prompt steers models toward: one entry per
+        // series in "data", every series sharing the same "x" category labels.
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """
+            {
+                "type": "groupedBar",
+                "title": "Coastline Tacos vs Apex Grill by Region",
+                "data": [
+                    {"legend": "Coastline Tacos", "values": [{"x": "Northeast", "y": 4200}, {"x": "West", "y": 4700}]},
+                    {"legend": "Apex Grill", "values": [{"x": "Northeast", "y": 3900}, {"x": "West", "y": 5200}]}
+                ]
+            }
+            """;
+
+        string result = await tool.CreateChart(spec);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+        doc.RootElement.GetProperty("recovered").GetBoolean().Should().BeFalse(
+            "the canonical schema binds via strict deserialization, not recovery");
+        doc.RootElement.GetProperty("chart").GetProperty("Data").GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CreateChart_UnevenCategoriesAndSeries_KeepsAlignmentByIndex()
+    {
+        // Mismatched lengths: 3 categories but a series with only 2 points, and another
+        // with an extra 4th point. Points must stay aligned to the categories by index
+        // and the extra point falls back to an index label — never fabricated or dropped
+        // into the wrong category.
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """
+            {
+                "type": "line",
+                "title": "Uneven Comparison",
+                "categories": ["Q1", "Q2", "Q3"],
+                "series": [
+                    {"name": "BrandA", "values": [100, 200]},
+                    {"name": "BrandB", "values": [110, 210, 310, 410]}
+                ]
+            }
+            """;
+
+        string result = await tool.CreateChart(spec);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+        JsonElement data = doc.RootElement.GetProperty("chart").GetProperty("Data");
+        data.GetArrayLength().Should().Be(2);
+        JsonElement a = data[0].GetProperty("Values");
+        a.GetArrayLength().Should().Be(2);
+        a[0].GetProperty("X").GetString().Should().Be("Q1");
+        a[1].GetProperty("X").GetString().Should().Be("Q2");
+        JsonElement b = data[1].GetProperty("Values");
+        b.GetArrayLength().Should().Be(4);
+        b[2].GetProperty("X").GetString().Should().Be("Q3");
+        b[3].GetProperty("X").GetString().Should().Be("4", "a point past the category list falls back to its 1-based index");
+    }
+
+    [Fact]
+    public async Task CreateChart_NumericStringValues_Bind()
+    {
+        // Models sometimes stringify the y values. Numeric strings must bind.
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """
+            {
+                "type": "bar",
+                "title": "Stringified Values",
+                "categories": ["NE", "SE"],
+                "series": [{"name": "BrandA", "dataPoints": ["1200.5", "980"]}]
+            }
+            """;
+
+        string result = await tool.CreateChart(spec);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+        JsonElement values = doc.RootElement.GetProperty("chart").GetProperty("Data")[0].GetProperty("Values");
+        values[0].GetProperty("Y").GetDouble().Should().Be(1200.5);
+        values[1].GetProperty("Y").GetDouble().Should().Be(980);
+    }
+
+    [Fact]
+    public async Task CreateChart_NonFiniteValues_AreDroppedNotRendered()
+    {
+        // NaN / Infinity tokens are not bindable. A series whose only points are
+        // non-finite is dropped; if that leaves nothing renderable, it is an error.
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """
+            {
+                "type": "line",
+                "title": "Non-finite",
+                "categories": ["A", "B"],
+                "series": [{"name": "BrandA", "dataPoints": ["NaN", "Infinity"]}]
+            }
+            """;
+
+        string result = await tool.CreateChart(spec);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.TryGetProperty("status", out _).Should().BeFalse();
+        doc.RootElement.TryGetProperty("error", out _).Should().BeTrue(
+            "non-finite values are not renderable and leave no usable data");
+    }
+
+    [Fact]
+    public async Task CreateChart_MixedFiniteAndNonFinite_KeepsFinitePoints()
+    {
+        ChartDataTool tool = CreateTool();
+        string spec = /*lang=json,strict*/ """
+            {
+                "type": "line",
+                "title": "Mixed",
+                "categories": ["A", "B", "C"],
+                "series": [{"name": "BrandA", "dataPoints": [10, "NaN", 30]}]
+            }
+            """;
+
+        string result = await tool.CreateChart(spec);
+
+        var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+        JsonElement values = doc.RootElement.GetProperty("chart").GetProperty("Data")[0].GetProperty("Values");
+        values.GetArrayLength().Should().Be(2, "the NaN point is dropped, the finite points kept");
+        values[0].GetProperty("Y").GetDouble().Should().Be(10);
+        values[1].GetProperty("X").GetString().Should().Be("C");
+        values[1].GetProperty("Y").GetDouble().Should().Be(30);
     }
 }


### PR DESCRIPTION
## Summary
Fixes #32 — a P0 production defect where the comparison prompt **"Compare Coastline Tacos vs Apex Grill depletions across all regions"** produced correct prose totals but rendered a **blank chart card** (titled card, empty axes, no series).

## Root cause
An unrenderable `ChartSpec` (empty / valueless `Data`) was promoted as `status:"success"` and drawn as a titled card at **three** boundaries:
1. `ChartDataTool.CreateChart` returned success with empty Data when the normalizer could not bind the model's schema.
2. `ExtractChartSpecs` added any success chart with no datapoint check.
3. Frontend `ChartRenderer`/`SingleChart` drew a `Card` + empty Recharts axes for any spec.

The failing payload nested numbers under each series' `dataPoints` alongside a top-level `categories` array; the normalizer only read `values`/`data`, so both series bound to **zero** points.

### Failing schema (observed shape)
```json
{ "type": "groupedBar", "title": "...", "categories": ["West","Central","East"],
  "series": [ { "name": "Coastline Tacos", "dataPoints": [1200,980,1450] },
              { "name": "Apex Grill",      "dataPoints": [1100,1320,890] } ] }
```
### Canonical target
```json
{ "type": "groupedBar", "title": "...", "xAxisTitle": "Region",
  "data": [ { "legend": "Coastline Tacos", "values": [{"x":"West","y":1200}, ...] },
            { "legend": "Apex Grill",      "values": [{"x":"West","y":1100}, ...] } ] }
```

## The fix — one shared "renderable" invariant at every boundary
A chart is renderable **only** with a recognized type, a non-empty title, and ≥1 series carrying ≥1 finite datapoint. Empty/malformed charts are **never** emitted or rendered as an empty card.

- **New `ChartSpecValidator`** — enforces the invariant; drops legend-less series and non-finite Y points; preserves original category (X) labels; never fabricates data.
- **`ChartSpecNormalizer`** — `BuildSeries` also binds `dataPoints`/`points`; `TryElementToDouble` rejects non-finite (`NaN`/`Infinity`) numbers and numeric strings.
- **`ChartDataTool`** — every CreateChart/recovery path runs through the validator and returns a **structured diagnostic** (never success) for empty/valueless charts.
- **`ExtractChartSpecs`** — only adds charts that pass the validator.
- **Frontend** — `chartIsRenderable` guard + non-disruptive `ChartUnavailable` diagnostic (`role="note"`, no CSS hiding) instead of an empty card; assistant prose preserved.
- **Prompt/tool contract** — added a canonical multi-series comparison example steering models to nest points under each series' `values` (no top-level `categories`/`series`, no per-series `dataPoints`), without overfitting to specific brand names.

## Tests
- **Backend** (`ChartDataToolTests`): two-brand `dataPoints` schema binds both series; extraction flows both series into the response; canonical two-series; uneven categories keep index alignment; numeric strings bind; non-finite dropped/mixed kept; empty data & valueless series → **error, not success**.
- **Frontend** (`ChartRenderer.comparison.test.tsx`): mocks `ResponsiveContainer` so real marks render, then asserts **both brand legends** (Coastline Tacos, Apex Grill) *and* actual bar/line marks; empty/valueless → diagnostic with **no chart svg**. Existing empty-data test updated to assert the diagnostic (no blank card).

## Validation
- `dotnet format --verify-no-changes` ✅ · Release build 0 warn/0 err ✅ · backend suite **2233 passed** ✅
- Frontend `eslint` ✅ · `tsc -b && vite build` ✅ · **361 vitest passed** ✅
- Bicep unaffected.

## Not done (by policy)
No merge, no deploy — awaiting parent review.

## Recommended live verification
1. Run the exact prompt: *Compare Coastline Tacos vs Apex Grill depletions across all regions*.
2. Confirm prose totals still render, and the chart card shows **two legends** and **actual bar/line marks** (inspect DOM for `.recharts-bar`/`.recharts-line` and legend text — not just a chart object).
3. Confirm no empty card and no raw JSON leaks into the message.
4. Force a malformed/empty payload and confirm the `ChartUnavailable` note appears (never a blank card), prose intact.
5. Confirm telemetry still shows the Demand Forecast Agent spans/tool calls connected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
