### PR TITLE
Route long-running chat directly to authenticated ACA

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ All brands operate across **6 regions**: Northeast, Southeast, Midwest, Southwes
 | **Monitoring** | Azure Application Insights | — | Production telemetry and traces |
 | **Gateway** | Azure API Management | — | Token metering, rate limiting, audit |
 | **Backend hosting** | Azure Container Apps | — | Runs the API, MCP Server, and Teams Bot as containers; scales to zero when idle |
-| **Frontend hosting** | Azure Static Web Apps | — | Serves the React/Vite static build; proxies REST `/api` requests to the linked Container Apps backend while SignalR connects directly to the Container Apps API |
+| **Frontend hosting** | Azure Static Web Apps | — | Serves the React/Vite static build; most REST requests use the linked Container Apps backend, while long-running chat and SignalR connect directly to the authenticated Container Apps API |
 | **Container registry** | Azure Container Registry (Basic) | — | Stores backend images; Container Apps pull them with managed identity (no admin secrets) |
 | **Testing** | xUnit + Vitest | — | Backend + frontend tests |
 

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -359,7 +359,10 @@ identity provider) for non-demo environments.
 ### Frontend → API routing and SignalR
 
 The postprovision hook idempotently links the ACA API as the Static Web App backend,
-so existing relative `/api/*` requests remain same-origin and are proxied to ACA.
+so ordinary relative `/api/*` requests remain same-origin and are proxied to ACA.
+The long-running `/api/chat` request uses the exact `VITE_API_ORIGIN` ACA origin
+directly to avoid the linked-backend request timeout; the frontend attaches its
+Entra bearer token only to that exact origin and `/api` path.
 SWA linked backends do **not** proxy WebSockets, so SignalR deliberately bypasses the
 link and connects directly to the ACA API using `VITE_API_ORIGIN`.
 

--- a/src/RetailPulse.Web/src/__tests__/api.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/api.test.ts
@@ -6,6 +6,7 @@ const originalFetch = globalThis.fetch;
 describe('api.sendMessage', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   afterEach(() => {
@@ -68,6 +69,20 @@ describe('api.sendMessage', () => {
         { role: 'assistant', content: 'previous answer' },
       ],
     }));
+  });
+
+  it('uses the configured direct ACA origin for long-running chat', async () => {
+    vi.stubEnv('VITE_API_ORIGIN', 'https://api.example.test');
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ reply: 'ok', sessionId: 's', spans: [] }), { status: 200 })
+    ) as unknown as typeof fetch;
+
+    await sendMessage({ message: 'compare two brands' });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://api.example.test/api/chat',
+      expect.objectContaining({ method: 'POST' }),
+    );
   });
 
   it('throws an Error containing the status when response is non-2xx', async () => {

--- a/src/RetailPulse.Web/src/__tests__/apiOrigin.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/apiOrigin.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveApiOrigin, resolveApiUrl } from '../config/apiOrigin';
+
+describe('API origin resolution', () => {
+  it('builds a direct API URL from a bare trusted origin', () => {
+    expect(resolveApiUrl('/api/chat', 'https://api.example.test/'))
+      .toBe('https://api.example.test/api/chat');
+  });
+
+  it.each([
+    'https://user@api.example.test',
+    'https://api.example.test/path',
+    'https://api.example.test?target=other',
+    'javascript:alert(1)',
+    'not a URL',
+  ])('rejects malformed or non-origin values: %s', value => {
+    expect(resolveApiOrigin(value)).toBeNull();
+    expect(resolveApiUrl('/api/chat', value)).toBe('/api/chat');
+  });
+
+  it('rejects non-API paths', () => {
+    expect(() => resolveApiUrl('/hubs/telemetry', 'https://api.example.test'))
+      .toThrow('/api/');
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/authorizedFetch.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/authorizedFetch.test.ts
@@ -23,6 +23,7 @@ function jsonResponse(status: number): Response {
 let originalFetch: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
+  vi.unstubAllEnvs();
   acquireApiToken.mockReset();
   originalFetch = vi.fn().mockResolvedValue(jsonResponse(200));
   window.fetch = originalFetch as unknown as typeof window.fetch;
@@ -82,6 +83,16 @@ describe('isApiRequest', () => {
     expect(isApiRequest(`${location.origin}/api/chat`)).toBe(true);
   });
 
+  it('matches only the exact configured ACA API origin', async () => {
+    vi.stubEnv('VITE_API_ORIGIN', 'https://api.example.test');
+    const { isApiRequest } = await freshModule();
+
+    expect(isApiRequest('https://api.example.test/api/chat')).toBe(true);
+    expect(isApiRequest('https://api.example.test.evil.example/api/chat')).toBe(false);
+    expect(isApiRequest('https://api.example.test:444/api/chat')).toBe(false);
+    expect(isApiRequest('https://api.example.test/assets/app.js')).toBe(false);
+  });
+
   it('does not match encoded traversal or paths that escape /api', async () => {
     const { isApiRequest } = await freshModule();
     // `..` (raw or percent-encoded %2e%2e) is normalized by the URL parser. When it escapes
@@ -113,6 +124,18 @@ describe('installAuthorizedFetch', () => {
 
     expect(acquireApiToken).toHaveBeenCalledTimes(1);
     expect(authHeader()).toBe('Bearer tok-1');
+  });
+
+  it('attaches the bearer token to the exact configured ACA API origin', async () => {
+    vi.stubEnv('VITE_API_ORIGIN', 'https://api.example.test');
+    const { installAuthorizedFetch } = await freshModule();
+    acquireApiToken.mockResolvedValue('tok-direct');
+    installAuthorizedFetch();
+
+    await window.fetch('https://api.example.test/api/chat', { method: 'POST' });
+
+    expect(acquireApiToken).toHaveBeenCalledTimes(1);
+    expect(authHeader()?.endsWith('tok-direct')).toBe(true);
   });
 
   it('does not touch non-API requests or acquire a token for them', async () => {

--- a/src/RetailPulse.Web/src/auth/authorizedFetch.ts
+++ b/src/RetailPulse.Web/src/auth/authorizedFetch.ts
@@ -1,5 +1,6 @@
 import { authConfig } from './authConfig';
 import { acquireApiToken } from './tokenService';
+import { resolveApiOrigin } from '../config/apiOrigin';
 
 /**
  * Global fetch interceptor that attaches the Entra bearer token to our protected `/api`
@@ -43,7 +44,7 @@ function requestUrl(input: RequestInfo | URL): string {
   return input.url;
 }
 
-/** True only for our own `/api` protected paths on the exact current origin. */
+/** True only for our own `/api` protected paths on an explicitly trusted origin. */
 function isProtectedApiPath(pathname: string): boolean {
   return pathname === PROTECTED_API_PREFIX || pathname.startsWith(`${PROTECTED_API_PREFIX}/`);
 }
@@ -78,9 +79,11 @@ export function isApiRequest(input: RequestInfo | URL): boolean {
     return false;
   }
 
-  // Exact same-origin only. This rejects trusted@evil, trusted.evil, suffix hosts,
-  // scheme/port mismatches, and cross-origin telemetry endpoints.
-  if (parsed.origin !== origin) {
+  // Exact-origin only: the SWA origin and the configured ACA API origin. This
+  // rejects trusted@evil, suffix hosts, scheme/port mismatches, and telemetry
+  // endpoints while allowing long-running chat to bypass the SWA proxy timeout.
+  const configuredApiOrigin = resolveApiOrigin(import.meta.env.VITE_API_ORIGIN);
+  if (parsed.origin !== origin && parsed.origin !== configuredApiOrigin) {
     return false;
   }
 

--- a/src/RetailPulse.Web/src/config/apiOrigin.ts
+++ b/src/RetailPulse.Web/src/config/apiOrigin.ts
@@ -1,0 +1,38 @@
+const API_PREFIX = '/api/';
+
+/**
+ * Accepts only a bare HTTP(S) origin. A malformed build-time value fails safe
+ * and callers retain the same-origin SWA route.
+ */
+export function resolveApiOrigin(value: string | undefined): string | null {
+  const candidate = value?.trim();
+  if (!candidate) return null;
+
+  try {
+    const parsed = new URL(candidate);
+    if (
+      (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') ||
+      parsed.username ||
+      parsed.password ||
+      (parsed.pathname !== '/' && parsed.pathname !== '') ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return null;
+    }
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveApiUrl(
+  path: string,
+  configuredOrigin: string | undefined = import.meta.env.VITE_API_ORIGIN,
+): string {
+  if (!path.startsWith(API_PREFIX)) {
+    throw new Error(`API path must start with ${API_PREFIX}`);
+  }
+  const origin = resolveApiOrigin(configuredOrigin);
+  return origin ? `${origin}${path}` : path;
+}

--- a/src/RetailPulse.Web/src/services/api.ts
+++ b/src/RetailPulse.Web/src/services/api.ts
@@ -1,4 +1,5 @@
 import type { ChatRequest, ChatResponse, RoutingInfo } from '../types';
+import { resolveApiUrl } from '../config/apiOrigin';
 
 async function parseErrorBody(res: Response): Promise<string> {
   const contentType = res.headers.get('content-type') ?? '';
@@ -108,7 +109,10 @@ export async function sendMessage(
 
   let res: Response;
   try {
-    res = await fetch('/api/chat', {
+    // Chat can exceed the linked Static Web Apps backend timeout while a model
+    // completes tool calls. Use the exact configured ACA origin when present;
+    // local development retains the same-origin route.
+    res = await fetch(resolveApiUrl('/api/chat'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request),


### PR DESCRIPTION
Closes #34.

The SWA linked-backend proxy cancels long model/tool requests around 45 seconds. Route only POST /api/chat to the exact configured ACA origin, retain a strict /api path allowlist, and attach the Entra bearer token only to the exact SWA or configured ACA origins. Other REST routes remain behind SWA.