### PR TITLE
Sprint 2: secure GitHub authentication mode (#36)

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,54 +2,6 @@
 
 ## Active Decisions
 
-### 2026-05-08: Sprint 2 — GitHub confidential OAuth BFF authentication mode (epic #27, issue #36)
-
-**By:** Costco (Backend Dev)
-
-**What:** Implemented `Authentication:Mode=GitHub` as an additive, opt-in,
-fail-closed provider behind the existing provider-neutral factory. It is a
-**confidential Backend-for-Frontend (BFF)** OAuth flow with three
-narrowly-anonymous, rate-limited endpoints — `GET /api/auth/github/start`,
-`GET /api/auth/github/callback`, `POST /api/auth/github/exchange` — mapped only in
-GitHub mode. The browser only ever talks to our API; the GitHub client secret and
-**provider token stay server-side** (used transiently to call `/user` and org
-membership, then discarded). The SPA receives only a one-time redemption code,
-exchanged for a short-lived HS256 Retail Pulse session token (`provider=GitHub`,
-`sub=github:<immutable numeric id>`, `RetailPulse.User` + `access_as_user`, `jti`,
-strict expiry, no refresh). **Live/production stays Entra** — no hook/config/IaC
-pin changed; deployment-contract tests still prove Entra-only artifacts.
-
-**Why:** GitHub OAuth Apps do **not** support PKCE, so a browser-only exchange
-would leak the client secret or the provider token. The BFF confidential exchange
-plus a server-side one-time `state` store bound to an HttpOnly/Secure/SameSite=Lax
-cookie (SHA-256 hash, constant-time compare, validated before any code exchange)
-closes login-CSRF, state fixation/replay, code/callback replay, and token
-substitution without PKCE. Fixed GitHub endpoints close SSRF/open-redirect; the
-server-side allowlist (immutable numeric id / login / **active** org membership,
-`read:org` only when an org allowlist is set, **never `repo`**) fails closed on any
-API/rate/error.
-
-**Team impact:**
-- **Chick (Frontend):** Sprint 3 owns the provider-neutral sign-in selector. The
-  GitHub SPA contract is: navigate to `/api/auth/github/start`; on return read the
-  one-time `code` query param from the single configured frontend callback URL and
-  `POST` it to `/api/auth/github/exchange`; store the returned session token
-  **session-only**; use it as a REST `Authorization: Bearer` and a `/hubs`
-  `?access_token`. The provider token is never exposed.
-- **Publix (QA):** New suites — `GitHubAuthenticationTests` (TestServer
-  integration + threat: start/callback/exchange happy path and every failure,
-  provider-token-never-leaked, exact scopes/no repo, rate limits,
-  anonymous-exception coverage) plus `GitHubAuthOptionsTests`,
-  `GitHubOneTimeStoreTests`, `GitHubSessionTokenTests`, `GitHubUserAllowlistTests`.
-- **Kroger (Lead):** **Operational limitation** — the state and redemption stores
-  are replica-local in-memory, so hosted GitHub requires `maxReplicas=1` until moved
-  to distributed storage. Documented in ADR-005, the authentication matrix,
-  security.md, and deployment-azd.md. Not deployed this sprint.
-
-**Validation:** backend `dotnet test` 2421 pass; Release build 0/0; `dotnet format
---verify-no-changes` clean; `az bicep build` clean; frontend `npm ci` + build +
-371 vitest pass. No GitHub/Azure writes, no deploy, no merge.
-
 ### 2026-08-05: Dedicated Basic ACR + postprovision hook for secretless Container Apps image pull
 
 **By:** Costco (Backend Dev)

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,6 +2,54 @@
 
 ## Active Decisions
 
+### 2026-05-08: Sprint 2 — GitHub confidential OAuth BFF authentication mode (epic #27, issue #36)
+
+**By:** Costco (Backend Dev)
+
+**What:** Implemented `Authentication:Mode=GitHub` as an additive, opt-in,
+fail-closed provider behind the existing provider-neutral factory. It is a
+**confidential Backend-for-Frontend (BFF)** OAuth flow with three
+narrowly-anonymous, rate-limited endpoints — `GET /api/auth/github/start`,
+`GET /api/auth/github/callback`, `POST /api/auth/github/exchange` — mapped only in
+GitHub mode. The browser only ever talks to our API; the GitHub client secret and
+**provider token stay server-side** (used transiently to call `/user` and org
+membership, then discarded). The SPA receives only a one-time redemption code,
+exchanged for a short-lived HS256 Retail Pulse session token (`provider=GitHub`,
+`sub=github:<immutable numeric id>`, `RetailPulse.User` + `access_as_user`, `jti`,
+strict expiry, no refresh). **Live/production stays Entra** — no hook/config/IaC
+pin changed; deployment-contract tests still prove Entra-only artifacts.
+
+**Why:** GitHub OAuth Apps do **not** support PKCE, so a browser-only exchange
+would leak the client secret or the provider token. The BFF confidential exchange
+plus a server-side one-time `state` store bound to an HttpOnly/Secure/SameSite=Lax
+cookie (SHA-256 hash, constant-time compare, validated before any code exchange)
+closes login-CSRF, state fixation/replay, code/callback replay, and token
+substitution without PKCE. Fixed GitHub endpoints close SSRF/open-redirect; the
+server-side allowlist (immutable numeric id / login / **active** org membership,
+`read:org` only when an org allowlist is set, **never `repo`**) fails closed on any
+API/rate/error.
+
+**Team impact:**
+- **Chick (Frontend):** Sprint 3 owns the provider-neutral sign-in selector. The
+  GitHub SPA contract is: navigate to `/api/auth/github/start`; on return read the
+  one-time `code` query param from the single configured frontend callback URL and
+  `POST` it to `/api/auth/github/exchange`; store the returned session token
+  **session-only**; use it as a REST `Authorization: Bearer` and a `/hubs`
+  `?access_token`. The provider token is never exposed.
+- **Publix (QA):** New suites — `GitHubAuthenticationTests` (TestServer
+  integration + threat: start/callback/exchange happy path and every failure,
+  provider-token-never-leaked, exact scopes/no repo, rate limits,
+  anonymous-exception coverage) plus `GitHubAuthOptionsTests`,
+  `GitHubOneTimeStoreTests`, `GitHubSessionTokenTests`, `GitHubUserAllowlistTests`.
+- **Kroger (Lead):** **Operational limitation** — the state and redemption stores
+  are replica-local in-memory, so hosted GitHub requires `maxReplicas=1` until moved
+  to distributed storage. Documented in ADR-005, the authentication matrix,
+  security.md, and deployment-azd.md. Not deployed this sprint.
+
+**Validation:** backend `dotnet test` 2421 pass; Release build 0/0; `dotnet format
+--verify-no-changes` clean; `az bicep build` clean; frontend `npm ci` + build +
+371 vitest pass. No GitHub/Azure writes, no deploy, no merge.
+
 ### 2026-08-05: Dedicated Basic ACR + postprovision hook for secretless Container Apps image pull
 
 **By:** Costco (Backend Dev)

--- a/docs/adr/005-provider-neutral-authentication.md
+++ b/docs/adr/005-provider-neutral-authentication.md
@@ -399,7 +399,8 @@ compared in constant time at callback). Both are required at callback.
 - **Outside Development**, `GitHubAuthOptions.FromConfiguration` requires a
   complete validated set: client id/secret, a ≥ 256-bit signing key, issuer,
   audience, exact callback URL, exact frontend return URL, and a non-empty
-  allowlist (user ids and/or logins and/or orgs). Missing/malformed/unsafe values
+  allowlist (immutable numeric user ids and/or active organization memberships).
+  Missing/malformed/unsafe values
   throw at startup, so a misconfigured hosted deploy never serves traffic.
 - Development may run with an ephemeral, process-local signing key (sessions do
   not survive a restart — intentional dev behavior, never a hosted fallback).

--- a/docs/adr/005-provider-neutral-authentication.md
+++ b/docs/adr/005-provider-neutral-authentication.md
@@ -5,6 +5,9 @@
 Accepted (Sprint 0 — foundation only; no live behavior change).
 Extended by the **Sprint 1 addendum** below (Anonymous mode implemented; still
 opt-in, fail-closed, and never deployed — Production stays Entra).
+Extended by the **Sprint 2 addendum** below (GitHub confidential OAuth BFF mode
+implemented; still opt-in, fail-closed, and never deployed — Production stays
+Entra).
 
 ## Context
 
@@ -361,7 +364,140 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
   `Security/RateLimitingConfigTests.cs` and
   `Deployment/ProviderNeutralDeploymentContractTests.cs`.
 
+## Sprint 2 addendum: GitHub confidential OAuth BFF mode (implemented)
+
+Sprint 2 implements the `GitHub` mode dispatched by the factory above. It is
+additive, opt-in, and fail-closed; the live/deployed configuration stays `Entra`
+and is proven to stay `Entra` by the deployment-contract tests. GitHub mode is
+**not deployed** this sprint. Child issue #36, epic #27.
+
+### Why a backend-for-frontend (BFF) confidential flow
+
+GitHub **OAuth Apps do not support PKCE** (only the newer GitHub Apps do, and
+only for some flows). A public/browser-only exchange would therefore either leak
+the client secret or rely on an unprotected code exchange, and would put a GitHub
+provider token in the SPA. The provider token is a bearer credential for the
+GitHub API and must never reach the browser. The flow is therefore a
+**confidential BFF**: the browser only ever talks to our API; the API holds the
+client secret, performs the code→token exchange server-side, validates the user
+with the token, and hands the SPA only a short-lived, single-use **redemption
+code** that is later exchanged for a Retail Pulse session token. Without PKCE,
+CSRF/fixation protection is provided by a random `state` in a server-side
+one-time store **plus** a separate random secret bound to the browser in an
+HttpOnly/Secure/SameSite=Lax cookie (only its SHA-256 hash is stored server-side;
+compared in constant time at callback). Both are required at callback.
+
+### Explicit activation and fail-closed hosted opt-in
+
+- `Authentication:Mode=GitHub` is the only switch; no auto-detection/fallback.
+- The GitHub **client id is public**; the **client secret** and the **session
+  signing key** are secrets — required for any hosted deployment, never committed,
+  never logged, never emitted in a response. Angle-bracket placeholder values
+  (as in the safe example config) are rejected at startup.
+- **Outside Development**, `GitHubAuthOptions.FromConfiguration` requires a
+  complete validated set: client id/secret, a ≥ 256-bit signing key, issuer,
+  audience, exact callback URL, exact frontend return URL, and a non-empty
+  allowlist (user ids and/or logins and/or orgs). Missing/malformed/unsafe values
+  throw at startup, so a misconfigured hosted deploy never serves traffic.
+- Development may run with an ephemeral, process-local signing key (sessions do
+  not survive a restart — intentional dev behavior, never a hosted fallback).
+
+### The three narrowly-anonymous BFF endpoints
+
+All three are mapped **only** in GitHub mode, are the only anonymous
+(`AllowAnonymous`) surface besides `/health` + `/alive`, and are rate limited.
+
+1. `GET /api/auth/github/start` — mints a random `state` (server-side one-time
+   store, short TTL) and a separate random cookie secret (HttpOnly/Secure/
+   SameSite=Lax, `__Host-` prefixed over HTTPS), then **redirects only** to the
+   fixed `https://github.com/login/oauth/authorize` with the exact registered
+   `redirect_uri`, minimal scopes (empty by default; `read:org` **only** when an
+   org allowlist is configured — never `repo`), and `allow_signup=false`. No
+   user-supplied redirect target is ever honored (open-redirect closed).
+2. `GET /api/auth/github/callback` — validates `state` + cookie presence, consumes
+   the state entry atomically (one-use), and constant-time compares the cookie
+   secret hash **before any code exchange**; deletes the state cookie on every
+   path. Handles user denial safely (no token). Exchanges the code server-side at
+   the fixed token endpoint, validates the token by calling `/user`, then runs the
+   server-side allowlist. On success it mints a random one-time **redemption code**
+   (bounded, atomic, TTL store) and **redirects to the one configured SPA URL**
+   carrying only that code — never a provider or app token. All failures redirect
+   with a generic error code or return a sanitized `400`.
+3. `POST /api/auth/github/exchange` — atomically redeems the one-time code
+   (replay/race impossible) and returns a freshly minted short-lived Retail Pulse
+   GitHub session token. No refresh token. CORS is the exact configured origin.
+
+### Server-side allowlist and minimal scopes
+
+- Authorization is decided **server-side** on the immutable numeric GitHub user id
+  first (`AllowedUserIds`), then a configurable login allowlist (`AllowedLogins`,
+  case-insensitive, informational identity only), and/or **active** organization
+  membership via `GET /user/memberships/orgs/{org}` requiring `state == "active"`.
+- Scopes are minimized: **no `repo` scope, ever**. With no org allowlist the
+  requested scope is empty (public profile only). Org membership checks require
+  `read:org`; private membership is only visible with that scope, so the org path
+  is documented as requiring `read:org` and the user consenting to it.
+- The allowlist **fails closed** on any GitHub API, rate-limit, or transport error
+  (deny, never allow-on-error), and on an inactive/absent membership.
+
+### Retail Pulse GitHub session token
+
+- The credential is a compact, short-lived **HS256 session JWT** with a **separate
+  issuer/audience** and `provider=GitHub`, subject from the immutable numeric id
+  (`github:<id>`), the login carried only as an informational claim, the required
+  `RetailPulse.User` role + `access_as_user` scope, a random `jti`, strict expiry,
+  and **no refresh token** — no PII beyond the public login. The client re-runs the
+  flow when the TTL elapses, bounding replay to the TTL.
+- HS256 is pinned (algorithm confusion closed); the signing key is ≥ 256-bit and a
+  secret. Key rotation is a built-in seam
+  (`GitHubSigningKeyProvider.ValidationKeys`).
+- The same token is usable as a REST `Authorization: Bearer` and a SignalR
+  `?access_token` (query token honored **only** on `/hubs/*`, exactly like Entra).
+  A dedicated policy (default + fallback) requires the authenticated user, the
+  role, the scope, and `provider==GitHub`, so an Entra/Anonymous/cross-provider
+  token can never satisfy it (authenticated-but-unauthorized → 403).
+- `GitHubPrincipalNormalizer` projects the token to `provider=GitHub` and the
+  immutable numeric subject; it never treats the mutable login as identity.
+
+### Concurrency, replica topology, and cleanup
+
+- The state and redemption stores are **bounded, concurrent, one-use, TTL** stores
+  with background/opportunistic cleanup. They are **replica-local** (in-memory):
+  a callback served by one replica and an exchange served by another would not
+  share state. Until moved to distributed storage, GitHub mode requires
+  **`maxReplicas=1`**; this is documented in the deployment doc and the example
+  config, and is a fail-closed operational constraint (never silently multi-replica).
+
+### Files (Sprint 2)
+
+- `src/RetailPulse.Api/Security/GitHub/` — `GitHubAuthConstants`,
+  `GitHubAuthOptions` (fail-closed config + validation), `GitHubSigningKeyProvider`
+  (rotation), `GitHubSessionTokenService` (HS256 session mint),
+  `GitHubOneTimeStores` (bounded one-use state + redemption stores),
+  `GitHubOAuthClient` (fixed-endpoint SSRF-safe HTTP transport + `/user` +
+  membership), `GitHubUserAllowlist` (id/login/active-org, fail-closed).
+- `src/RetailPulse.Api/Endpoints/GitHubAuthEndpoints.cs` — the three
+  narrowly-anonymous, rate-limited BFF endpoints.
+- `src/RetailPulse.Api/Security/ProviderNeutralAuthentication.cs` — factory
+  `AddGitHubMode` dispatch (mirrors `AddAnonymousMode`); `Program.cs` — GitHub
+  rate-limit policies + `MapGitHubAuthEndpoints` guarded by GitHub mode.
+- `src/RetailPulse.Api/appsettings.GitHub.example.json` — a non-live template
+  (loaded by no environment; contains no secret; documents fail-closed and the
+  replica-local `maxReplicas=1` constraint).
+- Tests: `tests/RetailPulse.Tests/Security/GitHubAuthenticationTests.cs`
+  (TestServer integration + threat suite — start/callback/exchange happy path and
+  every failure: missing/mismatched/expired/replayed state, absent cookie, denial,
+  exchange/`/user`/org errors, unallowlisted user, inactive membership, code
+  replay/race, wrong redirect, wrong signature/issuer/audience/provider/expiry,
+  cross-provider, REST + both hubs authorized after a session token, query token
+  on REST denied, provider token never in redirect/body/logs, exact scopes/no repo,
+  rate limits, anonymous-exception coverage), plus unit suites
+  `GitHubAuthOptionsTests`, `GitHubOneTimeStoreTests`, `GitHubSessionTokenTests`,
+  `GitHubUserAllowlistTests`, and extended `AuthenticationModeTests` /
+  `Deployment/ProviderNeutralDeploymentContractTests`.
+
 ## Alternatives rejected
+
 
 - **SWA-only authentication (Static Web Apps Easy Auth / `.auth`).** Rejected.
   The API — not the SWA — is the security boundary for the SWA + ACA topology.
@@ -398,24 +534,26 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 | Threat | Mitigation |
 |--------|------------|
 | A misconfiguration silently disables auth in Production | Missing mode outside Development throws at startup; `Security:RequireAuth` cannot be `false` outside Development. Fails closed. |
-| An operator selects an unfinished provider in Production | GitHub / Anonymous throw `NotSupportedException` before any scheme is registered — no fall-through to Entra / Development / anonymous. |
+| An operator selects an unfinished provider in Production | Production is pinned to `Entra` in three artifacts and a deployment contract test proves the hooks and Production config never emit GitHub / Anonymous; a hosted GitHub / Anonymous deploy additionally fails startup without its complete validated (secret-bearing) configuration. |
 | A typo or injected value selects an unintended provider | Unknown strings and bare numbers throw; only the three documented names resolve. |
 | Downgrade from Entra to a weaker provider | No non-Entra path is runnable; Production is pinned to `Entra` in three places; a deployment contract test asserts the hooks and Production config never emit GitHub / Anonymous. |
 | Subject / identity spoofing via client-supplied data | `Subject` comes from the token `oid` via `UserIdentity.Resolve` (claim-first), unchanged. The normalizer never trusts headers. |
 | A future provider weakens the role/scope requirement | The authorization policy is untouched and centralized; `RetailPulse.User` + `access_as_user` remain required. Normalization is separate from authorization. |
 | Hub token leakage via query string on REST | `?access_token` remains honored only on `/hubs/*`; unchanged. |
 | Anonymous visitors exhaust the model budget | Hosted Anonymous requires a second explicit opt-in plus rate, token, and cost ceilings; write-capable tools remain disabled. |
-| A GitHub OAuth code or session is replayed or redirected | The GitHub provider uses a backend confidential exchange, validated state and callback URI, short-lived app session tokens, rotation, and allowlists. |
+| A GitHub OAuth code or session is replayed or redirected | The GitHub provider uses a backend confidential exchange, a random `state` in a server-side one-time store bound to an HttpOnly/Secure/SameSite=Lax cookie (constant-time hash compare) validated before any exchange, the exact fixed authorize/callback/token endpoints (SSRF-safe), a one-time bounded redemption code (never a provider/app token) redeemed atomically, short-lived HS256 session tokens with a separate issuer/audience/provider and rotation, and a fail-closed server-side id/login/active-org allowlist with no `repo` scope. |
+| A GitHub provider token leaks to the SPA or logs | The provider token never leaves the server: it is used transiently to call `/user` and org membership, then discarded. Redirects and the exchange body carry only a one-time redemption code / the Retail Pulse session token; integration tests assert the provider token never appears in any redirect, body, or log. |
 
 ## No-downgrade and fail-closed rules
 
 1. Authentication never auto-detects a provider. The mode is always explicit
    outside Development.
 2. Outside Development, a missing mode is a startup failure, never a default.
-3. GitHub fails startup until a later sprint implements it; it never falls
-   through to another provider. Anonymous is implemented but opt-in and never
-   deployed — a hosted Anonymous deploy fails startup without the second explicit
-   opt-in and complete guardrail configuration.
+3. GitHub is implemented but opt-in and never deployed — a hosted GitHub deploy
+   fails startup without the complete validated (secret-bearing) configuration,
+   and it never falls through to another provider. Anonymous is implemented but
+   opt-in and never deployed — a hosted Anonymous deploy fails startup without the
+   second explicit opt-in and complete guardrail configuration.
 4. Production is pinned to `Entra` in base config, Production config, and the azd
    hooks, and a deployment contract test proves those artifacts cannot silently
    select GitHub or Anonymous.
@@ -430,9 +568,9 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 - **Sprint 1 (implemented — see addendum above):** Anonymous provider with
   explicit local/hosted opt-in, isolated identities and sessions, disabled
   write-capable tools, and billable-use ceilings. Production stays Entra.
-- **Sprint 2:** GitHub provider through a backend confidential OAuth flow,
-  short-lived Retail Pulse session tokens, and user/organization allowlists.
-  Production stays Entra.
+- **Sprint 2 (implemented — see addendum above):** GitHub provider through a
+  backend confidential OAuth BFF flow, short-lived Retail Pulse session tokens,
+  and user/organization allowlists. Production stays Entra.
 - **Sprint 3:** provider-neutral frontend sign-in selection and configuration
   templates. Production exposes only Microsoft sign-in.
 - **Sprint 4:** full provider matrix, security review, docs, and a production
@@ -442,8 +580,9 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
 
 - Current Entra live behavior is semantically identical (existing end-to-end auth
   tests stay green).
-- No code path enables GitHub or Anonymous; selecting either fails startup with a
-  precise message.
+- No live code path enables GitHub or Anonymous; Production stays Entra-pinned and
+  a hosted GitHub / Anonymous deploy fails startup without its complete validated
+  configuration, with a precise message.
 - Production and azd are explicitly Entra-pinned and fail closed on any mode
   error.
 - The foundation is small enough for later sprints to extend without another auth

--- a/docs/adr/005-provider-neutral-authentication.md
+++ b/docs/adr/005-provider-neutral-authentication.md
@@ -192,9 +192,11 @@ and is proven to stay `Entra` by the deployment-contract tests. Anonymous mode i
   `jti` — **no PII and no refresh token**. The client re-bootstraps when the TTL
   elapses, which bounds the replay window to the TTL.
 - The same token is usable as a REST `Authorization: Bearer` and as a SignalR
-  `?access_token` (query token honored **only** on `/hubs/*`). Key rotation is a
-  built-in seam (`AnonymousSigningKeyProvider.ValidationKeys`). The signing key is
-  a secret and is never committed.
+  `?access_token` (query token honored **only** on `/hubs/*`). Genuine signing-key
+  rotation is supported (`AnonymousSigningKeyProvider.ValidationKeys` /
+  `Anonymous:AdditionalValidationKeys`): validation-only keys keep pre-rotation
+  tokens valid while the current key signs, parity with GitHub mode. The signing
+  key is a secret and is never committed.
 
 ### Authorization and normalized principal
 
@@ -408,31 +410,49 @@ All three are mapped **only** in GitHub mode, are the only anonymous
 (`AllowAnonymous`) surface besides `/health` + `/alive`, and are rate limited.
 
 1. `GET /api/auth/github/start` — mints a random `state` (server-side one-time
-   store, short TTL) and a separate random cookie secret (HttpOnly/Secure/
-   SameSite=Lax, `__Host-` prefixed over HTTPS), then **redirects only** to the
-   fixed `https://github.com/login/oauth/authorize` with the exact registered
+   store, short TTL) and a separate random cookie secret. The cookie's security
+   attributes come from the validated `RequireSecureCookies` option, **never** from
+   the in-container `Request.IsHttps`: behind a TLS-terminating proxy (Azure
+   Container Apps) the browser↔edge hop is HTTPS while the edge↔container hop the
+   app observes is plain HTTP, so deriving `Secure`/`__Host-` from the request
+   scheme would silently emit an insecure cookie in production. In hosted/secure
+   mode the cookie is always `__Host-` prefixed (Secure, HttpOnly, SameSite=Lax,
+   Path=/, no Domain). Development may explicitly opt into an insecure, non-`__Host`
+   dev cookie over plain HTTP (`RequireSecureCookies=false`, rejected at startup
+   outside Development). The cookie **name is per-state** — a `__Host-rp_gh_state_`
+   base plus a bounded URL-safe suffix derived from the state (truncated SHA-256) —
+   so **parallel login tabs never collide**: two concurrent starts write two
+   differently-named cookies. It then **redirects only** to the fixed
+   `https://github.com/login/oauth/authorize` with the exact registered
    `redirect_uri`, minimal scopes (empty by default; `read:org` **only** when an
    org allowlist is configured — never `repo`), and `allow_signup=false`. No
    user-supplied redirect target is ever honored (open-redirect closed).
-2. `GET /api/auth/github/callback` — validates `state` + cookie presence, consumes
-   the state entry atomically (one-use), and constant-time compares the cookie
-   secret hash **before any code exchange**; deletes the state cookie on every
-   path. Handles user denial safely (no token). Exchanges the code server-side at
-   the fixed token endpoint, validates the token by calling `/user`, then runs the
-   server-side allowlist. On success it mints a random one-time **redemption code**
-   (bounded, atomic, TTL store) and **redirects to the one configured SPA URL**
-   carrying only that code — never a provider or app token. All failures redirect
-   with a generic error code or return a sanitized `400`.
+2. `GET /api/auth/github/callback` — validates the `state` **format** first (exactly
+   the fixed-length base64url shape our start emits), derives the exact per-state
+   cookie name from the validated state, and reads/deletes **only** that cookie.
+   It consumes the state entry atomically (one-use) and constant-time compares the
+   cookie secret hash **before any code exchange**; deletes the state cookie on
+   every path. Handles user denial safely (no token). Exchanges the code
+   server-side at the fixed token endpoint, validates the token by calling `/user`,
+   then runs the server-side allowlist. On success it mints a random one-time
+   **redemption code** (bounded, atomic, TTL store) and **redirects to the one
+   configured SPA URL** carrying only that code — never a provider or app token.
+   All failures redirect with a generic error code or return a sanitized `400`.
 3. `POST /api/auth/github/exchange` — atomically redeems the one-time code
    (replay/race impossible) and returns a freshly minted short-lived Retail Pulse
    GitHub session token. No refresh token. CORS is the exact configured origin.
 
 ### Server-side allowlist and minimal scopes
 
-- Authorization is decided **server-side** on the immutable numeric GitHub user id
-  first (`AllowedUserIds`), then a configurable login allowlist (`AllowedLogins`,
-  case-insensitive, informational identity only), and/or **active** organization
-  membership via `GET /user/memberships/orgs/{org}` requiring `state == "active"`.
+- Authorization is decided **server-side** on **immutable** signals only: the
+  numeric GitHub user id (`AllowedUserIds`, positive integers, deduped) and/or
+  **active** organization membership via `GET /user/memberships/orgs/{org}`
+  requiring `state == "active"`. The mutable login handle is **never** an access
+  mechanism — a renamed or re-created handle can never inherit access (handle-reuse
+  is denied). If a display login is ever surfaced it is informational only. Startup
+  **fails closed** unless at least one immutable mechanism (`AllowedUserIds` or
+  `AllowedOrgs`) is configured, so an empty allowlist can never admit every GitHub
+  account.
 - Scopes are minimized: **no `repo` scope, ever**. With no org allowlist the
   requested scope is empty (public profile only). Org membership checks require
   `read:org`; private membership is only visible with that scope, so the org path
@@ -449,8 +469,15 @@ All three are mapped **only** in GitHub mode, are the only anonymous
   and **no refresh token** — no PII beyond the public login. The client re-runs the
   flow when the TTL elapses, bounding replay to the TTL.
 - HS256 is pinned (algorithm confusion closed); the signing key is ≥ 256-bit and a
-  secret. Key rotation is a built-in seam
-  (`GitHubSigningKeyProvider.ValidationKeys`).
+  secret. **Genuine signing-key rotation** is supported via
+  `GitHub:AdditionalValidationKeys`: additional strong (≥ 256-bit, placeholders
+  rejected) keys are accepted for **validation only** while the current
+  `SigningKey` is always used to **sign** (and is tried first). Each key carries a
+  stable id derived from its own material, so a token signed before a rotation keeps
+  the same `kid` after its key is demoted to the validation-only list and therefore
+  keeps validating until it expires — a rotation never invalidates in-flight
+  sessions. Anonymous mode has the same rotation seam
+  (`AnonymousSigningKeyProvider` / `Anonymous:AdditionalValidationKeys`) for parity.
 - The same token is usable as a REST `Authorization: Bearer` and a SignalR
   `?access_token` (query token honored **only** on `/hubs/*`, exactly like Entra).
   A dedicated policy (default + fallback) requires the authenticated user, the
@@ -464,9 +491,14 @@ All three are mapped **only** in GitHub mode, are the only anonymous
 - The state and redemption stores are **bounded, concurrent, one-use, TTL** stores
   with background/opportunistic cleanup. They are **replica-local** (in-memory):
   a callback served by one replica and an exchange served by another would not
-  share state. Until moved to distributed storage, GitHub mode requires
-  **`maxReplicas=1`**; this is documented in the deployment doc and the example
-  config, and is a fail-closed operational constraint (never silently multi-replica).
+  share state. The state store is also **capacity/TTL bounded**, so a flood of
+  `start` requests (parallel-tab cookie-count abuse) is rejected with a `503`
+  rather than growing unboundedly. Until moved to distributed storage, GitHub mode
+  requires **`maxReplicas=1`**. Because the runtime cannot inspect ACA topology,
+  hosted GitHub additionally requires an explicit
+  `GitHub:AcknowledgeSingleReplica=true` — a fail-closed acknowledgement of the
+  single-replica pin; startup fails without it. This is documented in the
+  deployment doc and the example config, and is never silently multi-replica.
 
 ### Files (Sprint 2)
 
@@ -541,7 +573,10 @@ All three are mapped **only** in GitHub mode, are the only anonymous
 | A future provider weakens the role/scope requirement | The authorization policy is untouched and centralized; `RetailPulse.User` + `access_as_user` remain required. Normalization is separate from authorization. |
 | Hub token leakage via query string on REST | `?access_token` remains honored only on `/hubs/*`; unchanged. |
 | Anonymous visitors exhaust the model budget | Hosted Anonymous requires a second explicit opt-in plus rate, token, and cost ceilings; write-capable tools remain disabled. |
-| A GitHub OAuth code or session is replayed or redirected | The GitHub provider uses a backend confidential exchange, a random `state` in a server-side one-time store bound to an HttpOnly/Secure/SameSite=Lax cookie (constant-time hash compare) validated before any exchange, the exact fixed authorize/callback/token endpoints (SSRF-safe), a one-time bounded redemption code (never a provider/app token) redeemed atomically, short-lived HS256 session tokens with a separate issuer/audience/provider and rotation, and a fail-closed server-side id/login/active-org allowlist with no `repo` scope. |
+| A GitHub OAuth code or session is replayed or redirected | The GitHub provider uses a backend confidential exchange, a random `state` in a server-side one-time store bound to a per-state HttpOnly cookie whose Secure/`__Host-` attributes come from validated config (not the proxy-observed request scheme), constant-time hash compare validated before any exchange, the exact fixed authorize/callback/token endpoints (SSRF-safe), a one-time bounded redemption code (never a provider/app token) redeemed atomically, short-lived HS256 session tokens with a separate issuer/audience/provider and genuine key rotation, and a fail-closed server-side **immutable** id / active-org allowlist (mutable login never grants) with no `repo` scope. |
+| A renamed or re-created GitHub handle inherits another user's access | Authorization keys only on the immutable numeric id and/or active org membership; the mutable login is never an access mechanism, so a reused handle with a different id is denied. A login-only allowlist fails startup. |
+| Cookie hardening is bypassed behind TLS termination | Behind Azure Container Apps the in-container request is plain HTTP; deriving `Secure`/`__Host-` from `Request.IsHttps` would emit an insecure cookie. Cookie attributes come from the validated `RequireSecureCookies` option instead, which must be `true` in any hosted deployment (startup fails otherwise). |
+| Parallel login tabs clash or a state flood abuses cookies | Each `start` writes a distinct per-state cookie name (`__Host-rp_gh_state_` + bounded suffix derived from the state) and the callback consumes/deletes only its own, so concurrent tabs complete independently; the state store is capacity/TTL bounded and returns `503` under flood. |
 | A GitHub provider token leaks to the SPA or logs | The provider token never leaves the server: it is used transiently to call `/user` and org membership, then discarded. Redirects and the exchange body carry only a one-time redemption code / the Retail Pulse session token; integration tests assert the provider token never appears in any redirect, body, or log. |
 
 ## No-downgrade and fail-closed rules

--- a/docs/authentication-matrix.md
+++ b/docs/authentication-matrix.md
@@ -116,7 +116,7 @@ rate limited.
 | `GET /api/auth/github/callback` | missing/mismatched/expired/replayed `state`, or absent state cookie, or cookie hash mismatch | 400 `invalid_state`, no code exchange performed; state cookie deleted |
 | `GET /api/auth/github/callback` | `error=access_denied` (user denied) | 302 to the SPA URL with a generic error code; no token |
 | `GET /api/auth/github/callback` | GitHub code exchange or `/user` validation fails | 302 to the SPA URL with a generic `login_failed`; provider errors never leaked |
-| `GET /api/auth/github/callback` | user not on the id/login allowlist, or org membership absent/inactive, or the allowlist GitHub API errors/rate-limits | 302 to the SPA URL with `not_authorized` — **fail closed** (deny on error) |
+| `GET /api/auth/github/callback` | user not on the immutable id / active-org allowlist, or org membership absent/inactive, or the allowlist GitHub API errors/rate-limits | 302 to the SPA URL with `not_authorized` — **fail closed** (deny on error) |
 | `POST /api/auth/github/exchange` (valid one-time code) | one-time redemption code | 200 — mints a short-lived HS256 session token (`provider=GitHub`, `sub=github:<id>`, role `RetailPulse.User`, scope `access_as_user`, random `jti`, no refresh) |
 | `POST /api/auth/github/exchange` | replayed / unknown / expired code | 400 `invalid_code` — the code is one-use and redeemed atomically (replay/race impossible) |
 | `POST /api/auth/github/exchange` | over the exchange limit | 429 |
@@ -156,11 +156,16 @@ running without configuration. It never applies outside Development.
 - GitHub is implemented but **opt-in and never deployed**: a hosted
   (non-Development) GitHub deployment fails startup unless a complete, validated
   secret-bearing configuration is present (client id/secret, ≥ 256-bit signing
-  key, issuer, audience, exact callback + frontend URLs, non-empty allowlist);
-  placeholder secrets are rejected. The provider token never reaches the SPA, the
-  allowlist fails closed on any error, no `repo` scope is requested, and hosted
-  GitHub is pinned to a single replica (`maxReplicas=1`) because the state /
-  redemption stores are replica-local.
+  key, issuer, audience, exact callback + frontend URLs, an **immutable** allowlist
+  — numeric `AllowedUserIds` and/or active-org `AllowedOrgs`, `RequireSecureCookies=true`,
+  and `AcknowledgeSingleReplica=true`); placeholder secrets are rejected. The
+  mutable login handle never grants access (a login-only allowlist fails startup).
+  Cookie `Secure`/`__Host-` semantics come from validated config, not the
+  proxy-observed request scheme. The provider token never reaches the SPA, the
+  allowlist fails closed on any error, no `repo` scope is requested, genuine
+  signing-key rotation is supported, and hosted GitHub is pinned to a single
+  replica (`maxReplicas=1`, acknowledged via `AcknowledgeSingleReplica`) because
+  the state / redemption stores and login limiters are replica-local.
 - Anonymous is implemented but **opt-in and never deployed**: any hosted
   (non-Development) Anonymous deployment fails startup unless a second explicit
   opt-in (`Anonymous:AllowHosted=true`) and a complete, validated guardrail set

--- a/docs/authentication-matrix.md
+++ b/docs/authentication-matrix.md
@@ -23,7 +23,7 @@ resolver is deterministic and never auto-detects a provider.
 |-----------------------------|-------------|---------|
 | `Entra` (any case) | any | Resolves to `Entra`; wires the existing Entra boundary |
 | `GitHub` (any case) | Development | Resolves; wires the GitHub confidential OAuth BFF boundary. May use an ephemeral process-local signing key (sessions die on restart), but still requires a client id/secret and an allowlist. |
-| `GitHub` (any case) | Production (or any non-Development) | Resolves; requires a complete validated set — client id/secret, ≥ 256-bit signing key, issuer, audience, exact callback + frontend URLs, and a non-empty id/login/org allowlist — or startup fails closed. Placeholder (`<...>`) secrets are rejected. |
+| `GitHub` (any case) | Production (or any non-Development) | Resolves; requires a complete validated set — client id/secret, ≥ 256-bit signing key, issuer, audience, exact callback + frontend URLs, and a non-empty immutable user-id and/or active-organization allowlist — or startup fails closed. Placeholder (`<...>`) secrets are rejected. |
 | `Anonymous` (any case) | Development | Resolves; wires the Anonymous boundary with an ephemeral process-local signing key (sessions die on restart). No hosted guardrails required. |
 | `Anonymous` (any case) | Production (or any non-Development) | Resolves; requires `Anonymous:AllowHosted=true` **plus** a strong signing key (≥ 256-bit) **plus** positive daily request/token/cost ceilings, or startup fails closed |
 | missing / blank | Development | Defaults to `Entra` (documented Development-only default) |

--- a/docs/authentication-matrix.md
+++ b/docs/authentication-matrix.md
@@ -14,7 +14,7 @@ resolver is deterministic and never auto-detects a provider.
 | Mode | Status in this sprint | Production |
 |------|-----------------------|------------|
 | `Entra` | Implemented (unchanged) | Supported and pinned |
-| `GitHub` | Declared, not implemented — fails startup | Never enabled |
+| `GitHub` | Implemented (Sprint 2) — opt-in, fail-closed, not deployed (hosted requires complete validated secret-bearing config); confidential OAuth BFF | Never enabled (Entra pinned) |
 | `Anonymous` | Implemented (Sprint 1) — opt-in, fail-closed, not deployed by default (hosted only with `Anonymous:AllowHosted=true`) | Never enabled (Entra pinned) |
 
 ## Mode resolution matrix
@@ -22,7 +22,8 @@ resolver is deterministic and never auto-detects a provider.
 | `Authentication:Mode` value | Environment | Outcome |
 |-----------------------------|-------------|---------|
 | `Entra` (any case) | any | Resolves to `Entra`; wires the existing Entra boundary |
-| `GitHub` (any case) | any | Resolves, then the factory throws `NotSupportedException` — not implemented this sprint |
+| `GitHub` (any case) | Development | Resolves; wires the GitHub confidential OAuth BFF boundary. May use an ephemeral process-local signing key (sessions die on restart), but still requires a client id/secret and an allowlist. |
+| `GitHub` (any case) | Production (or any non-Development) | Resolves; requires a complete validated set — client id/secret, ≥ 256-bit signing key, issuer, audience, exact callback + frontend URLs, and a non-empty id/login/org allowlist — or startup fails closed. Placeholder (`<...>`) secrets are rejected. |
 | `Anonymous` (any case) | Development | Resolves; wires the Anonymous boundary with an ephemeral process-local signing key (sessions die on restart). No hosted guardrails required. |
 | `Anonymous` (any case) | Production (or any non-Development) | Resolves; requires `Anonymous:AllowHosted=true` **plus** a strong signing key (≥ 256-bit) **plus** positive daily request/token/cost ceilings, or startup fails closed |
 | missing / blank | Development | Defaults to `Entra` (documented Development-only default) |
@@ -92,7 +93,49 @@ hubs in anonymous mode. There is **no blanket GET allowance** — every other ro
 > still honoured as a backward-compatible fallback), and the **primary** post-bootstrap
 > control is the per-subject chat limit.
 
-## Environment behavior
+## Runtime authorization matrix (GitHub mode)
+
+GitHub mode is an **opt-in, fail-closed** capability that is **not deployed**.
+Authentication is a **confidential backend-for-frontend (BFF) OAuth flow**: the
+browser talks only to our API; the GitHub client secret stays on the server; the
+GitHub **provider token never reaches the SPA** (used transiently server-side to
+validate the user and org membership, then discarded). GitHub OAuth Apps do not
+support PKCE, so CSRF/fixation is closed by a random `state` in a server-side
+one-time store **plus** a separate random secret in an HttpOnly/Secure/
+SameSite=Lax cookie (SHA-256 hash stored server-side, constant-time compared).
+The SPA receives only a short-lived one-time **redemption code**, which it
+exchanges for a short-lived Retail Pulse **session token**. The three BFF
+endpoints are the only anonymous surface beyond `/health` + `/alive`, and all are
+rate limited.
+
+| Request | Credential | Expected result |
+|---------|-----------|-----------------|
+| `GET /api/auth/github/start` | none | 302 to `https://github.com/login/oauth/authorize` with the exact registered `redirect_uri`, a random `state`, minimal scope (empty by default; `read:org` only when an org allowlist is configured; **never `repo`**), `allow_signup=false`; sets the HttpOnly/Secure/SameSite=Lax state cookie |
+| `GET /api/auth/github/start` | none, over the start limit | 429 |
+| `GET /api/auth/github/callback` (valid state + cookie, allowlisted user) | GitHub redirect back | 302 to the **one** configured SPA URL carrying only a one-time redemption `code` (never a provider/app token); state cookie deleted |
+| `GET /api/auth/github/callback` | missing/mismatched/expired/replayed `state`, or absent state cookie, or cookie hash mismatch | 400 `invalid_state`, no code exchange performed; state cookie deleted |
+| `GET /api/auth/github/callback` | `error=access_denied` (user denied) | 302 to the SPA URL with a generic error code; no token |
+| `GET /api/auth/github/callback` | GitHub code exchange or `/user` validation fails | 302 to the SPA URL with a generic `login_failed`; provider errors never leaked |
+| `GET /api/auth/github/callback` | user not on the id/login allowlist, or org membership absent/inactive, or the allowlist GitHub API errors/rate-limits | 302 to the SPA URL with `not_authorized` — **fail closed** (deny on error) |
+| `POST /api/auth/github/exchange` (valid one-time code) | one-time redemption code | 200 — mints a short-lived HS256 session token (`provider=GitHub`, `sub=github:<id>`, role `RetailPulse.User`, scope `access_as_user`, random `jti`, no refresh) |
+| `POST /api/auth/github/exchange` | replayed / unknown / expired code | 400 `invalid_code` — the code is one-use and redeemed atomically (replay/race impossible) |
+| `POST /api/auth/github/exchange` | over the exchange limit | 429 |
+| Protected REST endpoint | valid GitHub session token | 200 — full authenticated capability, acceptable only because it was reached after server-side allowlist verification |
+| `/hubs/*` (connection + negotiate) | valid GitHub session token via `?access_token=` | connects — query token honored on `/hubs/*` exactly like Entra |
+| REST endpoint | GitHub session token via `?access_token` query string only | 401 (query token honored only on `/hubs/*`) |
+| Protected REST/hub | no token | 401 |
+| Protected REST/hub | malformed / expired / wrong issuer / wrong audience / wrong signature (algorithm pinned HS256) | 401 |
+| Protected REST/hub | valid-signature token with `provider != GitHub` (Entra/Anonymous/cross-provider) | 403 — the GitHub policy requires `provider=GitHub` |
+| Any redirect, response body, or log line | — | never contains the GitHub provider token (asserted by integration tests) |
+| `/health`, `/alive` | none | 200 |
+
+> **Replica-local limitation.** The state and redemption stores are
+> **replica-local, in-memory**, so a callback served by one replica and an
+> exchange served by another would not share state. Hosted GitHub is therefore
+> pinned to `maxReplicas=1` until the stores are moved to distributed storage; the
+> stores are bounded, one-use, and TTL-expiring with opportunistic cleanup.
+
+
 
 | Environment | Mode source | Auth handler |
 |-------------|-------------|--------------|
@@ -110,8 +153,14 @@ running without configuration. It never applies outside Development.
 - Production is pinned to `Entra` in three independent artifacts (base config,
   Production config, azd hooks). A deployment contract test proves those
   artifacts never emit `GitHub` or `Anonymous`.
-- GitHub is an opt-in capability for a later sprint and is never enabled in
-  production.
+- GitHub is implemented but **opt-in and never deployed**: a hosted
+  (non-Development) GitHub deployment fails startup unless a complete, validated
+  secret-bearing configuration is present (client id/secret, ≥ 256-bit signing
+  key, issuer, audience, exact callback + frontend URLs, non-empty allowlist);
+  placeholder secrets are rejected. The provider token never reaches the SPA, the
+  allowlist fails closed on any error, no `repo` scope is requested, and hosted
+  GitHub is pinned to a single replica (`maxReplicas=1`) because the state /
+  redemption stores are replica-local.
 - Anonymous is implemented but **opt-in and never deployed**: any hosted
   (non-Development) Anonymous deployment fails startup unless a second explicit
   opt-in (`Anonymous:AllowHosted=true`) and a complete, validated guardrail set
@@ -125,15 +174,17 @@ running without configuration. It never applies outside Development.
 | Matrix area | Test |
 |-------------|------|
 | Mode resolution (all rows above) | `tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs` |
-| Entra wiring + GitHub fail closed at the factory; Anonymous factory wiring | `tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs` |
+| Entra wiring + GitHub/Anonymous factory wiring and hosted fail-closed validation | `tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs` |
 | Entra success / 401 / 403 / hubs | `tests/RetailPulse.Tests/Security/EntraAuthenticationTests.cs` |
+| GitHub BFF start/callback/exchange happy path + every failure (state/cookie/TTL/replay, denial, exchange/`/user`/org errors, unallowlisted/inactive, code replay/race, wrong redirect, token validation incl. cross-provider, REST + both hubs after session token, query-token-on-REST denied, provider token never in redirect/body/logs, exact scopes/no repo, rate limits, anonymous-exception coverage) | `tests/RetailPulse.Tests/Security/GitHubAuthenticationTests.cs` |
+| GitHub options fail-closed validation, one-time stores (TTL/one-use/bounded), session token claims + validation, id/login/active-org allowlist (fail-closed) | `tests/RetailPulse.Tests/Security/GitHubAuthOptionsTests.cs`, `GitHubOneTimeStoreTests.cs`, `GitHubSessionTokenTests.cs`, `GitHubUserAllowlistTests.cs` |
 | Anonymous bootstrap, token validation, read-only 403, **both hubs 403 (connect + negotiate)**, budget/rate breakers, isolation, threat cases | `tests/RetailPulse.Tests/Security/AnonymousAuthenticationTests.cs` |
 | Anonymous options fail-closed validation, token claims (no PII), capability policy (hubs denied), normalizer | `tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs` |
 | Chat-internal bypasses closed: memory-management refusal (zero memory mutation), council refusal (zero `ConveneAsync`), single accounted pipeline with truthful cost/audit | `tests/RetailPulse.Tests/Security/AnonymousChatInternalBypassTests.cs` |
 | Endpoint graph policy: anonymous surface is bootstrap + `POST /api/chat` only; both hubs denied; REST + hubs carry authorization metadata | `tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs` |
 | Entra hub behaviour unchanged by the anonymous scope reduction | `tests/RetailPulse.Tests/Security/AnonymousHubOwnershipTests.cs` |
 | Normalized principal mapping | `tests/RetailPulse.Tests/Security/NormalizedPrincipalTests.cs` |
-| Production / hooks pinned to Entra, never GitHub/Anonymous; single-replica pin | `tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs` |
+| Production / hooks pinned to Entra, never GitHub/Anonymous; single-replica pin; GitHub example config not auto-loaded and secret-free | `tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs` |
 
 See [ADR-005](adr/005-provider-neutral-authentication.md) for the design and
 threat model, and [Entra authentication](authentication-entra.md) for the

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -254,6 +254,15 @@ All three Container Apps use `minReplicas: 0` / `maxReplicas: 1`. Consequences:
   conservative limits — it is explicitly not equivalent to authenticated production.
   See [ADR-005](adr/005-provider-neutral-authentication.md) and the
   [authentication matrix](authentication-matrix.md).
+- **GitHub mode (if opted-in) is replica-local too:** GitHub confidential-OAuth
+  mode is **not deployed** and is permitted hosted only with a complete validated
+  (secret-bearing) configuration. When enabled, its OAuth **state store** and its
+  one-time **redemption-code store** (both bounded, one-use, TTL-expiring) are held
+  in replica-local memory. A login `callback` served by one replica and the
+  `POST /api/auth/github/exchange` served by another would not share state, so
+  hosted GitHub requires `maxReplicas: 1` until the stores are moved to distributed
+  storage. See [ADR-005](adr/005-provider-neutral-authentication.md) and the
+  [authentication matrix](authentication-matrix.md).
 - **SignalR:** the Teams Bot holds a persistent SignalR connection to the API telemetry
   hub, and the frontend connects to `/hubs/telemetry` and `/hubs/streaming`. An active
   SignalR/WebSocket connection keeps the API replica warm; once all clients disconnect

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -261,7 +261,10 @@ All three Container Apps use `minReplicas: 0` / `maxReplicas: 1`. Consequences:
   in replica-local memory. A login `callback` served by one replica and the
   `POST /api/auth/github/exchange` served by another would not share state, so
   hosted GitHub requires `maxReplicas: 1` until the stores are moved to distributed
-  storage. See [ADR-005](adr/005-provider-neutral-authentication.md) and the
+  storage. Because the runtime cannot inspect ACA topology, hosted GitHub also
+  requires an explicit `AcknowledgeSingleReplica=true` fail-closed acknowledgement
+  of that pin (startup fails without it). See
+  [ADR-005](adr/005-provider-neutral-authentication.md) and the
   [authentication matrix](authentication-matrix.md).
 - **SignalR:** the Teams Bot holds a persistent SignalR connection to the API telemetry
   hub, and the frontend connects to `/hubs/telemetry` and `/hubs/streaming`. An active

--- a/docs/security.md
+++ b/docs/security.md
@@ -253,7 +253,9 @@ deployment-contract tests). It is **not deployed** this sprint.
 
 ### Development
 - `Security:RequireAuth` defaults to `false`
-- No API key required
+- `Authentication:Mode` defaults to `Entra`, whose `DevelopmentAuthHandler`
+  stamps a synthetic local identity. This bypass exists only in Development.
+- No API key required.
 
 ### Production
 - **API Key:** Required via `x-api-key` header (configured in `ApiKey:Value`)

--- a/docs/security.md
+++ b/docs/security.md
@@ -75,8 +75,9 @@ fails closed — it never auto-detects a provider:
   that is **not deployed by default** (hosted only behind an explicit
   `Anonymous:AllowHosted=true` opt-in) — see
   [Anonymous mode](#anonymous-mode-opt-in-fail-closed) below.
-- `GitHub` is declared but not implemented in this sprint; selecting it fails
-  startup and never falls through to another provider.
+- `GitHub` is implemented (Sprint 2) as an **opt-in, fail-closed** confidential
+  OAuth backend-for-frontend capability that is **not deployed** — see
+  [GitHub mode](#github-mode-confidential-oauth-bff-opt-in-fail-closed) below.
 - A missing mode defaults to `Entra` **only in Development**. Outside
   Development a missing, unknown, or malformed mode fails startup.
 
@@ -169,8 +170,70 @@ It is not deployed this sprint.
   authenticated production; **all of these counters reset on restart or
   replica replacement**.
 
+### GitHub mode (confidential OAuth BFF, opt-in, fail-closed)
+
+GitHub mode lets a future self-serve frontend (Sprint 3) sign in with GitHub
+without exposing a GitHub provider token to the browser. It is additive and
+fail-closed, and the **live deployment artifacts stay Entra** (proven by
+deployment-contract tests). It is **not deployed** this sprint.
+
+- **Confidential backend-for-frontend (BFF).** GitHub OAuth Apps **do not support
+  PKCE**, so a browser-only exchange is impossible without leaking the client
+  secret or the provider token. The browser therefore talks only to our API: the
+  API holds the client secret, performs the authorization-code→token exchange
+  **server-side**, validates the user by calling `/user`, and the GitHub
+  **provider token never reaches the SPA** (it is used transiently server-side,
+  then discarded). Integration tests assert it never appears in any redirect,
+  response body, or log.
+- **Three narrowly-anonymous, rate-limited endpoints** (the only anonymous surface
+  besides health): `GET /api/auth/github/start`, `GET /api/auth/github/callback`,
+  `POST /api/auth/github/exchange`.
+- **Login-CSRF / fixation closed without PKCE.** `start` mints a random `state`
+  in a server-side **one-time** store **and** a separate random secret in an
+  HttpOnly/Secure/SameSite=Lax cookie (`__Host-` prefixed over HTTPS); only the
+  cookie secret's SHA-256 hash is stored server-side. `callback` requires both,
+  consumes the state atomically (one-use), and **constant-time** compares the
+  cookie hash **before any code exchange**, then deletes the state cookie on every
+  path (success or failure).
+- **Open-redirect / SSRF closed.** `start` redirects **only** to the fixed
+  `https://github.com/login/oauth/authorize`; the token, `/user`, and org-membership
+  calls use fixed GitHub endpoints; the SPA return is the **one** configured,
+  validated absolute-HTTPS frontend URL — no user-supplied redirect target is ever
+  honored.
+- **One-time redemption, no token in the redirect.** On success `callback`
+  redirects to the SPA carrying only a random, short-lived, single-use **redemption
+  code** (never a provider/app token). `exchange` atomically redeems it (replay/race
+  impossible) and returns the session token. There is no refresh token.
+- **Server-side allowlist, minimal scopes.** Authorization is decided server-side
+  on the **immutable numeric GitHub user id** first, then a configurable login
+  allowlist (login is informational identity only), and/or **active** org
+  membership (`/user/memberships/orgs/{org}`, `state==active`). **No `repo` scope
+  is ever requested**; scope is empty by default and `read:org` only when an org
+  allowlist is configured (private membership requires the user's `read:org`
+  consent). The allowlist **fails closed** on any GitHub API/rate/transport error.
+- **Retail Pulse session token.** A compact short-lived HS256 JWT (algorithm
+  pinned) with a **separate issuer/audience**, `provider=GitHub`, subject
+  `github:<immutable id>`, the required `RetailPulse.User` role + `access_as_user`
+  scope, a random `jti`, strict expiry, no PII beyond the public login, and no
+  refresh token. The ≥ 256-bit signing key is a secret with a rotation seam. It
+  works as a REST bearer and a SignalR `?access_token` (query token honored only on
+  `/hubs/*`), exactly like Entra. A dedicated policy requires `provider=GitHub`, so
+  Entra/Anonymous/cross-provider tokens can never satisfy it.
+  `GitHubPrincipalNormalizer` trusts only the numeric subject, never the mutable
+  login.
+- **Fail-closed hosted config.** `Authentication:Mode=GitHub` enables it;
+  Development may run with an ephemeral process-local signing key (sessions die on
+  restart) but still needs a client id/secret and an allowlist. Any hosted deploy
+  requires a complete validated set (client id/secret, ≥ 256-bit signing key,
+  issuer, audience, exact callback + frontend URLs, non-empty allowlist) — missing,
+  malformed, or angle-bracket **placeholder** secrets fail startup. The client id is
+  public; the client secret and signing key are secrets, never committed/logged.
+- **Limitation.** The state and redemption stores are **replica-local, in-memory**
+  (bounded, one-use, TTL with opportunistic cleanup), so hosted GitHub is pinned to
+  `maxReplicas=1` until they move to distributed storage; a callback and exchange
+  served by different replicas would not share state.
+
 ### Development
-- `DevelopmentAuthHandler` bypasses all authentication
 - `Security:RequireAuth` defaults to `false`
 - No API key required
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -190,11 +190,21 @@ deployment-contract tests). It is **not deployed** this sprint.
   `POST /api/auth/github/exchange`.
 - **Login-CSRF / fixation closed without PKCE.** `start` mints a random `state`
   in a server-side **one-time** store **and** a separate random secret in an
-  HttpOnly/Secure/SameSite=Lax cookie (`__Host-` prefixed over HTTPS); only the
-  cookie secret's SHA-256 hash is stored server-side. `callback` requires both,
-  consumes the state atomically (one-use), and **constant-time** compares the
-  cookie hash **before any code exchange**, then deletes the state cookie on every
-  path (success or failure).
+  HttpOnly cookie whose **Secure / `__Host-` attributes come from the validated
+  `RequireSecureCookies` option, never from `Request.IsHttps`** — behind a
+  TLS-terminating proxy (Azure Container Apps) the in-container request is plain
+  HTTP even though the browser↔edge hop is HTTPS, so deriving cookie security from
+  the observed scheme would silently emit an insecure cookie in production. In
+  hosted/secure mode the cookie is `__Host-` prefixed (Secure, HttpOnly,
+  SameSite=Lax, Path=/, no Domain); Development may explicitly opt into an insecure,
+  non-`__Host` dev cookie over plain HTTP (rejected at startup outside Development).
+  Only the cookie secret's SHA-256 hash is stored server-side. The cookie **name is
+  per-state** (`__Host-rp_gh_state_` + a bounded URL-safe suffix derived from the
+  state), so **parallel login tabs never clash** — each `callback` reads/deletes
+  only its own cookie. `callback` validates the state **format** first, requires
+  both signals, consumes the state atomically (one-use), and **constant-time**
+  compares the cookie hash **before any code exchange**, then deletes the state
+  cookie on every path (success or failure).
 - **Open-redirect / SSRF closed.** `start` redirects **only** to the fixed
   `https://github.com/login/oauth/authorize`; the token, `/user`, and org-membership
   calls use fixed GitHub endpoints; the SPA return is the **one** configured,
@@ -204,10 +214,13 @@ deployment-contract tests). It is **not deployed** this sprint.
   redirects to the SPA carrying only a random, short-lived, single-use **redemption
   code** (never a provider/app token). `exchange` atomically redeems it (replay/race
   impossible) and returns the session token. There is no refresh token.
-- **Server-side allowlist, minimal scopes.** Authorization is decided server-side
-  on the **immutable numeric GitHub user id** first, then a configurable login
-  allowlist (login is informational identity only), and/or **active** org
-  membership (`/user/memberships/orgs/{org}`, `state==active`). **No `repo` scope
+- **Server-side immutable allowlist, minimal scopes.** Authorization is decided
+  server-side on **immutable** signals only: the **numeric GitHub user id**
+  (`AllowedUserIds`, positive, deduped) and/or **active** org membership
+  (`/user/memberships/orgs/{org}`, `state==active`). The **mutable login handle
+  never grants access** — a renamed/re-created handle cannot inherit access
+  (handle-reuse denied), and a login-only allowlist fails startup. Startup **fails
+  closed** unless at least one immutable mechanism is configured. **No `repo` scope
   is ever requested**; scope is empty by default and `read:org` only when an org
   allowlist is configured (private membership requires the user's `read:org`
   consent). The allowlist **fails closed** on any GitHub API/rate/transport error.
@@ -215,23 +228,28 @@ deployment-contract tests). It is **not deployed** this sprint.
   pinned) with a **separate issuer/audience**, `provider=GitHub`, subject
   `github:<immutable id>`, the required `RetailPulse.User` role + `access_as_user`
   scope, a random `jti`, strict expiry, no PII beyond the public login, and no
-  refresh token. The ≥ 256-bit signing key is a secret with a rotation seam. It
-  works as a REST bearer and a SignalR `?access_token` (query token honored only on
-  `/hubs/*`), exactly like Entra. A dedicated policy requires `provider=GitHub`, so
-  Entra/Anonymous/cross-provider tokens can never satisfy it.
-  `GitHubPrincipalNormalizer` trusts only the numeric subject, never the mutable
-  login.
+  refresh token. The ≥ 256-bit signing key is a secret; **genuine key rotation** is
+  supported via `AdditionalValidationKeys` (validation-only strong keys keep
+  pre-rotation tokens valid while the current key signs; each key has a stable
+  material-derived `kid`). It works as a REST bearer and a SignalR `?access_token`
+  (query token honored only on `/hubs/*`), exactly like Entra. A dedicated policy
+  requires `provider=GitHub`, so Entra/Anonymous/cross-provider tokens can never
+  satisfy it. `GitHubPrincipalNormalizer` trusts only the numeric subject, never the
+  mutable login.
 - **Fail-closed hosted config.** `Authentication:Mode=GitHub` enables it;
   Development may run with an ephemeral process-local signing key (sessions die on
-  restart) but still needs a client id/secret and an allowlist. Any hosted deploy
-  requires a complete validated set (client id/secret, ≥ 256-bit signing key,
-  issuer, audience, exact callback + frontend URLs, non-empty allowlist) — missing,
+  restart) but still needs a client id/secret and an immutable allowlist. Any hosted
+  deploy requires a complete validated set (client id/secret, ≥ 256-bit signing key,
+  issuer, audience, exact callback + frontend URLs, immutable allowlist,
+  `RequireSecureCookies=true`, and `AcknowledgeSingleReplica=true`) — missing,
   malformed, or angle-bracket **placeholder** secrets fail startup. The client id is
   public; the client secret and signing key are secrets, never committed/logged.
 - **Limitation.** The state and redemption stores are **replica-local, in-memory**
   (bounded, one-use, TTL with opportunistic cleanup), so hosted GitHub is pinned to
   `maxReplicas=1` until they move to distributed storage; a callback and exchange
-  served by different replicas would not share state.
+  served by different replicas would not share state. Because the runtime cannot
+  inspect ACA topology, hosted GitHub requires an explicit
+  `AcknowledgeSingleReplica=true` fail-closed acknowledgement of that pin.
 
 ### Development
 - `Security:RequireAuth` defaults to `false`

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -51,13 +51,18 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       // options under evaluation.
       //
       // maxReplicas: 1 is ALSO a hard requirement for the (non-Production) Anonymous
-      // authentication mode: its billable-use circuit breaker (daily request/token/cost
-      // ceilings), its rate-limit windows (including the global bootstrap limiter), and
-      // its hub session-ownership registry are all replica-local in-memory state, so exact
-      // global enforcement only holds with a single replica (and all of it resets on
-      // restart or replica replacement). This live deployment stays Authentication:Mode=Entra;
-      // the constraint is documented here so a future Anonymous demo deployment cannot
-      // scale out and silently bypass the ceilings. See docs/adr/005 and docs/security.md.
+      // authentication mode AND the Sprint 2 GitHub confidential-OAuth BFF mode: the
+      // Anonymous billable-use circuit breaker (daily request/token/cost ceilings) and
+      // rate-limit windows, and the GitHub OAuth state/redemption one-time stores and
+      // login rate limiters, are all replica-local in-memory state, so exact global
+      // enforcement and cross-request continuity (a callback handled by replica A cannot
+      // redeem a code on replica B) only hold with a single replica (and all of it resets
+      // on restart or replica replacement). This live deployment stays
+      // Authentication:Mode=Entra; the constraint is documented here so a future Anonymous
+      // or GitHub demo deployment cannot scale out and silently bypass the ceilings or
+      // break the OAuth handshake. Hosted GitHub additionally requires an explicit
+      // GitHub:AcknowledgeSingleReplica=true fail-closed acknowledgement of this pin. See
+      // docs/adr/005 and docs/security.md.
       scale: {
         minReplicas: 0
         maxReplicas: 1

--- a/src/RetailPulse.Api/Auth/GitHubPrincipalNormalizer.cs
+++ b/src/RetailPulse.Api/Auth/GitHubPrincipalNormalizer.cs
@@ -1,0 +1,70 @@
+using System.Security.Claims;
+using Microsoft.IdentityModel.JsonWebTokens;
+using RetailPulse.Api.Security;
+using RetailPulse.Api.Security.GitHub;
+
+namespace RetailPulse.Api.Auth;
+
+/// <summary>
+/// Maps a validated GitHub session <see cref="ClaimsPrincipal"/> onto the provider-neutral
+/// <see cref="NormalizedPrincipal"/>.
+///
+/// The subject comes exclusively from the server-signed token's <c>sub</c> claim — the immutable
+/// <c>github:&lt;numeric id&gt;</c> established at login. The mutable login handle is projected only as
+/// the <see cref="NormalizedPrincipal.DisplayName"/> (informational) and is NEVER used as identity, so
+/// a renamed GitHub account cannot impersonate another. Roles and scopes are pinned to the verified
+/// GitHub set and the provider is always <c>GitHub</c>.
+/// </summary>
+public sealed class GitHubPrincipalNormalizer : IPrincipalNormalizer
+{
+    public AuthenticationMode Mode => AuthenticationMode.GitHub;
+
+    public NormalizedPrincipal Normalize(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        string? subject =
+            principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        // Trust ONLY an immutable numeric subject of the exact shape github:<digits>. A missing or
+        // malformed subject — or a subject that is really the mutable login — must never normalize.
+        if (string.IsNullOrWhiteSpace(subject)
+            || !subject.StartsWith(GitHubAuthConstants.SubjectPrefix, StringComparison.Ordinal)
+            || !long.TryParse(subject.AsSpan(GitHubAuthConstants.SubjectPrefix.Length), out long id)
+            || id <= 0)
+        {
+            throw new InvalidOperationException(
+                "Cannot normalize a GitHub principal without an immutable numeric 'github:<id>' subject.");
+        }
+
+        // Defense in depth: the token must carry the GitHub provider stamp.
+        string? provider = principal.FindFirst(GitHubAuthConstants.ProviderClaimType)?.Value;
+        if (!string.Equals(provider, GitHubAuthConstants.ProviderName, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Cannot normalize a principal whose provider claim is not 'GitHub'.");
+        }
+
+        // Informational display only — never identity.
+        string? displayName =
+            principal.FindFirst(GitHubAuthConstants.LoginClaimType)?.Value
+            ?? principal.FindFirst("name")?.Value;
+
+        string[] roles = [.. principal.FindAll("roles").Select(c => c.Value)
+            .Concat(principal.FindAll(ClaimTypes.Role).Select(c => c.Value))
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Distinct(StringComparer.Ordinal)];
+
+        string[] scopes = [.. principal.FindAll("scp").Select(c => c.Value)
+            .SelectMany(v => v.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Distinct(StringComparer.Ordinal)];
+
+        return new NormalizedPrincipal(
+            Provider: GitHubAuthConstants.ProviderName,
+            Subject: subject,
+            DisplayName: displayName,
+            Roles: roles,
+            Scopes: scopes);
+    }
+}

--- a/src/RetailPulse.Api/Endpoints/GitHubAuthEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/GitHubAuthEndpoints.cs
@@ -42,6 +42,9 @@ public static class GitHubAuthEndpoints
 
         app.MapGet(GitHubAuthConstants.CallbackRoute, CallbackAsync)
             .AllowAnonymous()
+            // The callback INTENTIONALLY shares the "github-start" fixed window: start + callback are the
+            // two halves of one login attempt, so they are budgeted together against the same per-replica
+            // window. Exchange has its own, separate window.
             .RequireRateLimiting(StartRateLimitPolicy)
             .WithName("GitHubAuthCallback")
             .WithTags("Authentication");
@@ -79,7 +82,7 @@ public static class GitHubAuthEndpoints
                 statusCode: StatusCodes.Status503ServiceUnavailable);
         }
 
-        AppendStateCookie(context, options, cookieSecret);
+        AppendStateCookie(context, options, state, cookieSecret);
 
         // Redirect ONLY to the fixed GitHub authorize URL with minimal scopes. redirect_uri is the
         // exact registered callback; allow_signup=false avoids account-creation flows in a demo.
@@ -111,20 +114,32 @@ public static class GitHubAuthEndpoints
         CancellationToken ct = context.RequestAborted;
 
         string? state = context.Request.Query["state"];
-        string? cookieSecret = context.Request.Cookies[CookieName(context)];
+
+        // Validate the state FORMAT before anything else: it must be exactly the fixed-length base64url
+        // shape our start emits. This bounds the cookie-name derivation below and rejects a malformed or
+        // oversized callback up front. (Format-valid ≠ known; the one-time store still gates authenticity.)
+        if (string.IsNullOrEmpty(state) || !GitHubStateCookie.IsValidStateFormat(state))
+        {
+            return Results.BadRequest(Problem("invalid_state", "Missing or invalid login state."));
+        }
+
+        // The cookie name is DERIVED from this specific state, so parallel login tabs never collide and
+        // this callback reads/deletes ONLY its own cookie.
+        string cookieName = GitHubStateCookie.NameFor(state, options.RequireSecureCookies);
+        string? cookieSecret = context.Request.Cookies[cookieName];
 
         // The state cookie is one-use: always delete it, whatever the outcome.
         // 1) State + cookie must both be present, or this is not a genuine callback from our start.
-        if (string.IsNullOrEmpty(state) || string.IsNullOrEmpty(cookieSecret))
+        if (string.IsNullOrEmpty(cookieSecret))
         {
-            DeleteStateCookie(context, options);
+            DeleteStateCookie(context, options, state);
             return Results.BadRequest(Problem("invalid_state", "Missing or invalid login state."));
         }
 
         // 2) Consume the state entry atomically (one-time). Missing/expired ⇒ CSRF / replay / timeout.
         if (!stateStore.TryConsume(state, out GitHubStateEntry entry))
         {
-            DeleteStateCookie(context, options);
+            DeleteStateCookie(context, options, state);
             return Results.BadRequest(Problem("invalid_state", "The login state is unknown, already used, or expired."));
         }
 
@@ -132,12 +147,12 @@ public static class GitHubAuthEndpoints
         //    (constant-time). This defeats state fixation and a stolen/guessed state without the cookie.
         if (!CryptographicOperations.FixedTimeEquals(Sha256(cookieSecret), entry.CookieSecretHash))
         {
-            DeleteStateCookie(context, options);
+            DeleteStateCookie(context, options, state);
             return Results.BadRequest(Problem("invalid_state", "The login state does not match this browser."));
         }
 
         // The flow is now proven to originate from our start in this browser. Retire the cookie.
-        DeleteStateCookie(context, options);
+        DeleteStateCookie(context, options, state);
 
         // 4) The user may have denied consent — handle safely, no token, redirect to the fixed frontend.
         string? oauthError = context.Request.Query["error"];
@@ -233,33 +248,31 @@ public static class GitHubAuthEndpoints
         return Results.Redirect(url);
     }
 
-    private static string CookieName(HttpContext context) =>
-        // The __Host- prefix (Secure + Path=/ + no Domain) is the strongest anti-fixation binding, but
-        // it requires HTTPS. Fall back to a plain name only over plain HTTP (local dev / test host).
-        context.Request.IsHttps ? GitHubAuthConstants.StateCookieName : "rp_gh_state";
+    private static string CookieName(GitHubAuthOptions options, string state) =>
+        // Per-state name so parallel login tabs never clash. Secure/__Host semantics come from validated
+        // configuration (RequireSecureCookies), NEVER from Request.IsHttps — behind a TLS-terminating
+        // proxy (ACA) the container request is plain HTTP even though the browser↔edge hop is HTTPS.
+        GitHubStateCookie.NameFor(state, options.RequireSecureCookies);
 
-    private static void AppendStateCookie(HttpContext context, GitHubAuthOptions options, string secret)
+    private static void AppendStateCookie(HttpContext context, GitHubAuthOptions options, string state, string secret)
     {
-        bool secure = context.Request.IsHttps;
-        context.Response.Cookies.Append(CookieName(context), secret, new CookieOptions
+        context.Response.Cookies.Append(CookieName(options, state), secret, new CookieOptions
         {
             HttpOnly = true,
-            Secure = secure,
+            Secure = options.RequireSecureCookies, // fixed by config, not the observed scheme
             SameSite = SameSiteMode.Lax, // top-level GET navigation back from github.com carries it
-            Path = "/",
+            Path = "/", // __Host- requires Path=/ and no Domain
             IsEssential = true,
             MaxAge = TimeSpan.FromSeconds(options.StateTtlSeconds),
         });
     }
 
-    private static void DeleteStateCookie(HttpContext context, GitHubAuthOptions options)
+    private static void DeleteStateCookie(HttpContext context, GitHubAuthOptions options, string state)
     {
-        _ = options;
-        bool secure = context.Request.IsHttps;
-        context.Response.Cookies.Delete(CookieName(context), new CookieOptions
+        context.Response.Cookies.Delete(CookieName(options, state), new CookieOptions
         {
             HttpOnly = true,
-            Secure = secure,
+            Secure = options.RequireSecureCookies,
             SameSite = SameSiteMode.Lax,
             Path = "/",
         });

--- a/src/RetailPulse.Api/Endpoints/GitHubAuthEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/GitHubAuthEndpoints.cs
@@ -1,0 +1,279 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using RetailPulse.Api.Security;
+using RetailPulse.Api.Security.GitHub;
+
+namespace RetailPulse.Api.Endpoints;
+
+/// <summary>
+/// The three narrowly-anonymous endpoints of the GitHub confidential Backend-for-Frontend (BFF)
+/// OAuth flow. Mapped only when <c>Authentication:Mode=GitHub</c>. The GitHub PROVIDER token never
+/// reaches the browser — it is used transiently on the server to validate the user and read org
+/// membership, then discarded. The SPA only ever receives a short-lived one-time redemption code and,
+/// after exchanging it, a short-lived Retail Pulse session token.
+///
+/// Flow:
+/// <list type="number">
+///   <item><b>start</b> (GET) — mints a random state bound to an HttpOnly/Secure/SameSite=Lax cookie
+///     and a server-side one-time store, then redirects to the fixed GitHub authorize URL with
+///     minimal scopes. No user-supplied redirect target is honoured (open-redirect closed).</item>
+///   <item><b>callback</b> (GET) — validates state + cookie + TTL + one-use BEFORE any code exchange,
+///     exchanges the code server-side, validates the token via <c>/user</c>, verifies the server-side
+///     allowlist, and redirects to the ONE configured SPA URL carrying only a one-time redemption
+///     code (never a provider/app token). Denials and errors are handled without leaking anything.</item>
+///   <item><b>exchange</b> (POST) — atomically redeems the one-time code and returns a short-lived
+///     Retail Pulse GitHub session token (no refresh token). Replay/races are impossible (one-use).</item>
+/// </list>
+/// </summary>
+public static class GitHubAuthEndpoints
+{
+    public const string StartRateLimitPolicy = "github-start";
+    public const string ExchangeRateLimitPolicy = "github-exchange";
+
+    public static WebApplication MapGitHubAuthEndpoints(this WebApplication app)
+    {
+        app.MapGet(GitHubAuthConstants.StartRoute, StartAsync)
+            .AllowAnonymous()
+            .RequireRateLimiting(StartRateLimitPolicy)
+            .WithName("GitHubAuthStart")
+            .WithTags("Authentication");
+
+        app.MapGet(GitHubAuthConstants.CallbackRoute, CallbackAsync)
+            .AllowAnonymous()
+            .RequireRateLimiting(StartRateLimitPolicy)
+            .WithName("GitHubAuthCallback")
+            .WithTags("Authentication");
+
+        app.MapPost(GitHubAuthConstants.ExchangeRoute, ExchangeAsync)
+            .AllowAnonymous()
+            .RequireRateLimiting(ExchangeRateLimitPolicy)
+            .WithName("GitHubAuthExchange")
+            .WithTags("Authentication");
+
+        return app;
+    }
+
+    // ── start ──────────────────────────────────────────────────────────────────
+    private static IResult StartAsync(
+        HttpContext context,
+        GitHubAuthOptions options,
+        GitHubStateStore stateStore,
+        TimeProvider? timeProvider = null)
+    {
+        TimeProvider clock = timeProvider ?? TimeProvider.System;
+
+        // Random, unguessable state (server-side one-time entry) + a separate random secret placed in
+        // the browser-bound cookie. Verification at callback requires BOTH — defeating login-CSRF and
+        // state fixation (an attacker cannot both know our state and set our HttpOnly cookie).
+        string state = GitHubRandom.NewToken();
+        string cookieSecret = GitHubRandom.NewToken();
+        long expiresAt = clock.GetUtcNow().UtcDateTime.AddSeconds(options.StateTtlSeconds).Ticks;
+
+        if (!stateStore.TryStore(state, new GitHubStateEntry(Sha256(cookieSecret), expiresAt)))
+        {
+            return Results.Problem(
+                title: "github_start_unavailable",
+                detail: "The login state store is temporarily at capacity. Please retry shortly.",
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        AppendStateCookie(context, options, cookieSecret);
+
+        // Redirect ONLY to the fixed GitHub authorize URL with minimal scopes. redirect_uri is the
+        // exact registered callback; allow_signup=false avoids account-creation flows in a demo.
+        var query = new Dictionary<string, string?>
+        {
+            ["client_id"] = options.ClientId,
+            ["redirect_uri"] = options.CallbackUrl,
+            ["state"] = state,
+            ["scope"] = options.RequestedScopes,
+            ["allow_signup"] = "false",
+        };
+        string authorizeUrl = QueryHelpers.AddQueryString(GitHubAuthConstants.AuthorizeUrl, query);
+        return Results.Redirect(authorizeUrl);
+    }
+
+    // ── callback ─────────────────────────────────────────────────────────────────
+    private static async Task<IResult> CallbackAsync(
+        HttpContext context,
+        GitHubAuthOptions options,
+        GitHubStateStore stateStore,
+        GitHubRedemptionStore redemptionStore,
+        IGitHubOAuthClient oauthClient,
+        GitHubUserAllowlist allowlist,
+        ILoggerFactory loggerFactory,
+        TimeProvider? timeProvider = null)
+    {
+        ILogger logger = loggerFactory.CreateLogger("GitHubAuthCallback");
+        TimeProvider clock = timeProvider ?? TimeProvider.System;
+        CancellationToken ct = context.RequestAborted;
+
+        string? state = context.Request.Query["state"];
+        string? cookieSecret = context.Request.Cookies[CookieName(context)];
+
+        // The state cookie is one-use: always delete it, whatever the outcome.
+        // 1) State + cookie must both be present, or this is not a genuine callback from our start.
+        if (string.IsNullOrEmpty(state) || string.IsNullOrEmpty(cookieSecret))
+        {
+            DeleteStateCookie(context, options);
+            return Results.BadRequest(Problem("invalid_state", "Missing or invalid login state."));
+        }
+
+        // 2) Consume the state entry atomically (one-time). Missing/expired ⇒ CSRF / replay / timeout.
+        if (!stateStore.TryConsume(state, out GitHubStateEntry entry))
+        {
+            DeleteStateCookie(context, options);
+            return Results.BadRequest(Problem("invalid_state", "The login state is unknown, already used, or expired."));
+        }
+
+        // 3) Bind the state to THIS browser: the cookie secret must hash to the stored value
+        //    (constant-time). This defeats state fixation and a stolen/guessed state without the cookie.
+        if (!CryptographicOperations.FixedTimeEquals(Sha256(cookieSecret), entry.CookieSecretHash))
+        {
+            DeleteStateCookie(context, options);
+            return Results.BadRequest(Problem("invalid_state", "The login state does not match this browser."));
+        }
+
+        // The flow is now proven to originate from our start in this browser. Retire the cookie.
+        DeleteStateCookie(context, options);
+
+        // 4) The user may have denied consent — handle safely, no token, redirect to the fixed frontend.
+        string? oauthError = context.Request.Query["error"];
+        if (!string.IsNullOrEmpty(oauthError))
+        {
+            logger.LogInformation("GitHub login was not completed (provider error).");
+            return RedirectToFrontend(options, "error", "access_denied");
+        }
+
+        string? code = context.Request.Query["code"];
+        if (string.IsNullOrEmpty(code))
+        {
+            return Results.BadRequest(Problem("missing_code", "No authorization code was returned."));
+        }
+
+        // 5) Confidential server-side exchange. The provider token stays on the server.
+        GitHubTokenResult tokenResult = await oauthClient.ExchangeCodeAsync(code, ct);
+        if (!tokenResult.Success || string.IsNullOrEmpty(tokenResult.AccessToken))
+        {
+            logger.LogWarning("GitHub code exchange failed: {Reason}", tokenResult.Error);
+            return RedirectToFrontend(options, "error", "login_failed");
+        }
+
+        string providerToken = tokenResult.AccessToken;
+
+        // 6) Validate the provider token by reading the authenticated user (immutable id + login).
+        GitHubUserResult userResult = await oauthClient.GetUserAsync(providerToken, ct);
+        if (!userResult.Success)
+        {
+            logger.LogWarning("GitHub /user validation failed: {Reason}", userResult.Error);
+            return RedirectToFrontend(options, "error", "login_failed");
+        }
+
+        var verified = new GitHubVerifiedUser(userResult.UserId, userResult.Login);
+
+        // 7) Server-side allowlist (immutable numeric id / login / active org membership). Fail closed.
+        GitHubAllowlistDecision decision = await allowlist.EvaluateAsync(verified, providerToken, ct);
+        if (!decision.Allowed)
+        {
+            logger.LogInformation("GitHub user {UserId} denied by allowlist ({Reason}).", verified.UserId, decision.Reason);
+            return RedirectToFrontend(options, "error", "not_authorized");
+        }
+
+        // 8) Mint a one-time redemption code bound to the verified identity (NOT a token). The app
+        //    session JWT is minted fresh at exchange so its short TTL starts when the SPA receives it.
+        string redemptionCode = GitHubRandom.NewToken();
+        long redeemBy = clock.GetUtcNow().UtcDateTime.AddSeconds(options.RedemptionTtlSeconds).Ticks;
+        if (!redemptionStore.TryStore(redemptionCode, new GitHubRedemptionEntry(verified, redeemBy)))
+        {
+            return Results.Problem(
+                title: "github_callback_unavailable",
+                detail: "The login redemption store is temporarily at capacity. Please retry shortly.",
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        // 9) Redirect to the ONE configured SPA URL carrying only the one-time redemption code.
+        return RedirectToFrontend(options, "code", redemptionCode);
+    }
+
+    // ── exchange ─────────────────────────────────────────────────────────────────
+    private static IResult ExchangeAsync(
+        [FromBody] GitHubExchangeRequest request,
+        GitHubRedemptionStore redemptionStore,
+        IGitHubSessionTokenService tokenService)
+    {
+        if (request is null || string.IsNullOrWhiteSpace(request.Code))
+        {
+            return Results.BadRequest(Problem("invalid_request", "A redemption code is required."));
+        }
+
+        // Atomic one-time redemption — a second attempt (replay) or a race can never both succeed.
+        if (!redemptionStore.TryConsume(request.Code, out GitHubRedemptionEntry entry))
+        {
+            return Results.BadRequest(Problem("invalid_code", "The redemption code is unknown, already used, or expired."));
+        }
+
+        GitHubSession session = tokenService.CreateSession(entry.User);
+        return Results.Ok(new
+        {
+            token = session.Token,
+            tokenType = "Bearer",
+            expiresInSeconds = session.ExpiresInSeconds,
+            subject = session.Subject,
+        });
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────
+    private static IResult RedirectToFrontend(GitHubAuthOptions options, string key, string value)
+    {
+        // The frontend URL is a fixed, validated, absolute HTTPS config value — never user input — so
+        // this can never become an open redirect. Only a code OR an error code is ever appended.
+        string url = QueryHelpers.AddQueryString(options.FrontendReturnUrl, key, value);
+        return Results.Redirect(url);
+    }
+
+    private static string CookieName(HttpContext context) =>
+        // The __Host- prefix (Secure + Path=/ + no Domain) is the strongest anti-fixation binding, but
+        // it requires HTTPS. Fall back to a plain name only over plain HTTP (local dev / test host).
+        context.Request.IsHttps ? GitHubAuthConstants.StateCookieName : "rp_gh_state";
+
+    private static void AppendStateCookie(HttpContext context, GitHubAuthOptions options, string secret)
+    {
+        bool secure = context.Request.IsHttps;
+        context.Response.Cookies.Append(CookieName(context), secret, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = secure,
+            SameSite = SameSiteMode.Lax, // top-level GET navigation back from github.com carries it
+            Path = "/",
+            IsEssential = true,
+            MaxAge = TimeSpan.FromSeconds(options.StateTtlSeconds),
+        });
+    }
+
+    private static void DeleteStateCookie(HttpContext context, GitHubAuthOptions options)
+    {
+        _ = options;
+        bool secure = context.Request.IsHttps;
+        context.Response.Cookies.Delete(CookieName(context), new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = secure,
+            SameSite = SameSiteMode.Lax,
+            Path = "/",
+        });
+    }
+
+    private static byte[] Sha256(string value) => SHA256.HashData(Encoding.UTF8.GetBytes(value));
+
+    private static object Problem(string code, string detail) => new
+    {
+        type = $"https://retail-pulse/errors/{code}",
+        title = code,
+        detail,
+    };
+
+    /// <summary>Body of the exchange request: the one-time redemption code from the callback redirect.</summary>
+    public sealed record GitHubExchangeRequest(string? Code);
+}

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -147,6 +147,7 @@ builder.Services.AddCors(options =>
 AuthenticationMode resolvedAuthMode =
     AuthenticationModeOptions.Resolve(builder.Configuration, builder.Environment);
 bool anonymousAuthMode = resolvedAuthMode == AuthenticationMode.Anonymous;
+bool gitHubAuthMode = resolvedAuthMode == AuthenticationMode.GitHub;
 
 EntraAuthOptions? entraAuthOptions =
     builder.Services.AddProviderNeutralAuthentication(builder.Configuration, builder.Environment);
@@ -213,6 +214,32 @@ builder.Services.AddRateLimiter(options =>
             {
                 PermitLimit = builder.Configuration.GetValue("Anonymous:Bootstrap:GlobalPerMinute",
                     builder.Configuration.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 5)),
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+            }));
+
+    // Rate limiters for the GitHub confidential OAuth BFF endpoints. Always registered so the limiter
+    // graph is stable and testable; only used when Authentication:Mode=GitHub maps the endpoints.
+    // Behind ACA the client IP is the proxy's and X-Forwarded-For is forgeable, so these are single
+    // GLOBAL per-replica fixed windows (not per-IP) that cap login-flow abuse (state minting and code
+    // redemption) without being bypassable by header spoofing. Replica-local; hosted GitHub runs at
+    // maxReplicas=1. Config keys: GitHub:RateLimits:StartPerMinute / ExchangePerMinute.
+    options.AddPolicy("github-start", _ =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: "github-start-global",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = builder.Configuration.GetValue("GitHub:RateLimits:StartPerMinute", 10),
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+            }));
+
+    options.AddPolicy("github-exchange", _ =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: "github-exchange-global",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = builder.Configuration.GetValue("GitHub:RateLimits:ExchangePerMinute", 20),
                 Window = TimeSpan.FromMinutes(1),
                 QueueLimit = 0,
             }));
@@ -1049,6 +1076,15 @@ app.MapCacheEndpoints();
 if (anonymousAuthMode)
 {
     app.MapAnonymousAuthEndpoints();
+}
+
+// GitHub mode: map the three narrowly-anonymous confidential OAuth BFF endpoints (start / callback /
+// exchange). Mapped only when Authentication:Mode=GitHub so no GitHub surface exists in Entra
+// deployments. The GitHub provider token never reaches the browser; the SPA receives only a one-time
+// redemption code and, after exchange, a short-lived Retail Pulse session token.
+if (gitHubAuthMode)
+{
+    app.MapGitHubAuthEndpoints();
 }
 
 app.Run();

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -140,8 +140,8 @@ builder.Services.AddCors(options =>
 // honours the access_token query param only for /hubs, and requires the app role + API
 // scope on every protected endpoint and hub. Development uses the synthetic handler. The
 // default policy is never permissive — no RequireAssertion(_ => true) when auth is on.
-// GitHub mode is declared but fails startup ("not implemented in this sprint"); a missing mode
-// fails closed outside Development. Anonymous mode (Sprint 1) wires its own constrained session
+// GitHub mode wires a confidential OAuth BFF and short-lived Retail Pulse session tokens.
+// A missing mode fails closed outside Development. Anonymous mode (Sprint 1) wires its own constrained session
 // scheme + guardrails internally and returns null (see AddAnonymousMode); it never falls through
 // to Entra/Development and, in a hosted environment, requires a second explicit opt-in.
 AuthenticationMode resolvedAuthMode =

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousAuthOptions.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousAuthOptions.cs
@@ -34,6 +34,15 @@ public sealed class AnonymousAuthOptions
     /// <summary>HMAC signing key (secret). Required in hosted mode; ephemeral in Development.</summary>
     public string? SigningKey { get; init; }
 
+    /// <summary>
+    /// Additional strong HMAC keys accepted for VALIDATION only (never used to sign) — genuine
+    /// signing-key rotation, mirroring the GitHub provider. Publish the next key here alongside the
+    /// current <see cref="SigningKey"/>, deploy, then promote it on the next rotation; tokens signed with
+    /// the previous key keep validating until they expire. Each entry must be ≥256-bit; placeholders are
+    /// rejected. The current signing key is always tried first.
+    /// </summary>
+    public IReadOnlyList<string> AdditionalValidationKeys { get; init; } = [];
+
     public string Role { get; init; } = AnonymousCapabilityPolicy.DefaultRole;
     public string Scope { get; init; } = AnonymousCapabilityPolicy.DefaultScope;
 
@@ -105,6 +114,7 @@ public sealed class AnonymousAuthOptions
             Audience = Clean(section["Audience"]) ?? "retail-pulse-api",
             SessionTokenTtlSeconds = section.GetValue("SessionTokenTtlSeconds", 900),
             SigningKey = Clean(section["SigningKey"]),
+            AdditionalValidationKeys = CleanList(section.GetSection("AdditionalValidationKeys").Get<string[]>()),
             Role = Clean(section["Role"]) ?? AnonymousCapabilityPolicy.DefaultRole,
             Scope = Clean(section["Scope"]) ?? AnonymousCapabilityPolicy.DefaultScope,
             MaxOutputTokens = section.GetValue("MaxOutputTokens", 512),
@@ -139,6 +149,18 @@ public sealed class AnonymousAuthOptions
         {
             throw new InvalidOperationException(
                 "Anonymous:Issuer and Anonymous:Audience are required so session tokens can be validated.");
+        }
+
+        // Rotation keys must be strong wherever configured — a weak validation key would accept forged
+        // tokens in any environment.
+        foreach (string extra in AdditionalValidationKeys)
+        {
+            if (Encoding.UTF8.GetByteCount(extra) < 32)
+            {
+                throw new InvalidOperationException(
+                    "Anonymous:AdditionalValidationKeys entries must each be at least 32 bytes (256-bit). " +
+                    "A weak rotation key would validate forged tokens and fails closed.");
+            }
         }
 
         if (!enforce)
@@ -189,6 +211,9 @@ public sealed class AnonymousAuthOptions
 
     private static bool IsPlaceholder(string? value) =>
         !string.IsNullOrWhiteSpace(value) && (value.Contains('<') || value.Contains('>'));
+
+    private static IReadOnlyList<string> CleanList(string[]? raw) =>
+        raw is null ? [] : [.. raw.Select(Clean).Where(v => v is not null).Select(v => v!)];
 
     private static string? Clean(string? value)
     {

--- a/src/RetailPulse.Api/Security/Anonymous/AnonymousSigningKeyProvider.cs
+++ b/src/RetailPulse.Api/Security/Anonymous/AnonymousSigningKeyProvider.cs
@@ -20,6 +20,8 @@ namespace RetailPulse.Api.Security.Anonymous;
 /// </summary>
 public sealed class AnonymousSigningKeyProvider
 {
+    private readonly IReadOnlyList<SecurityKey> _validationKeys;
+
     /// <summary>True when the key was generated ephemerally (Development, no configured secret).</summary>
     public bool IsEphemeral { get; }
 
@@ -29,10 +31,8 @@ public sealed class AnonymousSigningKeyProvider
 
         if (options.HasConfiguredSigningKey)
         {
-            Key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(options.SigningKey!))
-            {
-                KeyId = "anon-configured",
-            };
+            byte[] material = Encoding.UTF8.GetBytes(options.SigningKey!);
+            Key = new SymmetricSecurityKey(material) { KeyId = KeyIdFor(material) };
             IsEphemeral = false;
         }
         else
@@ -42,11 +42,33 @@ public sealed class AnonymousSigningKeyProvider
             Key = new SymmetricSecurityKey(material) { KeyId = "anon-ephemeral" };
             IsEphemeral = true;
         }
+
+        // Genuine rotation (parity with GitHub): current signing key first, then each configured
+        // validation-only key. Each key gets a STABLE, key-material-derived id so a token keeps the
+        // same kid after its key is demoted to validation-only — that is what lets an in-flight token
+        // resolve to its original key across a rotation. Options validation already rejected
+        // weak/placeholder rotation keys.
+        var keys = new List<SecurityKey> { Key };
+        for (int i = 0; i < options.AdditionalValidationKeys.Count; i++)
+        {
+            byte[] extra = Encoding.UTF8.GetBytes(options.AdditionalValidationKeys[i]);
+            keys.Add(new SymmetricSecurityKey(extra) { KeyId = KeyIdFor(extra) });
+        }
+
+        _validationKeys = keys;
     }
+
+    // A deterministic, non-reversible id for a key: the first bytes of SHA-256(key material). Stable
+    // across process restarts and rotation "slots", so a demoted signing key keeps the same kid.
+    private static string KeyIdFor(byte[] material) =>
+        "anon-" + Convert.ToHexString(SHA256.HashData(material))[..12].ToLowerInvariant();
 
     /// <summary>The active signing key for token creation and validation.</summary>
     public SymmetricSecurityKey Key { get; }
 
-    /// <summary>All keys accepted for validation. Kept as a seam for future key rotation.</summary>
-    public IEnumerable<SecurityKey> ValidationKeys => [Key];
+    /// <summary>
+    /// All keys accepted for validation: the active signing key first, then every configured rotation
+    /// (validation-only) key, so tokens issued before a rotation stay valid until they expire.
+    /// </summary>
+    public IEnumerable<SecurityKey> ValidationKeys => _validationKeys;
 }

--- a/src/RetailPulse.Api/Security/GitHub/GitHubAuthConstants.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubAuthConstants.cs
@@ -1,0 +1,61 @@
+namespace RetailPulse.Api.Security.GitHub;
+
+/// <summary>
+/// Single source of truth for the GitHub authentication mode's identifiers: the normalized
+/// provider name, the token claim types, the constrained-but-full app role/scope a verified
+/// GitHub session carries, and the three narrowly-anonymous BFF endpoint routes.
+///
+/// GitHub mode is a backend-for-frontend (BFF) confidential OAuth flow. The GitHub provider
+/// access token never reaches the browser: the backend performs the code→token exchange, validates
+/// the token by calling <c>/user</c>, verifies a server-side allowlist, and only then mints the
+/// app's OWN short-lived session token. These constants keep the endpoints, the token service, the
+/// authorization policy, the normalizer, and the tests all reasoning about the same values.
+/// </summary>
+public static class GitHubAuthConstants
+{
+    /// <summary>The normalized provider name stamped on every GitHub principal/token.</summary>
+    public const string ProviderName = "GitHub";
+
+    /// <summary>Claim type that records the issuing provider on the session token.</summary>
+    public const string ProviderClaimType = "provider";
+
+    /// <summary>
+    /// Informational-only claim carrying the GitHub login handle. It is NEVER identity — the login
+    /// is mutable and a renamed account could impersonate another. Identity is the immutable numeric
+    /// id in the <c>sub</c> claim (<see cref="SubjectPrefix"/>).
+    /// </summary>
+    public const string LoginClaimType = "github_login";
+
+    /// <summary>
+    /// Prefix for the immutable subject: <c>github:&lt;numeric id&gt;</c>. The numeric id is the only
+    /// stable, non-reassignable GitHub identifier and is the sole basis for identity/authorization.
+    /// </summary>
+    public const string SubjectPrefix = "github:";
+
+    /// <summary>
+    /// App role a verified GitHub session carries. Full authenticated capabilities are acceptable in
+    /// GitHub mode ONLY after server-side allowlist verification succeeds, so this is the same role
+    /// the Entra boundary requires (<c>RetailPulse.User</c>).
+    /// </summary>
+    public const string DefaultRole = "RetailPulse.User";
+
+    /// <summary>Delegated scope a verified GitHub session carries (matches the Entra API scope).</summary>
+    public const string DefaultScope = "access_as_user";
+
+    // ── BFF endpoint routes (the ONLY narrowly-anonymous GitHub surface) ──────────
+    public const string StartRoute = "/api/auth/github/start";
+    public const string CallbackRoute = "/api/auth/github/callback";
+    public const string ExchangeRoute = "/api/auth/github/exchange";
+
+    // ── Fixed GitHub endpoints (SSRF defense: these are the ONLY hosts/paths ever called) ──
+    public const string AuthorizeUrl = "https://github.com/login/oauth/authorize";
+    public const string AccessTokenUrl = "https://github.com/login/oauth/access_token";
+    public const string UserApiUrl = "https://api.github.com/user";
+    public const string OrgMembershipUrlFormat = "https://api.github.com/user/memberships/orgs/{0}";
+
+    /// <summary>Name of the HttpOnly cookie that binds the browser to its OAuth state entry.</summary>
+    public const string StateCookieName = "__Host-rp_gh_state";
+
+    /// <summary>Path the state cookie is scoped to — the GitHub auth surface only.</summary>
+    public const string StateCookiePath = "/api/auth/github";
+}

--- a/src/RetailPulse.Api/Security/GitHub/GitHubAuthConstants.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubAuthConstants.cs
@@ -53,9 +53,17 @@ public static class GitHubAuthConstants
     public const string UserApiUrl = "https://api.github.com/user";
     public const string OrgMembershipUrlFormat = "https://api.github.com/user/memberships/orgs/{0}";
 
-    /// <summary>Name of the HttpOnly cookie that binds the browser to its OAuth state entry.</summary>
-    public const string StateCookieName = "__Host-rp_gh_state";
+    /// <summary>
+    /// Cookie-name base for the browser-bound OAuth state cookie in HOSTED / secure mode. The final
+    /// name is per-state (<see cref="GitHubStateCookie.NameFor"/>) so parallel login tabs never clash;
+    /// the <c>__Host-</c> prefix pins Secure + Path=/ + no Domain, the strongest anti-fixation binding.
+    /// </summary>
+    public const string SecureStateCookieBase = "__Host-rp_gh_state_";
 
-    /// <summary>Path the state cookie is scoped to — the GitHub auth surface only.</summary>
-    public const string StateCookiePath = "/api/auth/github";
+    /// <summary>
+    /// Cookie-name base for the DEVELOPMENT-only insecure state cookie (plain HTTP, no <c>__Host-</c>
+    /// prefix). Only used when <see cref="GitHubAuthOptions.RequireSecureCookies"/> is explicitly false,
+    /// which is rejected at startup outside Development.
+    /// </summary>
+    public const string DevStateCookieBase = "rp_gh_state_";
 }

--- a/src/RetailPulse.Api/Security/GitHub/GitHubAuthOptions.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubAuthOptions.cs
@@ -16,8 +16,10 @@ namespace RetailPulse.Api.Security.GitHub;
 ///     <c>GitHub__SigningKey</c> or a secret store) and are never committed, logged, or emitted.</item>
 ///   <item>Any hosted (non-Development) deployment requires a COMPLETE, validated configuration —
 ///     client id + client secret + a ≥ 256-bit signing key + the exact API callback URL + the exact
-///     frontend return URL + at least one allowlist mechanism. A missing, malformed, or placeholder
-///     value throws at startup so a misconfigured hosted deploy never serves traffic.</item>
+///     frontend return URL + at least one IMMUTABLE allowlist mechanism (numeric user ids and/or active
+///     org membership) + secure-cookie enforcement + a single-replica acknowledgement. A missing,
+///     malformed, or placeholder value throws at startup so a misconfigured hosted deploy never serves
+///     traffic.</item>
 ///   <item>Development may run the same real OAuth flow with an ephemeral process-local signing key
 ///     (sessions die on restart) but STILL requires the real OAuth app credentials, exact URLs, and
 ///     an allowlist — there is no "allow everyone" shortcut.</item>
@@ -60,6 +62,34 @@ public sealed class GitHubAuthOptions
     /// <summary>HMAC signing key (secret). Required in hosted mode; ephemeral in Development.</summary>
     public string? SigningKey { get; init; }
 
+    /// <summary>
+    /// Additional strong HMAC keys accepted for VALIDATION only (never used to sign). This is genuine
+    /// signing-key rotation: publish the next key here alongside the current <see cref="SigningKey"/>,
+    /// deploy, then promote it to <see cref="SigningKey"/> on the next rotation — tokens signed with the
+    /// previous key keep validating until they expire. Each entry must be a strong (≥256-bit) secret;
+    /// angle-bracket placeholders are rejected. The current signing key is always tried first.
+    /// </summary>
+    public IReadOnlyList<string> AdditionalValidationKeys { get; init; } = [];
+
+    /// <summary>
+    /// When true (the ONLY value permitted outside Development), the browser-bound OAuth state cookie is
+    /// ALWAYS emitted with fixed <c>__Host-</c> semantics — Secure=true, HttpOnly=true, SameSite=Lax,
+    /// Path=/, no Domain — regardless of the in-container <c>Request.IsHttps</c>. This is required behind
+    /// a TLS-terminating proxy (Azure Container Apps): the browser↔edge hop is HTTPS even though the
+    /// edge↔container hop the app sees is plain HTTP, so cookie security MUST come from validated
+    /// configuration, never from the observed request scheme. Development MAY set this false to opt into
+    /// an insecure, non-<c>__Host</c> dev cookie over plain HTTP; that is rejected at startup elsewhere.
+    /// </summary>
+    public bool RequireSecureCookies { get; init; } = true;
+
+    /// <summary>
+    /// Explicit operator acknowledgement that the hosted GitHub deployment runs at <c>maxReplicas=1</c>.
+    /// The OAuth state and redemption stores (and the login rate limiters) are replica-local in-memory,
+    /// so a callback handled by replica A cannot redeem a code on replica B. The app cannot inspect ACA
+    /// topology at runtime, so a hosted GitHub deployment fails closed unless this flag is set true.
+    /// </summary>
+    public bool AcknowledgeSingleReplica { get; init; }
+
     public string Role { get; init; } = GitHubAuthConstants.DefaultRole;
     public string Scope { get; init; } = GitHubAuthConstants.DefaultScope;
 
@@ -70,13 +100,9 @@ public sealed class GitHubAuthOptions
     /// <summary>How long the one-time redemption code is valid before the SPA must exchange it.</summary>
     public int RedemptionTtlSeconds { get; init; } = 120;
 
-    // ── Allowlist (server-side, immutable numeric id / login / org membership) ─
-    /// <summary>Immutable numeric GitHub user ids explicitly allowed.</summary>
+    // ── Allowlist (server-side, immutable numeric id / active org membership) ─
+    /// <summary>Immutable numeric GitHub user ids explicitly allowed. The sole per-user identity gate.</summary>
     public IReadOnlyList<long> AllowedUserIds { get; init; } = [];
-
-    /// <summary>Configurable login-handle allowlist (case-insensitive). Convenience only — the numeric
-    /// id remains the identity; a matched login is still keyed to its immutable id.</summary>
-    public IReadOnlyList<string> AllowedLogins { get; init; } = [];
 
     /// <summary>Organizations whose ACTIVE members are allowed (verified via
     /// <c>/user/memberships/orgs/{org}</c>; requires the <c>read:org</c> scope).</summary>
@@ -119,12 +145,14 @@ public sealed class GitHubAuthOptions
             Audience = Clean(section["Audience"]) ?? "retail-pulse-api",
             SessionTokenTtlSeconds = section.GetValue("SessionTokenTtlSeconds", 900),
             SigningKey = Clean(section["SigningKey"]),
+            AdditionalValidationKeys = CleanList(section.GetSection("AdditionalValidationKeys").Get<string[]>()),
+            RequireSecureCookies = section.GetValue("RequireSecureCookies", true),
+            AcknowledgeSingleReplica = section.GetValue("AcknowledgeSingleReplica", false),
             Role = Clean(section["Role"]) ?? GitHubAuthConstants.DefaultRole,
             Scope = Clean(section["Scope"]) ?? GitHubAuthConstants.DefaultScope,
             StateTtlSeconds = section.GetValue("StateTtlSeconds", 300),
             RedemptionTtlSeconds = section.GetValue("RedemptionTtlSeconds", 120),
             AllowedUserIds = ParseUserIds(section.GetSection("AllowedUserIds").Get<string[]>()),
-            AllowedLogins = CleanList(section.GetSection("AllowedLogins").Get<string[]>()),
             AllowedOrgs = CleanList(section.GetSection("AllowedOrgs").Get<string[]>()),
             StartPerMinute = section.GetValue("RateLimits:StartPerMinute", 10),
             ExchangePerMinute = section.GetValue("RateLimits:ExchangePerMinute", 20),
@@ -168,13 +196,15 @@ public sealed class GitHubAuthOptions
         }
 
         // Fail closed on an empty allowlist: GitHub mode must NEVER admit every GitHub account. At
-        // least one of numeric id / login / org membership must be configured.
-        if (AllowedUserIds.Count == 0 && AllowedLogins.Count == 0 && AllowedOrgs.Count == 0)
+        // least one IMMUTABLE mechanism must be configured — numeric user ids and/or active org
+        // membership. A mutable login handle is deliberately NOT an access mechanism.
+        if (AllowedUserIds.Count == 0 && AllowedOrgs.Count == 0)
         {
             throw new InvalidOperationException(
-                "GitHub mode requires an explicit allowlist — configure at least one of " +
-                "GitHub:AllowedUserIds, GitHub:AllowedLogins, or GitHub:AllowedOrgs. An empty allowlist " +
-                "would admit every GitHub user and fails closed.");
+                "GitHub mode requires an explicit immutable allowlist — configure at least one of " +
+                "GitHub:AllowedUserIds (numeric ids) or GitHub:AllowedOrgs (active org membership). An " +
+                "empty allowlist would admit every GitHub user and fails closed. Login handles are " +
+                "mutable and never grant access.");
         }
 
         // The client secret and signing key are secrets. Required in any hosted environment; in
@@ -210,6 +240,43 @@ public sealed class GitHubAuthOptions
             throw new InvalidOperationException(
                 "GitHub:SigningKey must be at least 32 bytes (256-bit) when configured.");
         }
+
+        // Every additional VALIDATION key (rotation) must be strong wherever it is configured — a weak
+        // rotation key would validate forged tokens. Placeholders were already dropped by CleanList.
+        foreach (string extra in AdditionalValidationKeys)
+        {
+            if (Encoding.UTF8.GetByteCount(extra) < 32)
+            {
+                throw new InvalidOperationException(
+                    "GitHub:AdditionalValidationKeys entries must each be at least 32 bytes (256-bit). " +
+                    "A weak rotation key would validate forged tokens and fails closed.");
+            }
+        }
+
+        if (enforceSecret)
+        {
+            // Behind a TLS-terminating proxy the container request is plain HTTP; cookie security must
+            // therefore come from validated config, never the observed scheme. Refuse to run a hosted
+            // GitHub deployment that has opted out of secure cookies.
+            if (!RequireSecureCookies)
+            {
+                throw new InvalidOperationException(
+                    $"GitHub:RequireSecureCookies must be true for a hosted GitHub deployment " +
+                    $"('{environmentName}'). The insecure dev cookie (no __Host- prefix / no Secure) is " +
+                    "only permitted in Development over plain HTTP.");
+            }
+
+            // The stores/limiters are replica-local and the app cannot inspect ACA topology, so require
+            // an explicit single-replica acknowledgement rather than silently assuming it.
+            if (!AcknowledgeSingleReplica)
+            {
+                throw new InvalidOperationException(
+                    $"GitHub:AcknowledgeSingleReplica must be true for a hosted GitHub deployment " +
+                    $"('{environmentName}'). The OAuth state/redemption stores and login rate limiters " +
+                    "are replica-local in-memory, so hosted GitHub must run at maxReplicas=1; the runtime " +
+                    "cannot verify topology, so this acknowledgement is required and fails closed.");
+            }
+        }
     }
 
     private static IReadOnlyList<long> ParseUserIds(string[]? raw)
@@ -235,7 +302,10 @@ public sealed class GitHubAuthOptions
                     "GitHub user ids are positive integers.");
             }
 
-            ids.Add(id);
+            if (!ids.Contains(id))
+            {
+                ids.Add(id);
+            }
         }
 
         return ids;

--- a/src/RetailPulse.Api/Security/GitHub/GitHubAuthOptions.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubAuthOptions.cs
@@ -1,0 +1,293 @@
+using System.Text;
+using Microsoft.Extensions.Hosting;
+
+namespace RetailPulse.Api.Security.GitHub;
+
+/// <summary>
+/// Resolved, validated configuration for the GitHub authentication mode.
+///
+/// GitHub mode is a confidential backend-for-frontend (BFF) OAuth flow that ultimately mints a
+/// billable-capable, full <c>RetailPulse.User</c> session, so it is fail-closed by construction:
+/// <list type="bullet">
+///   <item>It only runs when <c>Authentication:Mode=GitHub</c> is set explicitly (resolved by
+///     <see cref="AuthenticationModeOptions"/>; no auto-detection).</item>
+///   <item>The GitHub OAuth <b>client id</b> is public configuration; the <b>client secret</b> and the
+///     <b>app session signing key</b> are SECRETS supplied at runtime (<c>GitHub__ClientSecret</c> /
+///     <c>GitHub__SigningKey</c> or a secret store) and are never committed, logged, or emitted.</item>
+///   <item>Any hosted (non-Development) deployment requires a COMPLETE, validated configuration —
+///     client id + client secret + a ≥ 256-bit signing key + the exact API callback URL + the exact
+///     frontend return URL + at least one allowlist mechanism. A missing, malformed, or placeholder
+///     value throws at startup so a misconfigured hosted deploy never serves traffic.</item>
+///   <item>Development may run the same real OAuth flow with an ephemeral process-local signing key
+///     (sessions die on restart) but STILL requires the real OAuth app credentials, exact URLs, and
+///     an allowlist — there is no "allow everyone" shortcut.</item>
+/// </list>
+/// Angle-bracket placeholder values (e.g. <c>&lt;set-via-secret-store&gt;</c>) from the example config
+/// are treated as absent and rejected, so a copied template can never accidentally authenticate.
+/// </summary>
+public sealed class GitHubAuthOptions
+{
+    public const string SectionName = "GitHub";
+
+    // ── OAuth app (confidential client) ──────────────────────────────────────
+    /// <summary>GitHub OAuth app client id. PUBLIC configuration (appears in the authorize URL).</summary>
+    public string ClientId { get; init; } = string.Empty;
+
+    /// <summary>GitHub OAuth app client secret. SECRET — never committed/logged; required hosted.</summary>
+    public string? ClientSecret { get; init; }
+
+    /// <summary>
+    /// The EXACT OAuth callback URL registered with the GitHub app and sent as <c>redirect_uri</c>
+    /// on both the authorize request and the token exchange. Must be the API's own
+    /// <see cref="GitHubAuthConstants.CallbackRoute"/> endpoint over HTTPS.
+    /// </summary>
+    public string CallbackUrl { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The ONE exact SPA/SWA URL the browser is redirected to after a successful login, carrying only
+    /// a short-lived one-time redemption code (never a provider or app token). No user-supplied
+    /// redirect target is ever honoured — this closes the open-redirect class.
+    /// </summary>
+    public string FrontendReturnUrl { get; init; } = string.Empty;
+
+    // ── App session token ────────────────────────────────────────────────────
+    public string Issuer { get; init; } = "retail-pulse-github";
+    public string Audience { get; init; } = "retail-pulse-api";
+
+    /// <summary>Short-lived session token TTL. Bounded to keep the replay window small. No refresh.</summary>
+    public int SessionTokenTtlSeconds { get; init; } = 900;
+
+    /// <summary>HMAC signing key (secret). Required in hosted mode; ephemeral in Development.</summary>
+    public string? SigningKey { get; init; }
+
+    public string Role { get; init; } = GitHubAuthConstants.DefaultRole;
+    public string Scope { get; init; } = GitHubAuthConstants.DefaultScope;
+
+    // ── Server-side one-time stores (TTL) ────────────────────────────────────
+    /// <summary>How long an issued OAuth state entry is valid (login must complete within this).</summary>
+    public int StateTtlSeconds { get; init; } = 300;
+
+    /// <summary>How long the one-time redemption code is valid before the SPA must exchange it.</summary>
+    public int RedemptionTtlSeconds { get; init; } = 120;
+
+    // ── Allowlist (server-side, immutable numeric id / login / org membership) ─
+    /// <summary>Immutable numeric GitHub user ids explicitly allowed.</summary>
+    public IReadOnlyList<long> AllowedUserIds { get; init; } = [];
+
+    /// <summary>Configurable login-handle allowlist (case-insensitive). Convenience only — the numeric
+    /// id remains the identity; a matched login is still keyed to its immutable id.</summary>
+    public IReadOnlyList<string> AllowedLogins { get; init; } = [];
+
+    /// <summary>Organizations whose ACTIVE members are allowed (verified via
+    /// <c>/user/memberships/orgs/{org}</c>; requires the <c>read:org</c> scope).</summary>
+    public IReadOnlyList<string> AllowedOrgs { get; init; } = [];
+
+    // ── Rate limits ──────────────────────────────────────────────────────────
+    public int StartPerMinute { get; init; } = 10;
+    public int ExchangePerMinute { get; init; } = 20;
+
+    /// <summary>True when a strong signing key was configured (not ephemerally generated).</summary>
+    public bool HasConfiguredSigningKey => IsPresent(SigningKey);
+
+    /// <summary>
+    /// The OAuth scopes requested at authorize time. Deliberately MINIMAL and never includes
+    /// <c>repo</c> or any write scope: an empty scope suffices to read the numeric id + login from
+    /// <c>/user</c>; <c>read:org</c> is added ONLY when an org allowlist is configured (required to
+    /// read org membership). Returned as a single space-delimited string for the authorize URL.
+    /// </summary>
+    public string RequestedScopes => AllowedOrgs.Count > 0 ? "read:org" : string.Empty;
+
+    /// <summary>
+    /// Resolves and validates options from configuration. Throws at startup for any missing,
+    /// malformed, or placeholder value that would make a GitHub deployment unsafe or non-functional.
+    /// </summary>
+    public static GitHubAuthOptions FromConfiguration(IConfiguration configuration, IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        IConfigurationSection section = configuration.GetSection(SectionName);
+        bool enforceSecret = !environment.IsDevelopment();
+
+        var options = new GitHubAuthOptions
+        {
+            ClientId = Clean(section["ClientId"]) ?? string.Empty,
+            ClientSecret = Clean(section["ClientSecret"]),
+            CallbackUrl = Clean(section["CallbackUrl"]) ?? string.Empty,
+            FrontendReturnUrl = Clean(section["FrontendReturnUrl"]) ?? string.Empty,
+            Issuer = Clean(section["Issuer"]) ?? "retail-pulse-github",
+            Audience = Clean(section["Audience"]) ?? "retail-pulse-api",
+            SessionTokenTtlSeconds = section.GetValue("SessionTokenTtlSeconds", 900),
+            SigningKey = Clean(section["SigningKey"]),
+            Role = Clean(section["Role"]) ?? GitHubAuthConstants.DefaultRole,
+            Scope = Clean(section["Scope"]) ?? GitHubAuthConstants.DefaultScope,
+            StateTtlSeconds = section.GetValue("StateTtlSeconds", 300),
+            RedemptionTtlSeconds = section.GetValue("RedemptionTtlSeconds", 120),
+            AllowedUserIds = ParseUserIds(section.GetSection("AllowedUserIds").Get<string[]>()),
+            AllowedLogins = CleanList(section.GetSection("AllowedLogins").Get<string[]>()),
+            AllowedOrgs = CleanList(section.GetSection("AllowedOrgs").Get<string[]>()),
+            StartPerMinute = section.GetValue("RateLimits:StartPerMinute", 10),
+            ExchangePerMinute = section.GetValue("RateLimits:ExchangePerMinute", 20),
+        };
+
+        options.Validate(enforceSecret, environment.EnvironmentName);
+        return options;
+    }
+
+    private void Validate(bool enforceSecret, string environmentName)
+    {
+        RequireInRange(SessionTokenTtlSeconds, 30, 3600, "GitHub:SessionTokenTtlSeconds");
+        RequireInRange(StateTtlSeconds, 30, 1800, "GitHub:StateTtlSeconds");
+        RequireInRange(RedemptionTtlSeconds, 10, 600, "GitHub:RedemptionTtlSeconds");
+        RequirePositive(StartPerMinute, "GitHub:RateLimits:StartPerMinute");
+        RequirePositive(ExchangePerMinute, "GitHub:RateLimits:ExchangePerMinute");
+
+        if (string.IsNullOrWhiteSpace(Issuer) || string.IsNullOrWhiteSpace(Audience))
+        {
+            throw new InvalidOperationException(
+                "GitHub:Issuer and GitHub:Audience are required so session tokens can be validated.");
+        }
+
+        // The OAuth app client id is always required — the flow cannot start without it.
+        if (!IsPresent(ClientId))
+        {
+            throw new InvalidOperationException(
+                "GitHub:ClientId is required to run GitHub authentication mode. It is the public OAuth " +
+                "app client id (not a secret). A missing or placeholder value fails closed.");
+        }
+
+        // Exact, HTTPS, fixed redirect URLs — no user-supplied redirect is ever honoured, closing the
+        // open-redirect class. The callback must be the API's own callback route.
+        RequireHttpsUrl(CallbackUrl, "GitHub:CallbackUrl");
+        RequireHttpsUrl(FrontendReturnUrl, "GitHub:FrontendReturnUrl");
+        if (!CallbackUrl.EndsWith(GitHubAuthConstants.CallbackRoute, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"GitHub:CallbackUrl must be the API's own OAuth callback endpoint ending in " +
+                $"'{GitHubAuthConstants.CallbackRoute}' and match the URL registered with the GitHub OAuth app.");
+        }
+
+        // Fail closed on an empty allowlist: GitHub mode must NEVER admit every GitHub account. At
+        // least one of numeric id / login / org membership must be configured.
+        if (AllowedUserIds.Count == 0 && AllowedLogins.Count == 0 && AllowedOrgs.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "GitHub mode requires an explicit allowlist — configure at least one of " +
+                "GitHub:AllowedUserIds, GitHub:AllowedLogins, or GitHub:AllowedOrgs. An empty allowlist " +
+                "would admit every GitHub user and fails closed.");
+        }
+
+        // The client secret and signing key are secrets. Required in any hosted environment; in
+        // Development the secret is still required to talk to GitHub, but the signing key may be
+        // ephemeral (process-local; sessions die on restart).
+        if (!IsPresent(ClientSecret))
+        {
+            throw new InvalidOperationException(
+                $"GitHub:ClientSecret is required ('{environmentName}'). Supply the OAuth app client " +
+                "secret via GitHub__ClientSecret or a secret store — never commit it. A missing or " +
+                "placeholder value fails closed.");
+        }
+
+        if (enforceSecret)
+        {
+            if (!HasConfiguredSigningKey)
+            {
+                throw new InvalidOperationException(
+                    $"GitHub:SigningKey is required for a hosted GitHub deployment ('{environmentName}'). " +
+                    "Supply a strong secret via GitHub__SigningKey or a secret store — never commit it. " +
+                    "An ephemeral key is only permitted in Development.");
+            }
+
+            if (Encoding.UTF8.GetByteCount(SigningKey!) < 32)
+            {
+                throw new InvalidOperationException(
+                    "GitHub:SigningKey must be at least 32 bytes (256-bit) for HMAC-SHA256 signing.");
+            }
+        }
+        else if (HasConfiguredSigningKey && Encoding.UTF8.GetByteCount(SigningKey!) < 32)
+        {
+            // If a key IS supplied in Development it must still be strong (no weak keys anywhere).
+            throw new InvalidOperationException(
+                "GitHub:SigningKey must be at least 32 bytes (256-bit) when configured.");
+        }
+    }
+
+    private static IReadOnlyList<long> ParseUserIds(string[]? raw)
+    {
+        if (raw is null)
+        {
+            return [];
+        }
+
+        var ids = new List<long>();
+        foreach (string entry in raw)
+        {
+            string? cleaned = Clean(entry);
+            if (cleaned is null)
+            {
+                continue;
+            }
+
+            if (!long.TryParse(cleaned, out long id) || id <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"GitHub:AllowedUserIds contains a non-numeric or non-positive value '{entry}'. " +
+                    "GitHub user ids are positive integers.");
+            }
+
+            ids.Add(id);
+        }
+
+        return ids;
+    }
+
+    private static IReadOnlyList<string> CleanList(string[]? raw)
+    {
+        return raw is null
+            ? []
+            : [.. raw.Select(Clean).Where(v => v is not null).Select(v => v!).Distinct(StringComparer.OrdinalIgnoreCase)];
+    }
+
+    private static void RequireHttpsUrl(string value, string name)
+    {
+        if (!IsPresent(value)
+            || !Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+            || uri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new InvalidOperationException(
+                $"{name} must be a fixed, absolute HTTPS URL. A missing, non-absolute, non-HTTPS, or " +
+                "placeholder value fails closed.");
+        }
+    }
+
+    private static void RequirePositive(long value, string name)
+    {
+        if (value <= 0)
+        {
+            throw new InvalidOperationException($"{name} must be greater than zero (was {value}).");
+        }
+    }
+
+    private static void RequireInRange(int value, int min, int max, string name)
+    {
+        if (value < min || value > max)
+        {
+            throw new InvalidOperationException($"{name} must be between {min} and {max} (was {value}).");
+        }
+    }
+
+    /// <summary>A value is "present" only when it is non-blank AND not an angle-bracket placeholder.</summary>
+    private static bool IsPresent(string? value) =>
+        !string.IsNullOrWhiteSpace(value) && !value.Contains('<') && !value.Contains('>');
+
+    private static string? Clean(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        string trimmed = value.Trim();
+        return trimmed.Contains('<') || trimmed.Contains('>') ? null : trimmed;
+    }
+}

--- a/src/RetailPulse.Api/Security/GitHub/GitHubOAuthClient.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubOAuthClient.cs
@@ -1,0 +1,218 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RetailPulse.Api.Security.GitHub;
+
+/// <summary>Outcome of the confidential authorization-code → access-token exchange.</summary>
+/// <param name="Success">True when GitHub returned a usable access token.</param>
+/// <param name="AccessToken">The provider token — used only transiently for verification, never stored/returned/logged.</param>
+/// <param name="Error">A short, token-free error code/description safe to log.</param>
+public readonly record struct GitHubTokenResult(bool Success, string? AccessToken, string? Error);
+
+/// <summary>Outcome of the <c>/user</c> validation call.</summary>
+/// <param name="Success">True when GitHub returned a valid authenticated user.</param>
+/// <param name="UserId">The immutable numeric GitHub user id.</param>
+/// <param name="Login">The mutable login handle (informational only).</param>
+/// <param name="Error">A short, token-free error code/description safe to log.</param>
+public readonly record struct GitHubUserResult(bool Success, long UserId, string Login, string? Error);
+
+/// <summary>Outcome of an org active-membership check.</summary>
+/// <param name="IsActiveMember">True only when the user is an ACTIVE member of the org.</param>
+/// <param name="Error">Non-null when the check could not be completed (fail closed on any error).</param>
+public readonly record struct GitHubOrgMembershipResult(bool IsActiveMember, string? Error);
+
+/// <summary>
+/// The confidential-client transport to GitHub. The interface is the mock boundary for tests; the
+/// implementation talks ONLY to the fixed, hard-coded GitHub endpoints in
+/// <see cref="GitHubAuthConstants"/> (SSRF defense — no host, path, or redirect is ever derived from
+/// user input), with auto-redirect disabled so a crafted 3xx cannot bounce a request or a bearer
+/// token to another host.
+/// </summary>
+public interface IGitHubOAuthClient
+{
+    /// <summary>Exchanges an authorization code for a provider access token (server-side, confidential).</summary>
+    Task<GitHubTokenResult> ExchangeCodeAsync(string code, CancellationToken cancellationToken);
+
+    /// <summary>Validates the provider token by reading the authenticated user's immutable id + login.</summary>
+    Task<GitHubUserResult> GetUserAsync(string accessToken, CancellationToken cancellationToken);
+
+    /// <summary>Checks whether the authenticated user is an ACTIVE member of <paramref name="org"/>.</summary>
+    Task<GitHubOrgMembershipResult> GetActiveOrgMembershipAsync(string accessToken, string org, CancellationToken cancellationToken);
+}
+
+/// <inheritdoc />
+public sealed class GitHubOAuthClient : IGitHubOAuthClient
+{
+    private static readonly CompositeFormat _orgMembershipUrlFormat =
+        CompositeFormat.Parse(GitHubAuthConstants.OrgMembershipUrlFormat);
+
+    private readonly HttpClient _http;
+    private readonly GitHubAuthOptions _options;
+    private readonly ILogger<GitHubOAuthClient> _logger;
+
+    public GitHubOAuthClient(HttpClient http, GitHubAuthOptions options, ILogger<GitHubOAuthClient> logger)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GitHubTokenResult> ExchangeCodeAsync(string code, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return new GitHubTokenResult(false, null, "missing_code");
+        }
+
+        // Confidential exchange: the client secret is sent ONLY here, server→GitHub, over the fixed
+        // token endpoint. The redirect_uri is the exact registered callback (defense in depth).
+        using var request = new HttpRequestMessage(HttpMethod.Post, GitHubAuthConstants.AccessTokenUrl);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["client_id"] = _options.ClientId,
+            ["client_secret"] = _options.ClientSecret!,
+            ["code"] = code,
+            ["redirect_uri"] = _options.CallbackUrl,
+        });
+
+        try
+        {
+            using HttpResponseMessage response = await _http.SendAsync(request, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("GitHub token exchange failed with status {Status}", (int)response.StatusCode);
+                return new GitHubTokenResult(false, null, $"exchange_http_{(int)response.StatusCode}");
+            }
+
+            TokenResponse? body = await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken);
+            if (body is null || !string.IsNullOrEmpty(body.Error))
+            {
+                // GitHub reports a denied/expired/reused code as a 200 with an "error" field.
+                return new GitHubTokenResult(false, null, SafeError(body?.Error) ?? "exchange_no_token");
+            }
+
+            return string.IsNullOrWhiteSpace(body.AccessToken)
+                ? new GitHubTokenResult(false, null, "exchange_no_token")
+                : new GitHubTokenResult(true, body.AccessToken, null);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            // Never include the exception detail verbatim in a client-facing path; log the type only.
+            _logger.LogWarning("GitHub token exchange transport error: {Type}", ex.GetType().Name);
+            return new GitHubTokenResult(false, null, "exchange_transport_error");
+        }
+    }
+
+    public async Task<GitHubUserResult> GetUserAsync(string accessToken, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            return new GitHubUserResult(false, 0, string.Empty, "missing_token");
+        }
+
+        try
+        {
+            using HttpResponseMessage response = await SendAuthorizedGetAsync(
+                GitHubAuthConstants.UserApiUrl, accessToken, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("GitHub /user validation failed with status {Status}", (int)response.StatusCode);
+                return new GitHubUserResult(false, 0, string.Empty, $"user_http_{(int)response.StatusCode}");
+            }
+
+            UserResponse? user = await response.Content.ReadFromJsonAsync<UserResponse>(cancellationToken);
+            return user is null || user.Id <= 0 || string.IsNullOrWhiteSpace(user.Login)
+                ? new GitHubUserResult(false, 0, string.Empty, "user_invalid")
+                : new GitHubUserResult(true, user.Id, user.Login, null);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            _logger.LogWarning("GitHub /user transport error: {Type}", ex.GetType().Name);
+            return new GitHubUserResult(false, 0, string.Empty, "user_transport_error");
+        }
+    }
+
+    public async Task<GitHubOrgMembershipResult> GetActiveOrgMembershipAsync(
+        string accessToken, string org, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken) || string.IsNullOrWhiteSpace(org))
+        {
+            return new GitHubOrgMembershipResult(false, "missing_token_or_org");
+        }
+
+        // The org path segment is a configured, validated allowlist value — never user input — and is
+        // URL-escaped defensively. Fixed host/path, no redirects.
+        string url = string.Format(
+            CultureInfo.InvariantCulture,
+            _orgMembershipUrlFormat,
+            Uri.EscapeDataString(org));
+
+        try
+        {
+            using HttpResponseMessage response = await SendAuthorizedGetAsync(url, accessToken, cancellationToken);
+
+            // 404 = not a member (or membership not visible without read:org). 403 = insufficient scope.
+            // Any non-success is treated as "not an active member" and reported as a fail-closed error.
+            if (!response.IsSuccessStatusCode)
+            {
+                return new GitHubOrgMembershipResult(false, $"org_http_{(int)response.StatusCode}");
+            }
+
+            MembershipResponse? membership = await response.Content.ReadFromJsonAsync<MembershipResponse>(cancellationToken);
+            bool active = string.Equals(membership?.State, "active", StringComparison.OrdinalIgnoreCase);
+            return new GitHubOrgMembershipResult(active, active ? null : "org_not_active");
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            _logger.LogWarning("GitHub org membership transport error: {Type}", ex.GetType().Name);
+            return new GitHubOrgMembershipResult(false, "org_transport_error");
+        }
+    }
+
+    private async Task<HttpResponseMessage> SendAuthorizedGetAsync(
+        string url, string accessToken, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+        return await _http.SendAsync(request, cancellationToken);
+    }
+
+    /// <summary>Whitelist a small set of known GitHub OAuth error codes; drop anything unexpected.</summary>
+    private static string? SafeError(string? error)
+    {
+        return error switch
+        {
+            "bad_verification_code" => "exchange_bad_code",
+            "incorrect_client_credentials" => "exchange_bad_credentials",
+            "redirect_uri_mismatch" => "exchange_redirect_mismatch",
+            "access_denied" => "access_denied",
+            _ => string.IsNullOrEmpty(error) ? null : "exchange_error",
+        };
+    }
+
+    private sealed class TokenResponse
+    {
+        [JsonPropertyName("access_token")] public string? AccessToken { get; set; }
+        [JsonPropertyName("scope")] public string? Scope { get; set; }
+        [JsonPropertyName("token_type")] public string? TokenType { get; set; }
+        [JsonPropertyName("error")] public string? Error { get; set; }
+    }
+
+    private sealed class UserResponse
+    {
+        [JsonPropertyName("id")] public long Id { get; set; }
+        [JsonPropertyName("login")] public string? Login { get; set; }
+    }
+
+    private sealed class MembershipResponse
+    {
+        [JsonPropertyName("state")] public string? State { get; set; }
+    }
+}

--- a/src/RetailPulse.Api/Security/GitHub/GitHubOneTimeStores.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubOneTimeStores.cs
@@ -1,0 +1,171 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+
+namespace RetailPulse.Api.Security.GitHub;
+
+/// <summary>
+/// The server-side record bound to a single OAuth <c>state</c> value. The <c>state</c> string itself
+/// is the dictionary key (never stored in this record); the record holds the HASH of the browser-bound
+/// cookie secret and the expiry. Verification requires the caller to present BOTH the matching state
+/// (query) and the matching cookie secret, defeating login-CSRF and state fixation.
+/// </summary>
+/// <param name="CookieSecretHash">SHA-256 of the random secret placed in the HttpOnly state cookie.</param>
+/// <param name="ExpiresAtTicks">Absolute UTC expiry (ticks). Past this the entry is invalid.</param>
+public readonly record struct GitHubStateEntry(byte[] CookieSecretHash, long ExpiresAtTicks);
+
+/// <summary>
+/// The server-side record redeemed by the SPA at the exchange endpoint. It holds the VERIFIED GitHub
+/// identity (immutable numeric id + login) — NOT a provider token and NOT an app token. The app
+/// session JWT is minted fresh at redemption so its short TTL starts when the SPA receives it.
+/// </summary>
+/// <param name="User">The verified GitHub identity established during the callback.</param>
+/// <param name="ExpiresAtTicks">Absolute UTC expiry (ticks). Past this the code is invalid.</param>
+public readonly record struct GitHubRedemptionEntry(GitHubVerifiedUser User, long ExpiresAtTicks);
+
+/// <summary>
+/// A bounded, thread-safe, in-memory store with atomic one-time consumption and TTL, used for both
+/// the OAuth state entries and the post-login redemption codes.
+///
+/// Security properties:
+/// <list type="bullet">
+///   <item><b>One-time:</b> <see cref="TryConsume"/> removes the entry atomically
+///     (<see cref="ConcurrentDictionary{TKey,TValue}.TryRemove(TKey, out TValue)"/>), so two racing
+///     callers can never both succeed — this defeats state/code replay and exchange races.</item>
+///   <item><b>TTL:</b> an entry past its expiry is treated as absent (and removed), bounding the
+///     window for a captured value.</item>
+///   <item><b>Bounded + cleanup:</b> the store caps its size and opportunistically sweeps expired
+///     entries, so a flood of unfinished logins cannot exhaust memory.</item>
+/// </list>
+/// Keys are compared with <see cref="StringComparer.Ordinal"/>. The store is replica-local — see the
+/// deployment note: hosted GitHub mode is pinned to a single replica unless moved to a distributed
+/// store, because a callback handled by replica A cannot redeem a code on replica B.
+/// </summary>
+/// <typeparam name="TValue">The stored entry type (must expose its expiry via the selector).</typeparam>
+public class OneTimeTtlStore<TValue>
+{
+    private readonly ConcurrentDictionary<string, TValue> _entries = new(StringComparer.Ordinal);
+    private readonly Func<TValue, long> _expirySelector;
+    private readonly TimeProvider _timeProvider;
+    private readonly int _maxEntries;
+    private long _lastSweepTicks;
+
+    public OneTimeTtlStore(Func<TValue, long> expirySelector, int maxEntries = 10_000, TimeProvider? timeProvider = null)
+    {
+        _expirySelector = expirySelector ?? throw new ArgumentNullException(nameof(expirySelector));
+        _maxEntries = maxEntries > 0 ? maxEntries : throw new ArgumentOutOfRangeException(nameof(maxEntries));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>Current live entry count (used by tests to assert cleanup).</summary>
+    public int Count => _entries.Count;
+
+    /// <summary>
+    /// Stores <paramref name="value"/> under <paramref name="key"/>. Returns false if the store is at
+    /// capacity after a sweep (fail-closed rather than evicting an in-flight login). A duplicate key
+    /// (astronomically unlikely for a 256-bit random key) is rejected.
+    /// </summary>
+    public bool TryStore(string key, TValue value)
+    {
+        long nowTicks = _timeProvider.GetUtcNow().UtcDateTime.Ticks;
+        MaybeSweep(nowTicks);
+
+        if (_entries.Count >= _maxEntries)
+        {
+            // One more sweep before failing closed, in case many entries just expired.
+            Sweep(nowTicks);
+            if (_entries.Count >= _maxEntries)
+            {
+                return false;
+            }
+        }
+
+        return _entries.TryAdd(key, value);
+    }
+
+    /// <summary>
+    /// Atomically removes and returns the entry for <paramref name="key"/> IF it exists and has not
+    /// expired. One-time by construction: a second call for the same key fails. An expired entry is
+    /// removed and reported as a miss.
+    /// </summary>
+    public bool TryConsume(string key, out TValue value)
+    {
+        value = default!;
+        if (string.IsNullOrEmpty(key) || !_entries.TryRemove(key, out TValue? removed))
+        {
+            return false;
+        }
+
+        long nowTicks = _timeProvider.GetUtcNow().UtcDateTime.Ticks;
+        if (_expirySelector(removed!) <= nowTicks)
+        {
+            // Expired — treated as absent. Already removed above.
+            return false;
+        }
+
+        value = removed!;
+        return true;
+    }
+
+    private void MaybeSweep(long nowTicks)
+    {
+        long last = Interlocked.Read(ref _lastSweepTicks);
+        // Sweep at most once per ~30s to keep the hot path cheap.
+        if (nowTicks - last < TimeSpan.TicksPerSecond * 30)
+        {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _lastSweepTicks, nowTicks, last) == last)
+        {
+            Sweep(nowTicks);
+        }
+    }
+
+    private void Sweep(long nowTicks)
+    {
+        foreach (KeyValuePair<string, TValue> entry in _entries)
+        {
+            if (_expirySelector(entry.Value) <= nowTicks)
+            {
+                _entries.TryRemove(entry.Key, out _);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Non-generic helper for cryptographically random tokens, kept off the generic store type to
+/// avoid declaring static members on a generic type (CA1000).
+/// </summary>
+public static class GitHubRandom
+{
+    /// <summary>
+    /// Generates a new cryptographically random 256-bit key (base64url, no padding) suitable for a
+    /// state value, a cookie secret, or a redemption code.
+    /// </summary>
+    public static string NewToken()
+    {
+        Span<byte> bytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Base64UrlEncoder.Encode(bytes.ToArray());
+    }
+}
+
+/// <summary>Concrete singleton store for OAuth state entries (keyed by the random state value).</summary>
+public sealed class GitHubStateStore : OneTimeTtlStore<GitHubStateEntry>
+{
+    public GitHubStateStore(TimeProvider? timeProvider = null)
+        : base(static e => e.ExpiresAtTicks, maxEntries: 10_000, timeProvider)
+    {
+    }
+}
+
+/// <summary>Concrete singleton store for post-login redemption codes (keyed by the random code).</summary>
+public sealed class GitHubRedemptionStore : OneTimeTtlStore<GitHubRedemptionEntry>
+{
+    public GitHubRedemptionStore(TimeProvider? timeProvider = null)
+        : base(static e => e.ExpiresAtTicks, maxEntries: 10_000, timeProvider)
+    {
+    }
+}

--- a/src/RetailPulse.Api/Security/GitHub/GitHubSessionTokenService.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubSessionTokenService.cs
@@ -1,0 +1,96 @@
+using System.Security.Claims;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace RetailPulse.Api.Security.GitHub;
+
+/// <summary>A verified GitHub identity, established server-side AFTER the confidential token
+/// exchange, the <c>/user</c> validation call, and the server-side allowlist check succeed.</summary>
+/// <param name="UserId">The immutable numeric GitHub user id — the SOLE basis for identity.</param>
+/// <param name="Login">The mutable login handle — informational only, never identity.</param>
+public readonly record struct GitHubVerifiedUser(long UserId, string Login);
+
+/// <summary>Result of minting a GitHub session credential.</summary>
+/// <param name="Token">The signed, short-lived bearer/access token.</param>
+/// <param name="Subject">The immutable subject (<c>github:&lt;id&gt;</c>).</param>
+/// <param name="ExpiresInSeconds">Seconds until the token expires.</param>
+public readonly record struct GitHubSession(string Token, string Subject, int ExpiresInSeconds);
+
+/// <summary>
+/// Issues short-lived, server-signed Retail Pulse GitHub session tokens from an already-verified
+/// GitHub identity.
+///
+/// The token is a compact HS256 JWT whose issuer/audience/provider are SEPARATE from Entra and
+/// Anonymous, so a GitHub token can never satisfy another provider's policy and vice versa. Identity
+/// is the immutable numeric id (<c>sub = github:&lt;id&gt;</c>); the login is carried only as an
+/// informational claim. There is no refresh token — the client re-runs the OAuth flow when the short
+/// TTL elapses, which bounds replay. The GitHub PROVIDER token is never placed in this token or
+/// stored anywhere; it is used only transiently to call <c>/user</c> during verification.
+/// </summary>
+public interface IGitHubSessionTokenService
+{
+    /// <summary>Mints a signed session token for a verified GitHub user.</summary>
+    GitHubSession CreateSession(GitHubVerifiedUser user);
+}
+
+/// <inheritdoc />
+public sealed class GitHubSessionTokenService : IGitHubSessionTokenService
+{
+    private readonly GitHubAuthOptions _options;
+    private readonly GitHubSigningKeyProvider _keyProvider;
+    private readonly TimeProvider _timeProvider;
+    private readonly JsonWebTokenHandler _handler = new();
+
+    public GitHubSessionTokenService(
+        GitHubAuthOptions options,
+        GitHubSigningKeyProvider keyProvider,
+        TimeProvider? timeProvider = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _keyProvider = keyProvider ?? throw new ArgumentNullException(nameof(keyProvider));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public GitHubSession CreateSession(GitHubVerifiedUser user)
+    {
+        if (user.UserId <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(user), "A GitHub session requires a positive immutable numeric user id.");
+        }
+
+        string subject = GitHubAuthConstants.SubjectPrefix + user.UserId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        DateTime now = _timeProvider.GetUtcNow().UtcDateTime;
+        DateTime expires = now.AddSeconds(_options.SessionTokenTtlSeconds);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, subject),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+            new(GitHubAuthConstants.ProviderClaimType, GitHubAuthConstants.ProviderName),
+            new("roles", _options.Role),
+            new("scp", _options.Scope),
+        };
+
+        // Login is informational only — recorded for display/audit, never used for authorization.
+        if (!string.IsNullOrWhiteSpace(user.Login))
+        {
+            claims.Add(new Claim(GitHubAuthConstants.LoginClaimType, user.Login));
+            claims.Add(new Claim("name", user.Login));
+        }
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _options.Issuer,
+            Audience = _options.Audience,
+            IssuedAt = now,
+            NotBefore = now,
+            Expires = expires,
+            Subject = new ClaimsIdentity(claims),
+            SigningCredentials = new SigningCredentials(_keyProvider.Key, SecurityAlgorithms.HmacSha256),
+        };
+
+        string token = _handler.CreateToken(descriptor);
+        return new GitHubSession(token, subject, _options.SessionTokenTtlSeconds);
+    }
+}

--- a/src/RetailPulse.Api/Security/GitHub/GitHubSigningKeyProvider.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubSigningKeyProvider.cs
@@ -16,12 +16,17 @@ namespace RetailPulse.Api.Security.GitHub;
 ///     sessions are invalidated when the process restarts. This is documented, intentional dev
 ///     behavior, not a fallback that can leak into a hosted deployment.</item>
 /// </list>
-/// <see cref="ValidationKeys"/> is the rotation seam: additional retired keys can be accepted for
-/// validation while a new key signs, so tokens issued before a rotation stay valid until they expire.
-/// A single instance is registered as a singleton so the ephemeral key is stable within a process.
+/// Signing-key ROTATION is genuine, not merely a seam: <see cref="ValidationKeys"/> is the CURRENT
+/// signing key first, followed by every strong key configured in
+/// <see cref="GitHubAuthOptions.AdditionalValidationKeys"/>. New tokens are always signed with
+/// <see cref="Key"/>, but tokens signed by a key that has just been demoted to the additional list keep
+/// validating until they expire — so a rotation never invalidates in-flight sessions. A single instance
+/// is registered as a singleton so the ephemeral key is stable within a process.
 /// </summary>
 public sealed class GitHubSigningKeyProvider
 {
+    private readonly IReadOnlyList<SecurityKey> _validationKeys;
+
     /// <summary>True when the key was generated ephemerally (Development, no configured secret).</summary>
     public bool IsEphemeral { get; }
 
@@ -31,10 +36,8 @@ public sealed class GitHubSigningKeyProvider
 
         if (options.HasConfiguredSigningKey)
         {
-            Key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(options.SigningKey!))
-            {
-                KeyId = "github-configured",
-            };
+            byte[] material = Encoding.UTF8.GetBytes(options.SigningKey!);
+            Key = new SymmetricSecurityKey(material) { KeyId = KeyIdFor(material) };
             IsEphemeral = false;
         }
         else
@@ -44,14 +47,32 @@ public sealed class GitHubSigningKeyProvider
             Key = new SymmetricSecurityKey(material) { KeyId = "github-ephemeral" };
             IsEphemeral = true;
         }
+
+        // Current signing key FIRST, then each configured rotation (validation-only) key. Each key gets
+        // a STABLE, key-material-derived id so a token keeps the same kid after its key is demoted to
+        // validation-only — that is what lets an in-flight token resolve to its original key across a
+        // rotation. Options validation already rejected weak/placeholder rotation keys.
+        var keys = new List<SecurityKey> { Key };
+        for (int i = 0; i < options.AdditionalValidationKeys.Count; i++)
+        {
+            byte[] extra = Encoding.UTF8.GetBytes(options.AdditionalValidationKeys[i]);
+            keys.Add(new SymmetricSecurityKey(extra) { KeyId = KeyIdFor(extra) });
+        }
+
+        _validationKeys = keys;
     }
+
+    // A deterministic, non-reversible id for a key: the first bytes of SHA-256(key material). Stable
+    // across process restarts and rotation "slots", so a demoted signing key keeps the same kid.
+    private static string KeyIdFor(byte[] material) =>
+        "github-" + Convert.ToHexString(SHA256.HashData(material))[..12].ToLowerInvariant();
 
     /// <summary>The active signing key for token creation and validation.</summary>
     public SymmetricSecurityKey Key { get; }
 
     /// <summary>
-    /// All keys accepted for validation. The active key first; retired keys can be appended here
-    /// during a rotation so in-flight tokens validate until they expire.
+    /// All keys accepted for validation: the active signing key first, then every configured rotation
+    /// (validation-only) key, so tokens issued before a rotation stay valid until they expire.
     /// </summary>
-    public IEnumerable<SecurityKey> ValidationKeys => [Key];
+    public IEnumerable<SecurityKey> ValidationKeys => _validationKeys;
 }

--- a/src/RetailPulse.Api/Security/GitHub/GitHubSigningKeyProvider.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubSigningKeyProvider.cs
@@ -1,0 +1,57 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace RetailPulse.Api.Security.GitHub;
+
+/// <summary>
+/// Provides the symmetric HMAC key used to sign and validate the app's own GitHub session tokens.
+///
+/// Key resolution is fail-closed and environment-aware, mirroring the Anonymous mode seam:
+/// <list type="bullet">
+///   <item>When <see cref="GitHubAuthOptions.HasConfiguredSigningKey"/> is true, the configured
+///     secret is used (required in hosted mode; validated to be ≥ 256-bit by the options).</item>
+///   <item>Otherwise (Development only — hosted mode already failed startup) a cryptographically
+///     random 256-bit key is generated ONCE per process. It is never persisted, so all GitHub
+///     sessions are invalidated when the process restarts. This is documented, intentional dev
+///     behavior, not a fallback that can leak into a hosted deployment.</item>
+/// </list>
+/// <see cref="ValidationKeys"/> is the rotation seam: additional retired keys can be accepted for
+/// validation while a new key signs, so tokens issued before a rotation stay valid until they expire.
+/// A single instance is registered as a singleton so the ephemeral key is stable within a process.
+/// </summary>
+public sealed class GitHubSigningKeyProvider
+{
+    /// <summary>True when the key was generated ephemerally (Development, no configured secret).</summary>
+    public bool IsEphemeral { get; }
+
+    public GitHubSigningKeyProvider(GitHubAuthOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.HasConfiguredSigningKey)
+        {
+            Key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(options.SigningKey!))
+            {
+                KeyId = "github-configured",
+            };
+            IsEphemeral = false;
+        }
+        else
+        {
+            // Development-only: a fresh 256-bit key per process. Sessions do not survive a restart.
+            byte[] material = RandomNumberGenerator.GetBytes(32);
+            Key = new SymmetricSecurityKey(material) { KeyId = "github-ephemeral" };
+            IsEphemeral = true;
+        }
+    }
+
+    /// <summary>The active signing key for token creation and validation.</summary>
+    public SymmetricSecurityKey Key { get; }
+
+    /// <summary>
+    /// All keys accepted for validation. The active key first; retired keys can be appended here
+    /// during a rotation so in-flight tokens validate until they expire.
+    /// </summary>
+    public IEnumerable<SecurityKey> ValidationKeys => [Key];
+}

--- a/src/RetailPulse.Api/Security/GitHub/GitHubStateCookie.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubStateCookie.cs
@@ -1,0 +1,75 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace RetailPulse.Api.Security.GitHub;
+
+/// <summary>
+/// Derives the per-state name of the browser-bound OAuth state cookie and validates the format of an
+/// OAuth <c>state</c> value.
+///
+/// Each login gets its OWN cookie name so parallel tabs never clash: two concurrent
+/// <c>start</c> requests write two differently-named cookies and each callback consumes/deletes ONLY
+/// its own. The name suffix is a bounded, URL-safe value DERIVED from the state (a truncated SHA-256,
+/// never the raw state bytes), so:
+/// <list type="bullet">
+///   <item>the callback can recompute the exact cookie name from the (validated-format) state alone;</item>
+///   <item>the suffix is always a small, fixed-length token of the cookie-name-safe alphabet
+///     <c>[A-Za-z0-9_-]</c>, so a crafted state can never inject cookie attributes or an oversized name;</item>
+///   <item>in secure mode the name keeps the <c>__Host-</c> prefix (Secure + Path=/ + no Domain).</item>
+/// </list>
+/// The state itself must be exactly the shape <see cref="GitHubRandom.NewToken"/> emits — a 43-char
+/// base64url token — which is validated BEFORE the name is derived, bounding the work and rejecting
+/// any malformed/oversized callback input up front.
+/// </summary>
+public static class GitHubStateCookie
+{
+    // Base64url of 32 random bytes is exactly 43 chars (no padding), alphabet [A-Za-z0-9_-].
+    private const int _stateLength = 43;
+
+    // Length of the bounded URL-safe suffix appended to the cookie base.
+    private const int _suffixLength = 22;
+
+    /// <summary>
+    /// True only when <paramref name="state"/> is exactly the fixed-length base64url shape that
+    /// <see cref="GitHubRandom.NewToken"/> produces. Rejects null/empty, wrong length, and any
+    /// character outside the URL-safe alphabet — so a hostile callback cannot smuggle a huge or
+    /// specially-crafted state into cookie-name derivation.
+    /// </summary>
+    public static bool IsValidStateFormat(string? state)
+    {
+        if (string.IsNullOrEmpty(state) || state.Length != _stateLength)
+        {
+            return false;
+        }
+
+        foreach (char c in state)
+        {
+            bool ok = c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '-' or '_';
+            if (!ok)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The exact cookie name for <paramref name="state"/>. In <paramref name="secure"/> mode the name
+    /// keeps the <c>__Host-</c> prefix; otherwise it uses the Development-only insecure base. The state
+    /// MUST already be validated with <see cref="IsValidStateFormat"/>.
+    /// </summary>
+    public static string NameFor(string state, bool secure)
+    {
+        string @base = secure ? GitHubAuthConstants.SecureStateCookieBase : GitHubAuthConstants.DevStateCookieBase;
+        return @base + Suffix(state);
+    }
+
+    private static string Suffix(string state)
+    {
+        byte[] hash = SHA256.HashData(Encoding.ASCII.GetBytes(state));
+        // Base64url is already the cookie-name-safe alphabet [A-Za-z0-9_-]; truncate to a bounded len.
+        return Base64UrlEncoder.Encode(hash)[.._suffixLength];
+    }
+}

--- a/src/RetailPulse.Api/Security/GitHub/GitHubUserAllowlist.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubUserAllowlist.cs
@@ -14,15 +14,14 @@ public readonly record struct GitHubAllowlistDecision(bool Allowed, string Reaso
 /// A user is admitted when ANY configured rule matches, evaluated cheapest-first:
 /// <list type="number">
 ///   <item>the numeric id is in <see cref="GitHubAuthOptions.AllowedUserIds"/>;</item>
-///   <item>the login is in <see cref="GitHubAuthOptions.AllowedLogins"/> (case-insensitive — but the
-///     resulting session is still keyed to the immutable id);</item>
 ///   <item>the user is an ACTIVE member of any org in <see cref="GitHubAuthOptions.AllowedOrgs"/>,
 ///     confirmed via <c>/user/memberships/orgs/{org}</c> (requires the <c>read:org</c> scope).</item>
 /// </list>
-/// Every failure mode fails CLOSED: an empty allowlist (rejected at startup), an org API error, a
-/// rate-limit response, or an inactive/pending membership all deny access. Org membership can be
-/// private; reading it requires <c>read:org</c>, which is why that scope is requested only when an
-/// org allowlist is configured.
+/// The mutable login handle is NEVER an access mechanism — a renamed or re-created account that lands on
+/// a previously-allowed handle can never inherit access. Every failure mode fails CLOSED: an empty
+/// allowlist (rejected at startup), an org API error, a rate-limit response, or an inactive/pending
+/// membership all deny access. Org membership can be private; reading it requires <c>read:org</c>, which
+/// is why that scope is requested only when an org allowlist is configured.
 /// </summary>
 public sealed class GitHubUserAllowlist
 {
@@ -58,14 +57,7 @@ public sealed class GitHubUserAllowlist
             return new GitHubAllowlistDecision(true, "user_id");
         }
 
-        // 2) Login allowlist (case-insensitive). The session is still keyed to the immutable id.
-        if (!string.IsNullOrWhiteSpace(user.Login)
-            && _options.AllowedLogins.Any(l => string.Equals(l, user.Login, StringComparison.OrdinalIgnoreCase)))
-        {
-            return new GitHubAllowlistDecision(true, "login");
-        }
-
-        // 3) Active org membership — fail closed on any API/rate/error and on non-active states.
+        // 2) Active org membership — fail closed on any API/rate/error and on non-active states.
         foreach (string org in _options.AllowedOrgs)
         {
             GitHubOrgMembershipResult membership =

--- a/src/RetailPulse.Api/Security/GitHub/GitHubUserAllowlist.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubUserAllowlist.cs
@@ -1,0 +1,89 @@
+namespace RetailPulse.Api.Security.GitHub;
+
+/// <summary>The result of a server-side allowlist decision.</summary>
+/// <param name="Allowed">True only when the user satisfies at least one configured allowlist rule.</param>
+/// <param name="Reason">A short, non-sensitive reason (for audit/telemetry — never leaks a token).</param>
+public readonly record struct GitHubAllowlistDecision(bool Allowed, string Reason);
+
+/// <summary>
+/// Server-side allowlist enforcement for GitHub mode. Verified STRICTLY on the backend after the
+/// confidential exchange and the <c>/user</c> validation, and keyed on the IMMUTABLE numeric GitHub
+/// user id — never the mutable login — so a renamed or re-created account cannot inherit another
+/// account's access.
+///
+/// A user is admitted when ANY configured rule matches, evaluated cheapest-first:
+/// <list type="number">
+///   <item>the numeric id is in <see cref="GitHubAuthOptions.AllowedUserIds"/>;</item>
+///   <item>the login is in <see cref="GitHubAuthOptions.AllowedLogins"/> (case-insensitive — but the
+///     resulting session is still keyed to the immutable id);</item>
+///   <item>the user is an ACTIVE member of any org in <see cref="GitHubAuthOptions.AllowedOrgs"/>,
+///     confirmed via <c>/user/memberships/orgs/{org}</c> (requires the <c>read:org</c> scope).</item>
+/// </list>
+/// Every failure mode fails CLOSED: an empty allowlist (rejected at startup), an org API error, a
+/// rate-limit response, or an inactive/pending membership all deny access. Org membership can be
+/// private; reading it requires <c>read:org</c>, which is why that scope is requested only when an
+/// org allowlist is configured.
+/// </summary>
+public sealed class GitHubUserAllowlist
+{
+    private readonly GitHubAuthOptions _options;
+    private readonly IGitHubOAuthClient _client;
+    private readonly ILogger<GitHubUserAllowlist> _logger;
+
+    public GitHubUserAllowlist(
+        GitHubAuthOptions options,
+        IGitHubOAuthClient client,
+        ILogger<GitHubUserAllowlist> logger)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Decides whether <paramref name="user"/> may be admitted. The provider <paramref name="accessToken"/>
+    /// is used ONLY to read org membership when needed and is never stored, returned, or logged.
+    /// </summary>
+    public async Task<GitHubAllowlistDecision> EvaluateAsync(
+        GitHubVerifiedUser user, string accessToken, CancellationToken cancellationToken)
+    {
+        if (user.UserId <= 0)
+        {
+            return new GitHubAllowlistDecision(false, "invalid_user");
+        }
+
+        // 1) Immutable numeric id allowlist — the strongest, cheapest check.
+        if (_options.AllowedUserIds.Contains(user.UserId))
+        {
+            return new GitHubAllowlistDecision(true, "user_id");
+        }
+
+        // 2) Login allowlist (case-insensitive). The session is still keyed to the immutable id.
+        if (!string.IsNullOrWhiteSpace(user.Login)
+            && _options.AllowedLogins.Any(l => string.Equals(l, user.Login, StringComparison.OrdinalIgnoreCase)))
+        {
+            return new GitHubAllowlistDecision(true, "login");
+        }
+
+        // 3) Active org membership — fail closed on any API/rate/error and on non-active states.
+        foreach (string org in _options.AllowedOrgs)
+        {
+            GitHubOrgMembershipResult membership =
+                await _client.GetActiveOrgMembershipAsync(accessToken, org, cancellationToken);
+            if (membership.IsActiveMember)
+            {
+                return new GitHubAllowlistDecision(true, "org_membership");
+            }
+
+            if (membership.Error is not null && !membership.Error.StartsWith("org_http_404", StringComparison.Ordinal)
+                && membership.Error != "org_not_active")
+            {
+                // A genuine API/scope/rate error (not a plain "not a member" 404) — record it, but keep
+                // evaluating remaining orgs before failing closed.
+                _logger.LogWarning("GitHub org membership check for an allowlisted org returned {Reason}", membership.Error);
+            }
+        }
+
+        return new GitHubAllowlistDecision(false, "not_allowlisted");
+    }
+}

--- a/src/RetailPulse.Api/Security/GitHubAuthenticationSetup.cs
+++ b/src/RetailPulse.Api/Security/GitHubAuthenticationSetup.cs
@@ -1,0 +1,159 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Security.GitHub;
+
+namespace RetailPulse.Api.Security;
+
+/// <summary>
+/// Authentication + authorization wiring for the GitHub mode.
+///
+/// Mirrors the Entra/Anonymous boundary shape (a single JwtBearer scheme validating the app's OWN
+/// short-lived session token with a local HMAC key, a strong default AND fallback authorization
+/// policy, hub-only <c>?access_token</c> mapping) but binds the policy to the GitHub provider:
+/// <list type="bullet">
+///   <item>an authenticated user is always required;</item>
+///   <item>the <c>RetailPulse.User</c> role and <c>access_as_user</c> scope are required (full
+///     authenticated capabilities are acceptable ONLY because they are reached after server-side
+///     allowlist verification at login);</item>
+///   <item>the token's <c>provider</c> claim must equal <c>GitHub</c>, so an Entra, Anonymous, or any
+///     other cross-provider token can never satisfy the GitHub policy (and vice versa).</item>
+/// </list>
+/// Only <c>/health</c>, <c>/alive</c>, and the three narrowly-anonymous BFF endpoints
+/// (<c>start</c> / <c>callback</c> / <c>exchange</c>) opt out with AllowAnonymous.
+/// </summary>
+public static class GitHubAuthenticationSetup
+{
+    public const string GitHubPolicy = "RetailPulseGitHub";
+    private const string _hubPathPrefix = "/hubs";
+
+    /// <summary>
+    /// Registers the GitHub session services (options, signing key, token service, one-time stores,
+    /// OAuth client, allowlist, normalizer), the JwtBearer scheme that validates the app's own
+    /// session tokens, and the constrained authorization policy (as both default and fallback).
+    /// </summary>
+    public static void AddGitHubAuthentication(
+        this IServiceCollection services,
+        GitHubAuthOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        services.AddSingleton(options);
+        var keyProvider = new GitHubSigningKeyProvider(options);
+        services.AddSingleton(keyProvider);
+        services.AddSingleton<IGitHubSessionTokenService, GitHubSessionTokenService>();
+        services.AddSingleton<GitHubStateStore>();
+        services.AddSingleton<GitHubRedemptionStore>();
+        services.AddSingleton<GitHubUserAllowlist>();
+        services.AddSingleton<IPrincipalNormalizer, GitHubPrincipalNormalizer>();
+
+        // Confidential OAuth transport. Auto-redirect is DISABLED so a crafted 3xx from GitHub cannot
+        // bounce the request — or a bearer token — to another host (SSRF/redirect defense). The client
+        // talks only to the fixed endpoints in GitHubAuthConstants.
+        services.AddHttpClient<IGitHubOAuthClient, GitHubOAuthClient>(http =>
+            {
+                http.Timeout = TimeSpan.FromSeconds(10);
+                http.DefaultRequestHeaders.UserAgent.ParseAdd("RetailPulse-Auth/1.0");
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                AllowAutoRedirect = false,
+            });
+
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, jwt => ConfigureJwtBearer(jwt, keyProvider, options));
+
+        services.AddAuthorization(authz =>
+        {
+            AuthorizationPolicy policy = BuildGitHubPolicy(options);
+            authz.AddPolicy(GitHubPolicy, policy);
+            authz.DefaultPolicy = policy;
+            authz.FallbackPolicy = policy;
+        });
+    }
+
+    /// <summary>
+    /// Builds the GitHub authorization policy: authenticated + role + scope + provider==GitHub.
+    /// Exposed for tests.
+    /// </summary>
+    public static AuthorizationPolicy BuildGitHubPolicy(GitHubAuthOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return new AuthorizationPolicyBuilder()
+            .RequireAuthenticatedUser()
+            .RequireRole(options.Role)
+            .RequireAssertion(ctx => HasScope(ctx.User, options.Scope))
+            .RequireAssertion(ctx => string.Equals(
+                ctx.User.FindFirst(GitHubAuthConstants.ProviderClaimType)?.Value,
+                GitHubAuthConstants.ProviderName,
+                StringComparison.Ordinal))
+            .Build();
+    }
+
+    private static void ConfigureJwtBearer(
+        JwtBearerOptions jwt,
+        GitHubSigningKeyProvider keyProvider,
+        GitHubAuthOptions options)
+    {
+        jwt.MapInboundClaims = false;
+        jwt.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuers = [options.Issuer],
+            ValidateAudience = true,
+            ValidAudiences = [options.Audience],
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeys = keyProvider.ValidationKeys,
+            ValidAlgorithms = [SecurityAlgorithms.HmacSha256],
+            ClockSkew = TimeSpan.FromSeconds(30),
+            RoleClaimType = "roles",
+            NameClaimType = JwtRegisteredClaimNames.Sub,
+        };
+
+        jwt.Events = new JwtBearerEvents
+        {
+            OnMessageReceived = context =>
+            {
+                // WebSocket handshakes cannot set Authorization; SignalR passes ?access_token=.
+                // Honour it ONLY for /hubs so REST endpoints keep header-only tokens (a query token on
+                // a REST path is therefore ignored and the request is rejected — identical to Entra).
+                if (context.HttpContext.Request.Path.StartsWithSegments(_hubPathPrefix))
+                {
+                    string? queryToken = context.Request.Query["access_token"];
+                    if (!string.IsNullOrEmpty(queryToken))
+                    {
+                        context.Token = queryToken;
+                    }
+                }
+
+                return Task.CompletedTask;
+            },
+        };
+    }
+
+    private static bool HasScope(ClaimsPrincipal principal, string requiredScope)
+    {
+        if (string.IsNullOrWhiteSpace(requiredScope))
+        {
+            return true;
+        }
+
+        foreach (Claim claim in principal.FindAll("scp"))
+        {
+            foreach (string scope in claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (string.Equals(scope, requiredScope, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/RetailPulse.Api/Security/ProviderNeutralAuthentication.cs
+++ b/src/RetailPulse.Api/Security/ProviderNeutralAuthentication.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using RetailPulse.Api.Auth;
 using RetailPulse.Api.Middleware;
 using RetailPulse.Api.Security.Anonymous;
+using RetailPulse.Api.Security.GitHub;
 
 namespace RetailPulse.Api.Security;
 
@@ -23,10 +24,14 @@ namespace RetailPulse.Api.Security;
 ///     guardrails INTERNALLY, then returns <c>null</c> (the caller must not layer the Entra policy
 ///     on top). A hosted deployment must additionally pass the second explicit opt-in and complete
 ///     guardrail configuration, or startup fails closed (see <see cref="AnonymousAuthOptions"/>).</item>
-///   <item><see cref="AuthenticationMode.GitHub"/> → a deliberate fail-closed startup error. This
-///     mode is declared but NOT implemented in this sprint; selecting it throws before any
-///     authentication scheme is registered, so the app can never fall through to Entra,
-///     Development, or anonymous access.</item>
+///   <item><see cref="AuthenticationMode.GitHub"/> → the Sprint 2 GitHub confidential OAuth
+///     Backend-for-Frontend (BFF) boundary. It wires the app's own GitHub session scheme, the
+///     constrained authorization policy (provider==GitHub + role + scope), the one-time state and
+///     redemption stores, the SSRF-safe OAuth transport, and the server-side allowlist INTERNALLY,
+///     then returns <c>null</c> (the caller must not layer the Entra policy on top). Outside
+///     Development it fails startup unless a complete, validated configuration (client id + secret +
+///     ≥256-bit signing key + exact callback/frontend URLs + a non-empty allowlist) is present. It is
+///     never enabled in production.</item>
 /// </list>
 /// The boundary is intentionally thin: later sprints add a case per provider here without
 /// reworking the Entra path or the authorization policy.
@@ -68,11 +73,9 @@ public static class ProviderNeutralAuthentication
                 AddAnonymousMode(services, configuration, environment);
                 return null;
             case AuthenticationMode.GitHub:
-                throw new NotSupportedException(
-                    $"Authentication mode '{mode}' is not implemented in this sprint. Only 'Entra' and " +
-                    "'Anonymous' are currently supported. GitHub is an opt-in capability delivered in a later " +
-                    "sprint and is never enabled in production. This is a deliberate fail-closed startup error — " +
-                    "authentication does not fall through to Entra, Development, or Anonymous.");
+                services.AddSingleton(new AuthenticationModeOptions { Mode = mode });
+                AddGitHubMode(services, configuration, environment);
+                return null;
 
             default:
                 // Unreachable: AuthenticationModeOptions.Resolve only returns defined members.
@@ -106,5 +109,25 @@ public static class ProviderNeutralAuthentication
         services.AddSingleton<AnonymousRateLimiter>();
         services.AddSingleton<AnonymousUsageBudget>();
         services.AddSingleton<AnonymousGuardMiddleware>();
+    }
+
+    /// <summary>
+    /// Wires the GitHub confidential OAuth Backend-for-Frontend boundary: the app's own GitHub session
+    /// scheme, the constrained authorization policy, the one-time state/redemption stores, the
+    /// SSRF-safe OAuth transport, and the server-side allowlist. Resolution is fail-closed: outside
+    /// Development it throws here unless a complete, validated configuration is supplied (client id +
+    /// secret + strong signing key + exact callback/frontend URLs + a non-empty allowlist). The GitHub
+    /// provider token never leaves the server, and the live/deployed config stays Entra.
+    /// </summary>
+    private static void AddGitHubMode(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        var options = GitHubAuthOptions.FromConfiguration(configuration, environment);
+
+        // Session scheme + constrained authz policy (default + fallback) + token service + signing key
+        // provider + one-time stores + OAuth client + allowlist + GitHub principal normalizer.
+        services.AddGitHubAuthentication(options);
     }
 }

--- a/src/RetailPulse.Api/appsettings.GitHub.example.json
+++ b/src/RetailPulse.Api/appsettings.GitHub.example.json
@@ -1,0 +1,124 @@
+{
+  // ===========================================================================
+  // GitHub authentication mode — EXAMPLE / TEMPLATE (NON-LIVE)
+  // ===========================================================================
+  // This file documents the configuration schema for the Sprint 2 GitHub
+  // authentication mode. It is NOT loaded by the app (only appsettings.json and
+  // appsettings.{Environment}.json are auto-loaded; *.example.json is ignored).
+  // Copy the values you need into real configuration (environment variables /
+  // secret store) to run GitHub mode. NEVER commit real secrets.
+  //
+  // GitHub mode is a CONFIDENTIAL Backend-for-Frontend (BFF) OAuth flow. The
+  // browser never receives the GitHub provider token: the API performs the
+  // authorization-code -> access-token exchange server-side, verifies the user
+  // against a server-side allowlist, and hands the SPA only a short-lived
+  // one-time redemption code that is exchanged for a Retail Pulse session token.
+  // A successful login yields a FULL RetailPulse.User session, so the mode is
+  // fail-closed and is NEVER used in Production — every committed deployment
+  // artifact keeps Authentication:Mode=Entra.
+  //
+  // WHY NO PKCE: GitHub OAuth Apps do not support PKCE (no code_challenge on the
+  // authorize endpoint). Login-CSRF / state-fixation / replay are defeated
+  // instead by (a) a cryptographically random state stored one-time server-side,
+  // (b) a browser-bound HttpOnly/Secure/SameSite=Lax state cookie whose secret is
+  // hashed server-side and constant-time compared at callback, and (c) the
+  // confidential client secret guarding the code exchange.
+  //
+  // FAIL-CLOSED CONTRACT:
+  //   * Authentication:Mode=GitHub enables it (no auto-detection/fallback).
+  //   * ClientId is PUBLIC; ClientSecret and SigningKey are SECRETS supplied via
+  //     GitHub__ClientSecret / GitHub__SigningKey or a secret store — never
+  //     committed, logged, or emitted. Angle-bracket placeholders below are
+  //     treated as ABSENT and rejected at startup.
+  //   * An explicit allowlist is REQUIRED — at least one of AllowedUserIds,
+  //     AllowedLogins, or AllowedOrgs. An empty allowlist would admit every
+  //     GitHub account and fails closed.
+  //   * Any hosted (non-Development) run additionally requires a >=32-byte
+  //     (256-bit) SigningKey. Development MAY use an ephemeral process-local key
+  //     (sessions die on restart) but STILL needs the real OAuth credentials,
+  //     exact HTTPS URLs, and an allowlist.
+  //   * Hosted GitHub MUST run at maxReplicas=1: the state / redemption stores
+  //     and rate limiters are replica-local (a callback handled by replica A
+  //     cannot redeem a code on replica B). Move to a distributed store before
+  //     scaling out.
+  // ===========================================================================
+  "Authentication": {
+    // Set to "GitHub" ONLY in a dedicated configuration — never in a committed
+    // Production artifact (Production stays "Entra").
+    "Mode": "GitHub"
+  },
+
+  "GitHub": {
+    // -- OAuth app (confidential client) --------------------------------------
+    // PUBLIC OAuth app client id (appears in the authorize URL; not a secret).
+    "ClientId": "<github-oauth-app-client-id>",
+
+    // SECRET OAuth app client secret. Supply via GitHub__ClientSecret or a
+    // secret store. NEVER commit a real value.
+    "ClientSecret": "<set-via-secret-store>",
+
+    // The EXACT OAuth callback URL registered with the GitHub OAuth app. Must be
+    // this API's own callback endpoint over HTTPS and end with
+    // "/api/auth/github/callback". Sent as redirect_uri on both authorize and
+    // token exchange; no user-supplied redirect is ever honoured.
+    "CallbackUrl": "https://your-api.example.com/api/auth/github/callback",
+
+    // The ONE exact SPA/SWA URL the browser is redirected to after login,
+    // carrying only a short-lived one-time redemption code (never a token).
+    "FrontendReturnUrl": "https://your-frontend.example.com/auth/github/callback",
+
+    // -- App session token ----------------------------------------------------
+    // Separate issuer/audience from Entra and Anonymous. Cross-provider tokens
+    // are rejected. provider=GitHub is asserted on every request.
+    "Issuer": "retail-pulse-github",
+    "Audience": "retail-pulse-api",
+
+    // Short session TTL (seconds), 30..3600. Bounds the replay window. No refresh
+    // token is ever issued.
+    "SessionTokenTtlSeconds": 900,
+
+    // HMAC-SHA256 signing key for the session tokens. SECRET, >=32 bytes in
+    // hosted mode. Supply via GitHub__SigningKey or a secret store. NEVER commit.
+    "SigningKey": "<set-via-secret-store-min-32-bytes>",
+
+    // Full authenticated principal — granted only AFTER server-side allowlist
+    // verification.
+    "Role": "RetailPulse.User",
+    "Scope": "access_as_user",
+
+    // -- Server-side one-time stores (TTL, seconds) ---------------------------
+    // How long an issued OAuth state is valid (login must complete in this
+    // window), 30..1800.
+    "StateTtlSeconds": 300,
+
+    // How long the one-time redemption code is valid before the SPA must
+    // exchange it, 10..600.
+    "RedemptionTtlSeconds": 120,
+
+    // -- Allowlist (server-side; at least one mechanism REQUIRED) -------------
+    // Immutable numeric GitHub user ids explicitly allowed. This is the identity
+    // of record — the mutable login is only informational.
+    "AllowedUserIds": [ "<numeric-github-user-id>" ],
+
+    // Convenience login-handle allowlist (case-insensitive). A matched login is
+    // still keyed to its immutable numeric id after /user verification.
+    "AllowedLogins": [ "<github-login>" ],
+
+    // Organizations whose ACTIVE members are allowed. Verified server-side via
+    // /user/memberships/orgs/{org}; requires the read:org scope, which is added
+    // to the authorize request ONLY when this list is non-empty. Membership
+    // visibility caveat: private membership is only readable with read:org and an
+    // active membership state. Any API / rate / error fails closed.
+    "AllowedOrgs": [ "<github-org-login>" ],
+
+    // -- Rate limits (per replica, per minute) --------------------------------
+    // Global per-replica fixed windows on the anonymous login-flow endpoints.
+    // Behind Azure Container Apps the client IP is the proxy's and
+    // X-Forwarded-For is forgeable, so these are single global windows, not
+    // per-IP.
+    "RateLimits": {
+      "StartPerMinute": 10,
+      "ExchangePerMinute": 20
+    }
+  }
+}

--- a/src/RetailPulse.Api/appsettings.GitHub.example.json
+++ b/src/RetailPulse.Api/appsettings.GitHub.example.json
@@ -30,17 +30,22 @@
   //     GitHub__ClientSecret / GitHub__SigningKey or a secret store — never
   //     committed, logged, or emitted. Angle-bracket placeholders below are
   //     treated as ABSENT and rejected at startup.
-  //   * An explicit allowlist is REQUIRED — at least one of AllowedUserIds,
-  //     AllowedLogins, or AllowedOrgs. An empty allowlist would admit every
-  //     GitHub account and fails closed.
+  //   * An explicit IMMUTABLE allowlist is REQUIRED — at least one of
+  //     AllowedUserIds (numeric ids) or AllowedOrgs (active org membership). An
+  //     empty allowlist would admit every GitHub account and fails closed. Login
+  //     handles are mutable and NEVER grant access.
   //   * Any hosted (non-Development) run additionally requires a >=32-byte
-  //     (256-bit) SigningKey. Development MAY use an ephemeral process-local key
-  //     (sessions die on restart) but STILL needs the real OAuth credentials,
-  //     exact HTTPS URLs, and an allowlist.
+  //     (256-bit) SigningKey, RequireSecureCookies=true, and
+  //     AcknowledgeSingleReplica=true. Development MAY use an ephemeral
+  //     process-local key (sessions die on restart) and MAY set
+  //     RequireSecureCookies=false for an insecure localhost dev cookie, but
+  //     STILL needs the real OAuth credentials, exact HTTPS URLs, and an
+  //     immutable allowlist.
   //   * Hosted GitHub MUST run at maxReplicas=1: the state / redemption stores
   //     and rate limiters are replica-local (a callback handled by replica A
-  //     cannot redeem a code on replica B). Move to a distributed store before
-  //     scaling out.
+  //     cannot redeem a code on replica B). The runtime cannot inspect topology,
+  //     so AcknowledgeSingleReplica=true is a required fail-closed acknowledgement.
+  //     Move to a distributed store before scaling out.
   // ===========================================================================
   "Authentication": {
     // Set to "GitHub" ONLY in a dedicated configuration — never in a committed
@@ -81,6 +86,29 @@
     // hosted mode. Supply via GitHub__SigningKey or a secret store. NEVER commit.
     "SigningKey": "<set-via-secret-store-min-32-bytes>",
 
+    // Genuine signing-key ROTATION. Additional strong (>=32-byte) keys accepted for
+    // VALIDATION only (never used to sign). Publish the next key here alongside the
+    // current SigningKey and deploy; tokens signed with the previous key keep
+    // validating until they expire. Promote a key to SigningKey on the next
+    // rotation. Placeholders are rejected. Supply via secret store — NEVER commit.
+    "AdditionalValidationKeys": [ "<optional-previous-or-next-signing-key-min-32-bytes>" ],
+
+    // Cookie hardening. MUST be true in any hosted deployment (startup fails
+    // otherwise). Behind a TLS-terminating proxy (Azure Container Apps) the
+    // in-container request is plain HTTP, so cookie Secure/__Host- semantics come
+    // from THIS validated flag, never from the observed request scheme. The state
+    // cookie is then always __Host- prefixed: Secure, HttpOnly, SameSite=Lax,
+    // Path=/, no Domain. Development MAY set this false to opt into an insecure,
+    // non-__Host dev cookie over plain http://localhost — dev/test ONLY.
+    "RequireSecureCookies": true,
+
+    // Explicit single-replica acknowledgement. MUST be true in any hosted
+    // deployment (startup fails otherwise). The OAuth state / redemption stores and
+    // login rate limiters are replica-local in-memory, so hosted GitHub must run at
+    // maxReplicas=1; the runtime cannot inspect ACA topology, so this flag is a
+    // required, fail-closed acknowledgement.
+    "AcknowledgeSingleReplica": true,
+
     // Full authenticated principal — granted only AFTER server-side allowlist
     // verification.
     "Role": "RetailPulse.User",
@@ -95,14 +123,12 @@
     // exchange it, 10..600.
     "RedemptionTtlSeconds": 120,
 
-    // -- Allowlist (server-side; at least one mechanism REQUIRED) -------------
+    // -- Allowlist (server-side; at least one IMMUTABLE mechanism REQUIRED) ----
     // Immutable numeric GitHub user ids explicitly allowed. This is the identity
-    // of record — the mutable login is only informational.
+    // of record and the ONLY per-user access gate — the mutable login handle is
+    // never an access mechanism (a renamed/re-created handle can never inherit
+    // access). Configure at least one of AllowedUserIds or AllowedOrgs.
     "AllowedUserIds": [ "<numeric-github-user-id>" ],
-
-    // Convenience login-handle allowlist (case-insensitive). A matched login is
-    // still keyed to its immutable numeric id after /user verification.
-    "AllowedLogins": [ "<github-login>" ],
 
     // Organizations whose ACTIVE members are allowed. Verified server-side via
     // /user/memberships/orgs/{org}; requires the read:org scope, which is added

--- a/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
@@ -122,6 +122,35 @@ public sealed class ProviderNeutralDeploymentContractTests
             .Should().BeTrue("the non-live Anonymous template should be committed for documentation");
     }
 
+    [Fact]
+    public void ExampleGitHubConfig_IsNotLoadedByAnyEnvironment()
+    {
+        // The GitHub example/template MUST NOT be a real environment overlay. Only
+        // appsettings.json and appsettings.{Environment}.json are auto-loaded; the example
+        // is deliberately named appsettings.GitHub.example.json (note ".example.") so it
+        // can never be picked up by ASPNETCORE_ENVIRONMENT=GitHub.
+        string apiDir = Path.Combine(RepoRoot, "src", "RetailPulse.Api");
+
+        File.Exists(Path.Combine(apiDir, "appsettings.GitHub.json"))
+            .Should().BeFalse("a live appsettings.GitHub.json overlay must not exist");
+        File.Exists(Path.Combine(apiDir, "appsettings.GitHub.example.json"))
+            .Should().BeTrue("the non-live GitHub template should be committed for documentation");
+    }
+
+    [Fact]
+    public void ExampleGitHubConfig_ContainsNoRealSecrets()
+    {
+        // The committed GitHub example must only ever carry angle-bracket placeholders for the
+        // secret values — never a real client secret or signing key.
+        string json = File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "RetailPulse.Api", "appsettings.GitHub.example.json"));
+
+        json.Should().MatchRegex("\"ClientSecret\"\\s*:\\s*\"<[^\"]*>\"",
+            "the GitHub example client secret must be an angle-bracket placeholder");
+        json.Should().MatchRegex("\"SigningKey\"\\s*:\\s*\"<[^\"]*>\"",
+            "the GitHub example signing key must be an angle-bracket placeholder");
+    }
+
     private static string FindRepoRoot()
     {
         DirectoryInfo? dir = new(AppContext.BaseDirectory);

--- a/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
@@ -96,15 +96,28 @@ public sealed class ProviderNeutralDeploymentContractTests
     [Fact]
     public void ContainerAppsBicep_PinsApiToSingleReplica()
     {
-        // maxReplicas: 1 is required for the single SQLite writer AND for the (non-Production)
-        // Anonymous mode's replica-local billable-use circuit breaker. This proves the live
-        // artifact cannot scale the API out.
+        // maxReplicas: 1 is required for the single SQLite writer, the (non-Production)
+        // Anonymous mode's replica-local billable-use circuit breaker, AND the Sprint 2
+        // GitHub BFF mode's replica-local OAuth state/redemption stores + login limiters.
+        // This proves the live API artifact cannot scale out.
         string bicep = File.ReadAllText(Path.Combine(
             RepoRoot, "infra", "modules", "container-apps.bicep"));
 
-        bicep.Should().MatchRegex(
+        // Scope the assertion to the API container app's own scale block, so a maxReplicas on
+        // some OTHER container app (mcp/teamsbot) can never satisfy this contract by accident.
+        int apiIndex = bicep.IndexOf("'ca-retailpulse-api'", StringComparison.Ordinal);
+        apiIndex.Should().BeGreaterThan(-1, "the API container app must exist");
+        int nextResourceIndex = bicep.IndexOf("resource ", apiIndex, StringComparison.Ordinal);
+        string apiBlock = nextResourceIndex > apiIndex
+            ? bicep[apiIndex..nextResourceIndex]
+            : bicep[apiIndex..];
+
+        apiBlock.Should().MatchRegex(
             "maxReplicas\\s*:\\s*1",
             "the API container app must pin maxReplicas to 1");
+        apiBlock.Should().NotMatchRegex(
+            "maxReplicas\\s*:\\s*([2-9]|\\d{2,})",
+            "the API container app must never allow more than one replica");
     }
 
     [Fact]
@@ -149,6 +162,26 @@ public sealed class ProviderNeutralDeploymentContractTests
             "the GitHub example client secret must be an angle-bracket placeholder");
         json.Should().MatchRegex("\"SigningKey\"\\s*:\\s*\"<[^\"]*>\"",
             "the GitHub example signing key must be an angle-bracket placeholder");
+    }
+
+    [Fact]
+    public void ExampleGitHubConfig_HasImmutableAllowlistContract_NoLoginAllowlist()
+    {
+        // The example must teach the hardened contract: immutable allowlist + secure cookies +
+        // single-replica acknowledgement, and must NOT reintroduce a mutable login allowlist.
+        string json = File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "RetailPulse.Api", "appsettings.GitHub.example.json"));
+
+        json.Should().NotContain("\"AllowedLogins\"",
+            "the mutable login allowlist was removed and must never return to the example");
+        json.Should().Contain("\"AllowedUserIds\"",
+            "the example must show the immutable numeric-id allowlist");
+        json.Should().Contain("\"RequireSecureCookies\"",
+            "the example must document the secure-cookie enforcement flag");
+        json.Should().Contain("\"AcknowledgeSingleReplica\"",
+            "the example must document the single-replica acknowledgement flag");
+        json.Should().Contain("\"AdditionalValidationKeys\"",
+            "the example must document signing-key rotation via additional validation keys");
     }
 
     private static string FindRepoRoot()

--- a/tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousCapabilityTests.cs
@@ -116,6 +116,39 @@ public sealed class AnonymousCapabilityTests
             "anonymous tokens must carry no PII");
     }
 
+    [Fact]
+    public void TokenService_KeyRotation_OldTokenStillValidatesAndNewTokenUsesCurrentKey()
+    {
+        const string oldKey = "anon-OLD-signing-key-0123456789ABCDEF-32byte";
+        const string newKey = "anon-NEW-signing-key-0123456789ABCDEF-32byte";
+
+        // Before rotation: OLD key signs.
+        AnonymousAuthOptions before = HostedOptionsWithRotation(oldKey);
+        var beforeKp = new AnonymousSigningKeyProvider(before);
+        AnonymousSession oldSession = new AnonymousSessionTokenService(before, beforeKp).CreateSession();
+
+        // After rotation: NEW key signs, OLD demoted to validation-only.
+        AnonymousAuthOptions after = HostedOptionsWithRotation(newKey, oldKey);
+        var afterKp = new AnonymousSigningKeyProvider(after);
+        AnonymousSession newSession = new AnonymousSessionTokenService(after, afterKp).CreateSession();
+
+        var handler = new JsonWebTokenHandler { MapInboundClaims = false };
+
+        // The in-flight OLD token still validates against the rotated key set.
+        TokenValidationResult oldResult = handler.ValidateTokenAsync(oldSession.Token, new TokenValidationParameters
+        {
+            ValidateIssuer = false,
+            ValidateAudience = false,
+            IssuerSigningKeys = afterKp.ValidationKeys,
+            ValidAlgorithms = [SecurityAlgorithms.HmacSha256],
+        }).GetAwaiter().GetResult();
+        oldResult.IsValid.Should().BeTrue("a token signed by the previous key must validate after rotation");
+
+        // New tokens are signed by the CURRENT key (its kid), never the demoted one.
+        new JsonWebToken(newSession.Token).Kid.Should().Be(afterKp.Key.KeyId);
+        afterKp.Key.KeyId.Should().NotBe(beforeKp.Key.KeyId, "rotation changes the active signing key");
+    }
+
     // ── Principal normalizer: subject from token, provider pinned ──────────────
 
     [Fact]
@@ -305,6 +338,25 @@ public sealed class AnonymousCapabilityTests
                 ("Anonymous:Limits:DailyMaxTokens", dailyTokens.ToString()),
                 ("Anonymous:Limits:DailyMaxCostUsd", dailyCost.ToString(System.Globalization.CultureInfo.InvariantCulture))),
             Env("Production"));
+
+    private static AnonymousAuthOptions HostedOptionsWithRotation(string signingKey, params string[] additional)
+    {
+        var entries = new List<(string, string?)>
+        {
+            ("Authentication:Mode", "Anonymous"),
+            ("Anonymous:AllowHosted", "true"),
+            ("Anonymous:SigningKey", signingKey),
+            ("Anonymous:Limits:DailyMaxRequests", "500"),
+            ("Anonymous:Limits:DailyMaxTokens", "200000"),
+            ("Anonymous:Limits:DailyMaxCostUsd", "5"),
+        };
+        for (int i = 0; i < additional.Length; i++)
+        {
+            entries.Add(($"Anonymous:AdditionalValidationKeys:{i}", additional[i]));
+        }
+
+        return AnonymousAuthOptions.FromConfiguration(Config([.. entries]), Env("Production"));
+    }
 
     private static ClaimsPrincipal AnonymousPrincipal(
         string subject, string role = "RetailPulse.Anonymous", string scope = "chat_limited")

--- a/tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs
+++ b/tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs
@@ -15,8 +15,10 @@ namespace RetailPulse.Tests.Security;
 /// These prove the deterministic, fail-closed selection rules:
 /// <list type="bullet">
 ///   <item>Explicit <c>Entra</c> (any casing) resolves and wires the existing Entra boundary.</item>
-///   <item>GitHub resolves as a known mode but the factory fails startup
-///     ("not implemented in this sprint") and never falls through to Entra/dev/anonymous.</item>
+///   <item>GitHub (Sprint 2) resolves as a known mode and wires its own confidential OAuth BFF
+///     session stack; it fails startup fail-closed without a complete, validated configuration
+///     (client id + secret + signing key + exact HTTPS URLs + a non-empty allowlist) and never
+///     falls through to Entra/dev/anonymous.</item>
 ///   <item>Anonymous (Sprint 1) wires its own constrained session stack; hosted use fails
 ///     closed without the second opt-in + signing key + daily ceilings.</item>
 ///   <item>Unknown/malformed/numeric modes fail startup.</item>
@@ -182,46 +184,161 @@ public sealed class AuthenticationModeTests
         services.BuildServiceProvider().GetService<IPrincipalNormalizer>().Should().NotBeNull();
     }
 
-    // ── Factory boundary: GitHub still fails closed, no fall-through ───────────
+    // ── Factory boundary: GitHub mode (Sprint 2) ─────────────────────────────
 
-    [Theory]
-    [InlineData("GitHub")]
-    public void AddProviderNeutralAuthentication_UnimplementedMode_FailsStartup(string mode)
+    private const string GitHubSigningKey = "github-mode-test-signing-key-0123456789abcdef";
+
+    private static IConfiguration GitHubConfig(string environment, params (string Key, string? Value)[] extra)
     {
-        var services = new ServiceCollection();
+        var entries = new List<(string, string?)>
+        {
+            ("Authentication:Mode", "GitHub"),
+            ("GitHub:ClientId", "Iv1.abcdef0123456789"),
+            ("GitHub:ClientSecret", "test-github-client-secret-value"),
+            ("GitHub:CallbackUrl", "https://api.example.com/api/auth/github/callback"),
+            ("GitHub:FrontendReturnUrl", "https://app.example.com/auth/github/callback"),
+            ("GitHub:AllowedUserIds:0", "12345"),
+        };
+        if (!environment.Equals("Development", StringComparison.OrdinalIgnoreCase))
+        {
+            entries.Add(("GitHub:SigningKey", GitHubSigningKey));
+        }
 
-        Action act = () => services.AddProviderNeutralAuthentication(EntraConfig(mode), Env("Development"));
-
-        act.Should().Throw<NotSupportedException>()
-            .WithMessage("*not implemented in this sprint*");
+        entries.AddRange(extra);
+        return Config([.. entries]);
     }
 
-    [Theory]
-    [InlineData("GitHub")]
-    public void AddProviderNeutralAuthentication_UnimplementedMode_DoesNotWireAnyAuth(string mode)
+    [Fact]
+    public void AddProviderNeutralAuthentication_HostedGitHubFullyConfigured_WiresGitHubStackAndReturnsNull()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        EntraAuthOptions? options = services.AddProviderNeutralAuthentication(
+            GitHubConfig("Production"), Env("Production"));
+
+        // GitHub wires its own authorization internally, so it returns null (Program.cs must NOT
+        // layer the Entra policy on top).
+        options.Should().BeNull();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetService<AuthenticationModeOptions>()!.Mode.Should().Be(AuthenticationMode.GitHub);
+
+        // The GitHub principal normalizer, options, and session token service are registered.
+        IPrincipalNormalizer normalizer = provider.GetRequiredService<IPrincipalNormalizer>();
+        normalizer.Mode.Should().Be(AuthenticationMode.GitHub);
+        normalizer.Should().BeOfType<GitHubPrincipalNormalizer>();
+
+        Api.Security.GitHub.GitHubAuthOptions resolved =
+            provider.GetRequiredService<Api.Security.GitHub.GitHubAuthOptions>();
+        resolved.HasConfiguredSigningKey.Should().BeTrue("hosted GitHub requires a configured signing key");
+
+        provider.GetService<Api.Security.GitHub.IGitHubSessionTokenService>().Should().NotBeNull();
+        provider.GetService<Api.Security.GitHub.GitHubStateStore>().Should().NotBeNull();
+        provider.GetService<Api.Security.GitHub.GitHubRedemptionStore>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_GitHubInDevelopment_WiresWithEphemeralKey()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Development may run the real OAuth flow with an ephemeral signing key (no GitHub:SigningKey),
+        // but STILL requires the real OAuth credentials, exact URLs, and an allowlist.
+        EntraAuthOptions? options = services.AddProviderNeutralAuthentication(
+            GitHubConfig("Development"), Env("Development"));
+
+        options.Should().BeNull();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetService<AuthenticationModeOptions>()!.Mode.Should().Be(AuthenticationMode.GitHub);
+        Api.Security.GitHub.GitHubSigningKeyProvider keyProvider =
+            provider.GetRequiredService<Api.Security.GitHub.GitHubSigningKeyProvider>();
+        keyProvider.IsEphemeral.Should().BeTrue("Development GitHub mode generates an ephemeral signing key");
+    }
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_HostedGitHubWithoutSigningKey_FailsClosed()
     {
         var services = new ServiceCollection();
 
-        try
+        // Config WITHOUT GitHub:SigningKey but Production → must fail closed.
+        var entries = new List<(string, string?)>
         {
-            services.AddProviderNeutralAuthentication(EntraConfig(mode), Env("Production"));
-        }
-        catch (NotSupportedException)
-        {
-            // expected — the boundary fails closed
-        }
+            ("Authentication:Mode", "GitHub"),
+            ("GitHub:ClientId", "Iv1.abcdef0123456789"),
+            ("GitHub:ClientSecret", "test-github-client-secret-value"),
+            ("GitHub:CallbackUrl", "https://api.example.com/api/auth/github/callback"),
+            ("GitHub:FrontendReturnUrl", "https://app.example.com/auth/github/callback"),
+            ("GitHub:AllowedUserIds:0", "12345"),
+        };
 
-        // Nothing auth-related may be registered: no fall-through to the Entra boundary,
-        // no authentication scheme, no options singletons.
-        services.Should().NotContain(d => d.ServiceType == typeof(EntraAuthOptions),
-            "an unimplemented mode must never register the Entra options");
-        services.Should().NotContain(d => d.ServiceType == typeof(IPrincipalNormalizer),
-            "an unimplemented mode must never register a principal normalizer");
-        services.Should().NotContain(d => d.ServiceType == typeof(AuthenticationModeOptions),
-            "an unimplemented mode must not register a resolved mode");
-        services.Should().NotContain(
-            d => d.ServiceType.FullName == "Microsoft.AspNetCore.Authentication.IAuthenticationSchemeProvider",
-            "an unimplemented mode must never register an authentication scheme");
+        Action act = () => services.AddProviderNeutralAuthentication(Config([.. entries]), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*SigningKey*");
+    }
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_GitHubWithoutClientSecret_FailsClosed()
+    {
+        var services = new ServiceCollection();
+
+        var entries = new List<(string, string?)>
+        {
+            ("Authentication:Mode", "GitHub"),
+            ("GitHub:ClientId", "Iv1.abcdef0123456789"),
+            ("GitHub:CallbackUrl", "https://api.example.com/api/auth/github/callback"),
+            ("GitHub:FrontendReturnUrl", "https://app.example.com/auth/github/callback"),
+            ("GitHub:AllowedUserIds:0", "12345"),
+        };
+
+        // Even Development requires the OAuth client secret to talk to GitHub.
+        Action act = () => services.AddProviderNeutralAuthentication(Config([.. entries]), Env("Development"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*ClientSecret*");
+    }
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_GitHubWithoutAllowlist_FailsClosed()
+    {
+        var services = new ServiceCollection();
+
+        var entries = new List<(string, string?)>
+        {
+            ("Authentication:Mode", "GitHub"),
+            ("GitHub:ClientId", "Iv1.abcdef0123456789"),
+            ("GitHub:ClientSecret", "test-github-client-secret-value"),
+            ("GitHub:SigningKey", GitHubSigningKey),
+            ("GitHub:CallbackUrl", "https://api.example.com/api/auth/github/callback"),
+            ("GitHub:FrontendReturnUrl", "https://app.example.com/auth/github/callback"),
+        };
+
+        Action act = () => services.AddProviderNeutralAuthentication(Config([.. entries]), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*allowlist*");
+    }
+
+    [Fact]
+    public void AddProviderNeutralAuthentication_GitHub_PlaceholderValues_FailClosed()
+    {
+        var services = new ServiceCollection();
+
+        // Copying the example config verbatim (angle-bracket placeholders) must never authenticate.
+        var entries = new List<(string, string?)>
+        {
+            ("Authentication:Mode", "GitHub"),
+            ("GitHub:ClientId", "<github-oauth-app-client-id>"),
+            ("GitHub:ClientSecret", "<set-via-secret-store>"),
+            ("GitHub:SigningKey", "<set-via-secret-store-min-32-bytes>"),
+            ("GitHub:CallbackUrl", "https://api.example.com/api/auth/github/callback"),
+            ("GitHub:FrontendReturnUrl", "https://app.example.com/auth/github/callback"),
+            ("GitHub:AllowedUserIds:0", "12345"),
+        };
+
+        Action act = () => services.AddProviderNeutralAuthentication(Config([.. entries]), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>();
     }
 
     // ── Factory boundary: Anonymous mode (Sprint 1) ───────────────────────────

--- a/tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs
+++ b/tests/RetailPulse.Tests/Security/AuthenticationModeTests.cs
@@ -202,6 +202,8 @@ public sealed class AuthenticationModeTests
         if (!environment.Equals("Development", StringComparison.OrdinalIgnoreCase))
         {
             entries.Add(("GitHub:SigningKey", GitHubSigningKey));
+            entries.Add(("GitHub:RequireSecureCookies", "true"));
+            entries.Add(("GitHub:AcknowledgeSingleReplica", "true"));
         }
 
         entries.AddRange(extra);

--- a/tests/RetailPulse.Tests/Security/FakeGitHubOAuthClient.cs
+++ b/tests/RetailPulse.Tests/Security/FakeGitHubOAuthClient.cs
@@ -1,0 +1,44 @@
+using RetailPulse.Api.Security.GitHub;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// A programmable in-memory <see cref="IGitHubOAuthClient"/> test double. Tests set the exchange /
+/// user / org-membership outcomes; the object records the provider token it was handed so tests can
+/// assert the token is used only for verification and never leaks. No real HTTP is performed.
+/// </summary>
+internal sealed class FakeGitHubOAuthClient : IGitHubOAuthClient
+{
+    public Func<string, GitHubTokenResult> OnExchange { get; set; } =
+        _ => new GitHubTokenResult(true, "gho_provider_token_secret", null);
+
+    public Func<string, GitHubUserResult> OnGetUser { get; set; } =
+        _ => new GitHubUserResult(true, 12345, "octocat", null);
+
+    public Func<string, string, GitHubOrgMembershipResult> OnOrgMembership { get; set; } =
+        (_, _) => new GitHubOrgMembershipResult(false, "org_http_404");
+
+    public List<string> ExchangedCodes { get; } = [];
+    public List<string> SeenTokens { get; } = [];
+    public List<string> OrgChecks { get; } = [];
+
+    public Task<GitHubTokenResult> ExchangeCodeAsync(string code, CancellationToken cancellationToken)
+    {
+        ExchangedCodes.Add(code);
+        return Task.FromResult(OnExchange(code));
+    }
+
+    public Task<GitHubUserResult> GetUserAsync(string accessToken, CancellationToken cancellationToken)
+    {
+        SeenTokens.Add(accessToken);
+        return Task.FromResult(OnGetUser(accessToken));
+    }
+
+    public Task<GitHubOrgMembershipResult> GetActiveOrgMembershipAsync(
+        string accessToken, string org, CancellationToken cancellationToken)
+    {
+        SeenTokens.Add(accessToken);
+        OrgChecks.Add(org);
+        return Task.FromResult(OnOrgMembership(accessToken, org));
+    }
+}

--- a/tests/RetailPulse.Tests/Security/GitHubAuthOptionsTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubAuthOptionsTests.cs
@@ -44,6 +44,8 @@ public sealed class GitHubAuthOptionsTests
         ["GitHub:CallbackUrl"] = "https://api.example.com/api/auth/github/callback",
         ["GitHub:FrontendReturnUrl"] = "https://app.example.com/auth/github/callback",
         ["GitHub:AllowedUserIds:0"] = "12345",
+        ["GitHub:RequireSecureCookies"] = "true",
+        ["GitHub:AcknowledgeSingleReplica"] = "true",
     };
 
     [Fact]
@@ -194,14 +196,99 @@ public sealed class GitHubAuthOptionsTests
     }
 
     [Fact]
-    public void FromConfiguration_LoginOnlyAllowlist_Resolves()
+    public void FromConfiguration_LoginConfig_NeverExposesAccessGrantSurface()
     {
+        // A login-only allowlist must fail closed: the mutable handle can never be the sole gate.
         Dictionary<string, string?> cfg = Complete();
         cfg.Remove("GitHub:AllowedUserIds:0");
         cfg["GitHub:AllowedLogins:0"] = "octocat";
 
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*allowlist*");
+    }
+
+    [Fact]
+    public void FromConfiguration_HostedWithoutSecureCookies_FailsClosed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg["GitHub:RequireSecureCookies"] = "false";
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*RequireSecureCookies*");
+    }
+
+    [Fact]
+    public void FromConfiguration_DevelopmentInsecureCookies_Resolves()
+    {
+        // Development may opt into an insecure, non-__Host dev cookie over plain http://localhost.
+        Dictionary<string, string?> cfg = Complete();
+        cfg.Remove("GitHub:SigningKey");
+        cfg["GitHub:RequireSecureCookies"] = "false";
+        cfg["GitHub:AcknowledgeSingleReplica"] = "false";
+
+        var options = GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Development"));
+
+        options.RequireSecureCookies.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FromConfiguration_HostedWithoutSingleReplicaAck_FailsClosed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg.Remove("GitHub:AcknowledgeSingleReplica");
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*AcknowledgeSingleReplica*");
+    }
+
+    [Fact]
+    public void FromConfiguration_WeakAdditionalValidationKey_FailsClosed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg["GitHub:AdditionalValidationKeys:0"] = "too-short";
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*256-bit*");
+    }
+
+    [Fact]
+    public void FromConfiguration_StrongAdditionalValidationKeys_ResolveDedupedAndPlaceholderStripped()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg["GitHub:AdditionalValidationKeys:0"] = "github-rotated-previous-key-0123456789abcdef";
+        cfg["GitHub:AdditionalValidationKeys:1"] = "github-rotated-previous-key-0123456789abcdef"; // dupe
+        cfg["GitHub:AdditionalValidationKeys:2"] = "<optional-previous-or-next-signing-key-min-32-bytes>"; // placeholder
+
         var options = GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
 
-        options.AllowedLogins.Should().ContainSingle().Which.Should().Be("octocat");
+        options.AdditionalValidationKeys.Should().ContainSingle()
+            .Which.Should().Be("github-rotated-previous-key-0123456789abcdef");
+    }
+
+    [Fact]
+    public void FromConfiguration_AllowedUserIds_ParsedPositiveAndDeduped()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg["GitHub:AllowedUserIds:1"] = "12345"; // dupe
+        cfg["GitHub:AllowedUserIds:2"] = "67890";
+
+        var options = GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        options.AllowedUserIds.Should().BeEquivalentTo([12345L, 67890L]);
+    }
+
+    [Fact]
+    public void FromConfiguration_NonPositiveAllowedUserId_FailsClosed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg["GitHub:AllowedUserIds:0"] = "0";
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>();
     }
 }

--- a/tests/RetailPulse.Tests/Security/GitHubAuthOptionsTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubAuthOptionsTests.cs
@@ -1,0 +1,207 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using RetailPulse.Api.Security.GitHub;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Fail-closed validation contract for <see cref="GitHubAuthOptions.FromConfiguration"/>.
+///
+/// GitHub mode ultimately mints a full <c>RetailPulse.User</c> session, so a misconfigured deployment
+/// must never serve traffic. These prove:
+/// <list type="bullet">
+///   <item>a complete hosted config resolves and requests MINIMAL scopes (never repo);</item>
+///   <item>every missing/placeholder/malformed value throws at startup;</item>
+///   <item>the signing key is required and ≥256-bit hosted; ephemeral only in Development;</item>
+///   <item>an empty allowlist is rejected (never admit every GitHub user);</item>
+///   <item>read:org is requested ONLY when an org allowlist is configured.</item>
+/// </list>
+/// </summary>
+public sealed class GitHubAuthOptionsTests
+{
+    private const string StrongKey = "github-mode-test-signing-key-0123456789abcdef";
+
+    private static IHostEnvironment Env(string name) => new TestEnv { EnvironmentName = name };
+
+    private sealed class TestEnv : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "RetailPulse.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+
+    private static IConfiguration Config(IEnumerable<KeyValuePair<string, string?>> entries) =>
+        new ConfigurationBuilder().AddInMemoryCollection(entries).Build();
+
+    private static Dictionary<string, string?> Complete() => new()
+    {
+        ["GitHub:ClientId"] = "Iv1.abcdef0123456789",
+        ["GitHub:ClientSecret"] = "test-github-client-secret",
+        ["GitHub:SigningKey"] = StrongKey,
+        ["GitHub:CallbackUrl"] = "https://api.example.com/api/auth/github/callback",
+        ["GitHub:FrontendReturnUrl"] = "https://app.example.com/auth/github/callback",
+        ["GitHub:AllowedUserIds:0"] = "12345",
+    };
+
+    [Fact]
+    public void FromConfiguration_CompleteHosted_Resolves()
+    {
+        var options = GitHubAuthOptions.FromConfiguration(Config(Complete()), Env("Production"));
+
+        options.ClientId.Should().Be("Iv1.abcdef0123456789");
+        options.HasConfiguredSigningKey.Should().BeTrue();
+        options.AllowedUserIds.Should().ContainSingle().Which.Should().Be(12345);
+        options.CallbackUrl.Should().EndWith("/api/auth/github/callback");
+    }
+
+    [Fact]
+    public void RequestedScopes_NoOrgAllowlist_IsEmpty()
+    {
+        var options = GitHubAuthOptions.FromConfiguration(Config(Complete()), Env("Production"));
+
+        options.RequestedScopes.Should().BeEmpty("reading id + login from /user needs no scope");
+    }
+
+    [Fact]
+    public void RequestedScopes_WithOrgAllowlist_IsReadOrgOnly_NeverRepo()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg["GitHub:AllowedOrgs:0"] = "contoso";
+
+        var options = GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        options.RequestedScopes.Should().Be("read:org");
+        options.RequestedScopes.Should().NotContain("repo");
+    }
+
+    [Fact]
+    public void FromConfiguration_MissingClientId_FailsClosed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg.Remove("GitHub:ClientId");
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*ClientId*");
+    }
+
+    [Theory]
+    [InlineData("GitHub:ClientId", "<github-oauth-app-client-id>")]
+    [InlineData("GitHub:ClientSecret", "<set-via-secret-store>")]
+    [InlineData("GitHub:SigningKey", "<set-via-secret-store-min-32-bytes>")]
+    public void FromConfiguration_PlaceholderValue_IsTreatedAsAbsentAndFailsClosed(string key, string placeholder)
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg[key] = placeholder;
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void FromConfiguration_MissingClientSecret_FailsClosed_EvenInDevelopment()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg.Remove("GitHub:ClientSecret");
+        cfg.Remove("GitHub:SigningKey"); // Development allows ephemeral key
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Development"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*ClientSecret*");
+    }
+
+    [Fact]
+    public void FromConfiguration_HostedWithoutSigningKey_FailsClosed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg.Remove("GitHub:SigningKey");
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*SigningKey*");
+    }
+
+    [Fact]
+    public void FromConfiguration_DevelopmentWithoutSigningKey_ResolvesWithEphemeralAllowed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg.Remove("GitHub:SigningKey");
+
+        var options = GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Development"));
+
+        options.HasConfiguredSigningKey.Should().BeFalse("Development permits an ephemeral process-local key");
+    }
+
+    [Fact]
+    public void FromConfiguration_ShortSigningKey_FailsClosed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg["GitHub:SigningKey"] = "too-short";
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*256-bit*");
+    }
+
+    [Fact]
+    public void FromConfiguration_EmptyAllowlist_FailsClosed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg.Remove("GitHub:AllowedUserIds:0");
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*allowlist*");
+    }
+
+    [Theory]
+    [InlineData("http://api.example.com/api/auth/github/callback")] // not HTTPS
+    [InlineData("https://api.example.com/wrong/path")] // not the callback route
+    public void FromConfiguration_BadCallbackUrl_FailsClosed(string callback)
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg["GitHub:CallbackUrl"] = callback;
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void FromConfiguration_NonHttpsFrontendUrl_FailsClosed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg["GitHub:FrontendReturnUrl"] = "http://app.example.com/auth/github/callback";
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void FromConfiguration_NonNumericAllowedUserId_FailsClosed()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg["GitHub:AllowedUserIds:0"] = "octocat"; // login, not a numeric id
+
+        Action act = () => GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*non-numeric*");
+    }
+
+    [Fact]
+    public void FromConfiguration_LoginOnlyAllowlist_Resolves()
+    {
+        Dictionary<string, string?> cfg = Complete();
+        cfg.Remove("GitHub:AllowedUserIds:0");
+        cfg["GitHub:AllowedLogins:0"] = "octocat";
+
+        var options = GitHubAuthOptions.FromConfiguration(Config(cfg), Env("Production"));
+
+        options.AllowedLogins.Should().ContainSingle().Which.Should().Be("octocat");
+    }
+}

--- a/tests/RetailPulse.Tests/Security/GitHubAuthenticationTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubAuthenticationTests.cs
@@ -88,6 +88,87 @@ public sealed class GitHubAuthenticationTests
         q["scope"].Should().NotContain("repo");
     }
 
+    // ── cookie topology (Blocker 1) ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Start_HostedHttp_StateCookieHasHostPrefixAndFullSecureAttributes()
+    {
+        // In-container HTTP (TestServer is plain HTTP) but hosted (Production) config: cookie security
+        // MUST come from RequireSecureCookies, not the observed request scheme. Set-Cookie must be a
+        // __Host- cookie: Secure, HttpOnly, SameSite=Lax, Path=/, and NO Domain.
+        using TestFixture fx = CreateServer();
+
+        HttpResponseMessage resp = await fx.Client.GetAsync(GitHubAuthConstants.StartRoute);
+
+        string setCookie = resp.Headers.GetValues("Set-Cookie").First(c => c.Contains("rp_gh_state"));
+        string cookieName = setCookie.Split('=')[0];
+
+        cookieName.Should().StartWith("__Host-rp_gh_state_", "hosted cookies use fixed __Host- semantics");
+        setCookie.ToLowerInvariant().Should().Contain("secure", "TLS terminates at the edge; Secure comes from config");
+        setCookie.ToLowerInvariant().Should().Contain("httponly");
+        setCookie.ToLowerInvariant().Should().Contain("samesite=lax");
+        setCookie.ToLowerInvariant().Should().Contain("path=/");
+        setCookie.ToLowerInvariant().Should().NotContain("domain=", "__Host- cookies must not set Domain");
+    }
+
+    [Fact]
+    public void Start_HostedWithoutSecureCookies_FailsStartup()
+    {
+        // A hosted GitHub deployment that opts out of secure cookies must never boot.
+        Action act = () => CreateServer(requireSecureCookies: false);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*RequireSecureCookies*");
+    }
+
+    [Fact]
+    public void Start_HostedWithoutSingleReplicaAck_FailsStartup()
+    {
+        Action act = () => CreateServer(acknowledgeSingleReplica: false);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*AcknowledgeSingleReplica*");
+    }
+
+    [Fact]
+    public async Task Start_DevelopmentInsecure_UsesNonHostDevCookie()
+    {
+        // Development may explicitly opt into an insecure, non-__Host dev cookie over plain HTTP.
+        using TestFixture fx = CreateServer(
+            requireSecureCookies: false, acknowledgeSingleReplica: false, environment: "Development");
+
+        HttpResponseMessage resp = await fx.Client.GetAsync(GitHubAuthConstants.StartRoute);
+
+        string setCookie = resp.Headers.GetValues("Set-Cookie").First(c => c.Contains("rp_gh_state"));
+        string cookieName = setCookie.Split('=')[0];
+
+        cookieName.Should().NotStartWith("__Host-", "the dev cookie is deliberately non-__Host");
+        cookieName.Should().StartWith("rp_gh_state_");
+        setCookie.ToLowerInvariant().Should().Contain("httponly", "even the dev cookie stays HttpOnly");
+        setCookie.ToLowerInvariant().Should().NotContain("secure", "the dev cookie is served over plain HTTP");
+    }
+
+    // ── parallel tabs (related hardening) ────────────────────────────────────
+
+    [Fact]
+    public async Task Callback_ParallelTabs_BothLoginsCompleteIndependently()
+    {
+        using TestFixture fx = CreateServer();
+
+        // Two concurrent starts (two browser tabs) each get their own per-state cookie.
+        (string state1, string cookie1) = await BeginLogin(fx);
+        (string state2, string cookie2) = await BeginLogin(fx);
+
+        cookie1.Split('=')[0].Should().NotBe(cookie2.Split('=')[0], "each tab derives a distinct cookie name");
+
+        // Each callback consumes only its own cookie; both complete successfully and independently.
+        HttpResponseMessage first = await Callback(fx, state1, cookie1, code: "c1");
+        HttpResponseMessage second = await Callback(fx, state2, cookie2, code: "c2");
+
+        first.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        second.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        System.Web.HttpUtility.ParseQueryString(first.Headers.Location!.Query)["code"].Should().NotBeNullOrWhiteSpace();
+        System.Web.HttpUtility.ParseQueryString(second.Headers.Location!.Query)["code"].Should().NotBeNullOrWhiteSpace();
+    }
+
     // ── callback happy path ──────────────────────────────────────────────────
 
     [Fact]
@@ -583,7 +664,10 @@ public sealed class GitHubAuthenticationTests
         int stateTtlSeconds = 300,
         int redemptionTtlSeconds = 120,
         int startPerMinute = 100,
-        int exchangePerMinute = 100)
+        int exchangePerMinute = 100,
+        bool requireSecureCookies = true,
+        bool acknowledgeSingleReplica = true,
+        string environment = "Production")
     {
         var settings = new Dictionary<string, string?>
         {
@@ -597,6 +681,8 @@ public sealed class GitHubAuthenticationTests
             ["GitHub:FrontendReturnUrl"] = FrontendUrl,
             ["GitHub:StateTtlSeconds"] = stateTtlSeconds.ToString(),
             ["GitHub:RedemptionTtlSeconds"] = redemptionTtlSeconds.ToString(),
+            ["GitHub:RequireSecureCookies"] = requireSecureCookies ? "true" : "false",
+            ["GitHub:AcknowledgeSingleReplica"] = acknowledgeSingleReplica ? "true" : "false",
             ["GitHub:RateLimits:StartPerMinute"] = startPerMinute.ToString(),
             ["GitHub:RateLimits:ExchangePerMinute"] = exchangePerMinute.ToString(),
         };
@@ -604,7 +690,6 @@ public sealed class GitHubAuthenticationTests
         if (useUserIdAllowlist)
         {
             settings["GitHub:AllowedUserIds:0"] = AllowedId.ToString();
-            settings["GitHub:AllowedLogins:0"] = AllowedLogin;
         }
 
         if (allowedOrgs is not null)
@@ -626,7 +711,7 @@ public sealed class GitHubAuthenticationTests
         var logSink = new ListLoggerProvider();
 
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
-        builder.Environment.EnvironmentName = Environments.Production;
+        builder.Environment.EnvironmentName = environment;
         builder.WebHost.UseTestServer();
 
         builder.Services.AddRouting();

--- a/tests/RetailPulse.Tests/Security/GitHubAuthenticationTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubAuthenticationTests.cs
@@ -1,0 +1,788 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Api.Security;
+using RetailPulse.Api.Security.GitHub;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// End-to-end HTTP contract + threat tests for the Sprint 2 GitHub confidential OAuth
+/// Backend-for-Frontend (BFF) boundary.
+///
+/// A minimal in-process <see cref="TestServer"/> wires the EXACT GitHub stack (session JwtBearer
+/// scheme + constrained policy + one-time stores + allowlist), with the GitHub HTTP transport
+/// replaced by a programmable <see cref="FakeGitHubOAuthClient"/> and a configured signing key so
+/// tests can also mint session tokens offline. It proves the full happy path and every failure and
+/// abuse mode without ever calling GitHub or leaking the provider token.
+/// </summary>
+public sealed class GitHubAuthenticationTests
+{
+    private const string Issuer = "retail-pulse-github";
+    private const string Audience = "retail-pulse-api";
+    private const string SigningKeyText = "github-integration-test-signing-key-0123456789";
+    private const long AllowedId = 12345;
+    private const string AllowedLogin = "octocat";
+    private const string FrontendUrl = "https://app.example.com/auth/github/callback";
+    private static readonly SymmetricSecurityKey SigningKey = new(Encoding.UTF8.GetBytes(SigningKeyText));
+    private static readonly SymmetricSecurityKey WrongKey = new(Encoding.UTF8.GetBytes("a-totally-different-wrong-signing-key-999999"));
+
+    private const string ProviderToken = "gho_super_secret_provider_token_value";
+
+    // ── start ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Start_RedirectsToGitHubAuthorize_WithStateCookieAndMinimalScope()
+    {
+        using TestFixture fx = CreateServer();
+
+        HttpResponseMessage resp = await fx.Client.GetAsync(GitHubAuthConstants.StartRoute);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        Uri location = resp.Headers.Location!;
+        location.GetLeftPart(UriPartial.Path).Should().Be(GitHubAuthConstants.AuthorizeUrl);
+
+        System.Collections.Specialized.NameValueCollection q = System.Web.HttpUtility.ParseQueryString(location.Query);
+        q["client_id"].Should().Be("Iv1.testclientid");
+        q["redirect_uri"].Should().Be("https://api.example.com/api/auth/github/callback");
+        q["state"].Should().NotBeNullOrWhiteSpace();
+        q["allow_signup"].Should().Be("false");
+
+        // No org allowlist configured by default → minimal (empty) scope, never repo.
+        (q["scope"] ?? string.Empty).Should().NotContain("repo");
+
+        // The browser-binding state cookie is set HttpOnly.
+        resp.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies).Should().BeTrue();
+        string cookie = cookies!.Single(c => c.Contains("rp_gh_state"));
+        cookie.Should().Contain("httponly", "the state cookie must be HttpOnly");
+        cookie.Should().Contain("samesite=lax");
+    }
+
+    [Fact]
+    public async Task Start_WithOrgAllowlist_RequestsReadOrgScopeOnly()
+    {
+        using TestFixture fx = CreateServer(allowedOrgs: ["contoso"]);
+
+        HttpResponseMessage resp = await fx.Client.GetAsync(GitHubAuthConstants.StartRoute);
+
+        System.Collections.Specialized.NameValueCollection q =
+            System.Web.HttpUtility.ParseQueryString(resp.Headers.Location!.Query);
+        q["scope"].Should().Be("read:org");
+        q["scope"].Should().NotContain("repo");
+    }
+
+    // ── callback happy path ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Callback_HappyPath_RedirectsToFrontendWithOneTimeCode_NoProviderToken()
+    {
+        using TestFixture fx = CreateServer();
+        (string state, string cookie) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state, cookie, code: "gh-auth-code");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        Uri location = resp.Headers.Location!;
+        location.GetLeftPart(UriPartial.Path).Should().Be(FrontendUrl);
+
+        System.Collections.Specialized.NameValueCollection q = System.Web.HttpUtility.ParseQueryString(location.Query);
+        string? redemption = q["code"];
+        redemption.Should().NotBeNullOrWhiteSpace();
+
+        // CRITICAL: the provider token must NEVER appear in the redirect URL.
+        location.ToString().Should().NotContain(ProviderToken);
+        redemption.Should().NotBe(ProviderToken);
+
+        // The state cookie is deleted on success.
+        AssertStateCookieCleared(resp);
+    }
+
+    [Fact]
+    public async Task Callback_ThenExchange_ReturnsUsableSessionToken_NotProviderToken()
+    {
+        using TestFixture fx = CreateServer();
+        string redemption = await LoginToRedemption(fx);
+
+        HttpResponseMessage resp = await Exchange(fx, redemption);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        string raw = await resp.Content.ReadAsStringAsync();
+        raw.Should().NotContain(ProviderToken, "the provider token must never reach the exchange body");
+
+        ExchangeBody body = JsonSerializer.Deserialize<ExchangeBody>(raw, JsonOpts)!;
+        body.Token.Should().NotBeNullOrWhiteSpace();
+        body.TokenType.Should().Be("Bearer");
+        body.Subject.Should().Be($"github:{AllowedId}");
+
+        // The returned token is a valid GitHub session token that reaches a protected REST route.
+        WhoAmI who = await GetProtected(fx, body.Token!);
+        who.Subject.Should().Be($"github:{AllowedId}");
+    }
+
+    // ── state / cookie threats ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Callback_MissingState_IsRejected()
+    {
+        using TestFixture fx = CreateServer();
+        (_, string cookie) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state: null, cookie, code: "c");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Callback_AbsentCookie_IsRejected()
+    {
+        using TestFixture fx = CreateServer();
+        (string state, _) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state, cookie: null, code: "c");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Callback_MismatchedState_IsRejected()
+    {
+        using TestFixture fx = CreateServer();
+        (_, string cookie) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state: "not-the-issued-state", cookie, code: "c");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Callback_WrongCookieForState_IsRejected()
+    {
+        using TestFixture fx = CreateServer();
+        (string state, _) = await BeginLogin(fx);
+        // A second login yields a different cookie secret; pairing it with the first state must fail.
+        (_, string otherCookie) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state, otherCookie, code: "c");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Callback_ReplayedState_IsRejectedSecondTime()
+    {
+        using TestFixture fx = CreateServer();
+        (string state, string cookie) = await BeginLogin(fx);
+
+        HttpResponseMessage first = await Callback(fx, state, cookie, code: "c1");
+        first.StatusCode.Should().Be(HttpStatusCode.Redirect);
+
+        // Same state + cookie again → the one-time state entry is gone.
+        HttpResponseMessage second = await Callback(fx, state, cookie, code: "c2");
+        second.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Callback_ExpiredState_IsRejected()
+    {
+        using TestFixture fx = CreateServer(stateTtlSeconds: 30);
+        (string state, string cookie) = await BeginLogin(fx);
+
+        fx.Clock.Advance(TimeSpan.FromSeconds(31));
+
+        HttpResponseMessage resp = await Callback(fx, state, cookie, code: "c");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── provider / user / org / allowlist failures ───────────────────────────
+
+    [Fact]
+    public async Task Callback_UserDenial_RedirectsToFrontendWithError_NoToken()
+    {
+        using TestFixture fx = CreateServer();
+        (string state, string cookie) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state, cookie, code: null, error: "access_denied");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        Uri loc = resp.Headers.Location!;
+        loc.GetLeftPart(UriPartial.Path).Should().Be(FrontendUrl);
+        System.Web.HttpUtility.ParseQueryString(loc.Query)["error"].Should().NotBeNullOrWhiteSpace();
+        System.Web.HttpUtility.ParseQueryString(loc.Query)["code"].Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Callback_ExchangeFailure_RedirectsWithError()
+    {
+        using TestFixture fx = CreateServer();
+        fx.OAuth.OnExchange = _ => new GitHubTokenResult(false, null, "exchange_no_token");
+        (string state, string cookie) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state, cookie, code: "c");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        System.Web.HttpUtility.ParseQueryString(resp.Headers.Location!.Query)["error"].Should().Be("login_failed");
+    }
+
+    [Fact]
+    public async Task Callback_UserValidationFailure_RedirectsWithError()
+    {
+        using TestFixture fx = CreateServer();
+        fx.OAuth.OnGetUser = _ => new GitHubUserResult(false, 0, string.Empty, "user_invalid");
+        (string state, string cookie) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state, cookie, code: "c");
+
+        System.Web.HttpUtility.ParseQueryString(resp.Headers.Location!.Query)["error"].Should().Be("login_failed");
+    }
+
+    [Fact]
+    public async Task Callback_UnallowlistedUser_RedirectsWithNotAuthorized()
+    {
+        using TestFixture fx = CreateServer();
+        fx.OAuth.OnGetUser = _ => new GitHubUserResult(true, 999999, "stranger", null);
+        (string state, string cookie) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state, cookie, code: "c");
+
+        System.Web.HttpUtility.ParseQueryString(resp.Headers.Location!.Query)["error"].Should().Be("not_authorized");
+    }
+
+    [Fact]
+    public async Task Callback_InactiveOrgMembership_RedirectsWithNotAuthorized()
+    {
+        using TestFixture fx = CreateServer(allowedOrgs: ["contoso"], useUserIdAllowlist: false);
+        fx.OAuth.OnGetUser = _ => new GitHubUserResult(true, 999999, "stranger", null);
+        fx.OAuth.OnOrgMembership = (_, _) => new GitHubOrgMembershipResult(false, "org_not_active");
+        (string state, string cookie) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state, cookie, code: "c");
+
+        System.Web.HttpUtility.ParseQueryString(resp.Headers.Location!.Query)["error"].Should().Be("not_authorized");
+    }
+
+    [Fact]
+    public async Task Callback_ProviderTokenNeverAppearsInLogs()
+    {
+        using TestFixture fx = CreateServer();
+        (string state, string cookie) = await BeginLogin(fx);
+
+        await Callback(fx, state, cookie, code: "c");
+
+        fx.LogSink.Messages.Should().NotContain(m => m.Contains(ProviderToken),
+            "the provider token must never be written to logs");
+    }
+
+    // ── exchange threats ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Exchange_ReplayedCode_IsRejectedSecondTime()
+    {
+        using TestFixture fx = CreateServer();
+        string redemption = await LoginToRedemption(fx);
+
+        (await Exchange(fx, redemption)).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await Exchange(fx, redemption)).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Exchange_UnknownCode_IsRejected()
+    {
+        using TestFixture fx = CreateServer();
+
+        HttpResponseMessage resp = await Exchange(fx, "never-issued-code");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Exchange_ExpiredCode_IsRejected()
+    {
+        using TestFixture fx = CreateServer(redemptionTtlSeconds: 30);
+        string redemption = await LoginToRedemption(fx);
+
+        fx.Clock.Advance(TimeSpan.FromSeconds(31));
+
+        (await Exchange(fx, redemption)).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Exchange_ConcurrentRace_YieldsExactlyOneSuccess()
+    {
+        using TestFixture fx = CreateServer();
+        string redemption = await LoginToRedemption(fx);
+
+        Task<HttpResponseMessage>[] attempts =
+            [.. Enumerable.Range(0, 8).Select(_ => Exchange(fx, redemption))];
+        HttpResponseMessage[] results = await Task.WhenAll(attempts);
+
+        results.Count(r => r.StatusCode == HttpStatusCode.OK).Should().Be(1,
+            "atomic one-time redemption admits exactly one exchange");
+    }
+
+    // ── session token validation threats ─────────────────────────────────────
+
+    [Fact]
+    public async Task Protected_ValidSessionToken_Succeeds()
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token();
+
+        WhoAmI who = await GetProtected(fx, token);
+
+        who.Subject.Should().Be($"github:{AllowedId}");
+    }
+
+    [Theory]
+    [InlineData("wrong-issuer")]
+    [InlineData("wrong-audience")]
+    [InlineData("wrong-signature")]
+    [InlineData("wrong-provider")]
+    [InlineData("expired")]
+    [InlineData("cross-provider-anonymous")]
+    public async Task Protected_BadSessionToken_IsRejected(string flavor)
+    {
+        using TestFixture fx = CreateServer();
+        string token = flavor switch
+        {
+            "wrong-issuer" => Token(issuer: "evil-issuer"),
+            "wrong-audience" => Token(audience: "evil-audience"),
+            "wrong-signature" => Token(key: WrongKey),
+            "wrong-provider" => Token(provider: "Entra"),
+            "expired" => Token(expires: DateTime.UtcNow.AddMinutes(-5), notBefore: DateTime.UtcNow.AddMinutes(-10)),
+            "cross-provider-anonymous" => Token(provider: "Anonymous", role: "RetailPulse.Anonymous", scope: "chat_limited"),
+            _ => throw new ArgumentOutOfRangeException(nameof(flavor)),
+        };
+
+        HttpResponseMessage resp = await GetProtectedRaw(fx, token);
+
+        resp.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Protected_MissingRoleOrScope_IsForbidden()
+    {
+        using TestFixture fx = CreateServer();
+        string noRole = Token(role: "SomethingElse");
+
+        (await GetProtectedRaw(fx, noRole)).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── REST vs hub token-position parity ────────────────────────────────────
+
+    [Fact]
+    public async Task SessionToken_AuthorizesBothRestAndHub()
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token();
+
+        // REST bearer
+        (await GetProtectedRaw(fx, token)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Hub query token
+        HttpResponseMessage hub = await fx.Client.GetAsync($"/hubs/telemetry?access_token={token}");
+        hub.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task QueryToken_OnRestRoute_IsRejected()
+    {
+        using TestFixture fx = CreateServer();
+        string token = Token();
+
+        // A query token on a REST path must NOT authenticate (identical to Entra/Anonymous).
+        HttpResponseMessage resp = await fx.Client.GetAsync($"/api/whoami?access_token={token}");
+
+        resp.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    // ── rate limits ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Start_IsRateLimited()
+    {
+        using TestFixture fx = CreateServer(startPerMinute: 3);
+
+        var statuses = new List<HttpStatusCode>();
+        for (int i = 0; i < 6; i++)
+        {
+            statuses.Add((await fx.Client.GetAsync(GitHubAuthConstants.StartRoute)).StatusCode);
+        }
+
+        statuses.Should().Contain(HttpStatusCode.TooManyRequests, "the start endpoint is rate limited");
+    }
+
+    [Fact]
+    public async Task Exchange_IsRateLimited()
+    {
+        using TestFixture fx = CreateServer(exchangePerMinute: 3);
+
+        var statuses = new List<HttpStatusCode>();
+        for (int i = 0; i < 6; i++)
+        {
+            statuses.Add((await Exchange(fx, "bogus")).StatusCode);
+        }
+
+        statuses.Should().Contain(HttpStatusCode.TooManyRequests, "the exchange endpoint is rate limited");
+    }
+
+    // ── endpoint-graph anonymous exceptions ──────────────────────────────────
+
+    [Fact]
+    public async Task OnlyBffEndpoints_AreAnonymous_EverythingElseProtected()
+    {
+        using TestFixture fx = CreateServer();
+
+        // Protected route requires auth.
+        (await fx.Client.GetAsync("/api/whoami")).StatusCode
+            .Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+
+        // The three BFF endpoints are reachable anonymously (start redirects; exchange 400s on a bogus
+        // body but is NOT an auth rejection).
+        (await fx.Client.GetAsync(GitHubAuthConstants.StartRoute)).StatusCode.Should().Be(HttpStatusCode.Redirect);
+        (await Exchange(fx, "bogus")).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    private async Task<(string State, string Cookie)> BeginLogin(TestFixture fx)
+    {
+        HttpResponseMessage resp = await fx.Client.GetAsync(GitHubAuthConstants.StartRoute);
+        string state = System.Web.HttpUtility.ParseQueryString(resp.Headers.Location!.Query)["state"]!;
+        string setCookie = resp.Headers.GetValues("Set-Cookie").First(c => c.Contains("rp_gh_state"));
+        string cookie = setCookie.Split(';')[0]; // name=value
+        return (state, cookie);
+    }
+
+    private async Task<HttpResponseMessage> Callback(
+        TestFixture fx, string? state, string? cookie, string? code, string? error = null)
+    {
+        var qs = new List<string>();
+        if (state is not null)
+        {
+            qs.Add("state=" + Uri.EscapeDataString(state));
+        }
+
+        if (code is not null)
+        {
+            qs.Add("code=" + Uri.EscapeDataString(code));
+        }
+
+        if (error is not null)
+        {
+            qs.Add("error=" + Uri.EscapeDataString(error));
+        }
+
+        var req = new HttpRequestMessage(HttpMethod.Get, GitHubAuthConstants.CallbackRoute + "?" + string.Join("&", qs));
+        if (cookie is not null)
+        {
+            req.Headers.Add("Cookie", cookie);
+        }
+
+        return await fx.Client.SendAsync(req);
+    }
+
+    private async Task<string> LoginToRedemption(TestFixture fx)
+    {
+        (string state, string cookie) = await BeginLogin(fx);
+        HttpResponseMessage resp = await Callback(fx, state, cookie, code: "gh-auth-code");
+        resp.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        return System.Web.HttpUtility.ParseQueryString(resp.Headers.Location!.Query)["code"]!;
+    }
+
+    private static async Task<HttpResponseMessage> Exchange(TestFixture fx, string code)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, GitHubAuthConstants.ExchangeRoute)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(new { code }), Encoding.UTF8, "application/json"),
+        };
+        return await fx.Client.SendAsync(req);
+    }
+
+    private static async Task<HttpResponseMessage> GetProtectedRaw(TestFixture fx, string token)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "/api/whoami");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await fx.Client.SendAsync(req);
+    }
+
+    private static async Task<WhoAmI> GetProtected(TestFixture fx, string token)
+    {
+        HttpResponseMessage resp = await GetProtectedRaw(fx, token);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        return (await resp.Content.ReadFromJsonAsync<WhoAmI>())!;
+    }
+
+    private static void AssertStateCookieCleared(HttpResponseMessage resp)
+    {
+        resp.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies).Should().BeTrue();
+        string cleared = cookies!.Single(c => c.Contains("rp_gh_state"));
+        cleared.Should().Match(c => c.Contains("expires=Thu, 01 Jan 1970", StringComparison.OrdinalIgnoreCase)
+            || c.Contains("max-age=0", StringComparison.OrdinalIgnoreCase),
+            "the state cookie must be deleted after callback");
+    }
+
+    private static string Token(
+        long id = AllowedId,
+        string login = AllowedLogin,
+        string? issuer = null,
+        string? audience = null,
+        string provider = "GitHub",
+        string role = "RetailPulse.User",
+        string scope = "access_as_user",
+        DateTime? expires = null,
+        DateTime? notBefore = null,
+        SymmetricSecurityKey? key = null)
+    {
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, $"github:{id}"),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+            new("provider", provider),
+            new("roles", role),
+            new("scp", scope),
+            new(GitHubAuthConstants.LoginClaimType, login),
+        };
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = issuer ?? Issuer,
+            Audience = audience ?? Audience,
+            Subject = new ClaimsIdentity(claims),
+            NotBefore = notBefore ?? DateTime.UtcNow.AddMinutes(-1),
+            Expires = expires ?? DateTime.UtcNow.AddMinutes(10),
+            SigningCredentials = new SigningCredentials(key ?? SigningKey, SecurityAlgorithms.HmacSha256),
+        };
+
+        var handler = new JsonWebTokenHandler { SetDefaultTimesOnTokenCreation = false };
+        return handler.CreateToken(descriptor);
+    }
+
+    private static TestFixture CreateServer(
+        string[]? allowedOrgs = null,
+        bool useUserIdAllowlist = true,
+        int stateTtlSeconds = 300,
+        int redemptionTtlSeconds = 120,
+        int startPerMinute = 100,
+        int exchangePerMinute = 100)
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["Authentication:Mode"] = "GitHub",
+            ["GitHub:ClientId"] = "Iv1.testclientid",
+            ["GitHub:ClientSecret"] = "test-client-secret",
+            ["GitHub:SigningKey"] = SigningKeyText,
+            ["GitHub:Issuer"] = Issuer,
+            ["GitHub:Audience"] = Audience,
+            ["GitHub:CallbackUrl"] = "https://api.example.com/api/auth/github/callback",
+            ["GitHub:FrontendReturnUrl"] = FrontendUrl,
+            ["GitHub:StateTtlSeconds"] = stateTtlSeconds.ToString(),
+            ["GitHub:RedemptionTtlSeconds"] = redemptionTtlSeconds.ToString(),
+            ["GitHub:RateLimits:StartPerMinute"] = startPerMinute.ToString(),
+            ["GitHub:RateLimits:ExchangePerMinute"] = exchangePerMinute.ToString(),
+        };
+
+        if (useUserIdAllowlist)
+        {
+            settings["GitHub:AllowedUserIds:0"] = AllowedId.ToString();
+            settings["GitHub:AllowedLogins:0"] = AllowedLogin;
+        }
+
+        if (allowedOrgs is not null)
+        {
+            for (int i = 0; i < allowedOrgs.Length; i++)
+            {
+                settings[$"GitHub:AllowedOrgs:{i}"] = allowedOrgs[i];
+            }
+        }
+
+        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+        var clock = new TestClock();
+        var oauth = new FakeGitHubOAuthClient
+        {
+            OnExchange = _ => new GitHubTokenResult(true, ProviderToken, null),
+            OnGetUser = _ => new GitHubUserResult(true, AllowedId, AllowedLogin, null),
+        };
+        var logSink = new ListLoggerProvider();
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.Environment.EnvironmentName = Environments.Production;
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddRouting();
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(logSink);
+
+        // Wire the full GitHub stack (scheme + policy + stores + allowlist + normalizer).
+        builder.Services.AddProviderNeutralAuthentication(config, builder.Environment);
+
+        // Replace the real HTTP transport with the programmable fake, and pin the store clocks so
+        // TTL-expiry tests are deterministic. The session token service keeps real time so its tokens
+        // validate against the JwtBearer lifetime check.
+        builder.Services.RemoveAll<IGitHubOAuthClient>();
+        builder.Services.AddSingleton<IGitHubOAuthClient>(oauth);
+        builder.Services.RemoveAll<GitHubStateStore>();
+        builder.Services.AddSingleton(new GitHubStateStore(clock));
+        builder.Services.RemoveAll<GitHubRedemptionStore>();
+        builder.Services.AddSingleton(new GitHubRedemptionStore(clock));
+        // The endpoints resolve an optional TimeProvider used for state/redemption expiry; pin it to
+        // the same clock the stores use so "expired" tests advance a single coherent clock.
+        builder.Services.AddSingleton<TimeProvider>(clock);
+
+        builder.Services.AddRateLimiter(rl =>
+        {
+            rl.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+            rl.AddPolicy(GitHubAuthEndpoints.StartRateLimitPolicy, _ =>
+                System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
+                    "github-start",
+                    _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = startPerMinute,
+                        Window = TimeSpan.FromMinutes(1),
+                        QueueLimit = 0,
+                    }));
+            rl.AddPolicy(GitHubAuthEndpoints.ExchangeRateLimitPolicy, _ =>
+                System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
+                    "github-exchange",
+                    _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = exchangePerMinute,
+                        Window = TimeSpan.FromMinutes(1),
+                        QueueLimit = 0,
+                    }));
+        });
+
+        WebApplication app = builder.Build();
+
+        app.UseRouting();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseRateLimiter();
+
+        // The three narrowly-anonymous BFF endpoints, mapped exactly as Program.cs does in GitHub mode.
+        app.MapGitHubAuthEndpoints();
+
+        // Protected stand-ins proving REST bearer + hub query-token parity and deny-by-default.
+        app.MapGet("/api/whoami", (HttpContext ctx) =>
+            Results.Ok(new { subject = ctx.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value }))
+            .RequireAuthorization();
+        app.MapGet("/hubs/telemetry", static () => Results.Ok(new { hub = "telemetry" }))
+            .RequireAuthorization();
+        app.MapGet("/health", static () => Results.Ok(new { status = "ok" })).AllowAnonymous();
+
+        app.Start();
+        return new TestFixture(app, oauth, clock, logSink);
+    }
+
+    private sealed class ExchangeBody
+    {
+        public string? Token { get; set; }
+        public string? TokenType { get; set; }
+        public int ExpiresInSeconds { get; set; }
+        public string? Subject { get; set; }
+    }
+
+    private sealed class WhoAmI
+    {
+        public string? Subject { get; set; }
+    }
+
+    private sealed class TestClock : TimeProvider
+    {
+        // Anchored to real "now" so session tokens minted through the pinned clock still validate
+        // against the JwtBearer lifetime check (which uses the real system clock). Advance() then
+        // drives the deterministic state/redemption TTL-expiry tests.
+        private DateTimeOffset _now = DateTimeOffset.UtcNow;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+
+    private sealed class TestFixture : IDisposable
+    {
+        private readonly IHost _host;
+
+        public TestFixture(IHost host, FakeGitHubOAuthClient oauth, TestClock clock, ListLoggerProvider logSink)
+        {
+            _host = host;
+            OAuth = oauth;
+            Clock = clock;
+            LogSink = logSink;
+            Client = host.GetTestClient();
+        }
+
+        public HttpClient Client { get; }
+        public FakeGitHubOAuthClient OAuth { get; }
+        public TestClock Clock { get; }
+        public ListLoggerProvider LogSink { get; }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _host.StopAsync().GetAwaiter().GetResult();
+            _host.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Captures every formatted log message into a thread-safe list so tests can assert the GitHub
+    /// PROVIDER token (and other secrets) never appear anywhere in the logging pipeline.
+    /// </summary>
+    private sealed class ListLoggerProvider : ILoggerProvider
+    {
+        private readonly System.Collections.Concurrent.ConcurrentQueue<string> _messages = new();
+
+        public IReadOnlyCollection<string> Messages => [.. _messages];
+
+        public ILogger CreateLogger(string categoryName) => new ListLogger(_messages);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class ListLogger(System.Collections.Concurrent.ConcurrentQueue<string> messages) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                string message = formatter(state, exception);
+                if (exception is not null)
+                {
+                    message += " " + exception;
+                }
+
+                messages.Enqueue(message);
+            }
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Security/GitHubOneTimeStoreTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubOneTimeStoreTests.cs
@@ -1,0 +1,142 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using RetailPulse.Api.Security.GitHub;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Concurrency, replay, TTL and bounded-capacity contract for <see cref="OneTimeTtlStore{TValue}"/>,
+/// which backs both the OAuth state store and the post-login redemption store.
+///
+/// These are the primitives that make callback replay, code replay, and one-time-exchange races
+/// impossible, so they are proven directly:
+/// <list type="bullet">
+///   <item>a stored entry can be consumed exactly ONCE;</item>
+///   <item>N racing consumers of the same key yield exactly ONE winner;</item>
+///   <item>an expired entry is a miss and is removed;</item>
+///   <item>the store is bounded and fails closed (rejects new entries) at capacity;</item>
+///   <item><see cref="GitHubRandom.NewToken"/> is high-entropy and unique.</item>
+/// </list>
+/// </summary>
+public sealed class GitHubOneTimeStoreTests
+{
+    private static long Ttl(TestClock clock, int seconds) =>
+        clock.GetUtcNow().UtcDateTime.AddSeconds(seconds).Ticks;
+
+    [Fact]
+    public void Consume_AfterStore_SucceedsExactlyOnce()
+    {
+        var clock = new TestClock();
+        var store = new OneTimeTtlStore<GitHubRedemptionEntry>(static e => e.ExpiresAtTicks, timeProvider: clock);
+        var entry = new GitHubRedemptionEntry(new GitHubVerifiedUser(1, "octocat"), Ttl(clock, 120));
+
+        store.TryStore("code-1", entry).Should().BeTrue();
+
+        store.TryConsume("code-1", out GitHubRedemptionEntry first).Should().BeTrue();
+        first.User.UserId.Should().Be(1);
+
+        // Replay: the SAME code can never be redeemed twice.
+        store.TryConsume("code-1", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Consume_UnknownKey_IsMiss()
+    {
+        var store = new OneTimeTtlStore<GitHubStateEntry>(static e => e.ExpiresAtTicks);
+
+        store.TryConsume("never-stored", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Consume_ExpiredEntry_IsMissAndRemoved()
+    {
+        var clock = new TestClock();
+        var store = new OneTimeTtlStore<GitHubStateEntry>(static e => e.ExpiresAtTicks, timeProvider: clock);
+        store.TryStore("state-1", new GitHubStateEntry([1, 2, 3], Ttl(clock, 60))).Should().BeTrue();
+
+        clock.Advance(TimeSpan.FromSeconds(61));
+
+        store.TryConsume("state-1", out _).Should().BeFalse("the entry has expired");
+        store.Count.Should().Be(0, "an expired entry is removed on access");
+    }
+
+    [Fact]
+    public async Task Consume_ConcurrentRacers_YieldExactlyOneWinner()
+    {
+        var clock = new TestClock();
+        var store = new OneTimeTtlStore<GitHubRedemptionEntry>(static e => e.ExpiresAtTicks, timeProvider: clock);
+        store.TryStore("race", new GitHubRedemptionEntry(new GitHubVerifiedUser(7, "u"), Ttl(clock, 300)));
+
+        var winners = new ConcurrentBag<bool>();
+        using var start = new Barrier(32);
+
+        Task[] racers = [.. Enumerable.Range(0, 32).Select(i => Task.Run(() =>
+        {
+            _ = i;
+            start.SignalAndWait();
+            if (store.TryConsume("race", out _))
+            {
+                winners.Add(true);
+            }
+        }))];
+
+        await Task.WhenAll(racers);
+
+        winners.Count.Should().Be(1, "atomic one-time consumption admits exactly one racer");
+    }
+
+    [Fact]
+    public void Store_AtCapacity_FailsClosed()
+    {
+        var clock = new TestClock();
+        var store = new OneTimeTtlStore<GitHubStateEntry>(
+            static e => e.ExpiresAtTicks, maxEntries: 3, timeProvider: clock);
+
+        for (int i = 0; i < 3; i++)
+        {
+            store.TryStore($"k{i}", new GitHubStateEntry([0], Ttl(clock, 300))).Should().BeTrue();
+        }
+
+        // Capacity reached and nothing has expired → fail closed rather than evict an in-flight login.
+        store.TryStore("overflow", new GitHubStateEntry([0], Ttl(clock, 300))).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Store_AtCapacity_SweepsExpiredThenAdmits()
+    {
+        var clock = new TestClock();
+        var store = new OneTimeTtlStore<GitHubStateEntry>(
+            static e => e.ExpiresAtTicks, maxEntries: 2, timeProvider: clock);
+
+        store.TryStore("a", new GitHubStateEntry([0], Ttl(clock, 30))).Should().BeTrue();
+        store.TryStore("b", new GitHubStateEntry([0], Ttl(clock, 30))).Should().BeTrue();
+
+        // Both expire; a subsequent store sweeps them and succeeds (bounded + cleanup).
+        clock.Advance(TimeSpan.FromSeconds(31));
+
+        store.TryStore("c", new GitHubStateEntry([0], Ttl(clock, 30))).Should().BeTrue();
+    }
+
+    [Fact]
+    public void NewToken_IsHighEntropyAndUnique()
+    {
+        var tokens = new HashSet<string>(StringComparer.Ordinal);
+        for (int i = 0; i < 1000; i++)
+        {
+            string token = GitHubRandom.NewToken();
+            token.Length.Should().BeGreaterThanOrEqualTo(43, "a 256-bit base64url token is ~43 chars");
+            token.Should().NotContain("+").And.NotContain("/").And.NotContain("=");
+            tokens.Add(token).Should().BeTrue("tokens must be unique");
+        }
+    }
+
+    /// <summary>A minimal controllable <see cref="TimeProvider"/> test double (no extra package).</summary>
+    private sealed class TestClock : TimeProvider
+    {
+        private DateTimeOffset _now = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+}

--- a/tests/RetailPulse.Tests/Security/GitHubSessionTokenTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubSessionTokenTests.cs
@@ -32,8 +32,30 @@ public sealed class GitHubSessionTokenTests
             ["GitHub:CallbackUrl"] = "https://api.example.com/api/auth/github/callback",
             ["GitHub:FrontendReturnUrl"] = "https://app.example.com/auth/github/callback",
             ["GitHub:AllowedUserIds:0"] = "12345",
+            ["GitHub:AcknowledgeSingleReplica"] = "true",
         }).Build(),
         new TestEnv());
+
+    private static GitHubAuthOptions OptionsWithRotation(string signingKey, params string[] additional)
+    {
+        var cfg = new Dictionary<string, string?>
+        {
+            ["GitHub:ClientId"] = "Iv1.abc",
+            ["GitHub:ClientSecret"] = "secret",
+            ["GitHub:SigningKey"] = signingKey,
+            ["GitHub:CallbackUrl"] = "https://api.example.com/api/auth/github/callback",
+            ["GitHub:FrontendReturnUrl"] = "https://app.example.com/auth/github/callback",
+            ["GitHub:AllowedUserIds:0"] = "12345",
+            ["GitHub:AcknowledgeSingleReplica"] = "true",
+        };
+        for (int i = 0; i < additional.Length; i++)
+        {
+            cfg[$"GitHub:AdditionalValidationKeys:{i}"] = additional[i];
+        }
+
+        return GitHubAuthOptions.FromConfiguration(
+            new ConfigurationBuilder().AddInMemoryCollection(cfg).Build(), new TestEnv());
+    }
 
     private sealed class TestEnv : IHostEnvironment
     {
@@ -123,6 +145,58 @@ public sealed class GitHubSessionTokenTests
 
         kp.IsEphemeral.Should().BeFalse();
         kp.Key.KeySize.Should().BeGreaterThanOrEqualTo(256);
+    }
+
+    // ── Signing-key rotation ────────────────────────────────────────────────────
+
+    private const string OldKey = "github-OLD-signing-key-0123456789abcdefZZZZ";
+    private const string NewKey = "github-NEW-signing-key-0123456789abcdefYYYY";
+
+    [Fact]
+    public void Rotation_TokenSignedWithPreviousKey_StillValidatesAfterRotation()
+    {
+        // Before rotation: the OLD key is the sole signing key; mint a session token with it.
+        GitHubAuthOptions before = OptionsWithRotation(OldKey);
+        var beforeKp = new GitHubSigningKeyProvider(before);
+        GitHubSession oldSession = new GitHubSessionTokenService(before, beforeKp)
+            .CreateSession(new GitHubVerifiedUser(12345, "octocat"));
+
+        // After rotation: NEW key signs, OLD key demoted to validation-only. The in-flight OLD token
+        // must keep validating against the rotated key set.
+        GitHubAuthOptions after = OptionsWithRotation(NewKey, OldKey);
+        var afterKp = new GitHubSigningKeyProvider(after);
+
+        ClaimsPrincipal principal = Validate(oldSession.Token, after, afterKp);
+
+        principal.FindFirst(JwtRegisteredClaimNames.Sub)!.Value.Should().Be("github:12345");
+    }
+
+    [Fact]
+    public void Rotation_NewTokensAreSignedWithCurrentKey_NotThePreviousKey()
+    {
+        GitHubAuthOptions after = OptionsWithRotation(NewKey, OldKey);
+        var afterKp = new GitHubSigningKeyProvider(after);
+        GitHubSession newSession = new GitHubSessionTokenService(after, afterKp)
+            .CreateSession(new GitHubVerifiedUser(12345, "octocat"));
+
+        // Freshly-minted tokens must be signed by the CURRENT key (listed first), never a rotation key.
+        var jwt = new JsonWebToken(newSession.Token);
+        jwt.Kid.Should().Be(afterKp.Key.KeyId);
+        jwt.Kid.Should().NotBe(new GitHubSigningKeyProvider(OptionsWithRotation(OldKey)).Key.KeyId,
+            "the new token's kid identifies the current key, not the demoted one");
+
+        // And a validator that ONLY trusts the OLD key must reject the new token.
+        GitHubAuthOptions oldOnly = OptionsWithRotation(OldKey);
+        var handler = new JsonWebTokenHandler { MapInboundClaims = false };
+        TokenValidationResult result = handler.ValidateTokenAsync(newSession.Token, new TokenValidationParameters
+        {
+            ValidIssuers = [after.Issuer],
+            ValidAudiences = [after.Audience],
+            IssuerSigningKeys = new GitHubSigningKeyProvider(oldOnly).ValidationKeys,
+            ValidAlgorithms = [SecurityAlgorithms.HmacSha256],
+        }).GetAwaiter().GetResult();
+
+        result.IsValid.Should().BeFalse("the new token is signed by the current key, not the old one");
     }
 
     // ── Normalizer ────────────────────────────────────────────────────────────

--- a/tests/RetailPulse.Tests/Security/GitHubSessionTokenTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubSessionTokenTests.cs
@@ -1,0 +1,187 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Security;
+using RetailPulse.Api.Security.GitHub;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Unit contract for the GitHub session token service, signing key provider, and principal
+/// normalizer.
+///
+/// Proves the identity is anchored to the IMMUTABLE numeric id (never the mutable login), the token
+/// carries the separate GitHub issuer/audience/provider + role + scope + jti and is HS256-signed, and
+/// the normalizer trusts only a well-formed <c>github:&lt;digits&gt;</c> subject with a GitHub provider
+/// stamp.
+/// </summary>
+public sealed class GitHubSessionTokenTests
+{
+    private const string Key = "github-mode-test-signing-key-0123456789abcdef";
+
+    private static GitHubAuthOptions Options() => GitHubAuthOptions.FromConfiguration(
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["GitHub:ClientId"] = "Iv1.abc",
+            ["GitHub:ClientSecret"] = "secret",
+            ["GitHub:SigningKey"] = Key,
+            ["GitHub:CallbackUrl"] = "https://api.example.com/api/auth/github/callback",
+            ["GitHub:FrontendReturnUrl"] = "https://app.example.com/auth/github/callback",
+            ["GitHub:AllowedUserIds:0"] = "12345",
+        }).Build(),
+        new TestEnv());
+
+    private sealed class TestEnv : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "RetailPulse.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+
+    private static (string Token, GitHubAuthOptions Opts, GitHubSigningKeyProvider KeyProvider) Mint(
+        long id = 12345, string login = "octocat")
+    {
+        GitHubAuthOptions opts = Options();
+        var keyProvider = new GitHubSigningKeyProvider(opts);
+        var svc = new GitHubSessionTokenService(opts, keyProvider);
+        GitHubSession session = svc.CreateSession(new GitHubVerifiedUser(id, login));
+        return (session.Token, opts, keyProvider);
+    }
+
+    private static ClaimsPrincipal Validate(string token, GitHubAuthOptions opts, GitHubSigningKeyProvider keyProvider)
+    {
+        var handler = new JsonWebTokenHandler { MapInboundClaims = false };
+        TokenValidationResult result = handler.ValidateTokenAsync(token, new TokenValidationParameters
+        {
+            ValidIssuers = [opts.Issuer],
+            ValidAudiences = [opts.Audience],
+            IssuerSigningKeys = keyProvider.ValidationKeys,
+            ValidAlgorithms = [SecurityAlgorithms.HmacSha256],
+            RoleClaimType = "roles",
+            NameClaimType = JwtRegisteredClaimNames.Sub,
+        }).GetAwaiter().GetResult();
+
+        result.IsValid.Should().BeTrue();
+        return new ClaimsPrincipal(result.ClaimsIdentity);
+    }
+
+    [Fact]
+    public void CreateSession_SubjectIsImmutableNumericId()
+    {
+        (string token, GitHubAuthOptions opts, GitHubSigningKeyProvider kp) = Mint(id: 99001, login: "renamed-login");
+
+        ClaimsPrincipal principal = Validate(token, opts, kp);
+
+        principal.FindFirst(JwtRegisteredClaimNames.Sub)!.Value.Should().Be("github:99001");
+        // The login is present but informational only.
+        principal.FindFirst(GitHubAuthConstants.LoginClaimType)!.Value.Should().Be("renamed-login");
+    }
+
+    [Fact]
+    public void CreateSession_CarriesProviderRoleScopeAndJti()
+    {
+        (string token, GitHubAuthOptions opts, GitHubSigningKeyProvider kp) = Mint();
+
+        ClaimsPrincipal principal = Validate(token, opts, kp);
+
+        principal.FindFirst("provider")!.Value.Should().Be("GitHub");
+        principal.FindFirst("roles")!.Value.Should().Be("RetailPulse.User");
+        principal.FindFirst("scp")!.Value.Should().Be("access_as_user");
+        principal.FindFirst(JwtRegisteredClaimNames.Jti)!.Value.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void CreateSession_IsHs256Signed()
+    {
+        (string token, _, _) = Mint();
+
+        var jwt = new JsonWebToken(token);
+        jwt.Alg.Should().Be(SecurityAlgorithms.HmacSha256);
+    }
+
+    [Fact]
+    public void CreateSession_RejectsNonPositiveId()
+    {
+        GitHubAuthOptions opts = Options();
+        var svc = new GitHubSessionTokenService(opts, new GitHubSigningKeyProvider(opts));
+
+        Action act = () => svc.CreateSession(new GitHubVerifiedUser(0, "x"));
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void SigningKeyProvider_Configured_IsNotEphemeralAndStrong()
+    {
+        var kp = new GitHubSigningKeyProvider(Options());
+
+        kp.IsEphemeral.Should().BeFalse();
+        kp.Key.KeySize.Should().BeGreaterThanOrEqualTo(256);
+    }
+
+    // ── Normalizer ────────────────────────────────────────────────────────────
+
+    private static ClaimsPrincipal PrincipalWith(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, "test"));
+
+    [Fact]
+    public void Normalizer_TrustsImmutableNumericSubject()
+    {
+        var normalizer = new GitHubPrincipalNormalizer();
+        ClaimsPrincipal principal = PrincipalWith(
+            new Claim(JwtRegisteredClaimNames.Sub, "github:12345"),
+            new Claim("provider", "GitHub"),
+            new Claim(GitHubAuthConstants.LoginClaimType, "octocat"),
+            new Claim("roles", "RetailPulse.User"),
+            new Claim("scp", "access_as_user"));
+
+        NormalizedPrincipal normalized = normalizer.Normalize(principal);
+
+        normalized.Provider.Should().Be("GitHub");
+        normalized.Subject.Should().Be("github:12345");
+        normalized.DisplayName.Should().Be("octocat", "login is display only");
+        normalized.Roles.Should().Contain("RetailPulse.User");
+        normalized.Scopes.Should().Contain("access_as_user");
+    }
+
+    [Theory]
+    [InlineData("octocat")] // mutable login as subject
+    [InlineData("github:")] // no digits
+    [InlineData("github:abc")] // non-numeric
+    [InlineData("github:-1")] // non-positive
+    [InlineData("gitlab:12345")] // wrong prefix
+    public void Normalizer_RejectsNonNumericOrMalformedSubject(string subject)
+    {
+        var normalizer = new GitHubPrincipalNormalizer();
+        ClaimsPrincipal principal = PrincipalWith(
+            new Claim(JwtRegisteredClaimNames.Sub, subject),
+            new Claim("provider", "GitHub"));
+
+        Action act = () => normalizer.Normalize(principal);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Normalizer_RejectsNonGitHubProvider()
+    {
+        var normalizer = new GitHubPrincipalNormalizer();
+        ClaimsPrincipal principal = PrincipalWith(
+            new Claim(JwtRegisteredClaimNames.Sub, "github:12345"),
+            new Claim("provider", "Entra"));
+
+        Action act = () => normalizer.Normalize(principal);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*provider*");
+    }
+
+    [Fact]
+    public void Normalizer_ModeIsGitHub() =>
+        new GitHubPrincipalNormalizer().Mode.Should().Be(AuthenticationMode.GitHub);
+}

--- a/tests/RetailPulse.Tests/Security/GitHubUserAllowlistTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubUserAllowlistTests.cs
@@ -9,8 +9,8 @@ namespace RetailPulse.Tests.Security;
 /// <summary>
 /// Server-side allowlist contract for GitHub mode. The allowlist is the gate that makes full
 /// authenticated capabilities acceptable, so it is proven to key on the IMMUTABLE numeric id, to
-/// admit via login or ACTIVE org membership, and to FAIL CLOSED on every error, inactive membership,
-/// or non-member response.
+/// admit via numeric id or ACTIVE org membership (never via the mutable login handle), and to FAIL
+/// CLOSED on every error, inactive membership, or non-member response.
 /// </summary>
 public sealed class GitHubUserAllowlistTests
 {
@@ -32,6 +32,7 @@ public sealed class GitHubUserAllowlistTests
             ["GitHub:SigningKey"] = "github-mode-test-signing-key-0123456789abcdef",
             ["GitHub:CallbackUrl"] = "https://api.example.com/api/auth/github/callback",
             ["GitHub:FrontendReturnUrl"] = "https://app.example.com/auth/github/callback",
+            ["GitHub:AcknowledgeSingleReplica"] = "true",
         };
         foreach ((string k, string? v) in extra)
         {
@@ -61,16 +62,28 @@ public sealed class GitHubUserAllowlistTests
     }
 
     [Fact]
-    public async Task LoginMatch_IsCaseInsensitive_Allows()
+    public async Task LoginNeverGrantsAccess_HandleReuseIsDenied()
     {
-        GitHubAuthOptions options = Options(new() { ["GitHub:AllowedLogins:0"] = "OctoCat" });
+        // Handle-reuse threat: an attacker recreates/renames to a previously-trusted login but has a
+        // DIFFERENT immutable id. Login must never be an access mechanism, so this is denied.
+        GitHubAuthOptions options = Options(new() { ["GitHub:AllowedUserIds:0"] = "12345" });
         GitHubUserAllowlist allowlist = Allowlist(options, new FakeGitHubOAuthClient());
 
+        // The trusted user 12345 uses login "octocat"; the attacker below reuses "octocat" with id 999.
         GitHubAllowlistDecision decision =
             await allowlist.EvaluateAsync(new GitHubVerifiedUser(999, "octocat"), "tok", CancellationToken.None);
 
-        decision.Allowed.Should().BeTrue();
-        decision.Reason.Should().Be("login");
+        decision.Allowed.Should().BeFalse("a matching login with a different id must never inherit access");
+        decision.Reason.Should().Be("not_allowlisted");
+    }
+
+    [Fact]
+    public void LoginOnlyConfig_FailsClosedAtStartup()
+    {
+        // A config that tries to gate solely on the mutable login handle must not resolve at all.
+        Action act = () => Options(new() { ["GitHub:AllowedLogins:0"] = "octocat" });
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*allowlist*");
     }
 
     [Fact]

--- a/tests/RetailPulse.Tests/Security/GitHubUserAllowlistTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubUserAllowlistTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using RetailPulse.Api.Security.GitHub;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Server-side allowlist contract for GitHub mode. The allowlist is the gate that makes full
+/// authenticated capabilities acceptable, so it is proven to key on the IMMUTABLE numeric id, to
+/// admit via login or ACTIVE org membership, and to FAIL CLOSED on every error, inactive membership,
+/// or non-member response.
+/// </summary>
+public sealed class GitHubUserAllowlistTests
+{
+    private sealed class TestEnv : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "RetailPulse.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+
+    private static GitHubAuthOptions Options(Dictionary<string, string?> extra)
+    {
+        var cfg = new Dictionary<string, string?>
+        {
+            ["GitHub:ClientId"] = "Iv1.abc",
+            ["GitHub:ClientSecret"] = "secret",
+            ["GitHub:SigningKey"] = "github-mode-test-signing-key-0123456789abcdef",
+            ["GitHub:CallbackUrl"] = "https://api.example.com/api/auth/github/callback",
+            ["GitHub:FrontendReturnUrl"] = "https://app.example.com/auth/github/callback",
+        };
+        foreach ((string k, string? v) in extra)
+        {
+            cfg[k] = v;
+        }
+
+        return GitHubAuthOptions.FromConfiguration(
+            new ConfigurationBuilder().AddInMemoryCollection(cfg).Build(), new TestEnv());
+    }
+
+    private static GitHubUserAllowlist Allowlist(GitHubAuthOptions options, FakeGitHubOAuthClient client) =>
+        new(options, client, NullLogger<GitHubUserAllowlist>.Instance);
+
+    [Fact]
+    public async Task NumericIdMatch_Allows()
+    {
+        GitHubAuthOptions options = Options(new() { ["GitHub:AllowedUserIds:0"] = "12345" });
+        var client = new FakeGitHubOAuthClient();
+        GitHubUserAllowlist allowlist = Allowlist(options, client);
+
+        GitHubAllowlistDecision decision =
+            await allowlist.EvaluateAsync(new GitHubVerifiedUser(12345, "octocat"), "tok", CancellationToken.None);
+
+        decision.Allowed.Should().BeTrue();
+        decision.Reason.Should().Be("user_id");
+        client.OrgChecks.Should().BeEmpty("a numeric id match must not need an org API call");
+    }
+
+    [Fact]
+    public async Task LoginMatch_IsCaseInsensitive_Allows()
+    {
+        GitHubAuthOptions options = Options(new() { ["GitHub:AllowedLogins:0"] = "OctoCat" });
+        GitHubUserAllowlist allowlist = Allowlist(options, new FakeGitHubOAuthClient());
+
+        GitHubAllowlistDecision decision =
+            await allowlist.EvaluateAsync(new GitHubVerifiedUser(999, "octocat"), "tok", CancellationToken.None);
+
+        decision.Allowed.Should().BeTrue();
+        decision.Reason.Should().Be("login");
+    }
+
+    [Fact]
+    public async Task ActiveOrgMembership_Allows()
+    {
+        GitHubAuthOptions options = Options(new() { ["GitHub:AllowedOrgs:0"] = "contoso" });
+        var client = new FakeGitHubOAuthClient
+        {
+            OnOrgMembership = (_, org) => org == "contoso"
+                ? new GitHubOrgMembershipResult(true, null)
+                : new GitHubOrgMembershipResult(false, "org_http_404"),
+        };
+        GitHubUserAllowlist allowlist = Allowlist(options, client);
+
+        GitHubAllowlistDecision decision =
+            await allowlist.EvaluateAsync(new GitHubVerifiedUser(999, "octocat"), "tok", CancellationToken.None);
+
+        decision.Allowed.Should().BeTrue();
+        decision.Reason.Should().Be("org_membership");
+    }
+
+    [Fact]
+    public async Task InactiveOrgMembership_FailsClosed()
+    {
+        GitHubAuthOptions options = Options(new() { ["GitHub:AllowedOrgs:0"] = "contoso" });
+        var client = new FakeGitHubOAuthClient
+        {
+            OnOrgMembership = (_, _) => new GitHubOrgMembershipResult(false, "org_not_active"),
+        };
+        GitHubUserAllowlist allowlist = Allowlist(options, client);
+
+        GitHubAllowlistDecision decision =
+            await allowlist.EvaluateAsync(new GitHubVerifiedUser(999, "octocat"), "tok", CancellationToken.None);
+
+        decision.Allowed.Should().BeFalse("a pending/inactive membership must not admit the user");
+    }
+
+    [Fact]
+    public async Task OrgApiError_FailsClosed()
+    {
+        GitHubAuthOptions options = Options(new() { ["GitHub:AllowedOrgs:0"] = "contoso" });
+        var client = new FakeGitHubOAuthClient
+        {
+            OnOrgMembership = (_, _) => new GitHubOrgMembershipResult(false, "org_http_403"),
+        };
+        GitHubUserAllowlist allowlist = Allowlist(options, client);
+
+        GitHubAllowlistDecision decision =
+            await allowlist.EvaluateAsync(new GitHubVerifiedUser(999, "octocat"), "tok", CancellationToken.None);
+
+        decision.Allowed.Should().BeFalse("an org API/scope/rate error must fail closed");
+    }
+
+    [Fact]
+    public async Task NoMatch_Denies()
+    {
+        GitHubAuthOptions options = Options(new() { ["GitHub:AllowedUserIds:0"] = "12345" });
+        GitHubUserAllowlist allowlist = Allowlist(options, new FakeGitHubOAuthClient());
+
+        GitHubAllowlistDecision decision =
+            await allowlist.EvaluateAsync(new GitHubVerifiedUser(777, "someone-else"), "tok", CancellationToken.None);
+
+        decision.Allowed.Should().BeFalse();
+        decision.Reason.Should().Be("not_allowlisted");
+    }
+
+    [Fact]
+    public async Task InvalidUserId_Denies()
+    {
+        GitHubAuthOptions options = Options(new() { ["GitHub:AllowedUserIds:0"] = "12345" });
+        GitHubUserAllowlist allowlist = Allowlist(options, new FakeGitHubOAuthClient());
+
+        GitHubAllowlistDecision decision =
+            await allowlist.EvaluateAsync(new GitHubVerifiedUser(0, "x"), "tok", CancellationToken.None);
+
+        decision.Allowed.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Sprint 2: secure GitHub authentication mode

Implements a complete backend **GitHub confidential OAuth Backend-for-Frontend (BFF)** provider behind the existing provider-neutral factory (epic #27). Additive, opt-in, and **fail-closed** — **live/production stays Entra**: no hook/config/IaC pin was changed and the deployment-contract tests still prove the deployed artifacts are Entra-only. **Not deployed this sprint; do not merge/deploy.**

Closes #36. Part of epic #27.

### Why a confidential BFF (no PKCE)
GitHub **OAuth Apps do not support PKCE**. A browser-only exchange would leak the client secret or place a GitHub provider token in the SPA. So the browser only ever talks to our API: the API holds the client secret, exchanges the code server-side, validates the user, and hands the SPA only a one-time redemption code. Login-CSRF/fixation is closed by a random `state` in a server-side one-time store **plus** a separate random secret in an HttpOnly/Secure/SameSite=Lax cookie (SHA-256 hash stored, constant-time compared) — **both required at callback, before any code exchange**.

### Endpoints (only anonymous surface besides health, all rate limited)
- `GET /api/auth/github/start` — mints state + cookie, redirects **only** to the fixed GitHub authorize URL with minimal scopes (empty by default, `read:org` only with an org allowlist, **never `repo`**), `allow_signup=false`.
- `GET /api/auth/github/callback` — validates state + cookie + TTL + one-use, constant-time hash compare, deletes the state cookie on every path, exchanges the code server-side, validates via `/user`, runs the server-side allowlist, then redirects to the **one** configured SPA URL carrying only a one-time redemption code (never a provider/app token). Handles denial/errors safely.
- `POST /api/auth/github/exchange` — atomically redeems the one-time code (replay/race impossible) and returns a short-lived Retail Pulse session token.

### Allowlist & session token
- Server-side allowlist on the **immutable numeric GitHub user id** first, then a configurable login allowlist (login is informational identity only), and/or **active** org membership (`/user/memberships/orgs/{org}`, `state==active`). **Fails closed** on any GitHub API/rate/transport error. No `repo` scope, ever.
- HS256 (algorithm pinned) session JWT with a **separate issuer/audience**, `provider=GitHub`, `sub=github:<id>`, required `RetailPulse.User` role + `access_as_user` scope, random `jti`, strict expiry, ≥256-bit key with rotation seam, **no refresh token**. REST bearer + `/hubs` `?access_token` parity with Entra; cross-provider tokens rejected. `GitHubPrincipalNormalizer` trusts only the numeric subject.

### Threats mitigated
Login CSRF, open redirect, state fixation/replay, code/callback replay, one-time exchange races, token substitution, cross-provider tokens, GitHub API redirects/SSRF (fixed endpoints only), secrets in logs/errors (provider token asserted absent from redirect/body/logs), and rate-limit abuse.

### Limitation
The state and redemption stores are **replica-local, in-memory** (bounded, one-use, TTL, opportunistic cleanup). Hosted GitHub is therefore pinned to **`maxReplicas=1`** until moved to distributed storage. Documented in ADR-005, the authentication matrix, security.md, and deployment-azd.md.

### Tests & validation
- `GitHubAuthenticationTests` (TestServer integration + threat): start/callback/exchange happy path and every failure (missing/mismatched/expired/replayed state, absent cookie, denial, exchange/`/user`/org errors, unallowlisted user, inactive membership, code replay/race, wrong redirect, wrong signature/issuer/audience/provider/expiry, cross-provider, REST + both hubs after session token, query-token-on-REST denied), provider-token-never-leaked, exact scopes/no repo, rate limits, anonymous-exception coverage.
- Unit suites: `GitHubAuthOptionsTests`, `GitHubOneTimeStoreTests`, `GitHubSessionTokenTests`, `GitHubUserAllowlistTests`; extended `AuthenticationModeTests` + `ProviderNeutralDeploymentContractTests`.
- Backend `dotnet test` **2421 pass**; Release build **0 warnings/0 errors**; `dotnet format --verify-no-changes` clean; `az bicep build` clean; frontend `npm ci` + build + **371 vitest pass**.

### Docs
ADR-005 Sprint 2 addendum, authentication-matrix GitHub rows + runtime matrix, security.md GitHub section, deployment-azd.md replica-local note, and a safe `appsettings.GitHub.example.json` (loaded by no environment, no real secrets).

🤖 Generated with GitHub Copilot
