### PR TITLE
Provider-neutral frontend sign-in UX and deployment templates (Sprint 3, closes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,8 @@ dotnet run -c Release --project tests/RetailPulse.Benchmarks
 
 | Area | Implementation |
 |------|---------------|
-| **API Authentication** | Auth middleware on all API endpoints |
+| **API Authentication** | Auth middleware on all API endpoints; provider-neutral mode contract (`Authentication__Mode` = `Entra`/`GitHub`/`Anonymous`, fail-closed) — see [ADR-005](docs/adr/005-provider-neutral-authentication.md) |
+| **Frontend sign-in** | Provider-neutral SPA: build-time `VITE_AUTH_MODE` (mirrors the API mode) renders exactly one sign-in UX; fail-closed resolver; session tokens are `sessionStorage`-only and cleared on logout/expiry/401/403. See [FRONTEND.md](docs/FRONTEND.md#authentication--sign-in-provider-neutral) and the [authentication matrix](docs/authentication-matrix.md). |
 | **Teams Bot** | JWT token validation on incoming activities |
 | **MCP Server** | Parameterized SQL queries (no string interpolation) |
 | **SignalR** | Telemetry scoped to session groups (no cross-session leakage) |

--- a/azd-hooks/postprovision.ps1
+++ b/azd-hooks/postprovision.ps1
@@ -133,7 +133,9 @@ Invoke-Az `
         # Provider-neutral auth is explicitly pinned to Entra for production (see
         # Security/ProviderNeutralAuthentication.cs). This is a deploy-time re-assertion of the
         # committed appsettings.Production.json value; the API fails closed on a missing/unknown
-        # mode and refuses to start under GitHub/Anonymous.
+        # mode and refuses to start under GitHub/Anonymous. It matches the SPA's VITE_AUTH_MODE
+        # (also pinned to Entra by infra/main.bicep) — ProviderNeutralDeploymentContractTests
+        # asserts the parity.
         'Authentication__Mode=Entra',
         "Security__AllowedOrigins__0=$frontendOrigin",
         "MicrosoftEntra__TenantId=$entraTenantId",

--- a/azd-hooks/preprovision.ps1
+++ b/azd-hooks/preprovision.ps1
@@ -17,4 +17,39 @@ foreach ($command in 'az', 'dotnet', 'node', 'npm') {
     }
 }
 
+# ── Auth-mode fail-closed guard ────────────────────────────────────────────
+# The live deployment defaults to the Entra provider (see infra/main.bicep's
+# VITE_AUTH_MODE output and the postprovision Authentication__Mode pin). An
+# Entra deployment MUST carry non-empty, non-placeholder tenant + client IDs,
+# otherwise the SPA would build a silent, unauthenticated shell. Fail the whole
+# provision here — before any resource is created — when they are missing.
+# GitHub/Anonymous deployments set RETAIL_PULSE_AUTH_MODE explicitly and skip
+# this Entra-specific check (they never require Entra IDs).
+$authMode = $env:RETAIL_PULSE_AUTH_MODE
+if ([string]::IsNullOrWhiteSpace($authMode)) { $authMode = 'Entra' }
+
+function Test-EntraIdPlaceholder([string] $value) {
+    $v = ($value ?? '').Trim()
+    if ([string]::IsNullOrWhiteSpace($v)) { return $true }
+    if ($v -eq '00000000-0000-0000-0000-000000000000') { return $true }
+    if ($v -match '[<>]' -or $v -match '\s') { return $true }
+    if ($v -match '(?i)(your[-_]?|placeholder|changeme|example|todo|xxxx+|fixme)') { return $true }
+    return $false
+}
+
+if ($authMode -ieq 'Entra') {
+    $tenant = $env:RETAIL_PULSE_ENTRA_TENANT_ID
+    $client = $env:RETAIL_PULSE_ENTRA_CLIENT_ID
+    if ((Test-EntraIdPlaceholder $tenant) -or (Test-EntraIdPlaceholder $client)) {
+        throw "Entra is the selected auth mode but RETAIL_PULSE_ENTRA_TENANT_ID and/or " +
+              "RETAIL_PULSE_ENTRA_CLIENT_ID are empty or placeholders. Set both to the real " +
+              "single-tenant app-registration GUIDs (e.g. ``azd env set RETAIL_PULSE_ENTRA_TENANT_ID <guid>``) " +
+              "before provisioning. Refusing to provision an Entra deployment with empty auth configuration."
+    }
+    Write-Host "Auth mode 'Entra' validated: tenant/client IDs are present."
+}
+else {
+    Write-Host "Auth mode '$authMode' selected: skipping the Entra-specific ID check."
+}
+
 Write-Host 'All prerequisites met. Proceeding with provisioning...'

--- a/azd-hooks/preprovision.sh
+++ b/azd-hooks/preprovision.sh
@@ -19,4 +19,41 @@ for cmd in az dotnet node npm; do
     fi
 done
 
+# ── Auth-mode fail-closed guard ────────────────────────────────────────────
+# The live deployment defaults to the Entra provider (see infra/main.bicep's
+# VITE_AUTH_MODE output and the postprovision Authentication__Mode pin). An
+# Entra deployment MUST carry non-empty, non-placeholder tenant + client IDs,
+# otherwise the SPA would build a silent, unauthenticated shell. Fail the whole
+# provision here — before any resource is created — when they are missing.
+# GitHub/Anonymous deployments set RETAIL_PULSE_AUTH_MODE explicitly and skip
+# this Entra-specific check (they never require Entra IDs).
+AUTH_MODE="${RETAIL_PULSE_AUTH_MODE:-Entra}"
+
+is_entra_id_placeholder() {
+    value="$1"
+    # trim leading/trailing whitespace
+    trimmed="$(printf '%s' "$value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ -z "$trimmed" ] && return 0
+    [ "$trimmed" = '00000000-0000-0000-0000-000000000000' ] && return 0
+    # angle-bracket template, embedded whitespace, or a well-known scaffold token → placeholder.
+    printf '%s' "$trimmed" | grep -Eq '[<>[:space:]]' && return 0
+    printf '%s' "$trimmed" | grep -Eiq '(your[-_]?|placeholder|changeme|example|todo|xxxx+|fixme)' && return 0
+    return 1
+}
+
+lower_auth_mode="$(printf '%s' "$AUTH_MODE" | tr '[:upper:]' '[:lower:]')"
+if [ "$lower_auth_mode" = 'entra' ]; then
+    if is_entra_id_placeholder "${RETAIL_PULSE_ENTRA_TENANT_ID:-}" || \
+       is_entra_id_placeholder "${RETAIL_PULSE_ENTRA_CLIENT_ID:-}"; then
+        echo "Entra is the selected auth mode but RETAIL_PULSE_ENTRA_TENANT_ID and/or" >&2
+        echo "RETAIL_PULSE_ENTRA_CLIENT_ID are empty or placeholders. Set both to the real" >&2
+        echo "single-tenant app-registration GUIDs (e.g. 'azd env set RETAIL_PULSE_ENTRA_TENANT_ID <guid>')" >&2
+        echo "before provisioning. Refusing to provision an Entra deployment with empty auth configuration." >&2
+        exit 1
+    fi
+    echo "Auth mode 'Entra' validated: tenant/client IDs are present."
+else
+    echo "Auth mode '$AUTH_MODE' selected: skipping the Entra-specific ID check."
+fi
+
 echo 'All prerequisites met. Proceeding with provisioning...'

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -37,6 +37,56 @@ App.tsx
 - **Centralized constants** — `constants/agentRouting.ts` holds all agent colors, emojis, labels, and domain configs
 - **Type-safe contracts** — `types/index.ts` defines all shared interfaces aligned with backend API responses
 
+## Authentication & sign-in (provider-neutral)
+
+The SPA is **provider-neutral**: it renders exactly one sign-in UX chosen at build
+time, with all provider logic centralized behind a single interface. See
+[ADR-005](adr/005-provider-neutral-authentication.md) and the
+[authentication matrix](authentication-matrix.md).
+
+```
+VITE_AUTH_MODE (build-time, mirrors backend Authentication__Mode)
+   └─ auth/authMode.ts        resolveAuthMode() — pure, fail-closed
+        └─ auth/activeProvider.ts   selects ONE SessionProvider + capabilities
+             ├─ providers/entraProvider.ts      (MSAL — live, unchanged)
+             ├─ providers/githubProvider.ts     (confidential BFF; no provider token in browser)
+             └─ providers/anonymousProvider.ts  (limited demo)
+                  ├─ AuthGate.tsx → gates/{Entra,GitHub,Anonymous}AuthGate.tsx  (mode UX)
+                  ├─ auth/tokenService.ts + auth/authorizedFetch.ts  (all REST + SignalR)
+                  └─ session/sessionCredentialStore.ts  (session-only token store)
+```
+
+**Build-time mode selection.** `VITE_AUTH_MODE` (`Entra` / `GitHub` / `Anonymous`) is
+injected by the deployment (Bicep output → azd env → Vite). `resolveAuthMode()` is
+fail-closed: a missing mode resolves to `Entra` only when safe (existing Entra config,
+or explicit local-dev pass-through); a missing mode in a production build, or any
+unknown/numeric value, **throws at load** — never a silent anonymous default. Only the
+configured mode is rendered (no provider chooser).
+
+**One credential path.** A single `SessionProvider` (selected by `activeProvider.ts`)
+feeds both `authorizedFetch` (global REST) and the SignalR `accessTokenFactory`;
+components never touch provider logic. `authorizedFetch` attaches the token only to our
+`/api` paths on an exact-origin match.
+
+**Mode UX (`AuthGate` dispatches to one gate):**
+
+| Mode | Gate label | Flow | Token in browser |
+|------|-----------|------|------------------|
+| Entra | "Sign in with Microsoft" | MSAL redirect (unchanged) | MSAL token (`sessionStorage`, MSAL-owned) |
+| GitHub | "Continue with GitHub" | Top-level nav to `GET /api/auth/github/start` → callback returns one-time code → stripped via `history.replaceState` → `POST /api/auth/github/exchange` | Retail Pulse session token only (**GitHub provider token never in browser**) |
+| Anonymous | "Continue in limited demo" | Explicit consent click → `POST /api/auth/anonymous/session` | Short-lived session token only |
+
+**Capabilities.** A build-time capability object per mode centrally hides/disables
+surfaces. Anonymous disables the SignalR hubs (`realtimeHub=false` — Dashboard never
+starts SignalR, hub token factory returns `''`), Observability, Approvals, Memory,
+telemetry, exports, write actions, and alternate views; a consent banner shows the
+limitations and a "New anonymous session" action. Entra/GitHub get full capabilities.
+This is a **usability layer only** — the backend remains authoritative.
+
+**Session-token storage.** GitHub/Anonymous session tokens live in memory (source of
+truth) mirrored to `sessionStorage` for same-tab reload — never `localStorage`, never
+a broadly-readable cookie, never cross-tab. Cleared on logout, expiry, and 401/403.
+
 ## Dashboard Tabs
 
 The header bar contains toggle buttons that switch the main content area between the chat and specialized dashboards. Click a tab to open it; click again (or "Back to Chat") to return.

--- a/docs/adr/005-provider-neutral-authentication.md
+++ b/docs/adr/005-provider-neutral-authentication.md
@@ -529,6 +529,95 @@ All three are mapped **only** in GitHub mode, are the only anonymous
   `GitHubUserAllowlistTests`, and extended `AuthenticationModeTests` /
   `Deployment/ProviderNeutralDeploymentContractTests`.
 
+## Sprint 3 addendum: Provider-neutral frontend sign-in UX (implemented)
+
+Sprints 1–2 implemented the **backend** for Anonymous and GitHub modes. Sprint 3
+generalizes the **SPA** from Entra-only (MSAL) into a build-time-selected,
+provider-neutral frontend that renders exactly one mode's sign-in UX, without
+regressing the live Entra path. Production stays Entra; nothing is deployed and no
+GitHub OAuth app/secret is created this sprint.
+
+### Build-time deterministic mode (`VITE_AUTH_MODE`)
+
+- A new `VITE_AUTH_MODE` variable (`Entra` / `GitHub` / `Anonymous`, case-insensitive)
+  selects the provider at build time, mirroring the backend's `Authentication:Mode`.
+  A deployment contract test proves `VITE_AUTH_MODE` ↔ `Authentication__Mode` parity.
+- Resolution is **fail-closed** (`src/auth/authMode.ts`, pure `resolveAuthMode(env)`):
+  an explicit known mode always wins; a missing mode resolves to Entra **only** when
+  it is safe (the SPA already carries Entra config — back-compat — or an explicit
+  local-dev build, which becomes a transparent pass-through against the API's
+  Development synthetic auth); a missing mode in a production build with no Entra
+  config **throws**; an unknown/numeric value always **throws**. It is never silently
+  anonymous.
+- Live `infra/main.bicep` emits a literal `output VITE_AUTH_MODE string = 'Entra'` and
+  the azd post-provision hooks stay hardcoded to `Authentication__Mode=Entra`. Other
+  deployments use the separate, secret-free templates
+  (`src/RetailPulse.Web/.env.github.example`, `.env.anonymous.example`, and the
+  backend `appsettings.{GitHub,Anonymous}.example.json`).
+
+### Provider-neutral session/token architecture
+
+- A single `SessionProvider` interface (`src/auth/session/types.ts`) is implemented by
+  three adapters (`providers/{entra,github,anonymous}Provider.ts`). Entra preserves the
+  exact MSAL behavior (MSAL still owns its `sessionStorage` cache). A central selector
+  (`src/auth/activeProvider.ts`) exposes the one active provider, its `capabilities`,
+  `requiresGate`, and `acquireActiveToken()`.
+- **One** credential-acquisition path feeds both the global REST `authorizedFetch` and
+  the SignalR `accessTokenFactory` (`tokenService.ts`) — provider logic is never
+  duplicated in components.
+- GitHub/Anonymous Retail Pulse **session** tokens live in a narrow store
+  (`session/sessionCredentialStore.ts`): in-memory source of truth, mirrored to
+  `sessionStorage` for same-tab reload only — never `localStorage`, never a
+  broadly-readable cookie, never cross-tab. Cleared on logout, expiry, and 401/403. The
+  GitHub **provider** token never reaches the browser at all (confidential BFF).
+
+### Mode-specific UX (single gate, no chooser)
+
+- `AuthGate.tsx` is a dispatcher: pass-through when `!requiresGate`, else it renders the
+  one configured gate (`gates/{Entra,GitHub,Anonymous}AuthGate.tsx`). A single-mode
+  deployment renders only its own provider — no provider chooser — minimizing attack
+  surface and confusion.
+- **Entra** (live): unchanged Microsoft button / redirect / role-denied states.
+- **GitHub**: branded "Continue with GitHub"; a top-level navigation to the fixed
+  same-origin `GET /api/auth/github/start` (no user-supplied return URL); the callback
+  code is consumed and stripped from the URL immediately via `history.replaceState`
+  (no replay on reload/bookmark/back), exchanged at `POST /api/auth/github/exchange`,
+  and a session-only token is stored. Denial/expired/replayed/unallowlisted/provider
+  errors map to safe messages with retry. Logout clears only our token (no github.com
+  logout assumption).
+- **Anonymous**: an explicit "Continue in limited demo" consent gate listing the
+  limitations (billable, rate-limited, read-only chat, no telemetry/streaming/memory/
+  observability/admin/export, short-lived). Only an explicit click bootstraps a
+  session-only token. An in-app banner shows remaining time and offers "New anonymous
+  session" / "Clear session".
+
+### Central capability gating (usability layer; backend remains authoritative)
+
+- A build-time `ProviderCapabilities` object (`FULL_CAPABILITIES` for Entra/GitHub,
+  all-false `ANONYMOUS_CAPABILITIES`) centrally hides/disables Observability, Approvals,
+  Memory, telemetry, streaming, write actions, and alternate operator views. The
+  Dashboard's SignalR effect early-returns when `capabilities.realtimeHub` is false, and
+  `getHubAccessToken()` returns `''` for those providers — so an anonymous build never
+  starts a hub. This is defense-in-depth: the backend still 403s any disallowed route.
+
+### Files (Sprint 3, all frontend + templates/tests/docs)
+
+- `src/RetailPulse.Web/src/auth/authMode.ts`, `activeProvider.ts`,
+  `session/{types.ts,sessionCredentialStore.ts}`,
+  `providers/{entra,github,anonymous}Provider.ts`, `tokenService.ts` (refactor),
+  `authorizedFetch.ts` (install guard now keys off `requiresGate`).
+- `src/auth/AuthGate.tsx` (dispatcher), `src/auth/gates/*` (three gates + shared
+  `gateStyles.ts`), `src/main.tsx` (provider-neutral bootstrap),
+  `src/components/Dashboard.tsx` (capability + SignalR gating + anonymous banner),
+  `src/vite-env.d.ts` (+`VITE_AUTH_MODE`).
+- Templates: `infra/main.bicep` (`output VITE_AUTH_MODE = 'Entra'`),
+  `src/RetailPulse.Web/.env.example` (documented), `.env.github.example`,
+  `.env.anonymous.example`.
+- Tests: `src/__tests__/{authMode,AuthGate,GitHubAuthGate,AnonymousAuthGate,
+  sessionCredentialStore,tokenService,Dashboard.capabilities}.test.ts(x)` and
+  `authorizedFetch.test.ts` (updated), plus the 5 new
+  `Deployment/ProviderNeutralDeploymentContractTests` parity/template cases.
+
 ## Alternatives rejected
 
 

--- a/docs/authentication-matrix.md
+++ b/docs/authentication-matrix.md
@@ -61,7 +61,7 @@ fail-closed function (`src/RetailPulse.Web/src/auth/authMode.ts`).
 | Login start | MSAL redirect | Top-level nav to fixed `GET /api/auth/github/start` (no return URL) | Explicit consent click → `POST /api/auth/anonymous/session` |
 | Callback handling | MSAL | One-time `code` stripped via `history.replaceState`, exchanged at `POST /api/auth/github/exchange` | n/a |
 | SignalR hubs | yes | yes | **no** (`realtimeHub=false`; hub never started, token factory returns `''`) |
-| Telemetry / Observability / Approvals / Memory / Export / write actions / alternate views | shown | shown | **hidden** (all capabilities false) |
+| Telemetry / Observability / Approvals / Memory / alternate views | shown | shown | **hidden** (all capabilities false) |
 | Token cleared on | logout / expiry / 401 / 403 | logout / expiry / 401 / 403 | clear-session / expiry / 401 / 403 |
 
 Capability gating in the UI is a **usability layer only** — the backend remains the

--- a/docs/authentication-matrix.md
+++ b/docs/authentication-matrix.md
@@ -1,9 +1,10 @@
 # Authentication matrix
 
 > The authoritative behavior matrix for Retail Pulse authentication after the
-> provider-neutral foundation (Sprint 0). It enumerates every mode and
-> environment combination and the exact expected outcome. Each row is backed by
-> an automated test — see [Coverage](#coverage).
+> provider-neutral foundation (Sprint 0), extended with the Sprint 3
+> provider-neutral **frontend** build modes (`VITE_AUTH_MODE`). It enumerates every
+> mode and environment combination and the exact expected outcome. Each row is
+> backed by an automated test — see [Coverage](#coverage).
 
 ## Modes
 
@@ -30,6 +31,42 @@ resolver is deterministic and never auto-detects a provider.
 | missing / blank | Production (or any non-Development) | Startup fails — mode must be pinned explicitly, fails closed |
 | unknown string (for example `Okta`) | any | Startup fails — not a recognized mode |
 | bare number (for example `1`) | any | Startup fails — numeric selection is rejected |
+
+## Frontend build-mode matrix (`VITE_AUTH_MODE`)
+
+The SPA renders exactly **one** provider's sign-in UX, chosen at build time by
+`VITE_AUTH_MODE` (injected by the deployment: `infra/main.bicep` output → azd env →
+Vite build). This mirrors the backend `Authentication:Mode` so both halves of a
+deployment agree — a deployment contract test proves the parity. Resolution is a pure,
+fail-closed function (`src/RetailPulse.Web/src/auth/authMode.ts`).
+
+| `VITE_AUTH_MODE` value | Build | Outcome |
+|------------------------|-------|---------|
+| `Entra` (any case) | any | Renders the Microsoft sign-in gate (MSAL). Live production build. |
+| `GitHub` (any case) | any | Renders the "Continue with GitHub" gate (confidential BFF; provider token never in the browser). |
+| `Anonymous` (any case) | any | Renders the "Continue in limited demo" consent gate; all privileged surfaces hidden. |
+| missing / blank | SPA already carries Entra config | Resolves to `Entra` (back-compat); mounts the Entra gate. |
+| missing / blank | local dev (`import.meta.env.DEV`), no Entra config | Transparent pass-through (no gate) against the API's Development synthetic auth. |
+| missing / blank | production build, no Entra config | **Throws at load** — never a silent, insecure default. |
+| unknown string (e.g. `Okta`) | any | **Throws** — not a recognized mode. |
+| bare number (e.g. `1`) | any | **Throws** — numeric selection rejected. |
+
+### Frontend UX & capability behavior per mode
+
+| Concern | Entra | GitHub | Anonymous |
+|---------|-------|--------|-----------|
+| Gate label | "Sign in with Microsoft" | "Continue with GitHub" | "Continue in limited demo" |
+| Credential in browser | MSAL token (`sessionStorage`, MSAL-owned) | Retail Pulse session token only (memory + `sessionStorage`) | Retail Pulse session token only (memory + `sessionStorage`) |
+| Provider token in browser | n/a | **Never** (server-side BFF) | n/a |
+| Login start | MSAL redirect | Top-level nav to fixed `GET /api/auth/github/start` (no return URL) | Explicit consent click → `POST /api/auth/anonymous/session` |
+| Callback handling | MSAL | One-time `code` stripped via `history.replaceState`, exchanged at `POST /api/auth/github/exchange` | n/a |
+| SignalR hubs | yes | yes | **no** (`realtimeHub=false`; hub never started, token factory returns `''`) |
+| Telemetry / Observability / Approvals / Memory / Export / write actions / alternate views | shown | shown | **hidden** (all capabilities false) |
+| Token cleared on | logout / expiry / 401 / 403 | logout / expiry / 401 / 403 | clear-session / expiry / 401 / 403 |
+
+Capability gating in the UI is a **usability layer only** — the backend remains the
+authoritative gate (an anonymous token is still `403`'d on any disallowed route
+regardless of what the UI renders).
 
 ## Runtime authorization matrix (Entra mode)
 
@@ -189,7 +226,9 @@ running without configuration. It never applies outside Development.
 | Endpoint graph policy: anonymous surface is bootstrap + `POST /api/chat` only; both hubs denied; REST + hubs carry authorization metadata | `tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs` |
 | Entra hub behaviour unchanged by the anonymous scope reduction | `tests/RetailPulse.Tests/Security/AnonymousHubOwnershipTests.cs` |
 | Normalized principal mapping | `tests/RetailPulse.Tests/Security/NormalizedPrincipalTests.cs` |
-| Production / hooks pinned to Entra, never GitHub/Anonymous; single-replica pin; GitHub example config not auto-loaded and secret-free | `tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs` |
+| Production / hooks pinned to Entra, never GitHub/Anonymous; single-replica pin; GitHub example config not auto-loaded and secret-free; **frontend `VITE_AUTH_MODE` ↔ API `Authentication__Mode` parity; web mode templates documented & secret-free** | `tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs` |
+| Frontend mode resolver (all `VITE_AUTH_MODE` rows: explicit modes, back-compat, local-dev pass-through, prod-missing throw, unknown/numeric throw) | `src/RetailPulse.Web/src/__tests__/authMode.test.ts` |
+| Provider-neutral gate dispatch + Entra gate unchanged; GitHub start/callback/exchange/history-strip/replay/error/logout/401/403; Anonymous consent/bootstrap/limited-nav/no-hub/expiry/banner; token storage (session-only, cleared on expiry/logout/401/403); exact-origin `authorizedFetch`; hub token gated by capabilities; Dashboard hides privileged surfaces & never starts SignalR for anonymous | `src/RetailPulse.Web/src/__tests__/{AuthGate,GitHubAuthGate,AnonymousAuthGate,sessionCredentialStore,tokenService,authorizedFetch,Dashboard.capabilities}.test.ts(x)` |
 
 See [ADR-005](adr/005-provider-neutral-authentication.md) for the design and
 threat model, and [Entra authentication](authentication-entra.md) for the

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -103,8 +103,20 @@ so azd's `${...}` substitution and Vite's `import.meta.env` resolve them:
 | Output (Bicep) | Source | Consumed by |
 |----------------|--------|-------------|
 | `VITE_API_ORIGIN` | API container app origin | Frontend Vite build → `import.meta.env.VITE_API_ORIGIN` → absolute `/hubs/telemetry` |
+| `VITE_AUTH_MODE` | literal `'Entra'` (live) | Frontend Vite build → `import.meta.env.VITE_AUTH_MODE` → selects the sign-in UX (must equal the API's `Authentication__Mode`) |
 | `RETAIL_PULSE_FRONTEND_ORIGIN` | Static Web App origin | `api` `Security__AllowedOrigins__0` (CORS) |
 | `MCP_SERVER_BASE_URL` | MCP server container app origin | `api` `McpServer__BaseUrl` |
+
+**Frontend/API mode parity.** `VITE_AUTH_MODE` (frontend) **must equal**
+`Authentication__Mode` (API) so the rendered sign-in UX matches the boundary the API
+enforces. The live Bicep emits `output VITE_AUTH_MODE = 'Entra'` and the postprovision
+hook pins `Authentication__Mode=Entra`, so the deployed pair is always `Entra`. A
+deployment contract test
+(`tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs`)
+asserts this parity and that the Bicep/hooks never emit `GitHub`/`Anonymous`. Non-live
+web builds can be produced from the secret-free templates
+`src/RetailPulse.Web/.env.github.example` and `.env.anonymous.example` (see below); they
+are documentation-only and are **not** auto-loaded by any deployment.
 
 The pre-existing `AZURE_*` outputs (`AZURE_API_APP_URL`, `AZURE_MCP_SERVER_APP_URL`,
 `AZURE_FRONTEND_APP_URL`, …) are retained as-is for tooling compatibility; the
@@ -391,6 +403,21 @@ identity provider) for non-demo environments.
 > deliberate, separate decision requiring `Anonymous:AllowHosted=true`, a strong signing
 > key, positive daily ceilings, and — because the ceilings are replica-local — a single
 > replica (`maxReplicas=1`). It is not equivalent to authenticated production.
+
+#### Safe web-build mode templates (`.env.*.example`)
+
+The frontend ships two **secret-free** example env files for producing a non-live web
+build in `GitHub` or `Anonymous` mode:
+
+- `src/RetailPulse.Web/.env.github.example` → `VITE_AUTH_MODE=GitHub`
+- `src/RetailPulse.Web/.env.anonymous.example` → `VITE_AUTH_MODE=Anonymous`
+
+Both are documentation/templates only — copy to `.env.local` and set `VITE_API_ORIGIN`
+to an API deployed in the **matching** backend mode. They contain no secrets and are
+**not** auto-loaded by azd, the Bicep, or any hook; the live deployment stays `Entra`.
+Because the SPA renders exactly the mode it was built with, a mismatched
+`VITE_AUTH_MODE`/`Authentication__Mode` pair is a build-time configuration error, not a
+runtime provider switch.
 
 ### Frontend → API routing and SignalR
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -251,6 +251,44 @@ deployment-contract tests). It is **not deployed** this sprint.
   inspect ACA topology, hosted GitHub requires an explicit
   `AcknowledgeSingleReplica=true` fail-closed acknowledgement of that pin.
 
+### Frontend build mode & session-token lifecycle (Sprint 3)
+
+The SPA renders exactly **one** provider's sign-in UX, selected at build time by
+`VITE_AUTH_MODE` (`Entra` / `GitHub` / `Anonymous`), which mirrors the backend
+`Authentication__Mode`; a deployment contract test proves the parity. Resolution is a
+pure, **fail-closed** function (`src/RetailPulse.Web/src/auth/authMode.ts`): a missing
+mode resolves to `Entra` only when safe (the SPA already carries Entra config, or an
+explicit local-dev pass-through); a missing mode in a production build, or any unknown/
+numeric value, **throws at load** — never a silent, insecure default. A single-mode
+deployment renders only its configured provider (no provider chooser), minimizing
+attack surface. The live build stays `Entra`.
+
+- **One centralized credential path.** A single `SessionProvider` interface, active
+  selector (`activeProvider.ts`), and token service feed both the global REST
+  `authorizedFetch` and the SignalR `accessTokenFactory`; provider logic is never
+  duplicated in components. `authorizedFetch` attaches the token **only** to our own
+  `/api` paths on an **exact-origin** match (same-origin or the exact configured
+  `VITE_API_ORIGIN`), rejecting userinfo-smuggling, lookalike hosts, scheme/port
+  mismatches, `/hubs`, assets, and third parties — so a token is never sent to a
+  lookalike or redirect target.
+- **Narrow session-token storage.** The Retail Pulse session tokens minted for GitHub
+  and Anonymous live in memory (source of truth) mirrored to `sessionStorage` for
+  same-tab reload only — **never `localStorage`, never a broadly-readable cookie,
+  never cross-tab**. They are cleared on logout / clear-session, on expiry, and on a
+  401/403 from the API. The **GitHub provider token never reaches the browser** (the
+  confidential BFF holds it server-side); the SPA only ever handles the one-time
+  redemption code (stripped from the URL immediately via `history.replaceState`) and
+  the resulting Retail Pulse session token.
+- **SignalR gated by capability.** A build-time capability object disables the real-time
+  hubs for Anonymous (`realtimeHub=false`): the Dashboard never starts SignalR and the
+  hub token factory returns `''`. Entra and GitHub retain full hub access. This is a
+  defense-in-depth usability layer — the backend remains authoritative and still `403`s
+  any disallowed route regardless of what the UI renders.
+- **Login start cannot be redirected.** GitHub login is a top-level navigation to the
+  fixed same-origin `GET /api/auth/github/start`; no return/redirect URL is ever read
+  from the query string or user input. Logout clears only our session token (no
+  github.com provider-logout assumption).
+
 ### Development
 - `Security:RequireAuth` defaults to `false`
 - `Authentication:Mode` defaults to `Entra`, whose `DevelopmentAuthHandler`

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -132,6 +132,16 @@ output MCP_SERVER_BASE_URL string = containerApps.outputs.mcpServerUrl
 output RETAIL_PULSE_FRONTEND_ORIGIN string = staticWebApp.outputs.staticWebAppUrl
 output VITE_API_ORIGIN string = containerApps.outputs.apiUrl
 
+// - VITE_AUTH_MODE: the provider-neutral sign-in mode read by the Vite frontend
+//   build (import.meta.env) so the deployed SPA renders exactly one provider's
+//   sign-in UX. The LIVE environment is pinned to Entra — matching the API's
+//   Authentication__Mode (set to Entra by the postprovision hook and committed in
+//   appsettings.Production.json). ProviderNeutralDeploymentContractTests asserts
+//   this parity. Other (non-production) deployments use a separate template that
+//   overrides both halves together (see docs/deployment-azd.md and the
+//   appsettings.{GitHub,Anonymous}.example.json / .env.*.example templates).
+output VITE_AUTH_MODE string = 'Entra'
+
 // - VITE_ENTRA_*: non-secret Entra identifiers read by the Vite frontend build
 //   (import.meta.env) so the deployed SPA can run MSAL PKCE sign-in against the
 //   single-tenant app registration. Round-tripped from the entra* params above.
@@ -140,4 +150,6 @@ output VITE_API_ORIGIN string = containerApps.outputs.apiUrl
 output VITE_ENTRA_TENANT_ID string = entraTenantId
 output VITE_ENTRA_CLIENT_ID string = entraClientId
 output VITE_ENTRA_API_SCOPE string = entraApiScope
-output VITE_ENTRA_AUDIENCE string = empty(entraAudience) && !empty(entraClientId) ? 'api://${entraClientId}' : entraAudience
+output VITE_ENTRA_AUDIENCE string = empty(entraAudience) && !empty(entraClientId)
+  ? 'api://${entraClientId}'
+  : entraAudience

--- a/src/RetailPulse.Api/Endpoints/GitHubAuthEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/GitHubAuthEndpoints.cs
@@ -23,8 +23,11 @@ namespace RetailPulse.Api.Endpoints;
 ///     exchanges the code server-side, validates the token via <c>/user</c>, verifies the server-side
 ///     allowlist, and redirects to the ONE configured SPA URL carrying only a one-time redemption
 ///     code (never a provider/app token). Denials and errors are handled without leaking anything.</item>
-///   <item><b>exchange</b> (POST) — atomically redeems the one-time code and returns a short-lived
-///     Retail Pulse GitHub session token (no refresh token). Replay/races are impossible (one-use).</item>
+///   <item><b>exchange</b> (POST) — requires the exact per-code browser-bound <c>__Host-</c> redemption
+///     cookie set at callback (constant-time hash compare), atomically redeems the one-time code, and
+///     returns a short-lived Retail Pulse GitHub session token (no refresh token). A stolen unused code
+///     replayed from another browser fails (no cookie); replay/races are impossible (one-use); the exact
+///     cookie is deleted on success and failure.</item>
 /// </list>
 /// </summary>
 public static class GitHubAuthEndpoints
@@ -196,11 +199,16 @@ public static class GitHubAuthEndpoints
             return RedirectToFrontend(options, "error", "not_authorized");
         }
 
-        // 8) Mint a one-time redemption code bound to the verified identity (NOT a token). The app
-        //    session JWT is minted fresh at exchange so its short TTL starts when the SPA receives it.
+        // 8) Mint a one-time redemption code bound to the verified identity (NOT a token) AND to THIS
+        //    browser. A separate random secret is placed in a per-code __Host- redemption cookie; only
+        //    its hash is stored server-side. The exchange must present both the code and the matching
+        //    cookie (constant-time compared), so a stolen unused code replayed from another browser —
+        //    which never received the cookie — can never be redeemed. The app session JWT is minted
+        //    fresh at exchange so its short TTL starts when the SPA receives it.
         string redemptionCode = GitHubRandom.NewToken();
+        string redemptionCookieSecret = GitHubRandom.NewToken();
         long redeemBy = clock.GetUtcNow().UtcDateTime.AddSeconds(options.RedemptionTtlSeconds).Ticks;
-        if (!redemptionStore.TryStore(redemptionCode, new GitHubRedemptionEntry(verified, redeemBy)))
+        if (!redemptionStore.TryStore(redemptionCode, new GitHubRedemptionEntry(verified, Sha256(redemptionCookieSecret), redeemBy)))
         {
             return Results.Problem(
                 title: "github_callback_unavailable",
@@ -208,25 +216,54 @@ public static class GitHubAuthEndpoints
                 statusCode: StatusCodes.Status503ServiceUnavailable);
         }
 
+        // Bind the redemption to this browser: set the per-code __Host- cookie carrying the secret.
+        AppendRedemptionCookie(context, options, redemptionCode, redemptionCookieSecret);
+
         // 9) Redirect to the ONE configured SPA URL carrying only the one-time redemption code.
         return RedirectToFrontend(options, "code", redemptionCode);
     }
 
     // ── exchange ─────────────────────────────────────────────────────────────────
     private static IResult ExchangeAsync(
+        HttpContext context,
         [FromBody] GitHubExchangeRequest request,
+        GitHubAuthOptions options,
         GitHubRedemptionStore redemptionStore,
         IGitHubSessionTokenService tokenService)
     {
-        if (request is null || string.IsNullOrWhiteSpace(request.Code))
+        // The code must be present AND exactly the fixed base64url shape our callback emits — this bounds
+        // the per-code cookie-name derivation and rejects any malformed/oversized code up front.
+        if (request is null || string.IsNullOrWhiteSpace(request.Code) || !GitHubStateCookie.IsValidStateFormat(request.Code))
         {
             return Results.BadRequest(Problem("invalid_request", "A redemption code is required."));
         }
 
-        // Atomic one-time redemption — a second attempt (replay) or a race can never both succeed.
-        if (!redemptionStore.TryConsume(request.Code, out GitHubRedemptionEntry entry))
+        string code = request.Code;
+
+        // The redemption is bound to the browser that completed the callback: read the per-code cookie
+        // and ALWAYS delete it, whatever the outcome (success or failure).
+        string cookieName = GitHubStateCookie.RedemptionNameFor(code, options.RequireSecureCookies);
+        string? cookieSecret = context.Request.Cookies[cookieName];
+        DeleteRedemptionCookie(context, options, code);
+
+        // 1) The per-code cookie must be present. A stolen unused code replayed from another browser has
+        //    no such cookie, so it fails HERE — and, crucially, without consuming the victim's code.
+        if (string.IsNullOrEmpty(cookieSecret))
         {
             return Results.BadRequest(Problem("invalid_code", "The redemption code is unknown, already used, or expired."));
+        }
+
+        // 2) Atomic one-time redemption — a second attempt (replay) or a race can never both succeed.
+        if (!redemptionStore.TryConsume(code, out GitHubRedemptionEntry entry))
+        {
+            return Results.BadRequest(Problem("invalid_code", "The redemption code is unknown, already used, or expired."));
+        }
+
+        // 3) Bind to THIS browser: the presented cookie secret must hash to the stored value
+        //    (constant-time). A wrong cookie fails even though the code existed (it is now consumed).
+        if (!CryptographicOperations.FixedTimeEquals(Sha256(cookieSecret), entry.CookieSecretHash))
+        {
+            return Results.BadRequest(Problem("invalid_code", "The redemption code does not match this browser."));
         }
 
         GitHubSession session = tokenService.CreateSession(entry.User);
@@ -270,6 +307,35 @@ public static class GitHubAuthEndpoints
     private static void DeleteStateCookie(HttpContext context, GitHubAuthOptions options, string state)
     {
         context.Response.Cookies.Delete(CookieName(options, state), new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = options.RequireSecureCookies,
+            SameSite = SameSiteMode.Lax,
+            Path = "/",
+        });
+    }
+
+    private static string RedemptionCookieName(GitHubAuthOptions options, string code) =>
+        // Per-code name so parallel logins never clash. Secure/__Host semantics come from validated
+        // configuration (RequireSecureCookies), NEVER from Request.IsHttps — identical to the state cookie.
+        GitHubStateCookie.RedemptionNameFor(code, options.RequireSecureCookies);
+
+    private static void AppendRedemptionCookie(HttpContext context, GitHubAuthOptions options, string code, string secret)
+    {
+        context.Response.Cookies.Append(RedemptionCookieName(options, code), secret, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = options.RequireSecureCookies, // fixed by config, not the observed scheme
+            SameSite = SameSiteMode.Lax, // the SPA's same-site exchange POST carries it
+            Path = "/", // __Host- requires Path=/ and no Domain
+            IsEssential = true,
+            MaxAge = TimeSpan.FromSeconds(options.RedemptionTtlSeconds),
+        });
+    }
+
+    private static void DeleteRedemptionCookie(HttpContext context, GitHubAuthOptions options, string code)
+    {
+        context.Response.Cookies.Delete(RedemptionCookieName(options, code), new CookieOptions
         {
             HttpOnly = true,
             Secure = options.RequireSecureCookies,

--- a/src/RetailPulse.Api/Security/GitHub/GitHubAuthConstants.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubAuthConstants.cs
@@ -66,4 +66,20 @@ public static class GitHubAuthConstants
     /// which is rejected at startup outside Development.
     /// </summary>
     public const string DevStateCookieBase = "rp_gh_state_";
+
+    /// <summary>
+    /// Cookie-name base for the per-code browser-bound REDEMPTION cookie in HOSTED / secure mode. The
+    /// final name is per-code (<see cref="GitHubStateCookie.RedemptionNameFor"/>) so parallel logins
+    /// never clash; the <c>__Host-</c> prefix pins Secure + Path=/ + no Domain. This cookie binds the
+    /// one-time redemption code to the browser that completed the callback: the exchange requires the
+    /// exact code-derived cookie, so a stolen unused code replayed from another browser fails.
+    /// </summary>
+    public const string SecureRedemptionCookieBase = "__Host-rp_gh_redeem_";
+
+    /// <summary>
+    /// Cookie-name base for the DEVELOPMENT-only insecure per-code redemption cookie (plain HTTP, no
+    /// <c>__Host-</c> prefix). Only used when <see cref="GitHubAuthOptions.RequireSecureCookies"/> is
+    /// explicitly false, which is rejected at startup outside Development.
+    /// </summary>
+    public const string DevRedemptionCookieBase = "rp_gh_redeem_";
 }

--- a/src/RetailPulse.Api/Security/GitHub/GitHubOneTimeStores.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubOneTimeStores.cs
@@ -18,10 +18,17 @@ public readonly record struct GitHubStateEntry(byte[] CookieSecretHash, long Exp
 /// The server-side record redeemed by the SPA at the exchange endpoint. It holds the VERIFIED GitHub
 /// identity (immutable numeric id + login) — NOT a provider token and NOT an app token. The app
 /// session JWT is minted fresh at redemption so its short TTL starts when the SPA receives it.
+///
+/// Like the OAuth state, the redemption code is bound to the SAME browser that completed the callback:
+/// the record stores only the HASH of a per-code random secret placed in a browser-bound
+/// <c>__Host-</c> cookie at callback time. The exchange must present BOTH the code (query/body) and the
+/// matching per-code cookie secret (constant-time compared), so a stolen but unused code replayed from
+/// another browser — which never received the cookie — can never be redeemed.
 /// </summary>
 /// <param name="User">The verified GitHub identity established during the callback.</param>
+/// <param name="CookieSecretHash">SHA-256 of the random secret placed in the per-code redemption cookie.</param>
 /// <param name="ExpiresAtTicks">Absolute UTC expiry (ticks). Past this the code is invalid.</param>
-public readonly record struct GitHubRedemptionEntry(GitHubVerifiedUser User, long ExpiresAtTicks);
+public readonly record struct GitHubRedemptionEntry(GitHubVerifiedUser User, byte[] CookieSecretHash, long ExpiresAtTicks);
 
 /// <summary>
 /// A bounded, thread-safe, in-memory store with atomic one-time consumption and TTL, used for both

--- a/src/RetailPulse.Api/Security/GitHub/GitHubStateCookie.cs
+++ b/src/RetailPulse.Api/Security/GitHub/GitHubStateCookie.cs
@@ -66,6 +66,20 @@ public static class GitHubStateCookie
         return @base + Suffix(state);
     }
 
+    /// <summary>
+    /// The exact per-code redemption cookie name for <paramref name="code"/>. This binds the one-time
+    /// redemption code to the browser that completed the callback: the callback sets this cookie and the
+    /// exchange requires it. In <paramref name="secure"/> mode the name keeps the <c>__Host-</c> prefix;
+    /// otherwise it uses the Development-only insecure base. The code MUST already be validated with
+    /// <see cref="IsValidStateFormat"/> (state and redemption codes share the same fixed base64url shape),
+    /// so a crafted code can never inject cookie attributes or an oversized name.
+    /// </summary>
+    public static string RedemptionNameFor(string code, bool secure)
+    {
+        string @base = secure ? GitHubAuthConstants.SecureRedemptionCookieBase : GitHubAuthConstants.DevRedemptionCookieBase;
+        return @base + Suffix(code);
+    }
+
     private static string Suffix(string state)
     {
         byte[] hash = SHA256.HashData(Encoding.ASCII.GetBytes(state));

--- a/src/RetailPulse.Web/.env.anonymous.example
+++ b/src/RetailPulse.Web/.env.anonymous.example
@@ -1,0 +1,23 @@
+# Retail Pulse Web — Anonymous mode build template (NON-PRODUCTION)
+#
+# This is a SAFE EXAMPLE for a separate, non-production deployment that renders the
+# "Continue in limited demo" sign-in UX. The live/production environment is ALWAYS Entra
+# (see infra/main.bicep VITE_AUTH_MODE output). Copy this to .env.local (or wire the
+# values into a non-live build pipeline) to exercise Anonymous mode.
+#
+# Anonymous mode is billable, rate-limited, and read-only (chat only). The SPA centrally
+# hides telemetry, observability, approvals, memory, streaming, export, write actions, and
+# all alternate operator views; the backend remains the authoritative gate. No SignalR hub
+# is started in this mode. These are build-time CONFIGURATION only — never secrets.
+#
+# This value MUST match the backend Authentication:Mode for the same deployment
+# (a deployment contract test enforces the Entra parity for the live path).
+VITE_AUTH_MODE=Anonymous
+
+# Direct API origin for the same-origin anonymous bootstrap (POST /api/auth/anonymous/session)
+# and chat. Set to the deployed API origin.
+# VITE_API_ORIGIN=
+
+# Entra variables are intentionally UNSET in Anonymous mode — MSAL is not loaded.
+# VITE_ENTRA_TENANT_ID=
+# VITE_ENTRA_CLIENT_ID=

--- a/src/RetailPulse.Web/.env.example
+++ b/src/RetailPulse.Web/.env.example
@@ -13,6 +13,20 @@
 # unaffected. Default: unset (relative /hubs/telemetry).
 # VITE_API_ORIGIN=
 
+# ── Authentication mode (provider-neutral, build-time) ────────────────────────
+# Selects the SINGLE sign-in provider this build renders. One of (case-insensitive):
+#   Entra      → live Microsoft Entra sign-in (production default).
+#   GitHub     → "Continue with GitHub" confidential BFF flow (opt-in, non-production).
+#   Anonymous  → "Continue in limited demo" (billable, rate-limited, read-only chat).
+# This MUST match the backend's Authentication__Mode for the same deployment — a deployment
+# contract test enforces the parity. In Azure it is injected by the deploy
+# (infra/main.bicep → azd env → Vite build) and is pinned to Entra for the live environment.
+#
+# Fail-closed: if VITE_AUTH_MODE is unset or unknown in a production build with no Entra config,
+# the app refuses to start (never a silent anonymous default). Leave it UNSET for local dev —
+# the app then runs the Entra pass-through against the API's Development synthetic auth handler.
+# VITE_AUTH_MODE=Entra
+
 # ── Microsoft Entra sign-in (single-tenant SPA, PKCE, no secret) ──────────────
 # These are build-time CONFIGURATION, not secrets. Leave them UNSET for local dev:
 # the app then skips MSAL entirely and runs against the API's Development synthetic

--- a/src/RetailPulse.Web/.env.github.example
+++ b/src/RetailPulse.Web/.env.github.example
@@ -1,0 +1,23 @@
+# Retail Pulse Web — GitHub mode build template (NON-PRODUCTION)
+#
+# This is a SAFE EXAMPLE for a separate, non-production deployment that renders the
+# "Continue with GitHub" sign-in UX. The live/production environment is ALWAYS Entra
+# (see infra/main.bicep VITE_AUTH_MODE output). Copy this to .env.local (or wire the
+# values into a non-live build pipeline) to exercise GitHub mode.
+#
+# IMPORTANT: These are build-time CONFIGURATION only — never secrets. The GitHub OAuth
+# client secret and session signing key live ONLY on the backend
+# (appsettings.GitHub.example.json), never in the SPA. The GitHub provider token never
+# reaches the browser; the SPA only ever holds a short-lived Retail Pulse session token.
+#
+# This value MUST match the backend Authentication:Mode for the same deployment
+# (a deployment contract test enforces the Entra parity for the live path).
+VITE_AUTH_MODE=GitHub
+
+# Direct API origin for same-origin /api auth calls and the SignalR hub. Set to the
+# deployed API origin (e.g. https://retail-pulse-api.<region>.azurecontainerapps.io).
+# VITE_API_ORIGIN=
+
+# Entra variables are intentionally UNSET in GitHub mode — MSAL is not loaded.
+# VITE_ENTRA_TENANT_ID=
+# VITE_ENTRA_CLIENT_ID=

--- a/src/RetailPulse.Web/package.json
+++ b/src/RetailPulse.Web/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "start": "vite",
+    "validate:auth-config": "node scripts/validate-auth-config.mjs",
+    "prebuild": "node scripts/validate-auth-config.mjs",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/src/RetailPulse.Web/scripts/validate-auth-config.d.mts
+++ b/src/RetailPulse.Web/scripts/validate-auth-config.d.mts
@@ -1,0 +1,13 @@
+export interface AuthConfigValidationResult {
+  readonly ok: boolean;
+  readonly error?: string;
+}
+
+export function validateEntraIds(
+  tenantId: string | undefined,
+  clientId: string | undefined,
+): AuthConfigValidationResult;
+
+export function validateAuthConfig(
+  env: Record<string, string | undefined>,
+): AuthConfigValidationResult;

--- a/src/RetailPulse.Web/scripts/validate-auth-config.mjs
+++ b/src/RetailPulse.Web/scripts/validate-auth-config.mjs
@@ -1,0 +1,101 @@
+// @ts-check
+/**
+ * Build-time / predeploy fail-closed guard for the Retail Pulse SPA (Blocker 2).
+ *
+ * A frontend-only deploy (e.g. Static Web Apps build) reads VITE_AUTH_MODE + VITE_ENTRA_* from the
+ * environment. If the azd infra outputs are absent or the operator forgot to set the Entra ids, an
+ * Entra build would otherwise embed empty configuration and silently ship an unauthenticated shell.
+ * This validator runs as the npm `prebuild` step so `npm run build` FAILS FAST when an explicit Entra
+ * build is missing/placeholder tenant/client ids.
+ *
+ * Contract (kept deliberately permissive so CI's plain `npm run build` stays green):
+ *   • VITE_AUTH_MODE unset/blank        → PASS  (local dev / CI type-check build; no provider pinned).
+ *   • VITE_AUTH_MODE = entra            → require VALID, non-placeholder tenant + client ids, else FAIL.
+ *   • VITE_AUTH_MODE = github|anonymous → PASS  (Entra ids intentionally not required for these modes).
+ *   • VITE_AUTH_MODE = anything else    → FAIL  (an unknown selector can never pick a provider).
+ *
+ * The tenant/client validation mirrors auth/authConfig.ts::validateEntraConfig so the deploy guard and
+ * the runtime fail-closed guard agree.
+ */
+
+const GUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const EMPTY_GUID = '00000000-0000-0000-0000-000000000000';
+const TENANT_DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+const KNOWN_MODES = ['entra', 'github', 'anonymous'];
+
+/** @param {string} value */
+function isPlaceholder(value) {
+  const v = (value ?? '').trim();
+  if (v === '' || v === EMPTY_GUID) return true;
+  if (/[<>]/.test(v) || /\s/.test(v)) return true;
+  return /(your[-_]?|placeholder|changeme|example|todo|xxxx+|\bfixme\b)/i.test(v);
+}
+
+/**
+ * @param {string} tenantId
+ * @param {string} clientId
+ * @returns {{ ok: boolean, error?: string }}
+ */
+export function validateEntraIds(tenantId, clientId) {
+  const tenant = (tenantId ?? '').trim();
+  const client = (clientId ?? '').trim();
+  if (isPlaceholder(tenant)) return { ok: false, error: 'Entra tenant id is missing or a placeholder.' };
+  if (!(GUID_RE.test(tenant) || TENANT_DOMAIN_RE.test(tenant))) {
+    return { ok: false, error: 'Entra tenant id is not a valid GUID or directory domain.' };
+  }
+  if (isPlaceholder(client)) return { ok: false, error: 'Entra client id is missing or a placeholder.' };
+  if (!GUID_RE.test(client)) return { ok: false, error: 'Entra client id is not a valid GUID.' };
+  return { ok: true };
+}
+
+/**
+ * Pure validator over an env-like record so it is unit-testable with arbitrary inputs.
+ * @param {Record<string, string | undefined>} env
+ * @returns {{ ok: boolean, error?: string }}
+ */
+export function validateAuthConfig(env) {
+  const mode = (env.VITE_AUTH_MODE ?? '').trim().toLowerCase();
+
+  // No pinned mode: nothing to validate (local dev / CI type-check build stays green).
+  if (mode === '') return { ok: true };
+
+  if (!KNOWN_MODES.includes(mode)) {
+    return {
+      ok: false,
+      error: `VITE_AUTH_MODE="${env.VITE_AUTH_MODE}" is not a recognized authentication mode ` +
+        `(one of: ${KNOWN_MODES.join(', ')}).`,
+    };
+  }
+
+  // Only Entra requires the SPA-embedded tenant/client ids; github/anonymous never do.
+  if (mode === 'entra') {
+    const result = validateEntraIds(env.VITE_ENTRA_TENANT_ID ?? '', env.VITE_ENTRA_CLIENT_ID ?? '');
+    if (!result.ok) {
+      return {
+        ok: false,
+        error: `VITE_AUTH_MODE=Entra but ${result.error} ` +
+          'Set non-empty, valid VITE_ENTRA_TENANT_ID and VITE_ENTRA_CLIENT_ID before building. ' +
+          'Refusing to build an Entra SPA with empty/placeholder configuration.',
+      };
+    }
+  }
+
+  return { ok: true };
+}
+
+// CLI entry point: used as the npm `prebuild` guard. Exits non-zero (fails the build) on invalid config.
+const invokedDirectly =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1] &&
+  import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href;
+
+if (invokedDirectly) {
+  const result = validateAuthConfig(/** @type {Record<string,string|undefined>} */ (process.env));
+  if (!result.ok) {
+    console.error(`\n[validate-auth-config] BUILD BLOCKED: ${result.error}\n`);
+    process.exit(1);
+  }
+  const mode = (process.env.VITE_AUTH_MODE ?? '').trim() || '(unset — no provider pinned)';
+  console.log(`[validate-auth-config] OK — auth mode: ${mode}`);
+}

--- a/src/RetailPulse.Web/src/__tests__/AnonymousAuthGate.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/AnonymousAuthGate.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+import { AUTH_REQUIRED_EVENT } from '../auth/authorizedFetch';
+import {
+  AnonymousAuthGate,
+  AnonymousSessionBanner,
+} from '../auth/gates/AnonymousAuthGate';
+import { AnonymousSessionProvider } from '../auth/providers/anonymousProvider';
+
+function wrap(ui: React.ReactNode) {
+  return <FluentProvider theme={teamsDarkTheme}>{ui}</FluentProvider>;
+}
+
+const child = <div data-testid="protected-child">chat</div>;
+const STORAGE_KEY = 'retailpulse:session:anonymous';
+const BOOTSTRAP_PATH = '/api/auth/anonymous/session';
+
+function tokenResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  fetchMock = vi.fn();
+  window.fetch = fetchMock as unknown as typeof window.fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function mountInitialized(provider: AnonymousSessionProvider) {
+  await act(async () => {
+    await provider.initialize();
+  });
+  render(wrap(<AnonymousAuthGate provider={provider}>{child}</AnonymousAuthGate>));
+}
+
+describe('AnonymousAuthGate — consent screen', () => {
+  it('shows the limited-demo warning, limitations, and a clear consent button', async () => {
+    const provider = new AnonymousSessionProvider();
+    await mountInitialized(provider);
+
+    expect(screen.getByTestId('anon-warning-badge')).toHaveTextContent(/billable/i);
+    expect(screen.getByTestId('anon-continue-button')).toHaveTextContent(
+      /Continue in limited demo/i,
+    );
+
+    const limitations = screen.getByTestId('anon-limitations');
+    expect(limitations).toHaveTextContent(/rate-limited/i);
+    expect(limitations).toHaveTextContent(/read-only chat/i);
+    expect(limitations).toHaveTextContent(/no.*telemetry|streaming|memory/i);
+    expect(limitations).toHaveTextContent(/short-lived|expiry|restart/i);
+
+    // Nothing billable happens before an explicit click.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('protected-child')).not.toBeInTheDocument();
+  });
+
+  it('bootstraps a session-only token ONLY on explicit consent click, then renders chat', async () => {
+    fetchMock.mockResolvedValueOnce(
+      tokenResponse({ token: 'anon-tok', tokenType: 'Bearer', expiresInSeconds: 600, subject: 'x' }),
+    );
+    const provider = new AnonymousSessionProvider();
+    await mountInitialized(provider);
+
+    await userEvent.click(screen.getByTestId('anon-continue-button'));
+
+    expect(await screen.findByTestId('protected-child')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(BOOTSTRAP_PATH);
+    expect(init.method).toBe('POST');
+
+    // Session-only storage; never localStorage.
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toContain('anon-tok');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('surfaces a rate-limited message on HTTP 429 and offers retry', async () => {
+    fetchMock.mockResolvedValueOnce(tokenResponse({ error: 'rate_limited' }, 429));
+    const provider = new AnonymousSessionProvider();
+    await mountInitialized(provider);
+
+    await userEvent.click(screen.getByTestId('anon-continue-button'));
+
+    expect(await screen.findByTestId('auth-error')).toHaveTextContent(/rate limit/i);
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    // The button becomes a retry; a subsequent success renders the app.
+    fetchMock.mockResolvedValueOnce(
+      tokenResponse({ token: 't2', tokenType: 'Bearer', expiresInSeconds: 600, subject: 'x' }),
+    );
+    await userEvent.click(screen.getByTestId('anon-continue-button')); // retry → unauthenticated
+    await userEvent.click(screen.getByTestId('anon-continue-button')); // consent again
+    expect(await screen.findByTestId('protected-child')).toBeInTheDocument();
+  });
+
+  it('returns to the consent screen on a 401 (AUTH_REQUIRED) and clears the token', async () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ token: 't', expiresAt: Date.now() + 60000 }),
+    );
+    const provider = new AnonymousSessionProvider();
+    await mountInitialized(provider);
+    expect(screen.getByTestId('protected-child')).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AUTH_REQUIRED_EVENT));
+    });
+
+    expect(await screen.findByTestId('anon-continue-button')).toBeInTheDocument();
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('AnonymousSessionBanner — in-app expiry & session controls', () => {
+  it('shows remaining time and a clear-session action', async () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ token: 't', expiresAt: Date.now() + 120000 }),
+    );
+    const provider = new AnonymousSessionProvider();
+    await act(async () => {
+      await provider.initialize();
+    });
+
+    render(wrap(<AnonymousSessionBanner provider={provider} />));
+
+    expect(screen.getByTestId('anon-session-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('anon-expiry')).toHaveTextContent(/expires in/i);
+    expect(screen.getByTestId('anon-new-session')).toBeInTheDocument();
+    expect(screen.getByTestId('anon-clear-session')).toBeInTheDocument();
+  });
+
+  it('clears the session token when "Clear session" is clicked', async () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ token: 't', expiresAt: Date.now() + 120000 }),
+    );
+    const provider = new AnonymousSessionProvider();
+    await act(async () => {
+      await provider.initialize();
+    });
+    render(wrap(<AnonymousSessionBanner provider={provider} />));
+
+    await userEvent.click(screen.getByTestId('anon-clear-session'));
+
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(provider.getState().status).toBe('unauthenticated');
+  });
+
+  it('mints a fresh token when "New anonymous session" is clicked', async () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ token: 'old', expiresAt: Date.now() + 120000 }),
+    );
+    const provider = new AnonymousSessionProvider();
+    await act(async () => {
+      await provider.initialize();
+    });
+    render(wrap(<AnonymousSessionBanner provider={provider} />));
+
+    fetchMock.mockResolvedValueOnce(
+      tokenResponse({ token: 'new', tokenType: 'Bearer', expiresInSeconds: 600, subject: 'x' }),
+    );
+    await userEvent.click(screen.getByTestId('anon-new-session'));
+
+    await waitFor(() => expect(window.sessionStorage.getItem(STORAGE_KEY)).toContain('new'));
+    expect(fetchMock).toHaveBeenCalledWith(BOOTSTRAP_PATH, expect.objectContaining({ method: 'POST' }));
+  });
+});
+
+describe('AnonymousSessionProvider — capabilities', () => {
+  it('exposes an all-false capability profile (read-only chat only)', () => {
+    const provider = new AnonymousSessionProvider();
+    const caps = provider.capabilities;
+    expect(caps.realtimeHub).toBe(false);
+    expect(caps.telemetryPanel).toBe(false);
+    expect(caps.observability).toBe(false);
+    expect(caps.approvals).toBe(false);
+    expect(caps.memory).toBe(false);
+    expect(caps.streaming).toBe(false);
+    expect(caps.export).toBe(false);
+    expect(caps.writeActions).toBe(false);
+    expect(caps.alternateViews).toBe(false);
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/AnonymousAuthGate.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/AnonymousAuthGate.test.tsx
@@ -187,9 +187,6 @@ describe('AnonymousSessionProvider — capabilities', () => {
     expect(caps.observability).toBe(false);
     expect(caps.approvals).toBe(false);
     expect(caps.memory).toBe(false);
-    expect(caps.streaming).toBe(false);
-    expect(caps.export).toBe(false);
-    expect(caps.writeActions).toBe(false);
     expect(caps.alternateViews).toBe(false);
   });
 });

--- a/src/RetailPulse.Web/src/__tests__/AuthGate.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/AuthGate.test.tsx
@@ -5,10 +5,28 @@ import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
 import { InteractionStatus } from '@azure/msal-browser';
 import { AUTH_FORBIDDEN_EVENT } from '../auth/authorizedFetch';
 
-// Mutable so individual tests can flip configured/unconfigured; AuthGate reads it per render.
-const { mockAuthConfig } = vi.hoisted(() => ({ mockAuthConfig: { isConfigured: true } }));
+// The dispatcher reads the active provider selection. A mutable mock lets each test pick the mode
+// and whether a gate is required, exercising the build-time dispatch without a real provider.
+const { mockActive } = vi.hoisted(() => ({
+  mockActive: {
+    requiresGate: true,
+    activeAuthMode: 'entra' as 'entra' | 'github' | 'anonymous',
+    provider: {} as unknown,
+  },
+}));
+vi.mock('../auth/activeProvider', () => ({
+  get requiresGate() {
+    return mockActive.requiresGate;
+  },
+  get activeAuthMode() {
+    return mockActive.activeAuthMode;
+  },
+  getActiveProvider: () => mockActive.provider,
+}));
+
+// authConfig/msal are only consumed by the Entra gate.
 vi.mock('../auth/authConfig', () => ({
-  authConfig: mockAuthConfig,
+  authConfig: { isConfigured: true },
   loginRequest: { scopes: ['api://client/access_as_user'] },
 }));
 
@@ -30,8 +48,27 @@ function wrap(ui: React.ReactNode) {
 
 const child = <div data-testid="protected-child">dashboard</div>;
 
+/** Minimal observable-provider stub for GitHub/Anonymous dispatch checks. */
+function stubProvider(status: string) {
+  const state = { status };
+  return {
+    subscribe: () => () => {},
+    getState: () => state,
+    startLogin: vi.fn(),
+    bootstrap: vi.fn(),
+    retry: vi.fn(),
+    handleAuthRequired: vi.fn(),
+    handleForbidden: vi.fn(),
+    msUntilExpiry: () => null,
+    endSession: vi.fn(),
+    newSession: vi.fn(),
+  };
+}
+
 beforeEach(() => {
-  mockAuthConfig.isConfigured = true;
+  mockActive.requiresGate = true;
+  mockActive.activeAuthMode = 'entra';
+  mockActive.provider = {};
   useIsAuthenticated.mockReset();
   useMsal.mockReset();
   loginRedirect.mockReset();
@@ -43,14 +80,34 @@ beforeEach(() => {
   });
 });
 
-describe('AuthGate', () => {
-  it('is a transparent pass-through when auth is not configured (local dev)', () => {
-    mockAuthConfig.isConfigured = false;
+describe('AuthGate dispatcher', () => {
+  it('is a transparent pass-through when no gate is required (local dev)', () => {
+    mockActive.requiresGate = false;
     render(wrap(<AuthGate>{child}</AuthGate>));
     expect(screen.getByTestId('protected-child')).toBeInTheDocument();
     expect(screen.queryByTestId('auth-gate')).not.toBeInTheDocument();
   });
 
+  it('dispatches to the GitHub gate in github mode', () => {
+    mockActive.activeAuthMode = 'github';
+    mockActive.provider = stubProvider('unauthenticated');
+    render(wrap(<AuthGate>{child}</AuthGate>));
+    expect(screen.getByTestId('auth-github-button')).toHaveTextContent(/Continue with GitHub/i);
+    expect(screen.queryByTestId('protected-child')).not.toBeInTheDocument();
+  });
+
+  it('dispatches to the Anonymous gate in anonymous mode', () => {
+    mockActive.activeAuthMode = 'anonymous';
+    mockActive.provider = stubProvider('unauthenticated');
+    render(wrap(<AuthGate>{child}</AuthGate>));
+    expect(screen.getByTestId('anon-continue-button')).toHaveTextContent(
+      /Continue in limited demo/i,
+    );
+    expect(screen.queryByTestId('protected-child')).not.toBeInTheDocument();
+  });
+});
+
+describe('AuthGate → Entra gate (live UX, unchanged)', () => {
   it('renders the protected app when the user is authenticated', () => {
     useIsAuthenticated.mockReturnValue(true);
     render(wrap(<AuthGate>{child}</AuthGate>));
@@ -58,13 +115,13 @@ describe('AuthGate', () => {
     expect(screen.queryByTestId('auth-gate')).not.toBeInTheDocument();
   });
 
-  it('shows the sign-in gate (and hides the app) when unauthenticated', async () => {
+  it('shows the Microsoft sign-in gate (and hides the app) when unauthenticated', async () => {
     useIsAuthenticated.mockReturnValue(false);
     render(wrap(<AuthGate>{child}</AuthGate>));
 
     expect(screen.queryByTestId('protected-child')).not.toBeInTheDocument();
     const button = screen.getByTestId('auth-signin-button');
-    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent(/Sign in with Microsoft/i);
 
     await userEvent.click(button);
     expect(loginRedirect).toHaveBeenCalledTimes(1);
@@ -85,10 +142,8 @@ describe('AuthGate', () => {
   it('surfaces a role/scope access-denied message on a 403 event', async () => {
     useIsAuthenticated.mockReturnValue(true);
     render(wrap(<AuthGate>{child}</AuthGate>));
-    // Authenticated user with the app rendered...
     expect(screen.getByTestId('protected-child')).toBeInTheDocument();
 
-    // ...then the API returns 403 (authenticated but unassigned): the gate takes over.
     act(() => {
       window.dispatchEvent(new CustomEvent(AUTH_FORBIDDEN_EVENT));
     });

--- a/src/RetailPulse.Web/src/__tests__/Dashboard.capabilities.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/Dashboard.capabilities.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+import type { ProviderCapabilities } from '../auth/session/types';
+import { FULL_CAPABILITIES, ANONYMOUS_CAPABILITIES } from '../auth/session/types';
+
+/**
+ * Dashboard capability-gating integration test. The Dashboard reads a build-time `capabilities`
+ * object to CENTRALLY hide/disable operator surfaces and to decide whether to start SignalR. These
+ * tests drive that object per mode and assert the SignalR hub and the privileged surfaces are gated,
+ * proving an anonymous build cannot start a hub or reach dashboards the backend would 403 anyway.
+ */
+
+const mockCaps: { value: ProviderCapabilities; mode: 'entra' | 'github' | 'anonymous' } = {
+  value: FULL_CAPABILITIES,
+  mode: 'entra',
+};
+
+const connectTelemetryHub = vi.fn((..._args: unknown[]) => ({ on: vi.fn(), off: vi.fn() }));
+vi.mock('../services/telemetryHub', () => ({
+  connectTelemetryHub: (...args: unknown[]) => connectTelemetryHub(...args),
+}));
+
+vi.mock('../auth/activeProvider', () => ({
+  get capabilities() {
+    return mockCaps.value;
+  },
+  get activeAuthMode() {
+    return mockCaps.mode;
+  },
+  getActiveProvider: () => ({ msUntilExpiry: () => 120000, endSession: vi.fn(), newSession: vi.fn() }),
+}));
+
+// All feature flags on, so any hidden alternate-view button is due to capability gating, not a flag.
+vi.mock('../config/featureFlags', () => ({
+  featureFlags: new Proxy({}, { get: () => true }),
+}));
+
+// Stub every heavy child so the test isolates Dashboard's own gating logic (not child behavior).
+function stub(testid: string) {
+  return () => <div data-testid={testid} />;
+}
+vi.mock('../components/ChatPanel', () => ({ ChatPanel: stub('chat-panel') }));
+vi.mock('../components/TelemetryPanel', () => ({ TelemetryPanel: stub('telemetry-panel') }));
+vi.mock('../components/AgentRoutingPanel', () => ({ AgentRoutingPanel: stub('agent-routing') }));
+vi.mock('../components/MemoryPanel', () => ({ MemoryPanel: stub('memory-panel') }));
+vi.mock('../components/CollapsibleSection', () => ({
+  CollapsibleSection: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../components/ApprovalHistory', () => ({ ApprovalHistory: stub('approval-history') }));
+vi.mock('../components/PendingApprovals', () => ({ PendingApprovals: stub('pending-approvals') }));
+vi.mock('../components/BrandLogo', () => ({ BrandLogo: stub('brand-logo') }));
+vi.mock('../components/alerts', () => ({
+  AlertFeed: stub('alert-feed'),
+  AlertHistory: stub('alert-history'),
+}));
+vi.mock('../components/traces', () => ({ TraceDashboard: stub('trace-dashboard') }));
+vi.mock('../components/promo', () => ({ PromoTaskModule: stub('promo') }));
+vi.mock('../components/competitive', () => ({ CompetitiveDashboard: stub('competitive') }));
+vi.mock('../components/knowledge', () => ({ KnowledgeBasePanel: stub('knowledge') }));
+vi.mock('../components/council', () => ({ CouncilPanel: stub('council') }));
+vi.mock('../components/guardrails', () => ({
+  GuardrailsDashboard: stub('guardrails'),
+  GuardrailsConfig: stub('guardrails-config'),
+}));
+vi.mock('../components/cards', () => ({ AdaptiveCardPanel: stub('cards') }));
+vi.mock('../components/observability', () => ({ ObservabilityPanel: stub('observability') }));
+vi.mock('../components/stores', () => ({
+  StoreHeatmap: stub('store-heatmap'),
+  StockoutAlert: stub('stockout'),
+  StorePerformanceTable: stub('store-table'),
+  StoreDetailDialog: stub('store-dialog'),
+}));
+vi.mock('../components/margin', () => ({
+  MarginWaterfall: stub('margin-waterfall'),
+  MarginDrivers: stub('margin-drivers'),
+}));
+vi.mock('../components/scorecard', () => ({
+  PortfolioScorecard: stub('portfolio'),
+  BrandScoreCard: stub('brand-score'),
+  ExplanationPanel: stub('explanation'),
+}));
+
+import { Dashboard } from '../components/Dashboard';
+
+function renderDashboard() {
+  return render(
+    <FluentProvider theme={teamsDarkTheme}>
+      <Dashboard />
+    </FluentProvider>,
+  );
+}
+
+beforeEach(() => {
+  connectTelemetryHub.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+describe('Dashboard — full capabilities (Entra/GitHub)', () => {
+  beforeEach(() => {
+    mockCaps.value = FULL_CAPABILITIES;
+    mockCaps.mode = 'entra';
+  });
+
+  it('starts the SignalR telemetry hub', () => {
+    renderDashboard();
+    expect(connectTelemetryHub).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders privileged surfaces and no anonymous banner', () => {
+    renderDashboard();
+    expect(screen.getByRole('button', { name: /Real-Time Telemetry/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Observability/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Competitive/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('anon-session-banner')).not.toBeInTheDocument();
+  });
+});
+
+describe('Dashboard — anonymous capabilities (limited demo)', () => {
+  beforeEach(() => {
+    mockCaps.value = ANONYMOUS_CAPABILITIES;
+    mockCaps.mode = 'anonymous';
+  });
+
+  it('NEVER starts the SignalR telemetry hub', () => {
+    renderDashboard();
+    expect(connectTelemetryHub).not.toHaveBeenCalled();
+  });
+
+  it('hides telemetry, observability, approvals, and all alternate-view surfaces', () => {
+    renderDashboard();
+    expect(screen.queryByRole('button', { name: /Real-Time Telemetry/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Observability/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Competitive/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Campaign Planner/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pending-approvals')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('memory-panel')).not.toBeInTheDocument();
+  });
+
+  it('shows the limited-demo banner and still renders the chat surface', () => {
+    renderDashboard();
+    expect(screen.getByTestId('anon-session-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-panel')).toBeInTheDocument();
+    // "New Chat" is always available regardless of capabilities.
+    expect(screen.getByRole('button', { name: /New Chat/i })).toBeInTheDocument();
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/GitHubAuthGate.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/GitHubAuthGate.test.tsx
@@ -15,8 +15,14 @@ function wrap(ui: React.ReactNode) {
 const child = <div data-testid="protected-child">app</div>;
 
 const STORAGE_KEY = 'retailpulse:session:github';
+const MARKER_KEY = 'retailpulse:login-started:github';
 const START_PATH = '/api/auth/github/start';
 const EXCHANGE_PATH = '/api/auth/github/exchange';
+
+/** Simulate a login that THIS tab started: startLogin() sets this marker before navigating away. */
+function markLoginStarted() {
+  window.sessionStorage.setItem(MARKER_KEY, '1');
+}
 
 function tokenResponse(body: Record<string, unknown>, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -106,12 +112,15 @@ describe('GitHubAuthGate — start', () => {
     // The provider never appends a return/redirect query parameter.
     expect(String(assignMock.mock.calls[0][0])).not.toMatch(/return|redirect|url=/i);
     expect(fetchMock).not.toHaveBeenCalled();
+    // startLogin set the single-use marker so the returning callback is trusted.
+    expect(window.sessionStorage.getItem(MARKER_KEY)).toBe('1');
   });
 });
 
 describe('GitHubAuthGate — callback exchange', () => {
   it('redeems a one-time code, strips it from the URL, and renders the app', async () => {
     navigate('/?code=abc123&extra=keep');
+    markLoginStarted();
     fetchMock.mockResolvedValueOnce(
       tokenResponse({ token: 'rp-session', tokenType: 'Bearer', expiresInSeconds: 900, subject: 's' }),
     );
@@ -120,11 +129,13 @@ describe('GitHubAuthGate — callback exchange', () => {
 
     expect(await screen.findByTestId('protected-child')).toBeInTheDocument();
 
-    // Exchange POSTed to the exact same-origin exchange route with the code.
+    // Exchange POSTed to the exact same-origin exchange route with the code, carrying credentials so the
+    // per-code __Host- redemption cookie is sent.
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(EXCHANGE_PATH);
     expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('include');
     expect(JSON.parse(init.body as string)).toEqual({ code: 'abc123' });
 
     // Code was stripped immediately via history.replaceState; unrelated params preserved.
@@ -132,13 +143,67 @@ describe('GitHubAuthGate — callback exchange', () => {
     expect(window.location.search).not.toContain('code=');
     expect(window.location.search).toContain('extra=keep');
 
+    // The single-use login marker was consumed.
+    expect(window.sessionStorage.getItem(MARKER_KEY)).toBeNull();
+
     // Token stored session-only.
     expect(window.sessionStorage.getItem(STORAGE_KEY)).toContain('rp-session');
     expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
+  it('ignores an injected code with no login marker: never calls exchange but still strips the URL', async () => {
+    // An attacker seeds ?code= into the victim's address bar WITHOUT the victim clicking "Sign in", so no
+    // login-started marker exists. The SPA must strip the param and never attempt an exchange. (The
+    // backend per-code cookie is the primary control; this is defense-in-depth.)
+    navigate('/?code=injected&extra=keep');
+    const provider = new GitHubSessionProvider();
+    await mountInitialized(provider);
+
+    // No exchange attempted, and the sign-in button is shown (unauthenticated).
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await screen.findByTestId('auth-github-button')).toBeInTheDocument();
+
+    // The injected code was still stripped from the address bar immediately.
+    expect(replaceStateSpy).toHaveBeenCalled();
+    expect(window.location.search).not.toContain('code=');
+    expect(window.location.search).toContain('extra=keep');
+  });
+
+  it('ignores an injected error with no login marker: shows no error, strips the URL', async () => {
+    navigate('/?error=not_authorized');
+    const provider = new GitHubSessionProvider();
+    await mountInitialized(provider);
+
+    expect(screen.queryByTestId('auth-error')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('auth-github-button')).toBeInTheDocument();
+    expect(window.location.search).not.toContain('error=');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('consumes the login marker exactly once: a genuine callback exchanges, an injected reload does not', async () => {
+    navigate('/?code=genuine');
+    markLoginStarted();
+    fetchMock.mockResolvedValueOnce(
+      tokenResponse({ token: 't', tokenType: 'Bearer', expiresInSeconds: 900, subject: 's' }),
+    );
+    const provider = new GitHubSessionProvider();
+    await act(async () => {
+      await provider.initialize();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The marker is single-use: a fresh injected code with no new marker does not exchange again.
+    navigate('/?code=injected-again');
+    const attacker = new GitHubSessionProvider();
+    await act(async () => {
+      await attacker.initialize();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('shows a safe access-denied message for a callback error and offers retry', async () => {
     navigate('/?error=access_denied');
+    markLoginStarted();
     const provider = new GitHubSessionProvider();
     await mountInitialized(provider);
 
@@ -153,6 +218,7 @@ describe('GitHubAuthGate — callback exchange', () => {
 
   it('maps a replayed/expired code (HTTP 400) to an invalid_code message', async () => {
     navigate('/?code=used');
+    markLoginStarted();
     fetchMock.mockResolvedValueOnce(tokenResponse({ error: 'invalid_code' }, 400));
     const provider = new GitHubSessionProvider();
     await mountInitialized(provider);
@@ -163,6 +229,7 @@ describe('GitHubAuthGate — callback exchange', () => {
 
   it('does not replay the code on a reload (it was already stripped from the URL)', async () => {
     navigate('/?code=abc123');
+    markLoginStarted();
     fetchMock.mockResolvedValueOnce(
       tokenResponse({ token: 't', tokenType: 'Bearer', expiresInSeconds: 900, subject: 's' }),
     );

--- a/src/RetailPulse.Web/src/__tests__/GitHubAuthGate.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/GitHubAuthGate.test.tsx
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+import { AUTH_FORBIDDEN_EVENT, AUTH_REQUIRED_EVENT } from '../auth/authorizedFetch';
+import { GitHubAuthGate } from '../auth/gates/GitHubAuthGate';
+import { GitHubSessionProvider } from '../auth/providers/githubProvider';
+
+// resolveApiUrl uses import.meta.env.VITE_API_ORIGIN; leaving it unset keeps requests same-origin.
+
+function wrap(ui: React.ReactNode) {
+  return <FluentProvider theme={teamsDarkTheme}>{ui}</FluentProvider>;
+}
+
+const child = <div data-testid="protected-child">app</div>;
+
+const STORAGE_KEY = 'retailpulse:session:github';
+const START_PATH = '/api/auth/github/start';
+const EXCHANGE_PATH = '/api/auth/github/exchange';
+
+function tokenResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let assignMock: Mock<(url: string) => void>;
+let replaceStateSpy: ReturnType<typeof vi.spyOn>;
+let currentUrl: URL;
+
+/** Point the mock location at a new URL (used to seed the callback query string). */
+function navigate(path: string) {
+  currentUrl = new URL(path, 'http://localhost:3000');
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  fetchMock = vi.fn();
+  window.fetch = fetchMock as unknown as typeof window.fetch;
+  assignMock = vi.fn<(url: string) => void>();
+  navigate('/');
+
+  // jsdom's location.assign is not implemented and navigation is inert, so we back window.location
+  // with a mutable URL. The history.replaceState spy rewrites it, so the provider's immediate
+  // code/error stripping is observable exactly as it would be in a browser.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      get href() {
+        return currentUrl.href;
+      },
+      get origin() {
+        return currentUrl.origin;
+      },
+      get search() {
+        return currentUrl.search;
+      },
+      get pathname() {
+        return currentUrl.pathname;
+      },
+      get hash() {
+        return currentUrl.hash;
+      },
+      assign: (url: string) => assignMock(url),
+    },
+  });
+  replaceStateSpy = vi
+    .spyOn(window.history, 'replaceState')
+    .mockImplementation((_state, _title, url) => {
+      currentUrl = new URL(String(url), currentUrl.origin);
+    });
+});
+
+afterEach(() => {
+  replaceStateSpy.mockRestore();
+  vi.restoreAllMocks();
+});
+
+async function mountInitialized(provider: GitHubSessionProvider) {
+  await act(async () => {
+    await provider.initialize();
+  });
+  render(wrap(<GitHubAuthGate provider={provider}>{child}</GitHubAuthGate>));
+}
+
+describe('GitHubAuthGate — start', () => {
+  it('shows a branded "Continue with GitHub" button when unauthenticated', async () => {
+    const provider = new GitHubSessionProvider();
+    await mountInitialized(provider);
+
+    const button = screen.getByTestId('auth-github-button');
+    expect(button).toHaveTextContent(/Continue with GitHub/i);
+    expect(screen.queryByTestId('protected-child')).not.toBeInTheDocument();
+  });
+
+  it('navigates to the fixed same-origin start route (no user-supplied return URL)', async () => {
+    const provider = new GitHubSessionProvider();
+    await mountInitialized(provider);
+
+    await userEvent.click(screen.getByTestId('auth-github-button'));
+
+    expect(assignMock).toHaveBeenCalledTimes(1);
+    expect(assignMock).toHaveBeenCalledWith(START_PATH);
+    // The provider never appends a return/redirect query parameter.
+    expect(String(assignMock.mock.calls[0][0])).not.toMatch(/return|redirect|url=/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('GitHubAuthGate — callback exchange', () => {
+  it('redeems a one-time code, strips it from the URL, and renders the app', async () => {
+    navigate('/?code=abc123&extra=keep');
+    fetchMock.mockResolvedValueOnce(
+      tokenResponse({ token: 'rp-session', tokenType: 'Bearer', expiresInSeconds: 900, subject: 's' }),
+    );
+    const provider = new GitHubSessionProvider();
+    await mountInitialized(provider);
+
+    expect(await screen.findByTestId('protected-child')).toBeInTheDocument();
+
+    // Exchange POSTed to the exact same-origin exchange route with the code.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(EXCHANGE_PATH);
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ code: 'abc123' });
+
+    // Code was stripped immediately via history.replaceState; unrelated params preserved.
+    expect(replaceStateSpy).toHaveBeenCalled();
+    expect(window.location.search).not.toContain('code=');
+    expect(window.location.search).toContain('extra=keep');
+
+    // Token stored session-only.
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toContain('rp-session');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('shows a safe access-denied message for a callback error and offers retry', async () => {
+    navigate('/?error=access_denied');
+    const provider = new GitHubSessionProvider();
+    await mountInitialized(provider);
+
+    expect(await screen.findByTestId('auth-error')).toHaveTextContent(/cancelled/i);
+    expect(window.location.search).not.toContain('error=');
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Retry returns to the interactive sign-in button.
+    await userEvent.click(screen.getByTestId('auth-retry-button'));
+    expect(await screen.findByTestId('auth-github-button')).toBeInTheDocument();
+  });
+
+  it('maps a replayed/expired code (HTTP 400) to an invalid_code message', async () => {
+    navigate('/?code=used');
+    fetchMock.mockResolvedValueOnce(tokenResponse({ error: 'invalid_code' }, 400));
+    const provider = new GitHubSessionProvider();
+    await mountInitialized(provider);
+
+    expect(await screen.findByTestId('auth-error')).toHaveTextContent(/expired or was already used/i);
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not replay the code on a reload (it was already stripped from the URL)', async () => {
+    navigate('/?code=abc123');
+    fetchMock.mockResolvedValueOnce(
+      tokenResponse({ token: 't', tokenType: 'Bearer', expiresInSeconds: 900, subject: 's' }),
+    );
+    const provider = new GitHubSessionProvider();
+    await act(async () => {
+      await provider.initialize();
+    });
+    // Simulate a reload: a brand-new provider with the (now stripped) URL.
+    expect(window.location.search).not.toContain('code=');
+    const reloaded = new GitHubSessionProvider();
+    await act(async () => {
+      await reloaded.initialize();
+    });
+    // Only the first initialize exchanged; the reload finds a surviving token, no second POST.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(reloaded.getState().status).toBe('authenticated');
+  });
+});
+
+describe('GitHubAuthGate — logout, 401, 403', () => {
+  it('clears the token and re-gates on logout (no github.com logout assumption)', async () => {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ token: 't', expiresAt: Date.now() + 60000 }));
+    const provider = new GitHubSessionProvider();
+    await mountInitialized(provider);
+    expect(screen.getByTestId('protected-child')).toBeInTheDocument();
+
+    act(() => {
+      provider.logout();
+    });
+
+    expect(await screen.findByTestId('auth-github-button')).toBeInTheDocument();
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    // Logout must not attempt any provider-side navigation.
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the token and re-gates on a persistent 401 (AUTH_REQUIRED)', async () => {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ token: 't', expiresAt: Date.now() + 60000 }));
+    const provider = new GitHubSessionProvider();
+    await mountInitialized(provider);
+    expect(screen.getByTestId('protected-child')).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AUTH_REQUIRED_EVENT));
+    });
+
+    expect(await screen.findByTestId('auth-github-button')).toBeInTheDocument();
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('shows a not-authorized message on a 403 (AUTH_FORBIDDEN)', async () => {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ token: 't', expiresAt: Date.now() + 60000 }));
+    const provider = new GitHubSessionProvider();
+    await mountInitialized(provider);
+    expect(screen.getByTestId('protected-child')).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AUTH_FORBIDDEN_EVENT));
+    });
+
+    expect(await screen.findByTestId('auth-error')).toHaveTextContent(/not authorized/i);
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('GitHubSessionProvider — token acquisition', () => {
+  it('returns the stored token, and null after it expires', async () => {
+    const provider = new GitHubSessionProvider();
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ token: 'live', expiresAt: Date.now() + 60000 }),
+    );
+    await expect(provider.acquireToken()).resolves.toBe('live');
+
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ token: 'stale', expiresAt: Date.now() - 1 }));
+    // A fresh provider so the in-memory cache does not mask the expired sessionStorage value.
+    const expired = new GitHubSessionProvider();
+    await expect(expired.acquireToken()).resolves.toBeNull();
+    // The expired credential self-clears from sessionStorage.
+    await waitFor(() => expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull());
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/authConfig.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/authConfig.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { buildAuthConfig, type RawAuthEnv } from '../auth/authConfig';
+import {
+  buildAuthConfig,
+  validateEntraConfig,
+  assertEntraConfigured,
+  type RawAuthEnv,
+} from '../auth/authConfig';
 
 const ORIGIN = 'https://retail-pulse.example.net';
 
@@ -67,5 +72,61 @@ describe('buildAuthConfig', () => {
       ORIGIN,
     );
     expect(cfg.msalConfig.auth.authority).toBe('https://login.microsoftonline.us/tenant');
+  });
+});
+
+const VALID_TENANT = '11111111-1111-1111-1111-111111111111';
+const VALID_CLIENT = '33333333-3333-3333-3333-333333333333';
+
+describe('validateEntraConfig', () => {
+  it('accepts a valid GUID tenant + GUID client', () => {
+    expect(validateEntraConfig(VALID_TENANT, VALID_CLIENT)).toEqual({ ok: true });
+  });
+
+  it('accepts a verified directory domain as the tenant', () => {
+    expect(validateEntraConfig('contoso.onmicrosoft.com', VALID_CLIENT).ok).toBe(true);
+  });
+
+  it.each([
+    ['', VALID_CLIENT, 'empty tenant'],
+    [VALID_TENANT, '', 'empty client'],
+    ['   ', VALID_CLIENT, 'whitespace tenant'],
+    ['<your-tenant-id>', VALID_CLIENT, 'angle-bracket placeholder tenant'],
+    [VALID_TENANT, '<your-client-id>', 'angle-bracket placeholder client'],
+    ['00000000-0000-0000-0000-000000000000', VALID_CLIENT, 'all-zero GUID tenant'],
+    [VALID_TENANT, '00000000-0000-0000-0000-000000000000', 'all-zero GUID client'],
+    ['your-tenant-id', VALID_CLIENT, 'scaffold token tenant'],
+    ['not-a-guid-or-domain', VALID_CLIENT, 'malformed tenant'],
+    [VALID_TENANT, 'not-a-guid', 'non-GUID client'],
+    ['tenant', VALID_CLIENT, 'non-GUID non-domain tenant'],
+  ])('rejects %s / %s (%s)', (tenant, client) => {
+    const result = validateEntraConfig(tenant, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});
+
+describe('assertEntraConfigured', () => {
+  it('does not throw for a valid configuration', () => {
+    const cfg = buildAuthConfig(
+      { VITE_ENTRA_TENANT_ID: VALID_TENANT, VITE_ENTRA_CLIENT_ID: VALID_CLIENT },
+      ORIGIN,
+    );
+    expect(() => assertEntraConfigured(cfg)).not.toThrow();
+  });
+
+  it('throws a deterministic configuration error when ids are missing', () => {
+    const cfg = buildAuthConfig({}, ORIGIN);
+    expect(() => assertEntraConfigured(cfg)).toThrowError(/configuration is invalid/i);
+  });
+
+  it('throws when ids are placeholders even though buildAuthConfig marks it "configured"', () => {
+    const cfg = buildAuthConfig(
+      { VITE_ENTRA_TENANT_ID: '<tenant>', VITE_ENTRA_CLIENT_ID: '<client>' },
+      ORIGIN,
+    );
+    // isConfigured is true (both non-empty) but the values are placeholders — must still fail closed.
+    expect(cfg.isConfigured).toBe(true);
+    expect(() => assertEntraConfigured(cfg)).toThrow();
   });
 });

--- a/src/RetailPulse.Web/src/__tests__/authMode.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/authMode.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAuthMode, type RawAuthModeEnv } from '../auth/authMode';
+
+/**
+ * Fail-closed resolver contract (never silently anonymous). The resolver is pure — env is injected —
+ * so every production/unknown branch is unit-testable without touching the real build environment.
+ */
+describe('resolveAuthMode', () => {
+  const entraConfig = {
+    VITE_ENTRA_TENANT_ID: 'tenant-guid',
+    VITE_ENTRA_CLIENT_ID: 'client-guid',
+  };
+
+  it('honors an explicit entra mode', () => {
+    const r = resolveAuthMode({ VITE_AUTH_MODE: 'entra', ...entraConfig });
+    expect(r.mode).toBe('entra');
+    expect(r.source).toBe('explicit');
+    expect(r.isLocalDevPassthrough).toBe(false);
+  });
+
+  it('honors an explicit github mode and always mounts a gate', () => {
+    const r = resolveAuthMode({ VITE_AUTH_MODE: 'github', DEV: true });
+    expect(r.mode).toBe('github');
+    expect(r.source).toBe('explicit');
+    expect(r.isLocalDevPassthrough).toBe(false);
+  });
+
+  it('honors an explicit anonymous mode and always mounts a gate', () => {
+    const r = resolveAuthMode({ VITE_AUTH_MODE: 'anonymous', DEV: true });
+    expect(r.mode).toBe('anonymous');
+    expect(r.isLocalDevPassthrough).toBe(false);
+  });
+
+  it('is case-insensitive for explicit modes', () => {
+    expect(resolveAuthMode({ VITE_AUTH_MODE: 'GitHub' }).mode).toBe('github');
+    expect(resolveAuthMode({ VITE_AUTH_MODE: '  Anonymous  ' }).mode).toBe('anonymous');
+    expect(resolveAuthMode({ VITE_AUTH_MODE: 'ENTRA', ...entraConfig }).mode).toBe('entra');
+  });
+
+  it('treats explicit entra without SPA config in local dev as a transparent pass-through', () => {
+    const r = resolveAuthMode({ VITE_AUTH_MODE: 'entra', DEV: true });
+    expect(r.mode).toBe('entra');
+    expect(r.isLocalDevPassthrough).toBe(true);
+  });
+
+  it('does NOT pass through for explicit entra without config when NOT in dev', () => {
+    const r = resolveAuthMode({ VITE_AUTH_MODE: 'entra', DEV: false });
+    expect(r.mode).toBe('entra');
+    expect(r.isLocalDevPassthrough).toBe(false);
+  });
+
+  it('resolves a missing mode to entra when the SPA already carries Entra config (back-compat)', () => {
+    const r = resolveAuthMode({ ...entraConfig, DEV: false, PROD: true });
+    expect(r.mode).toBe('entra');
+    expect(r.source).toBe('entra-config-backcompat');
+    expect(r.isLocalDevPassthrough).toBe(false);
+  });
+
+  it('resolves a missing mode to a dev pass-through when unconfigured and in dev', () => {
+    const r = resolveAuthMode({ DEV: true });
+    expect(r.mode).toBe('entra');
+    expect(r.source).toBe('local-dev-default');
+    expect(r.isLocalDevPassthrough).toBe(true);
+  });
+
+  it('THROWS on a missing mode in a production build with no Entra config (fail closed)', () => {
+    expect(() => resolveAuthMode({ DEV: false, PROD: true })).toThrow(/not set/i);
+  });
+
+  it('THROWS on a blank/whitespace mode with no config in production', () => {
+    expect(() => resolveAuthMode({ VITE_AUTH_MODE: '   ', DEV: false })).toThrow(/not set/i);
+  });
+
+  it('THROWS on an unknown named mode (e.g. okta)', () => {
+    expect(() => resolveAuthMode({ VITE_AUTH_MODE: 'okta', DEV: true } as RawAuthModeEnv)).toThrow(
+      /not a recognized/i,
+    );
+  });
+
+  it('THROWS on a bare numeric selector', () => {
+    expect(() => resolveAuthMode({ VITE_AUTH_MODE: '1', DEV: true })).toThrow(/not a recognized/i);
+  });
+
+  it('never resolves to anonymous by omission', () => {
+    // With no explicit mode, the only silent resolutions are entra (safe) or a throw — never anonymous.
+    expect(resolveAuthMode({ ...entraConfig }).mode).toBe('entra');
+    expect(() => resolveAuthMode({ DEV: false })).toThrow();
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/authorizedFetch.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/authorizedFetch.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// The wrapper only installs when auth is configured; force that in tests.
+// The wrapper only installs when a provider gate is active; force that in tests.
+vi.mock('../auth/activeProvider', () => ({ requiresGate: true }));
 vi.mock('../auth/authConfig', () => ({ authConfig: { isConfigured: true } }));
 
 // Central token acquisition is mocked so we can drive silent-refresh / retry behavior.

--- a/src/RetailPulse.Web/src/__tests__/mainBootstrap.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/mainBootstrap.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Bootstrap-level tests for the fail-closed Entra path (Blocker 2). They prove that an explicit Entra
+ * build with missing/placeholder configuration renders the safe branded configuration-error screen and
+ * makes NO MSAL/API/hub calls and never mounts <App/>, while a valid Entra build boots unchanged.
+ *
+ * main.tsx runs `void bootstrap()` on import, so each test wires the module mocks, imports main fresh
+ * (vi.resetModules), and asserts on the effects.
+ */
+
+const initializeMsal = vi.fn(async () => {});
+const installAuthorizedFetch = vi.fn();
+const getActiveProviderInit = vi.fn(async () => {});
+
+vi.mock('../App.tsx', () => ({
+  default: () => <div data-testid="app-root">app</div>,
+}));
+
+vi.mock('@azure/msal-react', () => ({
+  MsalProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="msal-provider">{children}</div>
+  ),
+}));
+
+vi.mock('../auth/msalInstance', () => ({
+  initializeMsal,
+  getMsalInstance: () => ({}) as unknown,
+}));
+
+vi.mock('../auth/authorizedFetch', () => ({
+  installAuthorizedFetch,
+}));
+
+let rootEl: HTMLElement;
+
+beforeEach(() => {
+  vi.resetModules();
+  initializeMsal.mockClear();
+  installAuthorizedFetch.mockClear();
+  getActiveProviderInit.mockClear();
+  document.body.innerHTML = '';
+  rootEl = document.createElement('div');
+  rootEl.id = 'root';
+  document.body.appendChild(rootEl);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Flush the microtasks the async bootstrap schedules so the DOM settles before assertions. */
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('bootstrap — explicit Entra with missing/placeholder config fails closed', () => {
+  it('renders the branded config-error screen and makes NO MSAL/API/hub/App calls', async () => {
+    vi.doMock('../auth/activeProvider', () => ({
+      activeAuthMode: 'entra',
+      requiresGate: true,
+      getActiveProvider: () => ({ initialize: getActiveProviderInit }),
+    }));
+    vi.doMock('../auth/authConfig', () => ({
+      assertEntraConfigured: () => {
+        throw new Error('Entra authentication is selected but its configuration is invalid.');
+      },
+    }));
+
+    await import('../main.tsx');
+    await flush();
+
+    // Safe branded error screen shown; dashboard/App never mounted.
+    expect(document.querySelector('[data-testid="config-error-screen"]')).not.toBeNull();
+    expect(document.querySelector('[data-testid="app-root"]')).toBeNull();
+    expect(document.querySelector('[data-testid="msal-provider"]')).toBeNull();
+
+    // No MSAL init, no fetch wrapper install — i.e. no API/hub calls were set up.
+    expect(initializeMsal).not.toHaveBeenCalled();
+    expect(installAuthorizedFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('bootstrap — valid Entra boots unchanged', () => {
+  it('initializes MSAL, installs the fetch wrapper, and mounts App inside MsalProvider', async () => {
+    vi.doMock('../auth/activeProvider', () => ({
+      activeAuthMode: 'entra',
+      requiresGate: true,
+      getActiveProvider: () => ({ initialize: getActiveProviderInit }),
+    }));
+    vi.doMock('../auth/authConfig', () => ({
+      assertEntraConfigured: () => {},
+    }));
+
+    await import('../main.tsx');
+    await flush();
+
+    expect(document.querySelector('[data-testid="config-error-screen"]')).toBeNull();
+    expect(document.querySelector('[data-testid="app-root"]')).not.toBeNull();
+    expect(document.querySelector('[data-testid="msal-provider"]')).not.toBeNull();
+    expect(initializeMsal).toHaveBeenCalledTimes(1);
+    expect(installAuthorizedFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/sessionCredentialStore.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/sessionCredentialStore.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SessionCredentialStore } from '../auth/session/sessionCredentialStore';
+
+const KEY = 'retailpulse:session:test-ns';
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+});
+
+describe('SessionCredentialStore — narrow storage policy', () => {
+  it('mirrors the credential to sessionStorage only, never localStorage or cookies', () => {
+    const store = new SessionCredentialStore('test-ns');
+    store.set({ token: 'abc', expiresAt: Date.now() + 60000 });
+
+    expect(window.sessionStorage.getItem(KEY)).toContain('abc');
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+    expect(document.cookie).not.toContain('abc');
+  });
+
+  it('returns the token while live and clears it on expiry', () => {
+    const store = new SessionCredentialStore('test-ns');
+    const now = 1_000_000;
+    store.set({ token: 'live', expiresAt: now + 1000 });
+
+    expect(store.getToken(now)).toBe('live');
+    // At/after expiry the store self-clears and returns null.
+    expect(store.getToken(now + 1000)).toBeNull();
+    expect(window.sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('clear() removes the credential from memory and sessionStorage', () => {
+    const store = new SessionCredentialStore('test-ns');
+    store.set({ token: 'abc' });
+    store.clear();
+
+    expect(store.getToken()).toBeNull();
+    expect(window.sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('rehydrates a same-tab credential from sessionStorage into a fresh instance', () => {
+    window.sessionStorage.setItem(KEY, JSON.stringify({ token: 'persisted', expiresAt: Date.now() + 60000 }));
+    const store = new SessionCredentialStore('test-ns');
+    expect(store.getToken()).toBe('persisted');
+  });
+
+  it('discards a malformed/empty persisted value', () => {
+    window.sessionStorage.setItem(KEY, '{not-json');
+    const store = new SessionCredentialStore('test-ns');
+    expect(store.getToken()).toBeNull();
+    expect(window.sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('notifies subscribers on set and clear', () => {
+    const store = new SessionCredentialStore('test-ns');
+    let hits = 0;
+    const unsub = store.subscribe(() => {
+      hits += 1;
+    });
+    store.set({ token: 'a' });
+    store.clear();
+    unsub();
+    store.set({ token: 'b' }); // no longer observed
+    expect(hits).toBe(2);
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/tokenService.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/tokenService.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The SignalR access-token factory must return '' (send no token, do not start the hub) whenever the
+ * active provider's capabilities forbid the real-time hubs — the Anonymous provider case. Entra and
+ * GitHub (full capabilities) return the bearer. Provider selection is mocked so each mode is exercised.
+ */
+const acquireActiveToken = vi.fn();
+const capabilities = { realtimeHub: true } as { realtimeHub: boolean };
+
+vi.mock('../auth/activeProvider', () => ({
+  acquireActiveToken: (...args: unknown[]) => acquireActiveToken(...args),
+  getActiveProvider: () => ({ capabilities }),
+}));
+
+import { getHubAccessToken, acquireApiToken } from '../auth/tokenService';
+
+beforeEach(() => {
+  acquireActiveToken.mockReset();
+  capabilities.realtimeHub = true;
+});
+
+describe('getHubAccessToken — capability gating', () => {
+  it('returns the bearer token when the provider permits the real-time hub', async () => {
+    acquireActiveToken.mockResolvedValue('hub-tok');
+    await expect(getHubAccessToken()).resolves.toBe('hub-tok');
+  });
+
+  it('returns an empty string (no hub) when realtimeHub is disabled (anonymous)', async () => {
+    capabilities.realtimeHub = false;
+    await expect(getHubAccessToken()).resolves.toBe('');
+    // Token acquisition is never even attempted for a forbidden hub.
+    expect(acquireActiveToken).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty string when acquisition throws', async () => {
+    acquireActiveToken.mockRejectedValue(new Error('boom'));
+    await expect(getHubAccessToken()).resolves.toBe('');
+  });
+
+  it('returns an empty string when there is no token', async () => {
+    acquireActiveToken.mockResolvedValue(null);
+    await expect(getHubAccessToken()).resolves.toBe('');
+  });
+});
+
+describe('acquireApiToken — forceRefresh passthrough', () => {
+  it('delegates forceRefresh to the active provider', async () => {
+    acquireActiveToken.mockResolvedValue('t');
+    await acquireApiToken({ forceRefresh: true });
+    expect(acquireActiveToken).toHaveBeenCalledWith({ forceRefresh: true });
+  });
+
+  it('defaults forceRefresh to false', async () => {
+    acquireActiveToken.mockResolvedValue('t');
+    await acquireApiToken();
+    expect(acquireActiveToken).toHaveBeenCalledWith({ forceRefresh: false });
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/validateAuthConfig.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/validateAuthConfig.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateAuthConfig,
+  validateEntraIds,
+} from '../../scripts/validate-auth-config.mjs';
+
+const VALID_TENANT = '11111111-1111-1111-1111-111111111111';
+const VALID_CLIENT = '33333333-3333-3333-3333-333333333333';
+
+describe('validate-auth-config — validateAuthConfig', () => {
+  it('passes when no auth mode is pinned (local dev / CI type-check build stays green)', () => {
+    expect(validateAuthConfig({}).ok).toBe(true);
+    expect(validateAuthConfig({ VITE_AUTH_MODE: '' }).ok).toBe(true);
+    expect(validateAuthConfig({ VITE_AUTH_MODE: '   ' }).ok).toBe(true);
+  });
+
+  it('fails an explicit Entra build with missing tenant/client ids', () => {
+    const result = validateAuthConfig({ VITE_AUTH_MODE: 'Entra' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/VITE_ENTRA_TENANT_ID/);
+  });
+
+  it('fails an explicit Entra build with placeholder ids', () => {
+    const result = validateAuthConfig({
+      VITE_AUTH_MODE: 'entra',
+      VITE_ENTRA_TENANT_ID: '<your-tenant-id>',
+      VITE_ENTRA_CLIENT_ID: '<your-client-id>',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('passes an explicit Entra build with valid ids (case-insensitive mode)', () => {
+    expect(
+      validateAuthConfig({
+        VITE_AUTH_MODE: 'ENTRA',
+        VITE_ENTRA_TENANT_ID: VALID_TENANT,
+        VITE_ENTRA_CLIENT_ID: VALID_CLIENT,
+      }).ok,
+    ).toBe(true);
+  });
+
+  it('passes github/anonymous builds without requiring Entra ids', () => {
+    expect(validateAuthConfig({ VITE_AUTH_MODE: 'github' }).ok).toBe(true);
+    expect(validateAuthConfig({ VITE_AUTH_MODE: 'anonymous' }).ok).toBe(true);
+  });
+
+  it('fails an unknown auth mode deterministically', () => {
+    const result = validateAuthConfig({ VITE_AUTH_MODE: 'okta' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not a recognized authentication mode/i);
+  });
+});
+
+describe('validate-auth-config — validateEntraIds', () => {
+  it('accepts GUID tenant + GUID client and a directory-domain tenant', () => {
+    expect(validateEntraIds(VALID_TENANT, VALID_CLIENT).ok).toBe(true);
+    expect(validateEntraIds('contoso.onmicrosoft.com', VALID_CLIENT).ok).toBe(true);
+  });
+
+  it('rejects empty, placeholder, all-zero, and malformed ids', () => {
+    expect(validateEntraIds('', VALID_CLIENT).ok).toBe(false);
+    expect(validateEntraIds(VALID_TENANT, '').ok).toBe(false);
+    expect(validateEntraIds('00000000-0000-0000-0000-000000000000', VALID_CLIENT).ok).toBe(false);
+    expect(validateEntraIds(VALID_TENANT, 'not-a-guid').ok).toBe(false);
+    expect(validateEntraIds('tenant', VALID_CLIENT).ok).toBe(false);
+  });
+});

--- a/src/RetailPulse.Web/src/auth/AuthGate.tsx
+++ b/src/RetailPulse.Web/src/auth/AuthGate.tsx
@@ -1,149 +1,45 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
-import {
-  Body1,
-  Button,
-  Spinner,
-  Subtitle1,
-  Title2,
-  makeStyles,
-  tokens,
-} from '@fluentui/react-components';
-import { useIsAuthenticated, useMsal } from '@azure/msal-react';
-import { InteractionStatus } from '@azure/msal-browser';
-import { BrandLogo } from '../components/BrandLogo';
-import { authConfig, loginRequest } from './authConfig';
-import { AUTH_FORBIDDEN_EVENT } from './authorizedFetch';
-
-const useStyles = makeStyles({
-  root: {
-    position: 'fixed',
-    inset: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    background:
-      'radial-gradient(1200px 800px at 50% -10%, rgba(91,124,255,0.18), transparent), #0b0e14',
-    padding: '24px',
-  },
-  card: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: '20px',
-    maxWidth: '420px',
-    width: '100%',
-    padding: '40px 36px',
-    borderRadius: tokens.borderRadiusXLarge,
-    background: tokens.colorNeutralBackground2,
-    boxShadow: tokens.shadow28,
-    textAlign: 'center',
-  },
-  headings: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '6px',
-  },
-  muted: {
-    color: tokens.colorNeutralForeground3,
-  },
-  error: {
-    color: tokens.colorPaletteRedForeground1,
-  },
-  actions: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '10px',
-    width: '100%',
-  },
-});
+import type { ReactNode } from 'react';
+import { activeAuthMode, getActiveProvider, requiresGate } from './activeProvider';
+import { EntraAuthGate } from './gates/EntraAuthGate';
+import { GitHubAuthGate } from './gates/GitHubAuthGate';
+import { AnonymousAuthGate } from './gates/AnonymousAuthGate';
+import type { GitHubSessionProvider } from './providers/githubProvider';
+import type { AnonymousSessionProvider } from './providers/anonymousProvider';
 
 /**
- * Polished Entra sign-in gate.
+ * Provider-neutral sign-in gate dispatcher.
  *
- * When auth is configured (production), the app tree renders only for a signed-in user; an
- * unauthenticated visitor sees a branded sign-in screen and interactive sign-in is triggered
- * explicitly (never silently from a data fetch). A 403 from the API — authenticated but not
- * assigned the RetailPulse.User role — shows a precise access-denied message instead of a
- * blank dashboard. When auth is NOT configured (local dev) the gate is a transparent
- * pass-through so the demo runs against the API's synthetic Development identity.
+ * The SPA renders exactly ONE provider's sign-in UX, fixed at build time by `VITE_AUTH_MODE`
+ * (see authMode). There is deliberately NO provider chooser in a single-mode deployment — only the
+ * configured mode is ever rendered, minimizing attack surface and user confusion. When no gate is
+ * required (the local-dev Entra pass-through) the gate is a transparent pass-through so the demo
+ * runs against the API's synthetic Development identity.
+ *
+ * Each concrete gate preserves its provider's exact behavior:
+ *   • Entra     → the unchanged live MSAL Microsoft sign-in UX.
+ *   • GitHub    → "Continue with GitHub" BFF redemption flow.
+ *   • Anonymous → "Continue in limited demo" explicit-consent flow.
  */
 export function AuthGate({ children }: { children: ReactNode }) {
-  if (!authConfig.isConfigured) {
-    return <>{children}</>;
-  }
-  return <EntraAuthGate>{children}</EntraAuthGate>;
-}
-
-function EntraAuthGate({ children }: { children: ReactNode }) {
-  const styles = useStyles();
-  const { instance, inProgress } = useMsal();
-  const isAuthenticated = useIsAuthenticated();
-  const [forbidden, setForbidden] = useState(false);
-
-  useEffect(() => {
-    const onForbidden = () => setForbidden(true);
-    window.addEventListener(AUTH_FORBIDDEN_EVENT, onForbidden);
-    return () => window.removeEventListener(AUTH_FORBIDDEN_EVENT, onForbidden);
-  }, []);
-
-  const signIn = useCallback(() => {
-    setForbidden(false);
-    void instance.loginRedirect(loginRequest);
-  }, [instance]);
-
-  const signOut = useCallback(() => {
-    void instance.logoutRedirect();
-  }, [instance]);
-
-  const busy =
-    inProgress === InteractionStatus.Login ||
-    inProgress === InteractionStatus.HandleRedirect ||
-    inProgress === InteractionStatus.Startup;
-
-  if (isAuthenticated && !forbidden) {
+  if (!requiresGate) {
     return <>{children}</>;
   }
 
-  return (
-    <div className={styles.root} data-testid="auth-gate">
-      <div className={styles.card}>
-        <BrandLogo size={56} showWordmark={false} />
-        <div className={styles.headings}>
-          <Title2>Retail Pulse</Title2>
-          <Subtitle1 className={styles.muted}>Real-time retail intelligence</Subtitle1>
-        </div>
-
-        {forbidden ? (
-          <>
-            <Body1 className={styles.error} data-testid="auth-forbidden">
-              Your account is signed in but not authorized for Retail Pulse. Ask an
-              administrator to assign you the <strong>RetailPulse.User</strong> role, then try
-              again.
-            </Body1>
-            <div className={styles.actions}>
-              <Button appearance="primary" onClick={signIn}>
-                Retry
-              </Button>
-              <Button appearance="subtle" onClick={signOut}>
-                Sign in with a different account
-              </Button>
-            </div>
-          </>
-        ) : busy ? (
-          <Spinner label="Signing you in…" data-testid="auth-signing-in" />
-        ) : (
-          <>
-            <Body1 className={styles.muted}>
-              Sign in with your organizational account to continue.
-            </Body1>
-            <div className={styles.actions}>
-              <Button appearance="primary" size="large" onClick={signIn} data-testid="auth-signin-button">
-                Sign in with Microsoft
-              </Button>
-            </div>
-          </>
-        )}
-      </div>
-    </div>
-  );
+  switch (activeAuthMode) {
+    case 'github':
+      return (
+        <GitHubAuthGate provider={getActiveProvider() as unknown as GitHubSessionProvider}>
+          {children}
+        </GitHubAuthGate>
+      );
+    case 'anonymous':
+      return (
+        <AnonymousAuthGate provider={getActiveProvider() as unknown as AnonymousSessionProvider}>
+          {children}
+        </AnonymousAuthGate>
+      );
+    case 'entra':
+    default:
+      return <EntraAuthGate>{children}</EntraAuthGate>;
+  }
 }

--- a/src/RetailPulse.Web/src/auth/ConfigErrorScreen.tsx
+++ b/src/RetailPulse.Web/src/auth/ConfigErrorScreen.tsx
@@ -1,0 +1,66 @@
+/**
+ * Safe, branded configuration-error screen rendered by {@link bootstrap} when the auth bootstrap fails
+ * closed (e.g. an explicit Entra build with missing/placeholder tenant/client configuration).
+ *
+ * It is intentionally dependency-light: pure inline styles, NO Fluent/MSAL/App imports, and — most
+ * importantly — it makes NO API or hub calls. It never renders the dashboard or any protected surface;
+ * it only tells an operator the deployment is misconfigured. The specific error text is deliberately
+ * generic (no secrets, ids, or PII) so it is safe to show in any environment.
+ */
+export function ConfigErrorScreen() {
+  return (
+    <div
+      role="alert"
+      data-testid="config-error-screen"
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '24px',
+        background: '#11100f',
+        color: '#f5f5f5',
+        fontFamily:
+          "'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+      }}
+    >
+      <main
+        style={{
+          maxWidth: '520px',
+          width: '100%',
+          background: '#1f1e1d',
+          border: '1px solid #3b3a39',
+          borderRadius: '12px',
+          padding: '32px',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+        }}
+      >
+        <div
+          aria-hidden="true"
+          style={{
+            fontSize: '13px',
+            fontWeight: 600,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            color: '#c8c6c4',
+            marginBottom: '12px',
+          }}
+        >
+          Retail Pulse
+        </div>
+        <h1 style={{ fontSize: '22px', margin: '0 0 12px', fontWeight: 600 }}>
+          Sign-in is unavailable
+        </h1>
+        <p style={{ margin: '0 0 16px', lineHeight: 1.5, color: '#e1dfdd' }}>
+          This deployment is not configured correctly, so signing in has been disabled to keep your
+          data safe. No dashboard or data is loaded on this screen.
+        </p>
+        <p style={{ margin: 0, lineHeight: 1.5, color: '#a19f9d', fontSize: '14px' }}>
+          If you are an administrator, verify the identity provider configuration for this
+          environment and redeploy. If you reached this page unexpectedly, please contact your Retail
+          Pulse administrator.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/RetailPulse.Web/src/auth/activeProvider.ts
+++ b/src/RetailPulse.Web/src/auth/activeProvider.ts
@@ -1,0 +1,54 @@
+import { authMode } from './authMode';
+import type { AuthMode } from './authMode';
+import type { ProviderCapabilities, SessionProvider } from './session/types';
+import { EntraSessionProvider } from './providers/entraProvider';
+import { GitHubSessionProvider } from './providers/githubProvider';
+import { AnonymousSessionProvider } from './providers/anonymousProvider';
+
+/**
+ * Selects and exposes the single build-time-configured session provider. Every consumer — the
+ * global `authorizedFetch`, the SignalR `accessTokenFactory`, and the provider-neutral `AuthGate` —
+ * reads the active provider from here, so provider logic is never duplicated across components.
+ */
+
+function createProvider(): SessionProvider {
+  switch (authMode.mode) {
+    case 'entra':
+      return new EntraSessionProvider(authMode.isLocalDevPassthrough);
+    case 'github':
+      return new GitHubSessionProvider();
+    case 'anonymous':
+      return new AnonymousSessionProvider();
+    default: {
+      // Exhaustiveness guard — resolveAuthMode already fails closed on unknown values.
+      const never: never = authMode.mode;
+      throw new Error(`Unhandled authentication mode: ${String(never)}`);
+    }
+  }
+}
+
+let provider: SessionProvider | null = null;
+
+export function getActiveProvider(): SessionProvider {
+  if (!provider) {
+    provider = createProvider();
+  }
+  return provider;
+}
+
+/** The active mode for this build. */
+export const activeAuthMode: AuthMode = authMode.mode;
+
+/** The active provider's capability descriptor — the central switch the UI reads to gate surfaces. */
+export const capabilities: ProviderCapabilities = getActiveProvider().capabilities;
+
+/** True when a provider gate must be mounted (i.e. not the local-dev Entra pass-through). */
+export const requiresGate: boolean = getActiveProvider().requiresGate;
+
+/**
+ * Central credential acquisition used by REST global fetch and SignalR. Delegates to the active
+ * provider so there is exactly one place that knows how each mode mints/refreshes a bearer token.
+ */
+export function acquireActiveToken(options?: { readonly forceRefresh?: boolean }): Promise<string | null> {
+  return getActiveProvider().acquireToken(options);
+}

--- a/src/RetailPulse.Web/src/auth/authConfig.ts
+++ b/src/RetailPulse.Web/src/auth/authConfig.ts
@@ -91,6 +91,71 @@ export const authConfig: ResolvedAuthConfig = buildAuthConfig(
   import.meta.env as unknown as RawAuthEnv,
 );
 
+/** A canonical GUID (accepts any case); rejects the all-zero GUID as a placeholder. */
+const GUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const EMPTY_GUID = '00000000-0000-0000-0000-000000000000';
+
+/** A single-tenant directory: a real GUID, or a verified domain (e.g. contoso.onmicrosoft.com). */
+const TENANT_DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+
+/**
+ * True when a configuration value is obviously a placeholder rather than a real id: empty, an
+ * angle-bracket template (`<your-tenant-id>`), the all-zero GUID, or a well-known scaffold token.
+ * Live Entra must never boot on any of these.
+ */
+function isPlaceholder(value: string): boolean {
+  const v = value.trim();
+  if (v === '' || v === EMPTY_GUID) return true;
+  if (/[<>]/.test(v) || /\s/.test(v)) return true;
+  return /(your[-_]?|placeholder|changeme|example|todo|xxxx+|\bfixme\b)/i.test(v);
+}
+
+export interface EntraConfigValidation {
+  readonly ok: boolean;
+  readonly error?: string;
+}
+
+/**
+ * Pure validator (unit-testable) proving that an explicit Entra deployment carries a NON-EMPTY, VALID
+ * single-tenant tenant id and client id. A placeholder, empty, or malformed id fails — so a live Entra
+ * build can never silently fall back to an unauthenticated shell.
+ */
+export function validateEntraConfig(tenantId: string, clientId: string): EntraConfigValidation {
+  const tenant = (tenantId ?? '').trim();
+  const client = (clientId ?? '').trim();
+
+  if (isPlaceholder(tenant)) {
+    return { ok: false, error: 'Entra tenant id is missing or a placeholder.' };
+  }
+  if (!(GUID_RE.test(tenant) || TENANT_DOMAIN_RE.test(tenant))) {
+    return { ok: false, error: 'Entra tenant id is not a valid GUID or directory domain.' };
+  }
+  if (isPlaceholder(client)) {
+    return { ok: false, error: 'Entra client id is missing or a placeholder.' };
+  }
+  if (!GUID_RE.test(client)) {
+    return { ok: false, error: 'Entra client id is not a valid GUID.' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Fail-closed guard for the live Entra path. Throws a deterministic configuration error when the
+ * tenant/client configuration is missing, a placeholder, or malformed — BEFORE any MSAL initialization
+ * or App render. `main.tsx` catches this and renders a safe branded configuration-error screen instead
+ * of the dashboard, and makes no API/hub calls.
+ */
+export function assertEntraConfigured(config: ResolvedAuthConfig = authConfig): void {
+  const { ok, error } = validateEntraConfig(config.tenantId, config.clientId);
+  if (!ok) {
+    throw new Error(
+      `Entra authentication is selected but its configuration is invalid: ${error} ` +
+        'Set non-empty, valid VITE_ENTRA_TENANT_ID and VITE_ENTRA_CLIENT_ID for this deployment. ' +
+        'Refusing to start to avoid a silent, unauthenticated shell.',
+    );
+  }
+}
+
 /** Convenience re-exports for the common consumers. */
 export const isAuthConfigured = authConfig.isConfigured;
 export const apiScopes = authConfig.apiScopes;

--- a/src/RetailPulse.Web/src/auth/authMode.ts
+++ b/src/RetailPulse.Web/src/auth/authMode.ts
@@ -1,0 +1,102 @@
+/**
+ * Build-time deterministic authentication-mode resolver for the Retail Pulse SPA.
+ *
+ * The SPA renders exactly ONE provider's sign-in UX, selected at build time by the
+ * `VITE_AUTH_MODE` variable (injected by the deployment: `infra/main.bicep` → azd env →
+ * Vite build). This mirrors the backend's `Authentication:Mode` resolver so the two halves
+ * of a deployment agree on a single provider — a deployment contract test proves the parity.
+ *
+ * Fail-closed rules (never silently anonymous):
+ *   - A recognized, explicit mode (`entra` / `github` / `anonymous`, any case) always wins.
+ *   - A missing/blank mode resolves to `entra` ONLY when it is safe to do so:
+ *       • a hosted build that already carries the Entra SPA configuration (back-compat with
+ *         deployments that pin the mode on the API but not yet in the frontend build), or
+ *       • an explicit local dev build (`import.meta.env.DEV`), where it becomes a transparent
+ *         pass-through against the API's Development synthetic-auth handler.
+ *   - A missing/blank mode in any OTHER case (a production build with no Entra config) THROWS,
+ *     so the misconfiguration is visible at load instead of silently degrading.
+ *   - An unknown value (e.g. `okta`) or a bare number (e.g. `1`) always THROWS — a numeric or
+ *     unrecognized selector can never pick a provider.
+ */
+
+export type AuthMode = 'entra' | 'github' | 'anonymous';
+
+export const AUTH_MODES: readonly AuthMode[] = ['entra', 'github', 'anonymous'];
+
+export interface RawAuthModeEnv {
+  readonly VITE_AUTH_MODE?: string;
+  readonly VITE_ENTRA_TENANT_ID?: string;
+  readonly VITE_ENTRA_CLIENT_ID?: string;
+  /** Vite sets DEV=true for the dev server, PROD=true for a production `vite build`. */
+  readonly DEV?: boolean;
+  readonly PROD?: boolean;
+}
+
+export type AuthModeSource =
+  | 'explicit'
+  | 'entra-config-backcompat'
+  | 'local-dev-default';
+
+export interface ResolvedAuthMode {
+  readonly mode: AuthMode;
+  /**
+   * True only for the local-dev, Entra-unconfigured case: no provider gate is mounted and the
+   * app renders straight to the API's Development synthetic identity (today's dev experience).
+   */
+  readonly isLocalDevPassthrough: boolean;
+  readonly source: AuthModeSource;
+}
+
+function isAuthMode(value: string): value is AuthMode {
+  return (AUTH_MODES as readonly string[]).includes(value);
+}
+
+/**
+ * Pure resolver so the fail-closed behavior is unit-testable with arbitrary env inputs.
+ * Throws an Error (fail visibly) for a missing mode outside local dev and for any unknown value.
+ */
+export function resolveAuthMode(env: RawAuthModeEnv): ResolvedAuthMode {
+  const raw = (env.VITE_AUTH_MODE ?? '').trim();
+  const dev = env.DEV === true;
+  const entraConfigured = Boolean(
+    (env.VITE_ENTRA_TENANT_ID ?? '').trim() && (env.VITE_ENTRA_CLIENT_ID ?? '').trim(),
+  );
+
+  if (raw !== '') {
+    const normalized = raw.toLowerCase();
+    if (isAuthMode(normalized)) {
+      // Entra with no SPA config in a local dev build is the transparent pass-through; every
+      // other named mode always mounts its provider gate.
+      const isLocalDevPassthrough = normalized === 'entra' && !entraConfigured && dev;
+      return { mode: normalized, isLocalDevPassthrough, source: 'explicit' };
+    }
+    throw new Error(
+      `VITE_AUTH_MODE="${raw}" is not a recognized authentication mode. ` +
+        `Set it to one of: ${AUTH_MODES.join(', ')}.`,
+    );
+  }
+
+  // Missing / blank mode.
+  if (entraConfigured) {
+    // Hosted Entra build that pins the mode on the API but not (yet) in the frontend build.
+    // Resolving to Entra is safe — it is the live, secure provider, never a downgrade.
+    return { mode: 'entra', isLocalDevPassthrough: false, source: 'entra-config-backcompat' };
+  }
+
+  if (dev) {
+    // Explicit local dev: transparent pass-through against the API's Development auth handler.
+    return { mode: 'entra', isLocalDevPassthrough: true, source: 'local-dev-default' };
+  }
+
+  throw new Error(
+    'VITE_AUTH_MODE is not set and no Entra SPA configuration is present. ' +
+      'A production build must pin an explicit authentication mode ' +
+      `(one of: ${AUTH_MODES.join(', ')}) — refusing to start to avoid a silent, ` +
+      'insecure default.',
+  );
+}
+
+/** The resolved mode for this build. Throws at module load on a fail-closed misconfiguration. */
+export const authMode: ResolvedAuthMode = resolveAuthMode(
+  import.meta.env as unknown as RawAuthModeEnv,
+);

--- a/src/RetailPulse.Web/src/auth/authorizedFetch.ts
+++ b/src/RetailPulse.Web/src/auth/authorizedFetch.ts
@@ -1,18 +1,19 @@
-import { authConfig } from './authConfig';
+import { requiresGate } from './activeProvider';
 import { acquireApiToken } from './tokenService';
 import { resolveApiOrigin } from '../config/apiOrigin';
 
 /**
- * Global fetch interceptor that attaches the Entra bearer token to our protected `/api`
- * REST requests only.
+ * Global fetch interceptor that attaches the ACTIVE provider's session bearer token to our
+ * protected `/api` REST requests only.
  *
  * Rather than editing ~16 service modules (and risking a future call that forgets the
  * header), token attachment is centralized here: {@link installAuthorizedFetch} wraps
- * `window.fetch` once at startup so ALL protected/billable REST goes out authenticated.
+ * `window.fetch` once at startup so ALL protected/billable REST goes out authenticated with
+ * whatever provider is configured (Entra MSAL, GitHub BFF session, or Anonymous session).
  * The token is scoped to same-origin `/api` paths (see {@link isApiRequest}); SignalR
  * (`/hubs`) handshakes carry the token via their own `accessTokenFactory` (see
  * tokenService) and are intentionally excluded, as are assets, third parties, and
- * App Insights. A no-op when auth is unconfigured (local dev).
+ * App Insights. A no-op when no provider gate is active (local dev pass-through).
  *
  * On a 401 the wrapper transparently forces a fresh token and retries once; if it still
  * fails it emits {@link AUTH_REQUIRED_EVENT} so the sign-in gate can re-authenticate. A 403
@@ -95,7 +96,7 @@ export function isApiRequest(input: RequestInfo | URL): boolean {
 let installed = false;
 
 export function installAuthorizedFetch(): void {
-  if (installed || !authConfig.isConfigured || typeof window === 'undefined') {
+  if (installed || !requiresGate || typeof window === 'undefined') {
     return;
   }
   installed = true;
@@ -121,7 +122,7 @@ export function installAuthorizedFetch(): void {
       return originalFetch(input, init);
     }
 
-    let token: string | null = null;
+    let token: string | null;
     try {
       token = await acquireApiToken();
     } catch {
@@ -131,7 +132,7 @@ export function installAuthorizedFetch(): void {
     let response = await send(input, init, token);
 
     if (response.status === 401) {
-      let fresh: string | null = null;
+      let fresh: string | null;
       try {
         fresh = await acquireApiToken({ forceRefresh: true });
       } catch {

--- a/src/RetailPulse.Web/src/auth/gates/AnonymousAuthGate.tsx
+++ b/src/RetailPulse.Web/src/auth/gates/AnonymousAuthGate.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useState, useSyncExternalStore, type ReactNode } from 'react';
+import {
+  Badge,
+  Body1,
+  Button,
+  Spinner,
+  Subtitle1,
+  Title2,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+import { BrandLogo } from '../../components/BrandLogo';
+import { AUTH_FORBIDDEN_EVENT, AUTH_REQUIRED_EVENT } from '../authorizedFetch';
+import type { AnonymousSessionProvider, AnonymousErrorCode } from '../providers/anonymousProvider';
+import { gateStyles } from './gateStyles';
+
+/**
+ * The limitations every visitor must acknowledge before an anonymous demo session is minted. These
+ * mirror the backend's deny-by-default anonymous surface; the UI hides the corresponding features
+ * centrally via the capability object, and the backend remains authoritative.
+ */
+const LIMITATIONS: readonly string[] = [
+  'This demo is billable and rate-limited.',
+  'Read-only chat only — no write actions, approvals, or configuration.',
+  'No live telemetry, streaming, memory, observability, admin, or export.',
+  'Sessions are short-lived and are lost on expiry or restart.',
+];
+
+/**
+ * Anonymous limited-demo sign-in gate (opt-in, non-production). Nothing billable happens until the
+ * visitor gives EXPLICIT consent by clicking "Continue in limited demo"; only then is a short-lived,
+ * session-only token minted. State comes from the provider's observable store.
+ */
+export function AnonymousAuthGate({
+  provider,
+  children,
+}: {
+  provider: AnonymousSessionProvider;
+  children: ReactNode;
+}) {
+  const styles = gateStyles();
+  const local = useLocalStyles();
+  const state = useSyncExternalStore(
+    (cb) => provider.subscribe(cb),
+    () => provider.getState(),
+    () => provider.getState(),
+  );
+
+  useEffect(() => {
+    const onRequired = () => provider.handleAuthRequired();
+    window.addEventListener(AUTH_REQUIRED_EVENT, onRequired);
+    // A 403 for an anonymous token means the backend rejected a disallowed surface: end the session.
+    window.addEventListener(AUTH_FORBIDDEN_EVENT, onRequired);
+    return () => {
+      window.removeEventListener(AUTH_REQUIRED_EVENT, onRequired);
+      window.removeEventListener(AUTH_FORBIDDEN_EVENT, onRequired);
+    };
+  }, [provider]);
+
+  const consent = useCallback(() => {
+    void provider.bootstrap();
+  }, [provider]);
+  const retry = useCallback(() => provider.retry(), [provider]);
+
+  if (state.status === 'authenticated') {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className={styles.root} data-testid="auth-gate">
+      <div className={styles.card}>
+        <BrandLogo size={56} showWordmark={false} />
+        <div className={styles.headings}>
+          <Title2>Retail Pulse</Title2>
+          <Subtitle1 className={styles.muted}>Limited demo mode</Subtitle1>
+        </div>
+
+        {state.status === 'authenticating' ? (
+          <Spinner label="Starting your demo session…" data-testid="auth-signing-in" />
+        ) : (
+          <>
+            <Badge appearance="tint" color="warning" data-testid="anon-warning-badge">
+              Limited demo — billable &amp; rate-limited
+            </Badge>
+            <ul className={local.limitations} data-testid="anon-limitations">
+              {LIMITATIONS.map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+
+            {state.status === 'error' ? (
+              <Body1 className={local.error} data-testid="auth-error">
+                {errorMessage(state.errorCode as AnonymousErrorCode | undefined)}
+              </Body1>
+            ) : null}
+
+            <div className={styles.actions}>
+              <Button
+                appearance="primary"
+                size="large"
+                onClick={state.status === 'error' ? retry : consent}
+                data-testid="anon-continue-button"
+              >
+                {state.status === 'error' ? 'Try again' : 'Continue in limited demo'}
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * In-app banner shown while an anonymous session is active: it restates the limitations, shows the
+ * remaining time before expiry, and offers "New anonymous session" / "Clear session" actions. It
+ * reads expiry and drives session lifecycle entirely through the provider — components never talk to
+ * the token store directly.
+ */
+export function AnonymousSessionBanner({ provider }: { provider: AnonymousSessionProvider }) {
+  const styles = useBannerStyles();
+  const [remainingMs, setRemainingMs] = useState<number | null>(() => provider.msUntilExpiry());
+
+  useEffect(() => {
+    const tick = () => setRemainingMs(provider.msUntilExpiry());
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [provider]);
+
+  const clear = useCallback(() => provider.endSession(), [provider]);
+  const renew = useCallback(() => {
+    void provider.newSession();
+  }, [provider]);
+
+  return (
+    <div className={styles.root} data-testid="anon-session-banner" role="status">
+      <Badge appearance="tint" color="warning">
+        Limited demo
+      </Badge>
+      <span className={styles.text}>
+        Read-only chat. No telemetry, memory, or export.
+        {remainingMs !== null ? (
+          <span data-testid="anon-expiry"> Session expires in {formatRemaining(remainingMs)}.</span>
+        ) : null}
+      </span>
+      <span className={styles.spacer} />
+      <Button size="small" appearance="secondary" onClick={renew} data-testid="anon-new-session">
+        New anonymous session
+      </Button>
+      <Button size="small" appearance="subtle" onClick={clear} data-testid="anon-clear-session">
+        Clear session
+      </Button>
+    </div>
+  );
+}
+
+function formatRemaining(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes <= 0) return `${seconds}s`;
+  return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+}
+
+function errorMessage(code: AnonymousErrorCode | undefined): string {
+  switch (code) {
+    case 'rate_limited':
+      return 'The demo is busy right now (rate limit reached). Please wait a moment and try again.';
+    case 'bootstrap_failed':
+    default:
+      return 'We could not start a demo session. Please try again.';
+  }
+}
+
+const useLocalStyles = makeStyles({
+  limitations: {
+    textAlign: 'left',
+    margin: 0,
+    paddingLeft: '20px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    color: tokens.colorNeutralForeground2,
+    fontSize: tokens.fontSizeBase200,
+  },
+  error: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+});
+
+const useBannerStyles = makeStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    padding: '6px 14px',
+    background: tokens.colorNeutralBackground3,
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground2,
+  },
+  text: {
+    color: tokens.colorNeutralForeground2,
+  },
+  spacer: {
+    flex: 1,
+  },
+});

--- a/src/RetailPulse.Web/src/auth/gates/EntraAuthGate.tsx
+++ b/src/RetailPulse.Web/src/auth/gates/EntraAuthGate.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import {
+  Body1,
+  Button,
+  Spinner,
+  Subtitle1,
+  Title2,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+import { useIsAuthenticated, useMsal } from '@azure/msal-react';
+import { InteractionStatus } from '@azure/msal-browser';
+import { BrandLogo } from '../../components/BrandLogo';
+import { loginRequest } from '../authConfig';
+import { AUTH_FORBIDDEN_EVENT } from '../authorizedFetch';
+import { gateStyles } from './gateStyles';
+
+/**
+ * Polished Entra sign-in gate — the live production sign-in UX, unchanged from the pre-Sprint-3
+ * implementation. The app tree renders only for a signed-in user; an unauthenticated visitor sees a
+ * branded Microsoft sign-in screen and interactive sign-in is triggered explicitly (never silently
+ * from a data fetch). A 403 from the API — authenticated but not assigned the RetailPulse.User role —
+ * shows a precise access-denied message instead of a blank dashboard.
+ */
+export function EntraAuthGate({ children }: { children: ReactNode }) {
+  const styles = gateStyles();
+  const local = useLocalStyles();
+  const { instance, inProgress } = useMsal();
+  const isAuthenticated = useIsAuthenticated();
+  const [forbidden, setForbidden] = useState(false);
+
+  useEffect(() => {
+    const onForbidden = () => setForbidden(true);
+    window.addEventListener(AUTH_FORBIDDEN_EVENT, onForbidden);
+    return () => window.removeEventListener(AUTH_FORBIDDEN_EVENT, onForbidden);
+  }, []);
+
+  const signIn = useCallback(() => {
+    setForbidden(false);
+    void instance.loginRedirect(loginRequest);
+  }, [instance]);
+
+  const signOut = useCallback(() => {
+    void instance.logoutRedirect();
+  }, [instance]);
+
+  const busy =
+    inProgress === InteractionStatus.Login ||
+    inProgress === InteractionStatus.HandleRedirect ||
+    inProgress === InteractionStatus.Startup;
+
+  if (isAuthenticated && !forbidden) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className={styles.root} data-testid="auth-gate">
+      <div className={styles.card}>
+        <BrandLogo size={56} showWordmark={false} />
+        <div className={styles.headings}>
+          <Title2>Retail Pulse</Title2>
+          <Subtitle1 className={styles.muted}>Real-time retail intelligence</Subtitle1>
+        </div>
+
+        {forbidden ? (
+          <>
+            <Body1 className={local.error} data-testid="auth-forbidden">
+              Your account is signed in but not authorized for Retail Pulse. Ask an
+              administrator to assign you the <strong>RetailPulse.User</strong> role, then try
+              again.
+            </Body1>
+            <div className={styles.actions}>
+              <Button appearance="primary" onClick={signIn}>
+                Retry
+              </Button>
+              <Button appearance="subtle" onClick={signOut}>
+                Sign in with a different account
+              </Button>
+            </div>
+          </>
+        ) : busy ? (
+          <Spinner label="Signing you in…" data-testid="auth-signing-in" />
+        ) : (
+          <>
+            <Body1 className={styles.muted}>
+              Sign in with your organizational account to continue.
+            </Body1>
+            <div className={styles.actions}>
+              <Button appearance="primary" size="large" onClick={signIn} data-testid="auth-signin-button">
+                Sign in with Microsoft
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const useLocalStyles = makeStyles({
+  error: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+});

--- a/src/RetailPulse.Web/src/auth/gates/GitHubAuthGate.tsx
+++ b/src/RetailPulse.Web/src/auth/gates/GitHubAuthGate.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useSyncExternalStore, type ReactNode } from 'react';
+import { Body1, Button, Spinner, Subtitle1, Title2, makeStyles, tokens } from '@fluentui/react-components';
+import { BrandLogo } from '../../components/BrandLogo';
+import { AUTH_FORBIDDEN_EVENT, AUTH_REQUIRED_EVENT } from '../authorizedFetch';
+import type { GitHubSessionProvider, GitHubErrorCode } from '../providers/githubProvider';
+import { gateStyles } from './gateStyles';
+
+/**
+ * GitHub Backend-for-Frontend sign-in gate (opt-in, non-production). The GitHub provider token never
+ * touches the browser: the gate only ever navigates to the fixed same-origin start route and renders
+ * the app once a short-lived Retail Pulse session token has been minted by the exchange. It reads its
+ * state from the provider's observable store (no MSAL/React-context here) via `useSyncExternalStore`.
+ */
+export function GitHubAuthGate({
+  provider,
+  children,
+}: {
+  provider: GitHubSessionProvider;
+  children: ReactNode;
+}) {
+  const styles = gateStyles();
+  const local = useLocalStyles();
+  const state = useSyncExternalStore(
+    (cb) => provider.subscribe(cb),
+    () => provider.getState(),
+    () => provider.getState(),
+  );
+
+  useEffect(() => {
+    const onRequired = () => provider.handleAuthRequired();
+    const onForbidden = () => provider.handleForbidden();
+    window.addEventListener(AUTH_REQUIRED_EVENT, onRequired);
+    window.addEventListener(AUTH_FORBIDDEN_EVENT, onForbidden);
+    return () => {
+      window.removeEventListener(AUTH_REQUIRED_EVENT, onRequired);
+      window.removeEventListener(AUTH_FORBIDDEN_EVENT, onForbidden);
+    };
+  }, [provider]);
+
+  const startLogin = useCallback(() => provider.startLogin(), [provider]);
+  const retry = useCallback(() => provider.retry(), [provider]);
+
+  if (state.status === 'authenticated') {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className={styles.root} data-testid="auth-gate">
+      <div className={styles.card}>
+        <BrandLogo size={56} showWordmark={false} />
+        <div className={styles.headings}>
+          <Title2>Retail Pulse</Title2>
+          <Subtitle1 className={styles.muted}>Real-time retail intelligence</Subtitle1>
+        </div>
+
+        {state.status === 'initializing' || state.status === 'authenticating' ? (
+          <Spinner label="Connecting to GitHub…" data-testid="auth-signing-in" />
+        ) : state.status === 'error' ? (
+          <>
+            <Body1 className={local.error} data-testid="auth-error">
+              {errorMessage(state.errorCode as GitHubErrorCode | undefined)}
+            </Body1>
+            <div className={styles.actions}>
+              <Button appearance="primary" onClick={retry} data-testid="auth-retry-button">
+                Try again
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <Body1 className={styles.muted}>Sign in with your GitHub account to continue.</Body1>
+            <div className={styles.actions}>
+              <Button
+                appearance="primary"
+                size="large"
+                icon={<GitHubMark />}
+                onClick={startLogin}
+                data-testid="auth-github-button"
+              >
+                Continue with GitHub
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Map a safe provider error code to a user-facing message. Never renders a raw provider string. */
+function errorMessage(code: GitHubErrorCode | undefined): string {
+  switch (code) {
+    case 'access_denied':
+      return 'GitHub sign-in was cancelled. You can try again when you are ready.';
+    case 'not_authorized':
+      return 'Your GitHub account is not authorized for Retail Pulse. Ask an administrator to add you to the allowlist, then try again.';
+    case 'invalid_code':
+      return 'That sign-in link has expired or was already used. Please sign in again.';
+    case 'login_failed':
+    case 'exchange_failed':
+    default:
+      return 'We could not complete GitHub sign-in. Please try again.';
+  }
+}
+
+function GitHubMark() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
+
+const useLocalStyles = makeStyles({
+  error: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+});

--- a/src/RetailPulse.Web/src/auth/gates/gateStyles.ts
+++ b/src/RetailPulse.Web/src/auth/gates/gateStyles.ts
@@ -1,0 +1,46 @@
+import { makeStyles, tokens } from '@fluentui/react-components';
+
+/**
+ * Shared visual shell for every provider sign-in gate (Entra / GitHub / Anonymous) so the
+ * unauthenticated experience is pixel-identical regardless of the configured provider. Only the
+ * headings, copy and action buttons differ per provider; the card chrome does not.
+ */
+export const gateStyles = makeStyles({
+  root: {
+    position: 'fixed',
+    inset: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background:
+      'radial-gradient(1200px 800px at 50% -10%, rgba(91,124,255,0.18), transparent), #0b0e14',
+    padding: '24px',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '20px',
+    maxWidth: '420px',
+    width: '100%',
+    padding: '40px 36px',
+    borderRadius: tokens.borderRadiusXLarge,
+    background: tokens.colorNeutralBackground2,
+    boxShadow: tokens.shadow28,
+    textAlign: 'center',
+  },
+  headings: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+  },
+  actions: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+    width: '100%',
+  },
+});

--- a/src/RetailPulse.Web/src/auth/providers/anonymousProvider.ts
+++ b/src/RetailPulse.Web/src/auth/providers/anonymousProvider.ts
@@ -1,0 +1,161 @@
+import { resolveApiUrl } from '../../config/apiOrigin';
+import { SessionCredentialStore } from '../session/sessionCredentialStore';
+import {
+  ANONYMOUS_CAPABILITIES,
+  type ProviderCapabilities,
+  type SessionProvider,
+  type SessionState,
+} from '../session/types';
+
+/**
+ * Anonymous limited-demo session provider (opt-in, non-production).
+ *
+ * Nothing happens until the user gives EXPLICIT consent: {@link bootstrap} POSTs
+ * `POST /api/auth/anonymous/session`, which mints a short-lived, no-refresh session token (random
+ * subject, no PII). The token is stored session-only and used as the bearer for the single
+ * allowlisted capability, `POST /api/chat`. There is no provider redirect and no cross-tab sharing.
+ *
+ * The request targets ONLY our trusted API origin (same-origin, or the exact configured
+ * `VITE_API_ORIGIN`) via {@link resolveApiUrl}. When the token expires the store returns null and
+ * the gate offers a fresh "New anonymous session".
+ */
+
+const BOOTSTRAP_ROUTE = '/api/auth/anonymous/session';
+
+export type AnonymousErrorCode = 'rate_limited' | 'bootstrap_failed';
+
+interface AnonymousBootstrapResponse {
+  readonly token: string;
+  readonly tokenType: string;
+  readonly expiresInSeconds: number;
+  readonly subject: string;
+}
+
+type Listener = () => void;
+
+export class AnonymousSessionProvider implements SessionProvider {
+  readonly mode = 'anonymous' as const;
+  readonly capabilities: ProviderCapabilities = ANONYMOUS_CAPABILITIES;
+  readonly requiresGate = true;
+
+  private readonly store = new SessionCredentialStore('anonymous');
+  private readonly listeners = new Set<Listener>();
+  private state: SessionState = { status: 'initializing' };
+  private initialized = false;
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+    // Never auto-start a billable session — require an explicit consent click. A surviving same-tab
+    // token (reload) is honoured so the demo does not force re-consent on refresh.
+    this.setState(
+      this.store.getToken() ? { status: 'authenticated' } : { status: 'unauthenticated' },
+    );
+    // Expire the local view when the token TTL lapses so the UI flips back to the consent screen.
+    this.scheduleExpiryWatch();
+  }
+
+  /** Explicit user consent → mint a short-lived anonymous session token. */
+  async bootstrap(): Promise<void> {
+    this.setState({ status: 'authenticating' });
+    try {
+      const response = await fetch(resolveApiUrl(BOOTSTRAP_ROUTE), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!response.ok) {
+        this.setState({
+          status: 'error',
+          errorCode: response.status === 429 ? 'rate_limited' : 'bootstrap_failed',
+        });
+        return;
+      }
+
+      const data = (await response.json()) as AnonymousBootstrapResponse;
+      if (!data?.token) {
+        this.setState({ status: 'error', errorCode: 'bootstrap_failed' });
+        return;
+      }
+
+      const expiresAt =
+        typeof data.expiresInSeconds === 'number' && data.expiresInSeconds > 0
+          ? Date.now() + data.expiresInSeconds * 1000
+          : undefined;
+      this.store.set({ token: data.token, expiresAt });
+      this.setState({ status: 'authenticated' });
+      this.scheduleExpiryWatch();
+    } catch {
+      this.setState({ status: 'error', errorCode: 'bootstrap_failed' });
+    }
+  }
+
+  /** Clear the current session and return to the consent screen (no new session is minted). */
+  endSession(): void {
+    this.store.clear();
+    this.setState({ status: 'unauthenticated' });
+  }
+
+  /** "New anonymous session": clear then immediately bootstrap a fresh one. */
+  async newSession(): Promise<void> {
+    this.store.clear();
+    await this.bootstrap();
+  }
+
+  retry(): void {
+    this.setState({ status: 'unauthenticated' });
+  }
+
+  async acquireToken(): Promise<string | null> {
+    return this.store.getToken();
+  }
+
+  logout(): void {
+    this.endSession();
+  }
+
+  /** 401 from the API: the short-lived session token expired/was rejected — return to consent. */
+  handleAuthRequired(): void {
+    this.endSession();
+  }
+
+  /** Milliseconds until the current token expires, or null when unknown/none. */
+  msUntilExpiry(now: number = Date.now()): number | null {
+    const credential = this.store.get(now);
+    if (!credential || credential.expiresAt === undefined) return null;
+    return Math.max(0, credential.expiresAt - now);
+  }
+
+  getState(): SessionState {
+    return this.state;
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private expiryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private scheduleExpiryWatch(): void {
+    if (this.expiryTimer) {
+      clearTimeout(this.expiryTimer);
+      this.expiryTimer = null;
+    }
+    const remaining = this.msUntilExpiry();
+    if (remaining === null || typeof setTimeout === 'undefined') return;
+    this.expiryTimer = setTimeout(() => {
+      // get() self-clears an expired credential; flip the gate back to consent.
+      if (!this.store.getToken()) {
+        this.setState({ status: 'unauthenticated' });
+      }
+    }, remaining + 50);
+  }
+
+  private setState(next: SessionState): void {
+    this.state = next;
+    for (const listener of this.listeners) listener();
+  }
+}

--- a/src/RetailPulse.Web/src/auth/providers/entraProvider.ts
+++ b/src/RetailPulse.Web/src/auth/providers/entraProvider.ts
@@ -25,7 +25,11 @@ export class EntraSessionProvider implements SessionProvider {
   }
 
   get requiresGate(): boolean {
-    return authConfig.isConfigured && !this.isLocalDevPassthrough;
+    // Outside the explicit local-dev pass-through, an Entra build ALWAYS requires the sign-in gate.
+    // We deliberately do NOT let authConfig.isConfigured turn the gate off: a missing/placeholder
+    // configuration must fail closed (assertEntraConfigured throws in main.tsx before render), never
+    // silently drop the gate and expose an unauthenticated shell.
+    return !this.isLocalDevPassthrough;
   }
 
   async initialize(): Promise<void> {

--- a/src/RetailPulse.Web/src/auth/providers/entraProvider.ts
+++ b/src/RetailPulse.Web/src/auth/providers/entraProvider.ts
@@ -1,0 +1,68 @@
+import { InteractionRequiredAuthError } from '@azure/msal-browser';
+import { authConfig } from '../authConfig';
+import { getMsalInstance } from '../msalInstance';
+import { FULL_CAPABILITIES, type ProviderCapabilities, type SessionProvider } from '../session/types';
+
+/**
+ * Entra session provider — the live production path. This preserves the EXACT prior MSAL behavior:
+ * silent acquisition of the delegated API scope for the active account, a redirect to interactive
+ * sign-in only when explicitly requested (never silently from a data fetch), and a null return when
+ * the user is not signed in so the sign-in gate (not an individual fetch) owns interactive login.
+ *
+ * The Entra tokens continue to live in MSAL's `sessionStorage` cache (see authConfig) — this
+ * provider does not use the Retail Pulse session store, which is only for the GitHub/Anonymous
+ * short-lived tokens.
+ */
+export class EntraSessionProvider implements SessionProvider {
+  readonly mode = 'entra' as const;
+  readonly capabilities: ProviderCapabilities = FULL_CAPABILITIES;
+
+  /** Local dev with no Entra config is a transparent pass-through: no gate, no token. */
+  private readonly isLocalDevPassthrough: boolean;
+
+  constructor(isLocalDevPassthrough: boolean) {
+    this.isLocalDevPassthrough = isLocalDevPassthrough;
+  }
+
+  get requiresGate(): boolean {
+    return authConfig.isConfigured && !this.isLocalDevPassthrough;
+  }
+
+  async initialize(): Promise<void> {
+    // MSAL initialization (redirect completion + active-account wiring) is handled in main.tsx via
+    // initializeMsal() before render, keeping the MsalProvider/React lifecycle intact. Nothing to do
+    // here for the pass-through case.
+  }
+
+  async acquireToken(options: { readonly forceRefresh?: boolean } = {}): Promise<string | null> {
+    if (!authConfig.isConfigured) {
+      return null;
+    }
+
+    const msal = getMsalInstance();
+    const account = msal.getActiveAccount() ?? msal.getAllAccounts()[0] ?? null;
+    if (!account) {
+      return null;
+    }
+
+    try {
+      const result = await msal.acquireTokenSilent({
+        scopes: authConfig.apiScopes,
+        account,
+        forceRefresh: options.forceRefresh ?? false,
+      });
+      return result.accessToken;
+    } catch (error) {
+      if (error instanceof InteractionRequiredAuthError) {
+        // The sign-in gate is responsible for starting interactive login; a fetch never triggers it.
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  logout(): void {
+    if (!authConfig.isConfigured) return;
+    void getMsalInstance().logoutRedirect();
+  }
+}

--- a/src/RetailPulse.Web/src/auth/providers/githubProvider.ts
+++ b/src/RetailPulse.Web/src/auth/providers/githubProvider.ts
@@ -1,0 +1,209 @@
+import { resolveApiUrl } from '../../config/apiOrigin';
+import { SessionCredentialStore } from '../session/sessionCredentialStore';
+import {
+  FULL_CAPABILITIES,
+  type ProviderCapabilities,
+  type SessionProvider,
+  type SessionState,
+} from '../session/types';
+
+/**
+ * GitHub confidential Backend-for-Frontend (BFF) session provider (opt-in, non-production).
+ *
+ * The GitHub PROVIDER token never touches the browser. The flow the SPA drives is:
+ *   1. {@link startLogin} performs a TOP-LEVEL navigation to `GET /api/auth/github/start` (never an
+ *      arbitrary/user-supplied return URL) — the backend sets its browser-bound state cookie and
+ *      redirects to github.com.
+ *   2. github.com redirects back to the backend callback, which redirects to THIS SPA carrying only
+ *      a one-time redemption `code` (or a safe `error` code) in the query string.
+ *   3. {@link initialize} runs at load: it reads `code`/`error`, IMMEDIATELY strips them from the URL
+ *      with `history.replaceState` (so a reload/bookmark/back can never replay them), and — for a
+ *      `code` — POSTs `POST /api/auth/github/exchange` to redeem it for a short-lived Retail Pulse
+ *      session token, stored session-only.
+ *
+ * The exchange targets ONLY our trusted API origin (same-origin, or the exact configured
+ * `VITE_API_ORIGIN`) via {@link resolveApiUrl}; a token is never posted to a third party.
+ */
+
+const START_ROUTE = '/api/auth/github/start';
+const EXCHANGE_ROUTE = '/api/auth/github/exchange';
+
+/** Safe, user-facing error codes surfaced by the callback or exchange. */
+export type GitHubErrorCode =
+  | 'access_denied'
+  | 'login_failed'
+  | 'not_authorized'
+  | 'invalid_code'
+  | 'exchange_failed';
+
+interface GitHubExchangeResponse {
+  readonly token: string;
+  readonly tokenType: string;
+  readonly expiresInSeconds: number;
+  readonly subject: string;
+}
+
+type Listener = () => void;
+
+export class GitHubSessionProvider implements SessionProvider {
+  readonly mode = 'github' as const;
+  readonly capabilities: ProviderCapabilities = FULL_CAPABILITIES;
+  readonly requiresGate = true;
+
+  private readonly store = new SessionCredentialStore('github');
+  private readonly listeners = new Set<Listener>();
+  private state: SessionState = { status: 'initializing' };
+  private initialized = false;
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+
+    const { code, error } = this.consumeCallbackParams();
+
+    if (error) {
+      this.setState({ status: 'error', errorCode: error });
+      return;
+    }
+
+    if (code) {
+      await this.exchange(code);
+      return;
+    }
+
+    // No callback params: authenticated iff a same-tab session token survives.
+    this.setState(
+      this.store.getToken() ? { status: 'authenticated' } : { status: 'unauthenticated' },
+    );
+  }
+
+  /** Begin login with a top-level navigation to the fixed start route. No return URL is accepted. */
+  startLogin(): void {
+    this.setState({ status: 'authenticating' });
+    if (typeof window !== 'undefined') {
+      window.location.assign(resolveApiUrl(START_ROUTE));
+    }
+  }
+
+  /** Retry after an error returns to an interactive unauthenticated state. */
+  retry(): void {
+    this.setState({ status: 'unauthenticated' });
+  }
+
+  async acquireToken(): Promise<string | null> {
+    // Short-lived, no refresh: the store returns null once expired, which drives a re-login.
+    return this.store.getToken();
+  }
+
+  logout(): void {
+    // Clear only OUR session token. There is no GitHub provider-logout assumption — we never held a
+    // provider session in the browser, so we do not attempt to sign the user out of github.com.
+    this.store.clear();
+    this.setState({ status: 'unauthenticated' });
+  }
+
+  /** 401 from the API after a retry: the session token is gone/rejected — clear and re-gate. */
+  handleAuthRequired(): void {
+    this.store.clear();
+    this.setState({ status: 'unauthenticated' });
+  }
+
+  /** 403 from the API: authenticated but the GitHub identity is not on the allowlist. */
+  handleForbidden(): void {
+    this.store.clear();
+    this.setState({ status: 'error', errorCode: 'not_authorized' });
+  }
+
+  getState(): SessionState {
+    return this.state;
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Reads `code`/`error` from the current URL and strips the whole query string immediately via
+   * `history.replaceState`, so the one-time code can never be reloaded, bookmarked, or replayed.
+   */
+  private consumeCallbackParams(): { code: string | null; error: GitHubErrorCode | null } {
+    if (typeof window === 'undefined' || !window.location) {
+      return { code: null, error: null };
+    }
+    const url = new URL(window.location.href);
+    const code = url.searchParams.get('code');
+    const rawError = url.searchParams.get('error');
+
+    if (!code && !rawError) {
+      return { code: null, error: null };
+    }
+
+    // Strip sensitive params from the address bar before anything else.
+    url.searchParams.delete('code');
+    url.searchParams.delete('error');
+    const cleaned = `${url.pathname}${url.search}${url.hash}`;
+    try {
+      window.history.replaceState(window.history.state, '', cleaned);
+    } catch {
+      // Non-fatal: exchange still proceeds even if the URL could not be rewritten.
+    }
+
+    return { code, error: rawError ? this.normalizeError(rawError) : null };
+  }
+
+  private normalizeError(raw: string): GitHubErrorCode {
+    switch (raw) {
+      case 'access_denied':
+      case 'login_failed':
+      case 'not_authorized':
+      case 'invalid_code':
+        return raw;
+      default:
+        // Never surface an unrecognized provider string; collapse to a generic failure.
+        return 'login_failed';
+    }
+  }
+
+  private async exchange(code: string): Promise<void> {
+    this.setState({ status: 'authenticating' });
+    try {
+      const response = await fetch(resolveApiUrl(EXCHANGE_ROUTE), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+
+      if (!response.ok) {
+        // A replayed/unknown/expired code returns 400 invalid_code; anything else is generic.
+        this.setState({
+          status: 'error',
+          errorCode: response.status === 400 ? 'invalid_code' : 'exchange_failed',
+        });
+        return;
+      }
+
+      const data = (await response.json()) as GitHubExchangeResponse;
+      if (!data?.token) {
+        this.setState({ status: 'error', errorCode: 'exchange_failed' });
+        return;
+      }
+
+      const expiresAt =
+        typeof data.expiresInSeconds === 'number' && data.expiresInSeconds > 0
+          ? Date.now() + data.expiresInSeconds * 1000
+          : undefined;
+      this.store.set({ token: data.token, expiresAt });
+      this.setState({ status: 'authenticated' });
+    } catch {
+      this.setState({ status: 'error', errorCode: 'exchange_failed' });
+    }
+  }
+
+  private setState(next: SessionState): void {
+    this.state = next;
+    for (const listener of this.listeners) listener();
+  }
+}

--- a/src/RetailPulse.Web/src/auth/providers/githubProvider.ts
+++ b/src/RetailPulse.Web/src/auth/providers/githubProvider.ts
@@ -28,6 +28,17 @@ import {
 const START_ROUTE = '/api/auth/github/start';
 const EXCHANGE_ROUTE = '/api/auth/github/exchange';
 
+/**
+ * Provider-namespaced sessionStorage marker set by {@link GitHubSessionProvider.startLogin} immediately
+ * before the top-level navigation to the backend start route. It is defense-in-depth ONLY — the backend
+ * per-code `__Host-` redemption cookie is the primary CSRF/login-forgery control. The marker ensures the
+ * SPA only attempts an exchange for a callback IT initiated in this tab: an attacker who injects a `?code=`
+ * into a victim's address bar (without the victim having clicked "Sign in") produces no marker, so the SPA
+ * strips the param and never calls exchange. It is single-use: cleared on read (success OR error) and on
+ * logout, so a stale marker can never authorize a second, unrelated callback.
+ */
+const LOGIN_STARTED_KEY = 'retailpulse:login-started:github';
+
 /** Safe, user-facing error codes surfaced by the callback or exchange. */
 export type GitHubErrorCode =
   | 'access_denied'
@@ -59,7 +70,21 @@ export class GitHubSessionProvider implements SessionProvider {
     if (this.initialized) return;
     this.initialized = true;
 
+    // ALWAYS strip code/error from the address bar first, whatever we decide to do with them, so a
+    // reload/bookmark/back can never replay them.
     const { code, error } = this.consumeCallbackParams();
+
+    // Defense-in-depth: only act on callback params for a login THIS tab actually started. The marker is
+    // single-use — reading it here clears it — so an injected `?code=`/`?error=` without a preceding
+    // startLogin() is ignored (params already stripped) and we fall through to the stored-token path.
+    const loginStarted = this.consumeLoginMarker();
+
+    if ((code || error) && !loginStarted) {
+      this.setState(
+        this.store.getToken() ? { status: 'authenticated' } : { status: 'unauthenticated' },
+      );
+      return;
+    }
 
     if (error) {
       this.setState({ status: 'error', errorCode: error });
@@ -80,6 +105,9 @@ export class GitHubSessionProvider implements SessionProvider {
   /** Begin login with a top-level navigation to the fixed start route. No return URL is accepted. */
   startLogin(): void {
     this.setState({ status: 'authenticating' });
+    // Mark that THIS tab initiated the login before leaving the page, so the returning callback's params
+    // are trusted by initialize(). Non-fatal if storage is unavailable — the backend cookie still gates.
+    this.setLoginMarker();
     if (typeof window !== 'undefined') {
       window.location.assign(resolveApiUrl(START_ROUTE));
     }
@@ -99,6 +127,7 @@ export class GitHubSessionProvider implements SessionProvider {
     // Clear only OUR session token. There is no GitHub provider-logout assumption — we never held a
     // provider session in the browser, so we do not attempt to sign the user out of github.com.
     this.store.clear();
+    this.clearLoginMarker();
     this.setState({ status: 'unauthenticated' });
   }
 
@@ -167,12 +196,44 @@ export class GitHubSessionProvider implements SessionProvider {
     }
   }
 
+  /** Set the single-use, provider-namespaced "this tab started a login" marker. */
+  private setLoginMarker(): void {
+    try {
+      window.sessionStorage?.setItem(LOGIN_STARTED_KEY, '1');
+    } catch {
+      // Non-fatal: the backend per-code cookie remains the primary control.
+    }
+  }
+
+  /** Read AND clear the marker (single-use). Returns true only if a login was started in this tab. */
+  private consumeLoginMarker(): boolean {
+    try {
+      const present = window.sessionStorage?.getItem(LOGIN_STARTED_KEY) === '1';
+      window.sessionStorage?.removeItem(LOGIN_STARTED_KEY);
+      return present;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Clear the marker without reading it (logout). */
+  private clearLoginMarker(): void {
+    try {
+      window.sessionStorage?.removeItem(LOGIN_STARTED_KEY);
+    } catch {
+      // Non-fatal.
+    }
+  }
+
   private async exchange(code: string): Promise<void> {
     this.setState({ status: 'authenticating' });
     try {
       const response = await fetch(resolveApiUrl(EXCHANGE_ROUTE), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        // The per-code `__Host-` redemption cookie set by the callback must accompany the exchange so the
+        // backend can bind this redemption to the browser that completed the callback.
+        credentials: 'include',
         body: JSON.stringify({ code }),
       });
 

--- a/src/RetailPulse.Web/src/auth/session/sessionCredentialStore.ts
+++ b/src/RetailPulse.Web/src/auth/session/sessionCredentialStore.ts
@@ -1,0 +1,117 @@
+import type { SessionCredential } from './types';
+
+/**
+ * A session-scoped credential store for the Retail Pulse short-lived session tokens minted by the
+ * GitHub BFF and Anonymous bootstrap flows.
+ *
+ * Storage policy (deliberately narrow):
+ *   - The live value is held in memory (module state) — the source of truth for token acquisition.
+ *   - A copy is mirrored to `sessionStorage` under a namespaced key so a same-tab reload survives,
+ *     but the credential dies on tab close and is NEVER shared across tabs/windows.
+ *   - It is NEVER written to `localStorage` or a broadly-readable cookie.
+ *
+ * The GitHub PROVIDER token never reaches the browser at all; only our own session token does, and
+ * only through this store. The token is cleared on logout, on expiry, and on a 401/403 from the API.
+ */
+
+const STORAGE_PREFIX = 'retailpulse:session:';
+
+type Listener = () => void;
+
+function safeSessionStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined' || !window.sessionStorage) return null;
+    return window.sessionStorage;
+  } catch {
+    // Access can throw in sandboxed/embedded contexts; degrade to memory-only.
+    return null;
+  }
+}
+
+export class SessionCredentialStore {
+  private readonly storageKey: string;
+  private readonly listeners = new Set<Listener>();
+  private credential: SessionCredential | null = null;
+  private hydrated = false;
+
+  constructor(namespace: string) {
+    this.storageKey = `${STORAGE_PREFIX}${namespace}`;
+  }
+
+  /** Lazily rehydrate a same-tab credential from sessionStorage exactly once. */
+  private hydrate(): void {
+    if (this.hydrated) return;
+    this.hydrated = true;
+    const store = safeSessionStorage();
+    if (!store) return;
+    const raw = store.getItem(this.storageKey);
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw) as SessionCredential;
+      if (parsed && typeof parsed.token === 'string' && parsed.token.length > 0) {
+        this.credential = parsed;
+      } else {
+        store.removeItem(this.storageKey);
+      }
+    } catch {
+      store.removeItem(this.storageKey);
+    }
+  }
+
+  /** Returns the current non-expired credential, clearing and returning null if it has expired. */
+  get(now: number = Date.now()): SessionCredential | null {
+    this.hydrate();
+    const current = this.credential;
+    if (!current) return null;
+    if (current.expiresAt !== undefined && current.expiresAt <= now) {
+      this.clear();
+      return null;
+    }
+    return current;
+  }
+
+  /** The bearer token, or null when there is no live credential. */
+  getToken(now: number = Date.now()): string | null {
+    return this.get(now)?.token ?? null;
+  }
+
+  set(credential: SessionCredential): void {
+    this.hydrate();
+    this.credential = credential;
+    const store = safeSessionStorage();
+    if (store) {
+      try {
+        store.setItem(this.storageKey, JSON.stringify(credential));
+      } catch {
+        // Non-fatal: memory remains the source of truth.
+      }
+    }
+    this.emit();
+  }
+
+  clear(): void {
+    this.hydrate();
+    const had = this.credential !== null;
+    this.credential = null;
+    const store = safeSessionStorage();
+    if (store) {
+      try {
+        store.removeItem(this.storageKey);
+      } catch {
+        // ignore
+      }
+    }
+    if (had) this.emit();
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) listener();
+  }
+}

--- a/src/RetailPulse.Web/src/auth/session/types.ts
+++ b/src/RetailPulse.Web/src/auth/session/types.ts
@@ -17,12 +17,6 @@ export interface ProviderCapabilities {
   readonly approvals: boolean;
   /** Memory panel + memory-management actions. */
   readonly memory: boolean;
-  /** Token-streaming chat responses. */
-  readonly streaming: boolean;
-  /** Conversation/data export. */
-  readonly export: boolean;
-  /** Any write-capable action (approve, configure, etc.). */
-  readonly writeActions: boolean;
   /** Non-chat alternate views/tabs (promo, competitive, stores, financials, portfolio, …). */
   readonly alternateViews: boolean;
 }
@@ -79,15 +73,12 @@ export const FULL_CAPABILITIES: ProviderCapabilities = {
   observability: true,
   approvals: true,
   memory: true,
-  streaming: true,
-  export: true,
-  writeActions: true,
   alternateViews: true,
 };
 
 /**
  * Anonymous demo capability profile: read-only chat only. Everything that implies real-time
- * telemetry, memory, write actions, observability, export, or alternate operator views is off —
+ * telemetry, memory, observability, or alternate operator views is off —
  * matching the backend's deny-by-default anonymous surface (bootstrap + `POST /api/chat` only).
  */
 export const ANONYMOUS_CAPABILITIES: ProviderCapabilities = {
@@ -96,8 +87,5 @@ export const ANONYMOUS_CAPABILITIES: ProviderCapabilities = {
   observability: false,
   approvals: false,
   memory: false,
-  streaming: false,
-  export: false,
-  writeActions: false,
   alternateViews: false,
 };

--- a/src/RetailPulse.Web/src/auth/session/types.ts
+++ b/src/RetailPulse.Web/src/auth/session/types.ts
@@ -1,0 +1,103 @@
+import type { AuthMode } from '../authMode';
+
+/**
+ * Provider-neutral capability descriptor. Because the mode is fixed at build time, this is a
+ * static object per deployment — the UI reads it to CENTRALLY hide/disable surfaces a given
+ * provider must not expose. It is a usability layer only: the backend remains the authoritative
+ * gate (an anonymous token is still 403'd on any disallowed route regardless of what the UI shows).
+ */
+export interface ProviderCapabilities {
+  /** SignalR telemetry/streaming hubs may be started. */
+  readonly realtimeHub: boolean;
+  /** The Real-Time Telemetry drawer (live spans, agent routing, traces). */
+  readonly telemetryPanel: boolean;
+  /** Observability tab (AI Gateway cost, tokens, APIM metrics). */
+  readonly observability: boolean;
+  /** Approvals surface (pending approvals + history). */
+  readonly approvals: boolean;
+  /** Memory panel + memory-management actions. */
+  readonly memory: boolean;
+  /** Token-streaming chat responses. */
+  readonly streaming: boolean;
+  /** Conversation/data export. */
+  readonly export: boolean;
+  /** Any write-capable action (approve, configure, etc.). */
+  readonly writeActions: boolean;
+  /** Non-chat alternate views/tabs (promo, competitive, stores, financials, portfolio, …). */
+  readonly alternateViews: boolean;
+}
+
+/** A short-lived bearer credential minted by a provider for REST + SignalR. */
+export interface SessionCredential {
+  readonly token: string;
+  /** Epoch milliseconds when the token expires, if known. */
+  readonly expiresAt?: number;
+}
+
+/** Discriminated auth state a provider gate renders from. */
+export type SessionStatus =
+  | 'initializing'
+  | 'unauthenticated'
+  | 'authenticating'
+  | 'authenticated'
+  | 'error';
+
+export interface SessionState {
+  readonly status: SessionStatus;
+  /** Present only when status === 'error'; a safe, user-facing code (never a provider secret). */
+  readonly errorCode?: string;
+}
+
+/**
+ * The single provider-neutral contract every mode implements. Token acquisition for the global
+ * `authorizedFetch` and for the SignalR `accessTokenFactory` funnels through {@link acquireToken},
+ * so provider logic is never duplicated in components.
+ */
+export interface SessionProvider {
+  readonly mode: AuthMode;
+  readonly capabilities: ProviderCapabilities;
+  /**
+   * False only for the local-dev Entra pass-through (no gate, no token). True whenever a provider
+   * gate must be mounted and the global fetch wrapper installed.
+   */
+  readonly requiresGate: boolean;
+
+  /** One-time bootstrap (MSAL redirect completion, GitHub code redemption, …). Idempotent. */
+  initialize(): Promise<void>;
+
+  /** Acquire a bearer token for a protected `/api` REST call or a hub handshake, or null. */
+  acquireToken(options?: { readonly forceRefresh?: boolean }): Promise<string | null>;
+
+  /** Clear the credential locally (and, where applicable, the provider session). */
+  logout(): Promise<void> | void;
+}
+
+/** Full-capability profile shared by the fully-authenticated providers (Entra, GitHub). */
+export const FULL_CAPABILITIES: ProviderCapabilities = {
+  realtimeHub: true,
+  telemetryPanel: true,
+  observability: true,
+  approvals: true,
+  memory: true,
+  streaming: true,
+  export: true,
+  writeActions: true,
+  alternateViews: true,
+};
+
+/**
+ * Anonymous demo capability profile: read-only chat only. Everything that implies real-time
+ * telemetry, memory, write actions, observability, export, or alternate operator views is off —
+ * matching the backend's deny-by-default anonymous surface (bootstrap + `POST /api/chat` only).
+ */
+export const ANONYMOUS_CAPABILITIES: ProviderCapabilities = {
+  realtimeHub: false,
+  telemetryPanel: false,
+  observability: false,
+  approvals: false,
+  memory: false,
+  streaming: false,
+  export: false,
+  writeActions: false,
+  alternateViews: false,
+};

--- a/src/RetailPulse.Web/src/auth/tokenService.ts
+++ b/src/RetailPulse.Web/src/auth/tokenService.ts
@@ -1,61 +1,41 @@
-import { InteractionRequiredAuthError } from '@azure/msal-browser';
-import { authConfig } from './authConfig';
-import { getMsalInstance } from './msalInstance';
+import { acquireActiveToken, getActiveProvider } from './activeProvider';
 
 /**
- * Central token acquisition for the Retail Pulse SPA. Every protected REST call and both
- * SignalR hub connections obtain their bearer token here so there is exactly one place that
- * talks to MSAL, requests the delegated API scope, and handles silent-refresh failures.
+ * Provider-neutral token acquisition for the Retail Pulse SPA. Every protected REST call and both
+ * SignalR hub connections obtain their bearer token here so there is exactly ONE place that talks
+ * to the active provider (Entra MSAL, GitHub BFF session, or Anonymous session). Provider-specific
+ * logic lives in the providers behind {@link getActiveProvider}; this module never branches on mode.
  */
 
 export interface AcquireTokenOptions {
-  /** When silent acquisition needs interaction, redirect to sign in (navigates away). */
+  /**
+   * Retained for source compatibility. Interactive sign-in is owned by the provider gate, not by an
+   * individual fetch, so this flag no longer triggers a redirect from token acquisition.
+   */
   readonly interactive?: boolean;
-  /** Force a fresh token from Entra (used on a 401 retry). */
+  /** Force a fresh token from the provider (used on a 401 retry). */
   readonly forceRefresh?: boolean;
 }
 
 /**
- * Returns an access token for the API, or null when the user is not signed in (the sign-in
- * gate, not an individual fetch, is responsible for starting interactive login). Throws only
- * on unexpected MSAL errors so callers can distinguish "not signed in" from "broken".
+ * Returns a bearer token for the API, or null when the user is not signed in (the sign-in gate, not
+ * an individual fetch, is responsible for starting interactive login). Throws only on an unexpected
+ * provider error so callers can distinguish "not signed in" from "broken".
  */
 export async function acquireApiToken(options: AcquireTokenOptions = {}): Promise<string | null> {
-  if (!authConfig.isConfigured) {
-    return null;
-  }
-
-  const msal = getMsalInstance();
-  const account = msal.getActiveAccount() ?? msal.getAllAccounts()[0] ?? null;
-  if (!account) {
-    return null;
-  }
-
-  try {
-    const result = await msal.acquireTokenSilent({
-      scopes: authConfig.apiScopes,
-      account,
-      forceRefresh: options.forceRefresh ?? false,
-    });
-    return result.accessToken;
-  } catch (error) {
-    if (error instanceof InteractionRequiredAuthError) {
-      if (options.interactive) {
-        await msal.acquireTokenRedirect({ scopes: authConfig.apiScopes, account });
-        return null; // redirect navigates away; nothing more to do here
-      }
-      return null;
-    }
-    throw error;
-  }
+  return acquireActiveToken({ forceRefresh: options.forceRefresh ?? false });
 }
 
 /**
- * SignalR `accessTokenFactory`. Always resolves to a string ('' when unauthenticated or
- * unconfigured) because SignalR treats a non-empty return as the bearer token and an empty
- * string as "send no token" — the local dev hub works without a token.
+ * SignalR `accessTokenFactory`. Always resolves to a string ('' when unauthenticated, unconfigured,
+ * or when the active provider's capabilities forbid the real-time hubs) because SignalR treats a
+ * non-empty return as the bearer token and an empty string as "send no token". The Anonymous
+ * provider disables the hubs, so this returns '' and the hub is never started for it (see Dashboard).
  */
 export async function getHubAccessToken(): Promise<string> {
+  if (!getActiveProvider().capabilities.realtimeHub) {
+    return '';
+  }
   try {
     return (await acquireApiToken()) ?? '';
   } catch {

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -25,6 +25,9 @@ import { PortfolioScorecard, BrandScoreCard, ExplanationPanel } from './scorecar
 import type { AgentSpan, RoutingInfo, TokenUsage, ApprovalRequest, ApprovalDecision, Alert, SnoozeDuration, Trace, TraceSpan, StorePerformance, StockoutRisk, MarginWaterfallStep, MarginDriver, BrandScore, ExplanationData } from '../types';
 import { connectTelemetryHub } from '../services/telemetryHub';
 import { featureFlags } from '../config/featureFlags';
+import { capabilities, activeAuthMode, getActiveProvider } from '../auth/activeProvider';
+import { AnonymousSessionBanner } from '../auth/gates/AnonymousAuthGate';
+import type { AnonymousSessionProvider } from '../auth/providers/anonymousProvider';
 
 const DRAWER_WIDTH_PX = 560;
 const DRAWER_BREAKPOINT_PX = 768;
@@ -195,7 +198,14 @@ export function Dashboard() {
   // SignalR connection lives at Dashboard level so spans persist across drawer open/close.
   // We intentionally do NOT disconnect on unmount — the connection is a module-level
   // singleton that survives React StrictMode double-mount and persists for the app lifetime.
+  //
+  // Gated by the active provider's capabilities: providers that forbid the real-time hubs
+  // (Anonymous) never start SignalR. The hub access-token factory also returns '' for those
+  // providers, so this is defense-in-depth on top of the backend's authoritative gate.
   useEffect(() => {
+    if (!capabilities.realtimeHub) {
+      return;
+    }
     const conn = connectTelemetryHub(
       (span) => setLiveSpans(prev => {
         const next = [...prev, span];
@@ -419,17 +429,24 @@ export function Dashboard() {
 
   return (
     <div className={styles.dashboard}>
+      {activeAuthMode === 'anonymous' && (
+        <AnonymousSessionBanner
+          provider={getActiveProvider() as unknown as AnonymousSessionProvider}
+        />
+      )}
       <header className={styles.header}>
         <div className={styles.headerBrand}>
           <BrandLogo size={36} />
           <span className={styles.headerTagline}>Brand Intelligence Platform</span>
         </div>
         <div className={`${styles.headerActions} ${telemetryOpen ? styles.headerActionsOpen : ''}`}>
-          <PendingApprovals
-            pendingApprovals={pendingApprovals}
-            onClick={() => setTelemetryOpen(true)}
-          />
-          {featureFlags.campaignPlanner && (
+          {capabilities.approvals && (
+            <PendingApprovals
+              pendingApprovals={pendingApprovals}
+              onClick={() => setTelemetryOpen(true)}
+            />
+          )}
+          {capabilities.alternateViews && featureFlags.campaignPlanner && (
             <Button
               appearance={activeView === 'promo' ? 'primary' : 'subtle'}
               icon={<TargetArrow24Regular />}
@@ -439,7 +456,7 @@ export function Dashboard() {
               {activeView === 'promo' ? 'Back to Chat' : 'Campaign Planner'}
             </Button>
           )}
-          {featureFlags.competitive && (
+          {capabilities.alternateViews && featureFlags.competitive && (
             <Button
               appearance={activeView === 'competitive' ? 'primary' : 'subtle'}
               icon={<Shield24Regular />}
@@ -449,7 +466,7 @@ export function Dashboard() {
               {activeView === 'competitive' ? 'Back to Chat' : 'Competitive'}
             </Button>
           )}
-          {featureFlags.knowledgeBase && (
+          {capabilities.alternateViews && featureFlags.knowledgeBase && (
             <Button
               appearance={activeView === 'knowledge' ? 'primary' : 'subtle'}
               icon={<Library24Regular />}
@@ -459,7 +476,7 @@ export function Dashboard() {
               {activeView === 'knowledge' ? 'Back to Chat' : 'Knowledge Base'}
             </Button>
           )}
-          {featureFlags.healthCouncil && (
+          {capabilities.alternateViews && featureFlags.healthCouncil && (
             <Button
               appearance={activeView === 'council' ? 'primary' : 'subtle'}
               icon={<HeartPulse24Regular />}
@@ -469,7 +486,7 @@ export function Dashboard() {
               {activeView === 'council' ? 'Back to Chat' : 'Health Council'}
             </Button>
           )}
-          {featureFlags.security && (
+          {capabilities.alternateViews && featureFlags.security && (
             <Button
               appearance={activeView === 'security' ? 'primary' : 'subtle'}
               icon={<ShieldCheckmark24Regular />}
@@ -479,7 +496,7 @@ export function Dashboard() {
               {activeView === 'security' ? 'Back to Chat' : 'Security'}
             </Button>
           )}
-          {featureFlags.cards && (
+          {capabilities.alternateViews && featureFlags.cards && (
             <Button
               appearance={activeView === 'cards' ? 'primary' : 'subtle'}
               icon={<CardUi24Regular />}
@@ -489,7 +506,7 @@ export function Dashboard() {
               {activeView === 'cards' ? 'Back to Chat' : 'Cards'}
             </Button>
           )}
-          {featureFlags.observability && (
+          {capabilities.observability && featureFlags.observability && (
             <Button
               appearance={activeView === 'observability' ? 'primary' : 'subtle'}
               icon={<Eye24Regular />}
@@ -499,7 +516,7 @@ export function Dashboard() {
               {activeView === 'observability' ? 'Back to Chat' : 'Observability'}
             </Button>
           )}
-          {featureFlags.stores && (
+          {capabilities.alternateViews && featureFlags.stores && (
             <Button
               appearance={activeView === 'stores' ? 'primary' : 'subtle'}
               icon={<Building24Regular />}
@@ -509,7 +526,7 @@ export function Dashboard() {
               {activeView === 'stores' ? 'Back to Chat' : 'Stores'}
             </Button>
           )}
-          {featureFlags.financials && (
+          {capabilities.alternateViews && featureFlags.financials && (
             <Button
               appearance={activeView === 'financials' ? 'primary' : 'subtle'}
               icon={<Money24Regular />}
@@ -519,7 +536,7 @@ export function Dashboard() {
               {activeView === 'financials' ? 'Back to Chat' : 'Financials'}
             </Button>
           )}
-          {featureFlags.portfolio && (
+          {capabilities.alternateViews && featureFlags.portfolio && (
             <Button
               appearance={activeView === 'portfolio' ? 'primary' : 'subtle'}
               icon={<Star24Regular />}
@@ -536,21 +553,23 @@ export function Dashboard() {
           >
             New Chat
           </Button>
-          <Button
-            appearance={telemetryOpen ? 'primary' : 'subtle'}
-            icon={telemetryOpen ? <Dismiss24Regular /> : <DataUsage24Regular />}
-            onClick={() => setTelemetryOpen(prev => !prev)}
-            aria-expanded={telemetryOpen}
-            aria-controls="telemetry-drawer"
-          >
-            {telemetryOpen ? 'Close' : 'Real-Time Telemetry'}
-          </Button>
+          {capabilities.telemetryPanel && (
+            <Button
+              appearance={telemetryOpen ? 'primary' : 'subtle'}
+              icon={telemetryOpen ? <Dismiss24Regular /> : <DataUsage24Regular />}
+              onClick={() => setTelemetryOpen(prev => !prev)}
+              aria-expanded={telemetryOpen}
+              aria-controls="telemetry-drawer"
+            >
+              {telemetryOpen ? 'Close' : 'Real-Time Telemetry'}
+            </Button>
+          )}
         </div>
       </header>
 
       <main className={styles.main}>
         <div className={`${styles.chatContainer} ${telemetryOpen ? styles.chatContainerOpen : ''}`}>
-          {activeView === 'promo' && featureFlags.campaignPlanner ? (
+          {capabilities.alternateViews && activeView === 'promo' && featureFlags.campaignPlanner ? (
             <div style={{ overflow: 'auto', height: '100%' }}>
               <PromoTaskModule />
             </div>
@@ -569,7 +588,7 @@ export function Dashboard() {
             <div style={{ overflow: 'auto', height: '100%' }}>
               <AdaptiveCardPanel />
             </div>
-          ) : activeView === 'observability' && featureFlags.observability ? (
+          ) : capabilities.observability && activeView === 'observability' && featureFlags.observability ? (
             <div style={{ overflow: 'auto', height: '100%' }}>
               <ObservabilityPanel />
             </div>
@@ -626,6 +645,7 @@ export function Dashboard() {
           )}
         </div>
 
+        {capabilities.telemetryPanel && (
         <Drawer
           id="telemetry-drawer"
           type="overlay"
@@ -680,9 +700,11 @@ export function Dashboard() {
                 <ApprovalHistory approvals={approvalHistory} />
               </CollapsibleSection>
             )}
-            <CollapsibleSection title="Memory">
-              <MemoryPanel refreshKey={memoryRefreshKey} />
-            </CollapsibleSection>
+            {capabilities.memory && (
+              <CollapsibleSection title="Memory">
+                <MemoryPanel refreshKey={memoryRefreshKey} />
+              </CollapsibleSection>
+            )}
             {traces.length > 0 && (
               <CollapsibleSection title="Trace Dashboard">
                 <TraceDashboard traces={traces} />
@@ -699,6 +721,7 @@ export function Dashboard() {
             </CollapsibleSection>
           </DrawerBody>
         </Drawer>
+        )}
       </main>
     </div>
   );

--- a/src/RetailPulse.Web/src/main.tsx
+++ b/src/RetailPulse.Web/src/main.tsx
@@ -3,16 +3,35 @@ import { createRoot } from 'react-dom/client'
 import { MsalProvider } from '@azure/msal-react'
 import './index.css'
 import App from './App.tsx'
-import { authConfig } from './auth/authConfig'
 import { getMsalInstance, initializeMsal } from './auth/msalInstance'
 import { installAuthorizedFetch } from './auth/authorizedFetch'
+import { activeAuthMode, getActiveProvider, requiresGate } from './auth/activeProvider'
 
+/**
+ * Provider-neutral bootstrap. The active provider is fixed at build time by `VITE_AUTH_MODE`
+ * (see auth/authMode). Exactly one provider path runs:
+ *   • local-dev pass-through (Entra unconfigured) → render straight to the app (synthetic dev auth),
+ *   • Entra                                       → unchanged MSAL lifecycle inside MsalProvider,
+ *   • GitHub / Anonymous                          → provider.initialize() (e.g. the GitHub code
+ *     exchange, which uses native fetch) runs BEFORE installAuthorizedFetch() so the exchange is
+ *     never intercepted, then the app renders without MSAL.
+ */
 async function bootstrap() {
   const root = createRoot(document.getElementById('root')!)
 
-  if (authConfig.isConfigured) {
-    // Production: complete any redirect sign-in, then centrally attach the bearer token to
-    // every API/hub fetch before the app makes its first protected call.
+  // Local-dev pass-through: no gate, no MSAL, no fetch wrapper.
+  if (!requiresGate) {
+    root.render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    )
+    return
+  }
+
+  if (activeAuthMode === 'entra') {
+    // Live production Entra path — complete any redirect sign-in, then centrally attach the bearer
+    // token to every API/hub fetch before the app makes its first protected call.
     await initializeMsal()
     installAuthorizedFetch()
 
@@ -26,7 +45,11 @@ async function bootstrap() {
     return
   }
 
-  // Local dev: no Entra config — render straight to the app (API uses synthetic dev auth).
+  // GitHub / Anonymous: run the provider's one-time bootstrap (GitHub code redemption happens here
+  // with native fetch) BEFORE installing the fetch wrapper, then render without MSAL.
+  await getActiveProvider().initialize()
+  installAuthorizedFetch()
+
   root.render(
     <StrictMode>
       <App />

--- a/src/RetailPulse.Web/src/main.tsx
+++ b/src/RetailPulse.Web/src/main.tsx
@@ -1,11 +1,13 @@
 import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
+import { createRoot, type Root } from 'react-dom/client'
 import { MsalProvider } from '@azure/msal-react'
 import './index.css'
 import App from './App.tsx'
 import { getMsalInstance, initializeMsal } from './auth/msalInstance'
 import { installAuthorizedFetch } from './auth/authorizedFetch'
 import { activeAuthMode, getActiveProvider, requiresGate } from './auth/activeProvider'
+import { assertEntraConfigured } from './auth/authConfig'
+import { ConfigErrorScreen } from './auth/ConfigErrorScreen'
 
 /**
  * Provider-neutral bootstrap. The active provider is fixed at build time by `VITE_AUTH_MODE`
@@ -15,10 +17,29 @@ import { activeAuthMode, getActiveProvider, requiresGate } from './auth/activePr
  *   • GitHub / Anonymous                          → provider.initialize() (e.g. the GitHub code
  *     exchange, which uses native fetch) runs BEFORE installAuthorizedFetch() so the exchange is
  *     never intercepted, then the app renders without MSAL.
+ *
+ * The whole sequence is wrapped in a fail-closed guard: if bootstrap throws (e.g. an explicit Entra
+ * build whose tenant/client configuration is missing or a placeholder), we render a safe, branded
+ * configuration-error screen that makes NO API/hub calls instead of the dashboard.
  */
 async function bootstrap() {
   const root = createRoot(document.getElementById('root')!)
 
+  try {
+    await bootstrapAuthenticated(root)
+  } catch (error) {
+    // Never expose a protected surface on a bootstrap failure; show a safe, branded error screen.
+    // eslint-disable-next-line no-console
+    console.error('Retail Pulse bootstrap failed:', error)
+    root.render(
+      <StrictMode>
+        <ConfigErrorScreen />
+      </StrictMode>,
+    )
+  }
+}
+
+async function bootstrapAuthenticated(root: Root) {
   // Local-dev pass-through: no gate, no MSAL, no fetch wrapper.
   if (!requiresGate) {
     root.render(
@@ -30,8 +51,12 @@ async function bootstrap() {
   }
 
   if (activeAuthMode === 'entra') {
-    // Live production Entra path — complete any redirect sign-in, then centrally attach the bearer
-    // token to every API/hub fetch before the app makes its first protected call.
+    // Live production Entra path. FAIL CLOSED FIRST: a missing/placeholder/invalid tenant or client id
+    // throws here — before any MSAL init or App render, and before any API/hub call is ever made.
+    assertEntraConfigured()
+
+    // Complete any redirect sign-in, then centrally attach the bearer token to every API/hub fetch
+    // before the app makes its first protected call.
     await initializeMsal()
     installAuthorizedFetch()
 

--- a/src/RetailPulse.Web/src/vite-env.d.ts
+++ b/src/RetailPulse.Web/src/vite-env.d.ts
@@ -2,6 +2,13 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_ORIGIN?: string;
+  // ── Authentication mode (provider-neutral, build-time) ─────────────────────
+  // Selects the single sign-in provider the SPA renders: `Entra` | `GitHub` | `Anonymous`
+  // (case-insensitive). Injected by infra/main.bicep → azd env → Vite build, and MUST match the
+  // backend's `Authentication__Mode` for the same deployment (a deployment contract test proves it).
+  // Missing/unknown fails the build/runtime visibly outside explicit local dev — never silently
+  // anonymous. Live/production is always `Entra`.
+  readonly VITE_AUTH_MODE?: string;
   // ── Microsoft Entra SPA auth (single-tenant, PKCE, no secret) ──────────────
   // Build-time configuration (NOT secrets). Injected by infra/main.bicep → azd env
   // → Vite build. Blank locally so the dev build uses the API's synthetic dev auth.

--- a/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
@@ -184,6 +184,81 @@ public sealed class ProviderNeutralDeploymentContractTests
             "the example must document signing-key rotation via additional validation keys");
     }
 
+    [Fact]
+    public void InfraBicep_PinsFrontendAuthModeToEntra()
+    {
+        // The SPA build reads VITE_AUTH_MODE from the azd env (an infra output). The live
+        // deployment must emit it pinned to Entra so the frontend renders ONLY the Microsoft
+        // sign-in UX — matching the API's Entra Authentication__Mode (proven above/below).
+        string bicep = File.ReadAllText(Path.Combine(RepoRoot, "infra", "main.bicep"));
+
+        bicep.Should().MatchRegex(
+            "output\\s+VITE_AUTH_MODE\\s+string\\s*=\\s*'Entra'",
+            "infra/main.bicep must emit VITE_AUTH_MODE pinned to Entra for the live SPA build");
+        bicep.Should().NotMatchRegex(
+            "output\\s+VITE_AUTH_MODE\\s+string\\s*=\\s*'(GitHub|Anonymous)'",
+            "the live SPA build must never be pinned to GitHub or Anonymous");
+    }
+
+    [Fact]
+    public void DeploymentContract_FrontendAndApiAuthModesAreInParity()
+    {
+        // End-to-end parity for the LIVE path: the frontend VITE_AUTH_MODE (infra output) and the
+        // API Authentication__Mode (both postprovision hooks + committed Production settings) must
+        // all resolve to the SAME provider — Entra. This is the single guardrail that proves the
+        // two halves of a deployment can never diverge into a mixed/misconfigured provider state.
+        string bicep = File.ReadAllText(Path.Combine(RepoRoot, "infra", "main.bicep"));
+        string ps1 = File.ReadAllText(Path.Combine(RepoRoot, "azd-hooks", "postprovision.ps1"));
+        string sh = File.ReadAllText(Path.Combine(RepoRoot, "azd-hooks", "postprovision.sh"));
+        string prod = File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "RetailPulse.Api", "appsettings.Production.json"));
+
+        const string frontendMode = "Entra";
+
+        bicep.Should().MatchRegex(
+            "output\\s+VITE_AUTH_MODE\\s+string\\s*=\\s*'" + frontendMode + "'",
+            "frontend VITE_AUTH_MODE must be " + frontendMode);
+        ps1.Should().Contain($"Authentication__Mode={frontendMode}",
+            "the pwsh hook API mode must match the frontend mode");
+        sh.Should().Contain($"Authentication__Mode={frontendMode}",
+            "the sh hook API mode must match the frontend mode");
+        prod.Should().MatchRegex(
+            "\"Authentication\"\\s*:\\s*\\{[^}]*\"Mode\"\\s*:\\s*\"" + frontendMode + "\"",
+            "the committed Production API mode must match the frontend mode");
+    }
+
+    [Theory]
+    [InlineData(".env.example")]
+    [InlineData(".env.github.example")]
+    [InlineData(".env.anonymous.example")]
+    public void WebEnvTemplates_DocumentAuthMode(string envFile)
+    {
+        // Every committed web env template must document VITE_AUTH_MODE so an operator building a
+        // non-default (GitHub/Anonymous) deployment has a safe, secret-free starting point and the
+        // fail-closed contract is discoverable. These are templates only — never auto-loaded.
+        string path = Path.Combine(RepoRoot, "src", "RetailPulse.Web", envFile);
+
+        File.Exists(path).Should().BeTrue($"{envFile} template should be committed");
+        File.ReadAllText(path).Should().Contain("VITE_AUTH_MODE",
+            $"{envFile} must document the VITE_AUTH_MODE build-time selector");
+    }
+
+    [Theory]
+    [InlineData(".env.github.example")]
+    [InlineData(".env.anonymous.example")]
+    public void WebModeTemplates_CarryNoSecrets(string envFile)
+    {
+        // The non-production SPA templates are build-time CONFIG only. They must never carry a
+        // provider secret or signing key — those live on the backend, never in the browser bundle.
+        string content = File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "RetailPulse.Web", envFile));
+
+        content.Should().NotContain("ClientSecret",
+            $"{envFile} must never carry a client secret");
+        content.Should().NotContain("SigningKey",
+            $"{envFile} must never carry a signing key");
+    }
+
     private static string FindRepoRoot()
     {
         DirectoryInfo? dir = new(AppContext.BaseDirectory);

--- a/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs
@@ -259,6 +259,74 @@ public sealed class ProviderNeutralDeploymentContractTests
             $"{envFile} must never carry a signing key");
     }
 
+    [Theory]
+    [InlineData("preprovision.ps1")]
+    [InlineData("preprovision.sh")]
+    public void PreprovisionHook_FailsClosedWhenEntraIdsMissing(string hookFile)
+    {
+        // The live default auth mode is Entra. The preprovision hook must fail the whole provision
+        // BEFORE any resource is created when the Entra tenant/client IDs are empty/placeholders, so a
+        // deployment can never silently ship an unauthenticated shell.
+        string script = File.ReadAllText(Path.Combine(RepoRoot, "azd-hooks", hookFile));
+
+        script.Should().Contain("RETAIL_PULSE_ENTRA_TENANT_ID",
+            $"{hookFile} must validate the Entra tenant id before provisioning");
+        script.Should().Contain("RETAIL_PULSE_ENTRA_CLIENT_ID",
+            $"{hookFile} must validate the Entra client id before provisioning");
+        script.Should().Contain("RETAIL_PULSE_AUTH_MODE",
+            $"{hookFile} must read the auth mode so non-Entra deployments can skip the Entra-specific check");
+        // The hook must actually abort (throw/exit) on the misconfiguration, not merely warn.
+        script.Should().MatchRegex(hookFile.EndsWith(".ps1") ? "throw " : "exit 1",
+            $"{hookFile} must abort provisioning when Entra IDs are missing");
+    }
+
+    [Theory]
+    [InlineData("preprovision.ps1")]
+    [InlineData("preprovision.sh")]
+    public void PreprovisionHook_DefaultsAuthModeToEntra(string hookFile)
+    {
+        // When RETAIL_PULSE_AUTH_MODE is unset the hook must treat the deployment as Entra (the live
+        // default), so an operator cannot bypass the Entra ID check simply by not setting the mode.
+        string script = File.ReadAllText(Path.Combine(RepoRoot, "azd-hooks", hookFile));
+
+        script.Should().Contain("Entra",
+            $"{hookFile} must default the auth mode to Entra when RETAIL_PULSE_AUTH_MODE is unset");
+    }
+
+    [Fact]
+    public void WebPackage_WiresPrebuildAuthConfigValidator()
+    {
+        // A frontend-only deploy (e.g. Static Web Apps) builds without azd outputs. The npm `prebuild`
+        // guard must run the validator so `npm run build` fails fast on an Entra build with empty config.
+        string pkg = File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "RetailPulse.Web", "package.json"));
+
+        pkg.Should().MatchRegex(
+            "\"prebuild\"\\s*:\\s*\"[^\"]*validate-auth-config\\.mjs[^\"]*\"",
+            "package.json must wire a prebuild step that runs the auth-config validator");
+
+        File.Exists(Path.Combine(RepoRoot, "src", "RetailPulse.Web", "scripts", "validate-auth-config.mjs"))
+            .Should().BeTrue("the auth-config validator script must be committed");
+    }
+
+    [Fact]
+    public void WebAuthConfigValidator_FailsClosedForEntra_ButPassesWhenModeUnset()
+    {
+        // Static guardrails on the validator's contract so it stays green for CI's plain `npm run build`
+        // (no VITE_AUTH_MODE) yet fails an explicit Entra build with empty ids.
+        string script = File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "RetailPulse.Web", "scripts", "validate-auth-config.mjs"));
+
+        script.Should().Contain("VITE_AUTH_MODE",
+            "the validator must key off the build-time auth-mode selector");
+        script.Should().Contain("VITE_ENTRA_TENANT_ID",
+            "the validator must require the Entra tenant id for an Entra build");
+        script.Should().Contain("VITE_ENTRA_CLIENT_ID",
+            "the validator must require the Entra client id for an Entra build");
+        script.Should().Contain("process.exit(1)",
+            "the validator CLI must fail the build (non-zero exit) on invalid config");
+    }
+
     private static string FindRepoRoot()
     {
         DirectoryInfo? dir = new(AppContext.BaseDirectory);

--- a/tests/RetailPulse.Tests/Security/GitHubAuthenticationTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubAuthenticationTests.cs
@@ -199,9 +199,9 @@ public sealed class GitHubAuthenticationTests
     public async Task Callback_ThenExchange_ReturnsUsableSessionToken_NotProviderToken()
     {
         using TestFixture fx = CreateServer();
-        string redemption = await LoginToRedemption(fx);
+        (string redemption, string cookie) = await LoginToRedemption(fx);
 
-        HttpResponseMessage resp = await Exchange(fx, redemption);
+        HttpResponseMessage resp = await Exchange(fx, redemption, cookie);
 
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
         string raw = await resp.Content.ReadAsStringAsync();
@@ -377,10 +377,10 @@ public sealed class GitHubAuthenticationTests
     public async Task Exchange_ReplayedCode_IsRejectedSecondTime()
     {
         using TestFixture fx = CreateServer();
-        string redemption = await LoginToRedemption(fx);
+        (string redemption, string cookie) = await LoginToRedemption(fx);
 
-        (await Exchange(fx, redemption)).StatusCode.Should().Be(HttpStatusCode.OK);
-        (await Exchange(fx, redemption)).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await Exchange(fx, redemption, cookie)).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await Exchange(fx, redemption, cookie)).StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
@@ -397,25 +397,157 @@ public sealed class GitHubAuthenticationTests
     public async Task Exchange_ExpiredCode_IsRejected()
     {
         using TestFixture fx = CreateServer(redemptionTtlSeconds: 30);
-        string redemption = await LoginToRedemption(fx);
+        (string redemption, string cookie) = await LoginToRedemption(fx);
 
         fx.Clock.Advance(TimeSpan.FromSeconds(31));
 
-        (await Exchange(fx, redemption)).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await Exchange(fx, redemption, cookie)).StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
     public async Task Exchange_ConcurrentRace_YieldsExactlyOneSuccess()
     {
         using TestFixture fx = CreateServer();
-        string redemption = await LoginToRedemption(fx);
+        (string redemption, string cookie) = await LoginToRedemption(fx);
 
         Task<HttpResponseMessage>[] attempts =
-            [.. Enumerable.Range(0, 8).Select(_ => Exchange(fx, redemption))];
+            [.. Enumerable.Range(0, 8).Select(_ => Exchange(fx, redemption, cookie))];
         HttpResponseMessage[] results = await Task.WhenAll(attempts);
 
         results.Count(r => r.StatusCode == HttpStatusCode.OK).Should().Be(1,
             "atomic one-time redemption admits exactly one exchange");
+    }
+
+    // ── redemption code ↔ browser binding threats (Blocker 1) ────────────────
+    //
+    // The one-time redemption code returned in the callback redirect is bound to the SAME browser that
+    // completed the callback via a per-code __Host- cookie carrying a random secret (only its hash is
+    // stored server-side). A stolen but unused code replayed from another browser — which never received
+    // that cookie — can never be redeemed.
+
+    [Fact]
+    public async Task Exchange_CorrectBrowserCookie_Succeeds()
+    {
+        using TestFixture fx = CreateServer();
+        (string redemption, string cookie) = await LoginToRedemption(fx);
+
+        HttpResponseMessage resp = await Exchange(fx, redemption, cookie);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK, "the code is redeemed from the browser that owns its cookie");
+    }
+
+    [Fact]
+    public async Task Exchange_StolenCodeFromDifferentBrowser_Fails_AndDoesNotBurnVictimCode()
+    {
+        using TestFixture fx = CreateServer();
+
+        // The victim completes login in their browser: they receive the code AND its redemption cookie.
+        (string redemption, string victimCookie) = await LoginToRedemption(fx);
+
+        // The attacker exfiltrates ONLY the code (e.g. from a leaked redirect URL / logs) and replays it
+        // from a DIFFERENT browser that has no redemption cookie. It must be rejected...
+        HttpResponseMessage stolen = await Exchange(fx, redemption, cookie: null);
+        stolen.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "a code replayed from a browser without the per-code cookie must fail");
+
+        // ...and critically the victim's code must NOT have been consumed by the attacker's attempt, so
+        // the legitimate browser can still complete its own exchange.
+        HttpResponseMessage victim = await Exchange(fx, redemption, victimCookie);
+        victim.StatusCode.Should().Be(HttpStatusCode.OK,
+            "an attacker without the cookie cannot burn the victim's still-valid code");
+    }
+
+    [Fact]
+    public async Task Exchange_MissingRedemptionCookie_IsRejected()
+    {
+        using TestFixture fx = CreateServer();
+        (string redemption, _) = await LoginToRedemption(fx);
+
+        HttpResponseMessage resp = await Exchange(fx, redemption, cookie: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest, "the per-code redemption cookie is required");
+    }
+
+    [Fact]
+    public async Task Exchange_WrongRedemptionCookieValue_IsRejected()
+    {
+        using TestFixture fx = CreateServer();
+        (string redemption, string cookie) = await LoginToRedemption(fx);
+
+        // Same cookie NAME (derivable from the known code) but a forged secret VALUE.
+        string cookieName = cookie.Split('=')[0];
+        string forged = cookieName + "=forged-cookie-secret-value-that-will-not-match-hash";
+
+        HttpResponseMessage resp = await Exchange(fx, redemption, forged);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "a forged cookie secret fails the constant-time hash comparison");
+    }
+
+    [Fact]
+    public async Task Exchange_ReplayedCookieAfterSuccess_IsRejected()
+    {
+        using TestFixture fx = CreateServer();
+        (string redemption, string cookie) = await LoginToRedemption(fx);
+
+        (await Exchange(fx, redemption, cookie)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Replaying the exact same code + cookie a second time must fail: the code is consumed atomically.
+        (await Exchange(fx, redemption, cookie)).StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "a replayed code+cookie pair cannot be redeemed twice");
+    }
+
+    [Fact]
+    public async Task Callback_SetsHostPrefixedSecureRedemptionCookie()
+    {
+        using TestFixture fx = CreateServer();
+        (string state, string cookie) = await BeginLogin(fx);
+
+        HttpResponseMessage resp = await Callback(fx, state, cookie, code: "gh-auth-code");
+
+        resp.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies).Should().BeTrue();
+        string redeem = cookies!.Single(c => c.Contains("rp_gh_redeem"));
+        redeem.Should().StartWith("__Host-", "the redemption cookie must carry the __Host- prefix in hosted mode");
+        redeem.Should().Contain("secure", "the redemption cookie must be Secure");
+        redeem.Should().Contain("httponly", "the redemption cookie must be HttpOnly");
+        redeem.Should().Contain("path=/", "the __Host- prefix requires Path=/");
+        redeem.Should().NotContain("domain=", "the __Host- prefix forbids a Domain attribute");
+        redeem.Should().Match(c => c.Contains("samesite=lax", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ParallelLogins_EachRedeemsWithOwnCookie()
+    {
+        using TestFixture fx = CreateServer();
+
+        (string codeA, string cookieA) = await LoginToRedemption(fx);
+        (string codeB, string cookieB) = await LoginToRedemption(fx);
+
+        codeA.Should().NotBe(codeB);
+        cookieA.Split('=')[0].Should().NotBe(cookieB.Split('=')[0], "each login gets its own per-code cookie name");
+
+        // Crossing the cookies fails: the exchange derives the cookie NAME from the code, so codeA never
+        // sees cookieB (different name) and is rejected without being consumed.
+        (await Exchange(fx, codeA, cookieB)).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await Exchange(fx, codeB, cookieA)).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // Both codes are still valid and each redeems cleanly with ITS OWN cookie — parallel logins are
+        // fully independent.
+        (await Exchange(fx, codeA, cookieA)).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await Exchange(fx, codeB, cookieB)).StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Exchange_CodeNeverAppearsAsTokenOrInLogs()
+    {
+        using TestFixture fx = CreateServer();
+        (string redemption, string cookie) = await LoginToRedemption(fx);
+
+        HttpResponseMessage resp = await Exchange(fx, redemption, cookie);
+        string body = await resp.Content.ReadAsStringAsync();
+
+        body.Should().NotContain(redemption, "the redemption code must never be echoed back as/with the session token");
+        fx.LogSink.Messages.Should().NotContain(m => m.Contains(redemption), "the redemption code must never be logged");
     }
 
     // ── session token validation threats ─────────────────────────────────────
@@ -582,20 +714,36 @@ public sealed class GitHubAuthenticationTests
         return await fx.Client.SendAsync(req);
     }
 
-    private async Task<string> LoginToRedemption(TestFixture fx)
+    private async Task<(string Code, string Cookie)> LoginToRedemption(TestFixture fx)
     {
         (string state, string cookie) = await BeginLogin(fx);
         HttpResponseMessage resp = await Callback(fx, state, cookie, code: "gh-auth-code");
         resp.StatusCode.Should().Be(HttpStatusCode.Redirect);
-        return System.Web.HttpUtility.ParseQueryString(resp.Headers.Location!.Query)["code"]!;
+        string code = System.Web.HttpUtility.ParseQueryString(resp.Headers.Location!.Query)["code"]!;
+        string redemptionCookie = RedemptionCookieFrom(resp);
+        return (code, redemptionCookie);
     }
 
-    private static async Task<HttpResponseMessage> Exchange(TestFixture fx, string code)
+    // The per-code browser-bound redemption cookie set by the callback (name=value), used by the exchange.
+    private static string RedemptionCookieFrom(HttpResponseMessage resp)
+    {
+        resp.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies).Should().BeTrue(
+            "the callback must set the per-code redemption cookie");
+        string setCookie = cookies!.First(c => c.Contains("rp_gh_redeem"));
+        return setCookie.Split(';')[0]; // name=value
+    }
+
+    private static async Task<HttpResponseMessage> Exchange(TestFixture fx, string code, string? cookie = null)
     {
         var req = new HttpRequestMessage(HttpMethod.Post, GitHubAuthConstants.ExchangeRoute)
         {
             Content = new StringContent(JsonSerializer.Serialize(new { code }), Encoding.UTF8, "application/json"),
         };
+        if (cookie is not null)
+        {
+            req.Headers.Add("Cookie", cookie);
+        }
+
         return await fx.Client.SendAsync(req);
     }
 

--- a/tests/RetailPulse.Tests/Security/GitHubOneTimeStoreTests.cs
+++ b/tests/RetailPulse.Tests/Security/GitHubOneTimeStoreTests.cs
@@ -28,7 +28,7 @@ public sealed class GitHubOneTimeStoreTests
     {
         var clock = new TestClock();
         var store = new OneTimeTtlStore<GitHubRedemptionEntry>(static e => e.ExpiresAtTicks, timeProvider: clock);
-        var entry = new GitHubRedemptionEntry(new GitHubVerifiedUser(1, "octocat"), Ttl(clock, 120));
+        var entry = new GitHubRedemptionEntry(new GitHubVerifiedUser(1, "octocat"), [0x01], Ttl(clock, 120));
 
         store.TryStore("code-1", entry).Should().BeTrue();
 
@@ -65,7 +65,7 @@ public sealed class GitHubOneTimeStoreTests
     {
         var clock = new TestClock();
         var store = new OneTimeTtlStore<GitHubRedemptionEntry>(static e => e.ExpiresAtTicks, timeProvider: clock);
-        store.TryStore("race", new GitHubRedemptionEntry(new GitHubVerifiedUser(7, "u"), Ttl(clock, 300)));
+        store.TryStore("race", new GitHubRedemptionEntry(new GitHubVerifiedUser(7, "u"), [0x01], Ttl(clock, 300)));
 
         var winners = new ConcurrentBag<bool>();
         using var start = new Barrier(32);


### PR DESCRIPTION
## Sprint 3 — Provider-neutral frontend sign-in UX & deployment templates

Working as **Chick (Frontend Dev)**. Child of epic #27. **Closes #38.**

⚠️ **needs review** — implementation only. Production stays **Entra**; nothing is deployed and **no GitHub OAuth app/secret was created**. Do not merge/deploy (Sprint 4 owns full review + live Entra-only deploy).

### What changed
Generalized the SPA sign-in from Entra-only (MSAL) into a **build-time, provider-neutral** frontend selected by `VITE_AUTH_MODE` (`Entra`/`GitHub`/`Anonymous`), with mode-specific UX, centralized token/capability handling, deployment mode-parity, tests, and docs — **without regressing the live Entra path**.

**Architecture:** `VITE_AUTH_MODE` → `auth/authMode.ts` (pure, fail-closed) → `auth/activeProvider.ts` selects one `SessionProvider` + capabilities → `AuthGate` dispatches to `gates/{Entra,GitHub,Anonymous}AuthGate`; a single `tokenService`/`authorizedFetch` feeds both global REST and SignalR (no provider logic in components).

- **Fail-closed resolution.** Missing mode → `Entra` only when safe (existing Entra config or explicit local-dev pass-through); unknown/numeric/prod-missing **throws at load** — never a silent anonymous default. Single-mode deployment renders exactly one provider (no chooser).
- **Entra unchanged.** MSAL button/redirect/role-denied UX is byte-for-byte the live experience; `sessionStorage` stays MSAL-owned.
- **GitHub UX.** "Continue with GitHub" → top-level nav to fixed same-origin `GET /api/auth/github/start` (no return URL) → one-time redemption code stripped via `history.replaceState` → `POST /api/auth/github/exchange` → session token stored session-only. **Provider token never in the browser** (confidential BFF). Denial/expired/replayed/unallowlisted/provider errors handled with safe messages + retry.
- **Anonymous UX.** Explicit "Continue in limited demo" consent (billable, rate-limited, read-only chat, no telemetry/streaming/memory/admin/export, sessions expire) → `POST /api/auth/anonymous/session`; capability object hides Observability/Approvals/Memory/telemetry/export/write/alt views and disables SignalR; limitation/expiry banner + New/clear session action.
- **Token lifecycle.** GitHub/Anonymous session tokens are memory + `sessionStorage` only (never localStorage/cookies/cross-tab), cleared on logout/expiry/401/403. `authorizedFetch` attaches the token only to `/api` on an **exact-origin** match. SignalR starts only when capabilities permit and a token exists.

### Deployment (mode parity)
`infra/main.bicep` now emits `output VITE_AUTH_MODE = 'Entra'`; azd hooks stay pinned to `Authentication__Mode=Entra`; secret-free `.env.github.example` / `.env.anonymous.example` templates added. A contract test asserts `VITE_AUTH_MODE == Authentication__Mode` and that live artifacts never emit GitHub/Anonymous. **Any future auth-mode change must update both the Bicep output and the API mode together.**

### Verification
- **vitest: 421 passed (50 files)** — up from 371 baseline, zero regressions (7 new/updated test files covering mode resolver, gate labels/dispatch, Entra-unchanged, GitHub start/callback/exchange/history-cleanup/replay/error/logout/401-403, Anonymous consent/bootstrap/limited-nav/no-hub/expiry, token storage/clear, exact-origin fetch, capability gating).
- Production build green (`tsc -b && vite build`, `VITE_AUTH_MODE=Entra`).
- Backend deployment contract tests: **21 passed** (5 new).
- `az bicep build`/`format` clean. Lint unchanged (16 pre-existing errors, none in new files).

### Docs
ADR-005 addendum, `authentication-matrix.md`, `security.md`, `FRONTEND.md`, `deployment-azd.md`, `README.md`.

### Limitations
GitHub/Anonymous are implemented and tested but **not deployed** (no OAuth app/secret); live stays Entra. Hosted GitHub remains `maxReplicas=1`; hosted Anonymous needs the two-key opt-in (both backend concerns, unchanged). Related epic #27.
