### PR TITLE
Preserve chat conversation across dashboard navigation (#46)

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -91,6 +91,8 @@ a broadly-readable cookie, never cross-tab. Cleared on logout, expiry, and 401/4
 
 The header bar contains toggle buttons that switch the main content area between the chat and specialized dashboards. Click a tab to open it; click again (or "Back to Chat") to return.
 
+**Chat persistence across navigation.** Switching to any tab (Observability, Competitive, etc.) or opening the Approvals overlay does **not** discard the conversation. A single `ChatPanel` instance stays mounted for the lifetime of the Dashboard; when a tab is active the chat host is hidden with `display:none` + `inert` + `aria-hidden` (removed from the tab order and the screen-reader tree) but its React state — messages, charts, session id/history, scroll position, and any in-flight request — is preserved. Returning to Chat restores the exact conversation with no refetch or replay, and a response that resolves while you are on another tab is waiting for you when you come back. **"New Chat" is the only intentional reset** — it remounts the panel (via a `chatKey` bump), clearing all messages/charts and starting a fresh session with the welcome prompts.
+
 | Tab | Icon | What It Shows |
 |-----|------|---------------|
 | Approvals | Badge | Pending human-in-the-loop approvals for promotions and campaigns |
@@ -196,6 +198,7 @@ The top-level app shell. Manages the `activeView` state (`'chat' | 'promo' | 'co
 - **State:** `telemetryOpen`, `activeView`, `connected`, `liveSpans`, `totalDurationMs`, `totalTokenUsage`, `routingHistory`, `pendingApprovals`, `approvalHistory`, `alerts`, `traces`, `selectedBrand`, `explanationOpen`, `explanationData`
 - **Services:** `connectTelemetryHub()` from `telemetryHub.ts`
 - **Renders:** `ChatPanel`, `TelemetryPanel`, `AgentRoutingPanel`, `MemoryPanel`, `ApprovalHistory`, `PendingApprovals`, plus all feature views
+- **Persistent chat host:** `ChatPanel` is rendered once inside a wrapper (`data-testid="chat-host"`) that is hidden with `display:none` + `inert` + `aria-hidden` whenever `activeView !== 'chat'` (or an alternate view is otherwise active), instead of being unmounted. This keeps the conversation, session id, charts, and pending requests alive across navigation. Only `handleNewChat` (the "New Chat" button) resets it, by incrementing `chatKey` to force a remount.
 
 #### `ErrorBoundary`
 React error boundary that catches render errors and shows a fallback UI with a retry button.

--- a/src/RetailPulse.Web/src/__tests__/DashboardChatPersistence.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/DashboardChatPersistence.test.tsx
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, act, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+import type { ProviderCapabilities } from '../auth/session/types';
+import { FULL_CAPABILITIES } from '../auth/session/types';
+import type { ApprovalRequest } from '../types';
+
+/**
+ * Regression suite for issue #46 — navigating to Observability (or opening the
+ * Approvals overlay) must NOT clear the current conversation. Only "New Chat"
+ * resets it.
+ *
+ * This exercises the REAL Dashboard + REAL ChatPanel together (the persistence
+ * contract lives in how Dashboard hosts ChatPanel). The alternate destination
+ * views and the telemetry-drawer panels are stubbed so the test isolates the
+ * mount/visibility behaviour, not the destination screens.
+ */
+
+// --- Service mocks ---------------------------------------------------------
+const sendMessageMock = vi.fn();
+const isErrorReplyMock = vi.fn((reply: string) => reply.startsWith('⏳'));
+vi.mock('../services/api', () => ({
+  sendMessage: (...args: unknown[]) => sendMessageMock(...args),
+  isErrorReply: (reply: string) => isErrorReplyMock(reply),
+}));
+
+// SignalR hub: Dashboard subscribes via connectTelemetryHub; ChatPanel joins a
+// session group via joinTelemetrySession and subscribes to progress. We capture
+// the hub event handlers so a test can push an `approval_requested` event, and
+// we count joinTelemetrySession calls to PROVE the ChatPanel is not remounted on
+// navigation (one join per real session).
+const hubHandlers: Record<string, (arg: unknown) => void> = {};
+const connectTelemetryHubMock = vi.fn<(...args: unknown[]) => {
+  on: (evt: string, cb: (arg: unknown) => void) => void;
+  off: (evt: string) => void;
+}>(() => ({
+  on: (evt: string, cb: (arg: unknown) => void) => { hubHandlers[evt] = cb; },
+  off: (evt: string) => { delete hubHandlers[evt]; },
+}));
+const joinTelemetrySessionMock = vi.fn<(...args: unknown[]) => Promise<void>>(() => Promise.resolve());
+vi.mock('../services/telemetryHub', () => ({
+  connectTelemetryHub: (...args: unknown[]) => connectTelemetryHubMock(...args),
+  joinTelemetrySession: (...args: unknown[]) => joinTelemetrySessionMock(...args),
+  onProgress: vi.fn(() => () => {}),
+}));
+
+// ChartRenderer is lazy-loaded inside ChatPanel; mock so Suspense resolves
+// synchronously and the presence of a chart is observable via a test id.
+vi.mock('../components/ChartRenderer', () => ({
+  default: () => <div data-testid="chart-renderer-mock" />,
+}));
+
+// Full (Entra) capabilities so Observability, Approvals, telemetry, and the hub
+// are all enabled.
+const mockCaps: { value: ProviderCapabilities; mode: 'entra' | 'github' | 'anonymous' } = {
+  value: FULL_CAPABILITIES,
+  mode: 'entra',
+};
+vi.mock('../auth/activeProvider', () => ({
+  get capabilities() { return mockCaps.value; },
+  get activeAuthMode() { return mockCaps.mode; },
+  getActiveProvider: () => ({ msUntilExpiry: () => 120000, endSession: vi.fn(), newSession: vi.fn() }),
+}));
+
+// Only Observability is flagged on, so the sole alternate-view toggle button is
+// Observability — its active label ("Back to Chat") is therefore unambiguous.
+vi.mock('../config/featureFlags', () => ({
+  featureFlags: {
+    campaignPlanner: false,
+    competitive: false,
+    knowledgeBase: false,
+    healthCouncil: false,
+    security: false,
+    cards: false,
+    stores: false,
+    financials: false,
+    portfolio: false,
+    observability: true,
+  },
+}));
+
+// Stub heavy destination views + drawer-only panels. ChatPanel, PendingApprovals,
+// and ApprovalCard are deliberately left REAL.
+function stub(testid: string) {
+  return () => <div data-testid={testid} />;
+}
+vi.mock('../components/TelemetryPanel', () => ({ TelemetryPanel: stub('telemetry-panel') }));
+vi.mock('../components/AgentRoutingPanel', () => ({ AgentRoutingPanel: stub('agent-routing') }));
+vi.mock('../components/MemoryPanel', () => ({ MemoryPanel: stub('memory-panel') }));
+vi.mock('../components/CollapsibleSection', () => ({
+  CollapsibleSection: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../components/ApprovalHistory', () => ({ ApprovalHistory: stub('approval-history') }));
+vi.mock('../components/BrandLogo', () => ({ BrandLogo: stub('brand-logo') }));
+vi.mock('../components/alerts', () => ({
+  AlertFeed: stub('alert-feed'),
+  AlertHistory: stub('alert-history'),
+}));
+vi.mock('../components/traces', () => ({ TraceDashboard: stub('trace-dashboard') }));
+vi.mock('../components/promo', () => ({ PromoTaskModule: stub('promo') }));
+vi.mock('../components/competitive', () => ({ CompetitiveDashboard: stub('competitive') }));
+vi.mock('../components/knowledge', () => ({ KnowledgeBasePanel: stub('knowledge') }));
+vi.mock('../components/council', () => ({ CouncilPanel: stub('council') }));
+vi.mock('../components/guardrails', () => ({
+  GuardrailsDashboard: stub('guardrails'),
+  GuardrailsConfig: stub('guardrails-config'),
+  BlockedRequestMessage: stub('blocked-request'),
+}));
+vi.mock('../components/cards', () => ({ AdaptiveCardPanel: stub('cards') }));
+vi.mock('../components/observability', () => ({ ObservabilityPanel: stub('observability') }));
+vi.mock('../components/stores', () => ({
+  StoreHeatmap: stub('store-heatmap'),
+  StockoutAlert: stub('stockout'),
+  StorePerformanceTable: stub('store-table'),
+  StoreDetailDialog: stub('store-dialog'),
+}));
+vi.mock('../components/margin', () => ({
+  MarginWaterfall: stub('margin-waterfall'),
+  MarginDrivers: stub('margin-drivers'),
+}));
+vi.mock('../components/scorecard', () => ({
+  PortfolioScorecard: stub('portfolio'),
+  BrandScoreCard: stub('brand-score'),
+  ExplanationPanel: stub('explanation'),
+}));
+
+import { Dashboard } from '../components/Dashboard';
+
+// --- Helpers ---------------------------------------------------------------
+function renderDashboard() {
+  return render(
+    <FluentProvider theme={teamsDarkTheme}>
+      <Dashboard />
+    </FluentProvider>,
+  );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+const CHART_REPLY = {
+  reply: 'Q1 depletion rose 12% across all regions.',
+  sessionId: 'sess-ignored',
+  spans: [],
+  totalDurationMs: 1234,
+  charts: [
+    {
+      type: 'bar',
+      title: 'Q1 Depletion by Region',
+      data: [{ legend: 'Depletion', values: [{ label: 'NE', value: 12 }] }],
+    },
+  ],
+};
+
+async function seedConversation(user: ReturnType<typeof userEvent.setup>, prompt = 'How did Q1 depletion trend?') {
+  const input = screen.getByPlaceholderText(/Ask about retail performance/i);
+  await user.type(input, prompt);
+  await user.click(screen.getByRole('button', { name: /Send message/i }));
+  await screen.findByText(CHART_REPLY.reply);
+  await waitFor(() => expect(screen.getByTestId('chart-renderer-mock')).toBeInTheDocument());
+}
+
+const pendingApproval: ApprovalRequest = {
+  id: 'ap-1',
+  action: 'Send promotional email to 10,000 customers',
+  reasoning: 'Campaign uplift is projected at 8%.',
+  impact: 'External communication to customers.',
+  urgency: 'high',
+  agentId: 'agent-1',
+  agentName: 'Campaign Agent',
+  requestedAt: new Date().toISOString(),
+  timeoutAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  status: 'pending',
+};
+
+beforeEach(() => {
+  mockCaps.value = FULL_CAPABILITIES;
+  mockCaps.mode = 'entra';
+  sendMessageMock.mockReset();
+  sendMessageMock.mockResolvedValue(CHART_REPLY);
+  isErrorReplyMock.mockClear();
+  isErrorReplyMock.mockImplementation((reply: string) => reply.startsWith('⏳'));
+  joinTelemetrySessionMock.mockClear();
+  connectTelemetryHubMock.mockClear();
+  for (const k of Object.keys(hubHandlers)) delete hubHandlers[k];
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+// ---------------------------------------------------------------------------
+describe('Dashboard — chat persists across navigation (issue #46)', () => {
+  it('keeps messages, chart, and session when switching to Observability and back', async () => {
+    const user = userEvent.setup();
+    renderDashboard();
+
+    await seedConversation(user);
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    // Exactly one hub session join → a single, stable session was established.
+    expect(joinTelemetrySessionMock).toHaveBeenCalledTimes(1);
+    const sessionId = joinTelemetrySessionMock.mock.calls[0][0];
+
+    // Navigate to Observability.
+    await user.click(screen.getByRole('button', { name: 'Observability' }));
+    expect(screen.getByTestId('observability')).toBeInTheDocument();
+
+    // Return to Chat.
+    await user.click(screen.getByRole('button', { name: /Back to Chat/i }));
+
+    // Conversation is intact — same DOM nodes, never refetched or rejoined.
+    expect(screen.getByText(CHART_REPLY.reply)).toBeInTheDocument();
+    expect(screen.getByText(/How did Q1 depletion trend\?/i)).toBeInTheDocument();
+    expect(screen.getByTestId('chart-renderer-mock')).toBeInTheDocument();
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(joinTelemetrySessionMock).toHaveBeenCalledTimes(1);
+    expect(joinTelemetrySessionMock.mock.calls[0][0]).toBe(sessionId);
+  });
+
+  it('surfaces a response that resolves while the user is viewing Observability', async () => {
+    const user = userEvent.setup();
+    const pending = deferred<typeof CHART_REPLY>();
+    sendMessageMock.mockImplementationOnce(() => pending.promise);
+
+    renderDashboard();
+
+    const input = screen.getByPlaceholderText(/Ask about retail performance/i);
+    await user.type(input, 'Give me the regional breakdown');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    // Navigate away while the request is still in flight.
+    await user.click(screen.getByRole('button', { name: 'Observability' }));
+    expect(screen.getByTestId('observability')).toBeInTheDocument();
+
+    // The promise resolves while the chat host is hidden but still mounted.
+    await act(async () => {
+      pending.resolve(CHART_REPLY);
+      await Promise.resolve();
+    });
+
+    // Returning shows the completed answer + chart — no replay, no lost result.
+    await user.click(screen.getByRole('button', { name: /Back to Chat/i }));
+    expect(await screen.findByText(CHART_REPLY.reply)).toBeInTheDocument();
+    expect(screen.getByTestId('chart-renderer-mock')).toBeInTheDocument();
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('opening and closing the Approvals overlay does not disturb the chat', async () => {
+    const user = userEvent.setup();
+    renderDashboard();
+
+    await seedConversation(user);
+
+    // A pending approval arrives over SignalR.
+    await act(async () => {
+      hubHandlers['approval_requested']?.(pendingApproval);
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('pending-count-badge')).toHaveTextContent('1');
+    // It renders inline in the chat stream too.
+    expect(screen.getAllByTestId('approval-card').length).toBeGreaterThan(0);
+
+    // Open the Approvals / telemetry overlay.
+    await user.click(screen.getByTestId('pending-approvals-button'));
+
+    // Chat is untouched: still visible, still holding its message + chart.
+    const host = screen.getByTestId('chat-host');
+    expect(host).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByText(CHART_REPLY.reply)).toBeInTheDocument();
+    expect(screen.getByTestId('chart-renderer-mock')).toBeInTheDocument();
+
+    // Close the overlay — returns to the same chat.
+    await user.click(screen.getByRole('button', { name: /Close telemetry panel/i }));
+    expect(screen.getByText(CHART_REPLY.reply)).toBeInTheDocument();
+    expect(screen.getByTestId('chart-renderer-mock')).toBeInTheDocument();
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Dashboard — New Chat is the only reset (issue #46)', () => {
+  it('clears messages, chart, and starts a fresh session', async () => {
+    const user = userEvent.setup();
+    renderDashboard();
+
+    await seedConversation(user);
+    expect(joinTelemetrySessionMock).toHaveBeenCalledTimes(1);
+    const firstSession = joinTelemetrySessionMock.mock.calls[0][0];
+
+    await user.click(screen.getByRole('button', { name: /New Chat/i }));
+
+    // Fresh chat: welcome prompts return, prior message + chart are gone.
+    expect(await screen.findByText(/Welcome to Retail Pulse/i)).toBeInTheDocument();
+    expect(screen.queryByText(CHART_REPLY.reply)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('chart-renderer-mock')).not.toBeInTheDocument();
+
+    // A brand-new session id was joined (ChatPanel remounted via chatKey).
+    await waitFor(() => expect(joinTelemetrySessionMock).toHaveBeenCalledTimes(2));
+    expect(joinTelemetrySessionMock.mock.calls[1][0]).not.toBe(firstSession);
+  });
+});
+
+describe('Dashboard — accessibility of the persistent chat host (issue #46)', () => {
+  it('marks the chat host inert + aria-hidden when an alternate view is active, and restores it on return', async () => {
+    const user = userEvent.setup();
+    renderDashboard();
+
+    await seedConversation(user);
+    const host = screen.getByTestId('chat-host');
+
+    // Active chat: in the tab order + accessibility tree.
+    expect(host).not.toHaveAttribute('aria-hidden');
+    expect(host).not.toHaveAttribute('inert');
+
+    // Switch to Observability: chat host removed from tab order + SR tree.
+    await user.click(screen.getByRole('button', { name: 'Observability' }));
+    expect(host).toHaveAttribute('aria-hidden', 'true');
+    expect(host).toHaveAttribute('inert');
+    expect(host).toHaveStyle({ display: 'none' });
+    // The active view is visible and not inert.
+    const active = screen.getByTestId('observability');
+    expect(active).toBeVisible();
+    expect(within(host).queryByPlaceholderText(/Ask about retail performance/i)).toBeInTheDocument();
+
+    // Return: host restored to the accessibility tree.
+    await user.click(screen.getByRole('button', { name: /Back to Chat/i }));
+    expect(host).not.toHaveAttribute('aria-hidden');
+    expect(host).not.toHaveAttribute('inert');
+    expect(screen.getByPlaceholderText(/Ask about retail performance/i)).toBeVisible();
+  });
+});

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -38,6 +38,14 @@ const drawerStyle: React.CSSProperties = {
   borderLeft: '1px solid var(--brand-accent-border-faint)',
 };
 
+// Applied to the persistent ChatPanel host while an alternate dashboard view
+// (Observability, Approvals overlay, etc.) is active. `display: none` keeps the
+// single ChatPanel instance mounted — preserving its messages, charts, session
+// id/history, scroll, and any pending request — while fully removing it from the
+// tab order and the screen-reader accessibility tree. Navigation no longer
+// unmounts chat, so returning restores the exact conversation with no refetch.
+const HIDDEN_CHAT_STYLE: React.CSSProperties = { display: 'none' };
+
 const useStyles = makeStyles({
   dashboard: {
     display: 'flex',
@@ -101,6 +109,9 @@ const useStyles = makeStyles({
     [`@media (max-width: ${DRAWER_BREAKPOINT_PX}px)`]: {
       marginRight: '0',
     },
+  },
+  chatHost: {
+    height: '100%',
   },
 });
 
@@ -427,6 +438,24 @@ export function Dashboard() {
     setAlerts(prev => prev.map(a => a.status === 'active' ? { ...a, status: 'dismissed' as const } : a));
   }, []);
 
+  // The chat surface is a SINGLE persistently-mounted ChatPanel. It is visible only
+  // when no alternate dashboard view is active; otherwise it is hidden (but kept
+  // mounted) so its conversation state survives navigation. This boolean mirrors —
+  // exactly — the alternate-view conditions rendered below, so chat shows whenever
+  // none of them match (including the "feature flag off" fall-through cases).
+  const chatVisible = !(
+    (capabilities.alternateViews && activeView === 'promo' && featureFlags.campaignPlanner) ||
+    (activeView === 'competitive' && featureFlags.competitive) ||
+    (activeView === 'knowledge' && featureFlags.knowledgeBase) ||
+    (activeView === 'council' && featureFlags.healthCouncil) ||
+    (activeView === 'security' && featureFlags.security) ||
+    (activeView === 'cards' && featureFlags.cards) ||
+    (capabilities.observability && activeView === 'observability' && featureFlags.observability) ||
+    (activeView === 'stores' && featureFlags.stores) ||
+    (activeView === 'financials' && featureFlags.financials) ||
+    (activeView === 'portfolio' && featureFlags.portfolio)
+  );
+
   return (
     <div className={styles.dashboard}>
       {activeAuthMode === 'anonymous' && (
@@ -569,6 +598,29 @@ export function Dashboard() {
 
       <main className={styles.main}>
         <div className={`${styles.chatContainer} ${telemetryOpen ? styles.chatContainerOpen : ''}`}>
+          {/*
+            Persistent chat surface. A single ChatPanel instance stays mounted for the
+            lifetime of the Dashboard (or until New Chat remounts it via `chatKey`), so
+            switching to Observability/Approvals/any alternate view no longer discards
+            the conversation, session id, charts, scroll, or an in-flight request. When
+            an alternate view is active the host is `display:none` + `inert` +
+            `aria-hidden`, which removes it from the tab order and the screen-reader
+            tree while keeping its React state alive.
+          */}
+          <div
+            className={styles.chatHost}
+            data-testid="chat-host"
+            style={chatVisible ? undefined : HIDDEN_CHAT_STYLE}
+            inert={!chatVisible}
+            aria-hidden={chatVisible ? undefined : true}
+          >
+            <ChatPanel
+              key={chatKey}
+              onResponseReceived={handleResponseReceived}
+              approvals={pendingApprovals}
+              onApprovalResolved={handleApprovalResolved}
+            />
+          </div>
           {capabilities.alternateViews && activeView === 'promo' && featureFlags.campaignPlanner ? (
             <div style={{ overflow: 'auto', height: '100%' }}>
               <PromoTaskModule />
@@ -635,14 +687,7 @@ export function Dashboard() {
               )}
               <ExplanationPanel explanation={explanationData} open={explanationOpen} onClose={() => setExplanationOpen(false)} />
             </div>
-          ) : (
-            <ChatPanel
-              key={chatKey}
-              onResponseReceived={handleResponseReceived}
-              approvals={pendingApprovals}
-              onApprovalResolved={handleApprovalResolved}
-            />
-          )}
+          ) : null}
         </div>
 
         {capabilities.telemetryPanel && (


### PR DESCRIPTION
Closes #46

## Root cause
`Dashboard.tsx` rendered the main content as one big ternary: **either** an alternate view (Observability, Competitive, Stores, Financials, …) **or** `<ChatPanel/>`. Switching `activeView` away from `chat` therefore **unmounted** `ChatPanel`, destroying all of its local state — `messages`, charts, scroll position, the in-flight request (aborted on unmount), and its `sessionId`. Returning **remounted a fresh instance**: new `sessionId`, welcome screen, and a second `joinTelemetrySession()` call (broken telemetry/trace association).

## Fix — persistent, hidden chat host (not lift-state)
A **single `ChatPanel` instance** now stays mounted inside a host wrapper (`data-testid="chat-host"`). When an alternate view is active the host is hidden with **`display:none` + `inert` + `aria-hidden`** instead of being removed from the tree:

- State survives navigation — returning to Chat restores the **exact** conversation (messages, charts, scroll, session id/history) with **no refetch/replay**.
- A response that resolves while the user is on another view is preserved and shown on return.
- **New Chat** remains the sole intentional reset (`handleNewChat` bumps `chatKey` → remount → fresh session + welcome prompts).
- Single mount ⇒ no duplicate `ChatPanel` instances, no duplicate SignalR `JoinSession`, no duplicate chat API calls.
- `display:none` removes the inactive host from the **tab order and screen-reader tree**; `inert` + `aria-hidden` are belt-and-suspenders. The active view stays visible/focusable.
- **Approvals** is an overlay (telemetry `Drawer`), not a route — it never changes `activeView`, so chat stays mounted underneath; open/close preserves it.
- **Anonymous** capability gating unchanged (can't open restricted views; chat host simply stays visible). Entra/GitHub unchanged.

Why not lift all conversation state into the Dashboard: much larger, riskier refactor for no extra user benefit; keep-mounted+hidden achieves full preservation with a surgical change.

## Tests (`DashboardChatPersistence.test.tsx`, real Dashboard + real ChatPanel)
1. Send message + chart → switch to Observability → return: exact contents + session remain; `joinTelemetrySession` called **once**, no duplicate chat API call.
2. Response resolves **while on Observability** → appears on return.
3. Approvals overlay open/close preserves chat.
4. New Chat clears messages/chart and starts a fresh session (welcome prompts return).
5. a11y: hidden host is `inert` + `aria-hidden` + `display:none`; active view visible; restored on return.

## Verification
- Full suite: **466 tests pass (54 files)** — 461 baseline + 5 new.
- `npm run build` (`tsc -b && vite build`) succeeds.
- `package-lock.json` unchanged (internal proxy, no lockfile churn).
- The new tests genuinely fail against the pre-fix code (valid regression guards).

Docs updated in `docs/FRONTEND.md`. Not for merge/deploy.
