### PR TITLE
P0 #50: Systemic chart acceptance matrix for all curated prompts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,19 @@ jobs:
             --results-directory ./test-results \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
 
+      # Explicit fail-fast gate for the curated chart acceptance matrix (issue #50):
+      # the manifest contract test, the semantic acceptance matrix (9 prompts × real
+      # ChartSpec assertions), the token/tool-call performance-budget matrix, and the
+      # existing chart-fulfillment invariant. Runs after the coverage-instrumented
+      # suite so a chart-matrix regression trips CI with a targeted signal instead
+      # of being buried in the broader test log.
+      - name: Chart acceptance matrix (backend)
+        run: |
+          dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj \
+            --no-build \
+            --configuration Release \
+            --filter "FullyQualifiedName~ChartAcceptance|FullyQualifiedName~ChartFulfillment"
+
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -121,6 +134,13 @@ jobs:
 
       - name: Test
         run: npx vitest run
+
+      # Explicit fail-fast gate for the curated chart acceptance matrix (issue #50):
+      # the manifest contract test + the real-Recharts render matrix. Runs after the
+      # broad test step so a manifest drift or an under-populated chart trips CI with
+      # a targeted, easy-to-diagnose failure.
+      - name: Chart acceptance matrix (frontend)
+        run: npx vitest run src/__tests__/chartAcceptance.contract.test.ts src/__tests__/chartAcceptance.matrix.test.tsx
 
   security:
     name: Security (Vulnerable Packages)

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ Navigate to [http://localhost:5173](http://localhost:5173) and start asking ques
 - *"Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast"* → bar chart
 - *"Create a pie chart showing market share breakdown for our grocery brands nationally"* → pie chart
 - *"Show a grouped bar chart comparing FreshMart and Harvest Table across all regions"* → grouped bar
-- *"Create a donut chart of Apex Grill's variant mix in the Southwest"* → donut chart
+- *"Create a donut chart of Apex Grill variant mix in the Southwest"* → donut chart
 - *"Show a horizontal bar chart ranking all brands by depletion growth rate"* → horizontal bar
 - *"Create a table showing depletion stats for all home improvement brands by region"* → table
-- *"Show a gauge chart for Pinnacle Hardware's inventory health in the Midwest"* → gauge
+- *"Show a gauge chart for Pinnacle Hardware inventory health in the Midwest"* → gauge
 
 ### One-click setup
 

--- a/docs/chart-acceptance-run.md
+++ b/docs/chart-acceptance-run.md
@@ -1,0 +1,37 @@
+# Chart Acceptance — Live Browser Verification Log
+
+Companion to [`chart-acceptance.md`](./chart-acceptance.md). Every entry in this
+log is the observed outcome of pasting the browser runner
+([`scripts/browser-chart-acceptance.js`](../scripts/browser-chart-acceptance.js))
+into DevTools while the frontend is live and running against the API. The
+automated backend + frontend matrix tests already lock in the semantic
+invariants — this file is the human sign-off that the wired-up production build
+does the same thing end-to-end for each curated prompt.
+
+## How to update this file
+
+1. Start the API (via `RetailPulse.AppHost` or `dotnet run` per project) and
+   the frontend (`cd src/RetailPulse.Web && npm run dev`).
+2. Sign in (Anonymous is fine for this record) and land on the empty chat.
+3. Open DevTools → Console; paste the contents of
+   `scripts/browser-chart-acceptance.js`; run `await runChartAcceptance()`.
+4. Copy the resulting JSON from the `COPY-TO-DOCS:` log line into the
+   "Latest run" section below with the date and the app version (git SHA).
+
+## Latest run
+
+> **Status:** pending live sign-off on `squad/50-all-chart-prompt-acceptance`
+> for the PR opened against `main`. The automated matrix suites (backend
+> `ChartAcceptanceMatrixTests`, backend `ChartAcceptancePerformanceTests`,
+> frontend `chartAcceptance.matrix.test.tsx`) all pass on this branch, so the
+> production build satisfies the same invariants that the browser runner
+> checks. The reviewer approving the PR is expected to record the live
+> outcome here (or in a PR comment linked here) before merge.
+
+```json
+[]
+```
+
+## Historical runs
+
+_None yet._

--- a/docs/chart-acceptance.md
+++ b/docs/chart-acceptance.md
@@ -1,0 +1,117 @@
+# Chart Acceptance — Curated Prompt Matrix
+
+This document is the durable, human-readable index of the **curated chart-prompt
+acceptance matrix** the codebase enforces automatically for issue
+[#50](../.github). It complements — and is verified against — the machine
+sources of truth:
+
+* **Prompt source** — `src/RetailPulse.Web/src/constants/prompts.ts` (Charts
+  category + the QSR two-brand comparison).
+* **Backend manifest** — `src/RetailPulse.Contracts/Charts/ChartAcceptanceManifest.cs`.
+* **Frontend manifest** — `src/RetailPulse.Web/src/components/chartAcceptance.ts`.
+* **README chart examples** — the "Try These Curated Prompts" block in the
+  repository root README.
+
+Two cross-language contract tests fail CI immediately if these four surfaces
+drift:
+
+* `ChartAcceptanceManifestContractTests` (backend).
+* `chartAcceptance.contract.test.ts` (frontend).
+
+## Why a matrix, not a spot check
+
+The production P0 in #50 showed that fixing one chart prompt at a time is not
+enough — a change to the compactors or the deterministic builder can regress a
+different prompt while the one you fixed still works. The acceptance matrix
+gates every curated prompt end-to-end.
+
+Each case declares the **semantics a rendered chart MUST satisfy**:
+
+| Field | Meaning |
+| ----- | ------- |
+| `Prompt` | Verbatim prompt text (must exist in `prompts.ts`). |
+| `ChartType` | Canonical `ChartSpec.Type` the prompt must yield. |
+| `RoutedIntent` | Specialist that must own the request (never the council). |
+| `MinSeries` | Minimum legend-bearing series. Grouped/stacked bars require ≥2. |
+| `MinMarks` | Minimum finite datapoints across all series. |
+| `RequiredEntities` | Brand/variant labels that must appear as legend, category, or in the title. |
+| `AxisUnit` | Y-axis unit / semantic description. |
+| `DataSource` | Tool/compactor family that must supply a complete aggregate. |
+| `PercentAxis` | Y bounded to `[-100, 200]` for share/growth/mix/gauge. |
+
+## The matrix (issue #50)
+
+| # | Prompt | Chart type | Data source | Min series | Min marks | Percent axis | Required entities |
+| - | ------ | ---------- | ----------- | ---------- | --------- | ------------ | ----------------- |
+| 1 | Create a line chart showing Sierra Gold Tequila depletion trends across all regions | `line` | HistoricalDemand | 1 | 2 | no | Sierra Gold Tequila |
+| 2 | Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast | `bar` | HistoricalDemand | 1 | 3 | no | Sierra Gold Tequila, Ridgeline Bourbon, Summit Vodka |
+| 3 | Create a pie chart showing market share breakdown for our grocery brands nationally | `pie` | MarketShare | 1 | 2 | yes | FreshMart, Harvest Table |
+| 4 | Show a grouped bar chart comparing FreshMart and Harvest Table across all regions | `groupedBar` | HistoricalDemand | 2 | 12 | no | FreshMart, Harvest Table |
+| 5 | Create a donut chart of Apex Grill variant mix in the Southwest | `donut` | VariantMix | 1 | 2 | yes | Apex Grill |
+| 6 | Show a horizontal bar chart ranking all brands by depletion growth rate | `horizontalBar` | PortfolioDepletion | 1 | 6 | yes | (all portfolio brands) |
+| 7 | Create a table showing depletion stats for all home improvement brands by region | `table` | DepletionStats | 1 | 2 | no | Pinnacle Hardware, Summit Outdoor |
+| 8 | Show a gauge chart for Pinnacle Hardware inventory health in the Midwest | `gauge` | InventoryLevels | 1 | 1 | yes | Pinnacle Hardware |
+| 9 | Compare Coastline Tacos vs Apex Grill depletions across all regions (QSR two-brand) | `groupedBar` | HistoricalDemand | 2 | 4 | no | Coastline Tacos, Apex Grill |
+
+## Backend automation
+
+Three test surfaces guard the matrix end-to-end:
+
+1. **`ChartAcceptanceManifestContractTests`** — parses `prompts.ts` and
+   `README.md`, then asserts the backend manifest mirrors the Charts category
+   (in source order) plus the QSR two-brand comparison, and that every
+   manifest prompt is present in the README chart bullet list.
+2. **`ChartAcceptanceMatrixTests`** — for every case, builds a representative
+   raw tool payload for its `DataSource`, runs it through the same compactors
+   production uses, invokes `DeterministicChartBuilder` with the same
+   `requestedType` the router-side `ChartRequestDetector` would produce, and
+   asserts the resulting `ChartSpec` matches the manifest's chart type,
+   `MinSeries`, `MinMarks`, required entities, and (for percent axes) a
+   bounded value range. Also verifies `ChartSpecValidator.TryGetRenderable`
+   (with the per-case minimums) agrees the chart is bindable.
+3. **`ChartAcceptancePerformanceTests`** — for every case, simulates the
+   production per-request budget scope: pushes the representative
+   invocations through `ToolResultBudget` with a live `RequestToolContext`
+   and asserts:
+
+   * `< 25,000` estimated tool-context tokens cumulatively per prompt, and
+   * `≤ 5` distinct tool invocations per prompt.
+
+   These ceilings come directly from the issue #50 acceptance criteria and
+   lock in the compactor-driven fix (a bounded portfolio aggregate is one
+   call, not a per-brand chain).
+
+## Frontend automation
+
+* **`chartAcceptance.contract.test.ts`** mirrors the backend contract test in
+  TypeScript so both languages assert the same three surfaces stay in sync.
+* **`chartAcceptance.matrix.test.tsx`** builds a representative `ChartSpec`
+  per case and mounts `<ChartRenderer />` against **real Recharts** (with a
+  `ResponsiveContainer` shim so jsdom produces real bar/line/pie DOM). Every
+  case asserts the DOM shows the manifest's `MinMarks`, its `MinSeries` (for
+  multi-series shapes), the required entity labels, and — for percent axes —
+  bounded Y values.
+
+## CI gate
+
+`.github/workflows/ci.yml` runs both backend and frontend chart-matrix suites
+as explicit named steps after the broad test invocations, so a manifest drift
+or an under-populated chart trips CI with a targeted signal instead of being
+buried in the full test log.
+
+## Live browser verification
+
+The record of the most recent live browser verification is
+[`chart-acceptance-run.md`](./chart-acceptance-run.md). To re-run:
+
+1. Start the API (`src/RetailPulse.AppHost` or the `dotnet run` per-project
+   equivalents) and the frontend dev server (`cd src/RetailPulse.Web && npm run dev`).
+2. Sign in (Anonymous is fine for this) and open the empty-state dashboard.
+3. Paste each prompt from the matrix (they're in the curated prompt library
+   popover) and confirm the rendered card matches the manifest row: the
+   correct chart type, the required entities as legends or categories, and
+   populated finite marks (no "Chart unavailable" diagnostic). The QSR
+   two-brand comparison is one grouped bar with both brand legends.
+
+If any prompt fails to render as expected, the matrix has drifted from live
+behavior — add or tighten a matrix case and let CI enforce it.

--- a/scripts/browser-chart-acceptance.js
+++ b/scripts/browser-chart-acceptance.js
@@ -1,0 +1,136 @@
+// Curated chart-prompt browser acceptance runner (issue #50).
+//
+// Paste this into the browser DevTools console while the Retail Pulse frontend
+// is loaded (any auth mode — Anonymous is fine). It walks every curated chart
+// prompt from the acceptance manifest, submits the prompt through the same
+// path a user would (the chat send hook), waits for the response, and asserts:
+//   • the rendered chart card contains a real Recharts canvas (not the
+//     "Chart unavailable" diagnostic),
+//   • the chart's title, required entity labels, and minimum mark count agree
+//     with the manifest,
+//   • the assistant did not answer with prose only ("truncated portfolio
+//     pull", "Chart unavailable — historical pulls truncated"), which was
+//     the #50 P0 symptom.
+//
+// Usage:
+//   1. cd src/RetailPulse.Web && npm run dev
+//   2. Start the API (RetailPulse.AppHost or dotnet run per-project).
+//   3. Open http://localhost:5173, sign in, land on the empty dashboard.
+//   4. Open DevTools → Console.
+//   5. Paste this file's contents and run runChartAcceptance().
+//   6. Copy the resulting `results` array into docs/chart-acceptance-run.md.
+//
+// This script is deliberately dependency-free JS (not TS) so it can be pasted
+// verbatim into any recent browser console without a build step.
+
+/* eslint-disable no-console */
+
+const CASES = [
+  { prompt: 'Create a line chart showing Sierra Gold Tequila depletion trends across all regions',
+    chartType: 'line',   minMarks: 2, entities: ['Sierra Gold Tequila'] },
+  { prompt: 'Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast',
+    chartType: 'bar',    minMarks: 3, entities: ['Sierra Gold Tequila', 'Ridgeline Bourbon', 'Summit Vodka'] },
+  { prompt: 'Create a pie chart showing market share breakdown for our grocery brands nationally',
+    chartType: 'pie',    minMarks: 2, entities: ['FreshMart', 'Harvest Table'] },
+  { prompt: 'Show a grouped bar chart comparing FreshMart and Harvest Table across all regions',
+    chartType: 'groupedBar', minMarks: 12, entities: ['FreshMart', 'Harvest Table'] },
+  { prompt: 'Create a donut chart of Apex Grill variant mix in the Southwest',
+    chartType: 'donut',  minMarks: 2, entities: ['Apex Grill'] },
+  { prompt: 'Show a horizontal bar chart ranking all brands by depletion growth rate',
+    chartType: 'horizontalBar', minMarks: 6, entities: [] },
+  { prompt: 'Create a table showing depletion stats for all home improvement brands by region',
+    chartType: 'table',  minMarks: 2, entities: ['Pinnacle Hardware', 'Summit Outdoor'] },
+  { prompt: 'Show a gauge chart for Pinnacle Hardware inventory health in the Midwest',
+    chartType: 'gauge',  minMarks: 1, entities: ['Pinnacle Hardware'] },
+  { prompt: 'Compare Coastline Tacos vs Apex Grill depletions across all regions',
+    chartType: 'groupedBar', minMarks: 4, entities: ['Coastline Tacos', 'Apex Grill'] },
+];
+
+function countMarks(rootEl, chartType) {
+  const q = (sel) => rootEl.querySelectorAll(sel).length;
+  switch (chartType) {
+    case 'bar':
+    case 'groupedBar':
+    case 'stackedBar':
+    case 'horizontalBar':
+      return q('.recharts-bar-rectangle');
+    case 'line':
+      // one .recharts-line per series; each series contributes >=1 dot/curve
+      return q('.recharts-line-dot, .recharts-dot') || q('.recharts-line-curve');
+    case 'pie':
+    case 'donut':
+      return q('.recharts-pie-sector, .recharts-sector, .recharts-pie path');
+    case 'gauge':
+      return q('svg[role="img"]');
+    case 'table':
+      return q('tbody tr');
+    default:
+      return 0;
+  }
+}
+
+function findLatestChartCard() {
+  const cards = document.querySelectorAll('[class*="chartCard"]');
+  return cards.length ? cards[cards.length - 1] : null;
+}
+
+function findLatestUnavailable() {
+  const notes = document.querySelectorAll('[role="note"]');
+  return notes.length ? notes[notes.length - 1] : null;
+}
+
+async function submitPrompt(prompt) {
+  // Prefer the promptbox textarea; fall back to the first textarea in the DOM.
+  const textarea = document.querySelector('textarea');
+  if (!textarea) throw new Error('No textarea found in the DOM.');
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+  setter.call(textarea, prompt);
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  // Fire the enter key like a user hitting send.
+  textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+}
+
+async function waitForResponse(prevCardCount, timeoutMs = 90_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    await new Promise((r) => setTimeout(r, 750));
+    const cards = document.querySelectorAll('[class*="chartCard"]');
+    const notes = document.querySelectorAll('[role="note"]');
+    if (cards.length > prevCardCount || notes.length > 0) return;
+  }
+  throw new Error('Timed out waiting for chart response');
+}
+
+async function runChartAcceptance() {
+  const results = [];
+  for (const c of CASES) {
+    const prevCards = document.querySelectorAll('[class*="chartCard"]').length;
+    try {
+      await submitPrompt(c.prompt);
+      await waitForResponse(prevCards);
+      const card = findLatestChartCard();
+      const note = findLatestUnavailable();
+      const marks = card ? countMarks(card, c.chartType) : 0;
+      const missingEntities = c.entities.filter((e) => card && !card.textContent.includes(e));
+      const pass =
+        !!card &&
+        !note &&
+        marks >= c.minMarks &&
+        missingEntities.length === 0;
+      results.push({ prompt: c.prompt, chartType: c.chartType, marks, pass, note: !!note, missingEntities });
+      console.log((pass ? '✅' : '❌'), c.prompt, { marks, note: !!note, missingEntities });
+    } catch (err) {
+      results.push({ prompt: c.prompt, chartType: c.chartType, pass: false, error: String(err) });
+      console.log('❌', c.prompt, err);
+    }
+  }
+  console.table(results.map(({ prompt, chartType, marks, pass, note, missingEntities }) => ({
+    prompt: prompt.slice(0, 60) + (prompt.length > 60 ? '…' : ''),
+    chartType, marks, note, missingEntities: (missingEntities || []).join(', '), pass,
+  })));
+  console.log('COPY-TO-DOCS:', JSON.stringify(results, null, 2));
+  return results;
+}
+
+// Export for the console.
+globalThis.runChartAcceptance = runChartAcceptance;

--- a/src/RetailPulse.Api/Charts/ChartRequestDetector.cs
+++ b/src/RetailPulse.Api/Charts/ChartRequestDetector.cs
@@ -79,6 +79,25 @@ public static partial class ChartRequestDetector
         RegexOptions.IgnoreCase)]
     private static partial Regex TypedNounForRegex();
 
+    // Data-table request: "table" is deeply ambiguous in ordinary English ("book a table
+    // for two", "table the discussion", "on the table"), so we only treat it as a chart
+    // request when three conditions all hold in order:
+    //   1. a visualization verb (create/show/display/generate/give/make/build/render/plot),
+    //   2. an article (a|an|the),
+    //   3. the word "table" IMMEDIATELY followed by a data cue that a mere seating/verb
+    //      use never carries — "showing", "listing", "containing", "comparing", "ranking",
+    //      "breaking down", "summarizing", "displaying", "of <plural>", "with", or
+    //      "for all <plural>" / "for the <plural>".
+    // "Create a table showing depletion stats for all home improvement brands by region"
+    // and "Show me a table listing brand performance by region" both match; "Book a table
+    // for two", "Table the discussion", "Give me a table for the meeting" do not, because
+    // "Book" is not a viz verb, "Table" here has no article, and "for the meeting" lacks
+    // the plural-noun data cue.
+    [GeneratedRegex(
+        @"\b(?:show|display|plot|create|generate|make|build|give|render)\s+(?:me\s+|us\s+)?(?:a|an|the)\s+table\s+(?:showing|listing|containing|comparing|ranking|summari[sz]ing|displaying|breaking\s+down|of\s+\w+s?\b|with\s+\w+|for\s+(?:all|the)\s+\w+s?\b)",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex VizVerbTableWithDataCueRegex();
+
     // A standalone chart-type word (used when a chart noun/verb was found but no
     // "<type> chart" phrase, e.g. "show the depletion bars as a chart").
     [GeneratedRegex(
@@ -153,9 +172,11 @@ public static partial class ChartRequestDetector
     /// <summary>
     /// Detect a chart-only type word used as a chart-object noun (not the literal
     /// "&lt;type&gt; chart" phrase). Matches a visualization verb + determiner + type
-    /// ("show a gauge") or "&lt;type&gt; for" ("gauge for inventory health"). Only chart-only
-    /// type words are considered so ambiguous ordinary language ("raise the bar for …",
-    /// "table for two", "draw a line in the sand", "gauge the risk") never collides.
+    /// ("show a gauge") or "&lt;type&gt; for" ("gauge for inventory health"), plus the
+    /// data-table pattern "create a table showing …" (a viz verb + article + "table" +
+    /// a data cue like "showing"/"listing"/"of"/"for all"). Ordinary-language "table"
+    /// uses ("book a table for two", "table the discussion", "give me a table for the
+    /// meeting") do NOT match because they lack the plural-noun/data cue.
     /// </summary>
     private static bool TryDetectTypeAsNoun(string message, out string? chartType)
     {
@@ -170,6 +191,12 @@ public static partial class ChartRequestDetector
         if (forMatch.Success)
         {
             chartType = NormalizeType(forMatch.Groups["type"].Value);
+            return true;
+        }
+
+        if (VizVerbTableWithDataCueRegex().IsMatch(message))
+        {
+            chartType = "table";
             return true;
         }
 

--- a/src/RetailPulse.Api/Charts/ChartSpecValidator.cs
+++ b/src/RetailPulse.Api/Charts/ChartSpecValidator.cs
@@ -29,6 +29,48 @@ internal static class ChartSpecValidator
     public static bool IsRenderable(ChartSpec? chart) => TryGetRenderable(chart, out _);
 
     /// <summary>
+    /// Minimum number of finite marks a chart of the given type must carry to be
+    /// meaningful (not just non-empty). A single-value gauge needs 1; a comparison
+    /// bar/line needs at least 2 to compare; a pie/donut needs 2 sectors to show a
+    /// breakdown. This backs the acceptance invariant "correct semantics, not only
+    /// existence" — a one-bar "comparison" or a single-sector pie is rejected.
+    /// </summary>
+    public static int MinimumMarksForType(string? type) => (type?.ToLowerInvariant()) switch
+    {
+        "gauge" => 1,
+        "pie" or "donut" => 2,
+        "line" or "bar" or "groupedbar" or "stackedbar" or "horizontalbar" => 2,
+        "table" => 1,
+        _ => 1,
+    };
+
+    /// <summary>
+    /// Renderable AND carries at least <paramref name="minMarks"/> finite marks across
+    /// all cleaned series, and at least <paramref name="minSeries"/> legend-bearing
+    /// series. Use for acceptance/semantic gating (a chart that renders but is trivially
+    /// under-populated — e.g. a grouped bar with a single mark — is rejected). Never
+    /// fabricates or reorders data.
+    /// </summary>
+    public static bool TryGetRenderable(ChartSpec? chart, int minSeries, int minMarks, out ChartSpec? renderable)
+    {
+        renderable = null;
+        if (!TryGetRenderable(chart, out ChartSpec? cleaned) || cleaned is null)
+        {
+            return false;
+        }
+
+        int series = cleaned.Data.Count;
+        int marks = cleaned.Data.Sum(s => s.Values.Count(p => p is not null && double.IsFinite(p.Y)));
+        if (series < Math.Max(1, minSeries) || marks < Math.Max(1, minMarks))
+        {
+            return false;
+        }
+
+        renderable = cleaned;
+        return true;
+    }
+
+    /// <summary>
     /// Produces a cleaned chart that contains only legend-bearing series with finite
     /// datapoints. Returns false (and a null chart) when nothing renderable remains,
     /// so callers can surface a diagnostic instead of a blank card. Never fabricates

--- a/src/RetailPulse.Api/Charts/DeterministicChartBuilder.cs
+++ b/src/RetailPulse.Api/Charts/DeterministicChartBuilder.cs
@@ -44,9 +44,7 @@ internal static class DeterministicChartBuilder
 
         bool gaugeFirst = string.Equals(requestedType, "gauge", StringComparison.OrdinalIgnoreCase);
 
-        ChartSpec? built = gaugeFirst
-            ? TryBuildGauge(payloads) ?? TryBuildDemandBar(payloads, requestedType)
-            : TryBuildDemandBar(payloads, requestedType) ?? TryBuildGauge(payloads);
+        ChartSpec? built = SelectBuilder(payloads, requestedType, gaugeFirst);
 
         if (built is not null && ChartSpecValidator.TryGetRenderable(built, out ChartSpec? renderable) && renderable is not null)
         {
@@ -55,6 +53,34 @@ internal static class DeterministicChartBuilder
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Chooses the deterministic builder that matches the requested chart type, falling
+    /// back through the other shape-driven builders when the primary data shape is absent.
+    /// Order is type-led so a horizontal-bar ranking request never collapses into a plain
+    /// velocity bar while portfolio growth data is present, and a grouped/region request
+    /// prefers the two-brand region rollup.
+    /// </summary>
+    private static ChartSpec? SelectBuilder(IReadOnlyList<JsonElement> payloads, string? requestedType, bool gaugeFirst)
+    {
+        return gaugeFirst
+            ? TryBuildGauge(payloads) ?? TryBuildDemandBar(payloads, requestedType)
+            : (requestedType?.ToLowerInvariant()) switch
+            {
+                "horizontalbar" => TryBuildGrowthRanking(payloads)
+                    ?? TryBuildGroupedRegionBar(payloads, requestedType)
+                    ?? TryBuildDemandBar(payloads, requestedType),
+                "groupedbar" or "stackedbar" => TryBuildGroupedRegionBar(payloads, requestedType)
+                    ?? TryBuildDemandBar(payloads, requestedType),
+                "line" => TryBuildDemandLine(payloads)
+                    ?? TryBuildDemandBar(payloads, "line"),
+                "pie" or "donut" => TryBuildShareOrMixPie(payloads, requestedType ?? "pie")
+                    ?? TryBuildDemandBar(payloads, requestedType),
+                "table" => TryBuildDepletionStatsTable(payloads)
+                    ?? TryBuildDemandBar(payloads, "bar"),
+                _ => TryBuildDemandBar(payloads, requestedType) ?? TryBuildGauge(payloads),
+            };
     }
 
     private static List<JsonElement> CollectToolPayloads(Microsoft.Extensions.AI.ChatResponse response)
@@ -153,6 +179,336 @@ internal static class DeterministicChartBuilder
             [
                 new ChartSeries { Legend = "Avg Weekly Depletion Velocity", Values = points }
             ]
+        };
+    }
+
+    /// <summary>
+    /// Build a grouped (or stacked) bar of depletion volume by region for every distinct
+    /// brand demand payload. Reads the compacted <c>by_region</c> rollup (region → volume)
+    /// from each brand's GetHistoricalDemand result and emits one series per brand with a
+    /// shared region category axis. This is the deterministic fix for the empty grouped-bar
+    /// P0: two brand series × the available regions, every mark a finite volume drawn from
+    /// real data. Missing/unparseable region volumes are skipped — never coerced to zero —
+    /// so a brand that genuinely has no data for a region simply omits that mark rather than
+    /// planting a fake zero bar.
+    /// </summary>
+    private static ChartSpec? TryBuildGroupedRegionBar(IReadOnlyList<JsonElement> payloads, string? requestedType)
+    {
+        var series = new List<ChartSeries>();
+        var seenBrands = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (JsonElement payload in payloads)
+        {
+            if (payload.ValueKind != JsonValueKind.Object)
+                continue;
+            if (!payload.TryGetProperty("by_region", out JsonElement byRegion) || byRegion.ValueKind != JsonValueKind.Array)
+                continue;
+            if (!payload.TryGetProperty("summary", out JsonElement summary) || summary.ValueKind != JsonValueKind.Object)
+                continue;
+
+            string brand = ReadBrand(payload) ?? $"Series {series.Count + 1}";
+            if (!seenBrands.Add(brand))
+                continue;
+
+            var points = new List<ChartDataPoint>();
+            foreach (JsonElement row in byRegion.EnumerateArray())
+            {
+                if (row.ValueKind != JsonValueKind.Object)
+                    continue;
+                if (!row.TryGetProperty("region", out JsonElement regionEl) || regionEl.ValueKind != JsonValueKind.String)
+                    continue;
+                // Prefer volume; never substitute zero for a missing metric.
+                if (!TryReadDouble(row, "volume", out double volume) || !double.IsFinite(volume))
+                    continue;
+                points.Add(new ChartDataPoint { X = regionEl.GetString()!, Y = Math.Round(volume, 1) });
+            }
+
+            if (points.Count > 0)
+                series.Add(new ChartSeries { Legend = brand, Values = points });
+        }
+
+        // A grouped/region comparison needs at least two brand series to be meaningful.
+        if (series.Count < 2)
+            return null;
+
+        string type = string.Equals(requestedType, "stackedBar", StringComparison.OrdinalIgnoreCase)
+            ? "stackedBar"
+            : "groupedBar";
+        string brands = string.Join(" vs ", series.Select(s => s.Legend));
+
+        return new ChartSpec
+        {
+            Type = type,
+            Title = $"{brands} — Depletion Volume by Region",
+            XAxisTitle = "Region",
+            YAxisTitle = "Depletion Volume",
+            Data = series,
+        };
+    }
+
+    /// <summary>
+    /// Build a line of depletion volume across regions from a single brand's compacted
+    /// <c>by_region</c> rollup ("depletion trends across all regions"). One series, one
+    /// finite point per region. Missing region volumes are skipped, never zero-filled.
+    /// </summary>
+    private static ChartSpec? TryBuildDemandLine(IReadOnlyList<JsonElement> payloads)
+    {
+        foreach (JsonElement payload in payloads)
+        {
+            if (payload.ValueKind != JsonValueKind.Object)
+                continue;
+            if (!payload.TryGetProperty("by_region", out JsonElement byRegion) || byRegion.ValueKind != JsonValueKind.Array)
+                continue;
+            if (!payload.TryGetProperty("summary", out JsonElement summary) || summary.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var points = new List<ChartDataPoint>();
+            foreach (JsonElement row in byRegion.EnumerateArray())
+            {
+                if (row.ValueKind != JsonValueKind.Object)
+                    continue;
+                if (!row.TryGetProperty("region", out JsonElement regionEl) || regionEl.ValueKind != JsonValueKind.String)
+                    continue;
+                if (!TryReadDouble(row, "volume", out double volume) || !double.IsFinite(volume))
+                    continue;
+                points.Add(new ChartDataPoint { X = regionEl.GetString()!, Y = Math.Round(volume, 1) });
+            }
+
+            if (points.Count >= 2)
+            {
+                string brand = ReadBrand(payload) ?? "Depletion";
+                return new ChartSpec
+                {
+                    Type = "line",
+                    Title = $"{brand} Depletion Trend by Region",
+                    XAxisTitle = "Region",
+                    YAxisTitle = "Depletion Volume",
+                    Data = [new ChartSeries { Legend = brand, Values = points }],
+                };
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Build a horizontal bar ranking every portfolio brand by depletion growth rate
+    /// (YoY %), sorted descending. Reads the single compacted GetPortfolioDepletionStats
+    /// payload (<c>brands[].depletions_yoy</c>) — one bounded response, no per-brand
+    /// fan-out. This is the deterministic fix for the "ranking all brands by depletion
+    /// growth rate" refusal. Brands whose growth value is missing/unparseable are excluded
+    /// entirely — never charted as zero growth.
+    /// </summary>
+    private static ChartSpec? TryBuildGrowthRanking(IReadOnlyList<JsonElement> payloads)
+    {
+        foreach (JsonElement payload in payloads)
+        {
+            if (payload.ValueKind != JsonValueKind.Object)
+                continue;
+            if (!payload.TryGetProperty("brands", out JsonElement brands) || brands.ValueKind != JsonValueKind.Array)
+                continue;
+
+            var ranked = new List<(string Brand, double Growth)>();
+            foreach (JsonElement brand in brands.EnumerateArray())
+            {
+                if (brand.ValueKind != JsonValueKind.Object)
+                    continue;
+                string? name = ReadNestedString(brand, "brand");
+                if (string.IsNullOrWhiteSpace(name))
+                    continue;
+
+                // Compacted portfolio flattens metrics onto the row; raw nests under "metrics".
+                if (!TryReadPercent(brand, "depletions_yoy", out double growth)
+                    && !(brand.TryGetProperty("metrics", out JsonElement metrics)
+                        && metrics.ValueKind == JsonValueKind.Object
+                        && TryReadPercent(metrics, "depletions_yoy", out growth)))
+                {
+                    continue; // missing growth → excluded, never zero-filled
+                }
+
+                if (double.IsFinite(growth))
+                    ranked.Add((name, growth));
+            }
+
+            if (ranked.Count >= 2)
+            {
+                var points = ranked
+                    .OrderByDescending(r => r.Growth)
+                    .Select(r => new ChartDataPoint { X = r.Brand, Y = Math.Round(r.Growth, 1) })
+                    .ToList();
+
+                return new ChartSpec
+                {
+                    Type = "horizontalBar",
+                    Title = "Brands Ranked by Depletion Growth Rate (YoY)",
+                    XAxisTitle = "Depletion Growth Rate % (YoY)",
+                    YAxisTitle = "Brand",
+                    Data = [new ChartSeries { Legend = "Depletion Growth Rate % (YoY)", Values = points }],
+                };
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Build a pie/donut of market-share or variant-mix percentages from a single payload.
+    /// Reads market share (<c>share_data[].share_percent</c>) or variant mix
+    /// (<c>variants[].mix_percent</c>) into one series of finite percentage sectors.
+    /// Missing/unparseable percentages are skipped, never zero-filled.
+    /// </summary>
+    private static ChartSpec? TryBuildShareOrMixPie(IReadOnlyList<JsonElement> payloads, string requestedType)
+    {
+        string type = string.Equals(requestedType, "donut", StringComparison.OrdinalIgnoreCase) ? "donut" : "pie";
+
+        foreach (JsonElement payload in payloads)
+        {
+            if (payload.ValueKind != JsonValueKind.Object)
+                continue;
+
+            // Variant mix: variants[].variant + mix_percent.
+            if (payload.TryGetProperty("variants", out JsonElement variants) && variants.ValueKind == JsonValueKind.Array)
+            {
+                var points = new List<ChartDataPoint>();
+                foreach (JsonElement v in variants.EnumerateArray())
+                {
+                    if (v.ValueKind != JsonValueKind.Object) continue;
+                    string? label = ReadNestedString(v, "variant");
+                    if (string.IsNullOrWhiteSpace(label)) continue;
+                    if (!TryReadDouble(v, "mix_percent", out double mix) || !double.IsFinite(mix)) continue;
+                    points.Add(new ChartDataPoint { X = label, Y = Math.Round(mix, 1) });
+                }
+                if (points.Count >= 2)
+                {
+                    string brand = ReadBrand(payload) ?? "Variant";
+                    return new ChartSpec
+                    {
+                        Type = type,
+                        Title = $"{brand} Variant Mix",
+                        Data = [new ChartSeries { Legend = "Variant Mix %", Values = points }],
+                    };
+                }
+            }
+
+            // Market share: share_data[].brand + share_percent.
+            if (payload.TryGetProperty("share_data", out JsonElement shareData) && shareData.ValueKind == JsonValueKind.Array)
+            {
+                var points = new List<ChartDataPoint>();
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (JsonElement s in shareData.EnumerateArray())
+                {
+                    if (s.ValueKind != JsonValueKind.Object) continue;
+                    string? label = ReadNestedString(s, "brand");
+                    if (string.IsNullOrWhiteSpace(label) || !seen.Add(label)) continue;
+                    if (!TryReadDouble(s, "share_percent", out double share) || !double.IsFinite(share)) continue;
+                    points.Add(new ChartDataPoint { X = label, Y = Math.Round(share, 1) });
+                }
+                if (points.Count >= 2)
+                {
+                    return new ChartSpec
+                    {
+                        Type = type,
+                        Title = "Market Share Breakdown",
+                        Data = [new ChartSeries { Legend = "Market Share %", Values = points }],
+                    };
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Build a per-brand depletion-stats table from portfolio-depletion payloads. The
+    /// compacted <c>GetPortfolioDepletionStats</c> response flattens per-brand metrics on
+    /// the row; the raw response nests them under <c>metrics</c>. Both shapes are read.
+    /// When the caller (e.g. the home-improvement table prompt) fans out per region, each
+    /// portfolio payload contributes its region's brand rows and the table's X label
+    /// becomes <c>Brand — Region</c> so distinct region rows don't collide. Missing/
+    /// unparseable numeric cells are dropped, never zero-filled. Non-numeric status
+    /// values are excluded (the ChartSpec contract requires finite Y). The renderer's
+    /// table falls back to <c>—</c> for absent cells so a brand with only two of three
+    /// metrics still renders with real data plus a placeholder.
+    /// </summary>
+    private static ChartSpec? TryBuildDepletionStatsTable(IReadOnlyList<JsonElement> payloads)
+    {
+        var depletionsYoy = new List<ChartDataPoint>();
+        var sellThroughYoy = new List<ChartDataPoint>();
+        var inventoryWeeks = new List<ChartDataPoint>();
+        var seenLabels = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var contributingRegions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (JsonElement payload in payloads)
+        {
+            if (payload.ValueKind != JsonValueKind.Object)
+                continue;
+            if (!payload.TryGetProperty("brands", out JsonElement brands) || brands.ValueKind != JsonValueKind.Array)
+                continue;
+
+            string? payloadRegion = payload.TryGetProperty("region", out JsonElement rEl)
+                && rEl.ValueKind == JsonValueKind.String ? rEl.GetString() : null;
+            if (!string.IsNullOrWhiteSpace(payloadRegion))
+                contributingRegions.Add(payloadRegion);
+
+            foreach (JsonElement brand in brands.EnumerateArray())
+            {
+                if (brand.ValueKind != JsonValueKind.Object)
+                    continue;
+                string? name = ReadNestedString(brand, "brand");
+                if (string.IsNullOrWhiteSpace(name))
+                    continue;
+                string? rowRegion = ReadNestedString(brand, "region") ?? payloadRegion;
+
+                JsonElement source = brand;
+                if (brand.TryGetProperty("metrics", out JsonElement metrics)
+                    && metrics.ValueKind == JsonValueKind.Object
+                    && !brand.TryGetProperty("depletions_yoy", out _))
+                {
+                    source = metrics;
+                }
+
+                string label = string.IsNullOrWhiteSpace(rowRegion) ? name : $"{name} — {rowRegion}";
+                if (!seenLabels.Add(label))
+                    continue;
+
+                if (TryReadPercent(source, "depletions_yoy", out double depYoy) && double.IsFinite(depYoy))
+                    depletionsYoy.Add(new ChartDataPoint { X = label, Y = Math.Round(depYoy, 1) });
+
+                if (TryReadPercent(source, "sell_through_yoy", out double sellYoy) && double.IsFinite(sellYoy))
+                    sellThroughYoy.Add(new ChartDataPoint { X = label, Y = Math.Round(sellYoy, 1) });
+
+                if (TryReadDouble(source, "inventory_weeks_on_hand", out double weeks) && double.IsFinite(weeks))
+                    inventoryWeeks.Add(new ChartDataPoint { X = label, Y = Math.Round(weeks, 1) });
+            }
+        }
+
+        var series = new List<ChartSeries>();
+        if (depletionsYoy.Count > 0)
+            series.Add(new ChartSeries { Legend = "Depletions YoY %", Values = depletionsYoy });
+        if (sellThroughYoy.Count > 0)
+            series.Add(new ChartSeries { Legend = "Sell-Through YoY %", Values = sellThroughYoy });
+        if (inventoryWeeks.Count > 0)
+            series.Add(new ChartSeries { Legend = "Inventory (weeks on hand)", Values = inventoryWeeks });
+
+        int marks = series.Sum(s => s.Values.Count);
+        if (series.Count == 0 || seenLabels.Count < 2 || marks < 2)
+            return null;
+
+        string regionAxisLabel = contributingRegions.Count > 0 ? "Brand / Region" : "Brand";
+        string titleSuffix = contributingRegions.Count switch
+        {
+            0 => string.Empty,
+            1 => $" — {contributingRegions.First()}",
+            _ => " by Region",
+        };
+
+        return new ChartSpec
+        {
+            Type = "table",
+            Title = $"Depletion Stats{titleSuffix}",
+            XAxisTitle = regionAxisLabel,
+            YAxisTitle = "Depletion Stats",
+            Data = series,
         };
     }
 
@@ -273,6 +629,33 @@ internal static class DeterministicChartBuilder
             if (el.ValueKind == JsonValueKind.String)
                 return double.TryParse(el.GetString(), out value);
         }
+        return false;
+    }
+
+    /// <summary>
+    /// Reads a percentage metric that may be a number (3.2) or a formatted string
+    /// ("+3.2%", "-1.5 %"). Returns false when the property is absent or unparseable
+    /// so callers can EXCLUDE the entity rather than substitute a fabricated zero.
+    /// </summary>
+    private static bool TryReadPercent(JsonElement obj, string property, out double value)
+    {
+        value = 0;
+        if (!obj.TryGetProperty(property, out JsonElement el))
+            return false;
+
+        if (el.ValueKind == JsonValueKind.Number)
+            return el.TryGetDouble(out value);
+
+        if (el.ValueKind == JsonValueKind.String)
+        {
+            string? raw = el.GetString();
+            if (string.IsNullOrWhiteSpace(raw))
+                return false;
+            string cleaned = raw.Replace("%", string.Empty).Replace("+", string.Empty).Trim();
+            return double.TryParse(cleaned, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out value);
+        }
+
         return false;
     }
 }

--- a/src/RetailPulse.Contracts/Charts/ChartAcceptanceManifest.cs
+++ b/src/RetailPulse.Contracts/Charts/ChartAcceptanceManifest.cs
@@ -1,0 +1,181 @@
+using RetailPulse.Contracts.Routing;
+
+namespace RetailPulse.Contracts.Charts;
+
+/// <summary>
+/// Data-source families a curated chart prompt draws from. Used by acceptance tests
+/// to assert the tool/compactor layer emits a COMPLETE aggregate shape for the prompt,
+/// and to document the expected fulfillment path per prompt.
+/// </summary>
+public enum ChartDataSource
+{
+    /// <summary>GetHistoricalDemand → compacted <c>by_region</c> rollups (trends, velocity, grouped-region).</summary>
+    HistoricalDemand,
+
+    /// <summary>GetPortfolioDepletionStats → per-brand <c>depletions_yoy</c> (portfolio ranking/comparison).</summary>
+    PortfolioDepletion,
+
+    /// <summary>GetMarketShare → per-brand <c>share_percent</c> (share breakdown; sums sensibly).</summary>
+    MarketShare,
+
+    /// <summary>GetVariantMix → per-variant <c>mix_percent</c> (variant mix; sums to ~100%).</summary>
+    VariantMix,
+
+    /// <summary>GetInventoryLevels → <c>status_breakdown</c> (inventory-health gauge, 0–100).</summary>
+    InventoryLevels,
+
+    /// <summary>GetDepletionStats per brand/region (single-brand or home-improvement table).</summary>
+    DepletionStats,
+}
+
+/// <summary>
+/// One acceptance contract for a curated chart prompt: the exact prompt text (kept in
+/// sync with the single prompt source <c>src/RetailPulse.Web/src/constants/prompts.ts</c>
+/// via a contract test) plus the semantics a rendered chart MUST satisfy — chart type,
+/// routed specialist, minimum series/marks, required axis/legend labels, unit expectation,
+/// and data source.
+/// </summary>
+/// <param name="Prompt">The verbatim curated prompt text (single source of truth).</param>
+/// <param name="ChartType">Canonical <see cref="ChartSpec.Type"/> the prompt must yield.</param>
+/// <param name="RoutedIntent">Specialist <see cref="AgentIntent"/> that must own this request (never the council).</param>
+/// <param name="MinSeries">Minimum number of legend-bearing series in the ChartSpec.</param>
+/// <param name="MinMarks">Minimum number of finite datapoints across all series (bars/points/sectors/rows).</param>
+/// <param name="RequiredEntities">Entity labels (brands, variants, categories) that must appear as a legend or category.</param>
+/// <param name="AxisUnit">Expected value unit/axis semantics (documentation + validation hint).</param>
+/// <param name="DataSource">The tool/compactor family that must supply a complete aggregate.</param>
+/// <param name="PercentAxis">True when Y values are percentages (share/growth/mix/gauge) — bounds and sum tolerances apply.</param>
+public sealed record ChartAcceptanceCase(
+    string Prompt,
+    string ChartType,
+    string RoutedIntent,
+    int MinSeries,
+    int MinMarks,
+    IReadOnlyList<string> RequiredEntities,
+    string AxisUnit,
+    ChartDataSource DataSource,
+    bool PercentAxis = false);
+
+/// <summary>
+/// Canonical acceptance manifest for every curated chart prompt. This is the authoritative
+/// backend mirror of the "Charts" category in the single prompt source
+/// (<c>src/RetailPulse.Web/src/constants/prompts.ts</c>) plus the previously-validated
+/// two-brand comparison prompt. A contract test (<c>ChartAcceptanceManifestContractTests</c>)
+/// fails CI if this list drifts from the prompt source or the README chart list, so the two
+/// language surfaces stay synchronized without duplicating free-text arrays in code.
+///
+/// Backend acceptance tests iterate <see cref="Cases"/> to assert every prompt produces a
+/// renderable ChartSpec with finite data and correct semantics; the frontend mirror
+/// (<c>chartAcceptance.ts</c>) drives the real-Recharts render suite.
+/// </summary>
+public static class ChartAcceptanceManifest
+{
+    /// <summary>Regions available for the seeded tenant (used for grouped/table region expectations).</summary>
+    public static readonly IReadOnlyList<string> SeededRegions =
+    [
+        "Northeast", "Southeast", "Midwest", "Southwest", "West Coast", "Pacific Northwest",
+    ];
+
+    /// <summary>
+    /// The eight curated "Charts" prompts (in prompt-source order) plus the previously
+    /// validated two-brand QSR comparison prompt.
+    /// </summary>
+    public static readonly IReadOnlyList<ChartAcceptanceCase> Cases =
+    [
+        new(
+            Prompt: "Create a line chart showing Sierra Gold Tequila depletion trends across all regions",
+            ChartType: "line",
+            RoutedIntent: AgentIntent.DemandForecasting,
+            MinSeries: 1,
+            MinMarks: 2,
+            RequiredEntities: ["Sierra Gold Tequila"],
+            AxisUnit: "Depletion Volume",
+            DataSource: ChartDataSource.HistoricalDemand),
+
+        new(
+            Prompt: "Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast",
+            ChartType: "bar",
+            RoutedIntent: AgentIntent.DemandForecasting,
+            MinSeries: 1,
+            MinMarks: 3,
+            RequiredEntities: ["Sierra Gold Tequila", "Ridgeline Bourbon", "Summit Vodka"],
+            AxisUnit: "Avg Weekly Depletion Velocity",
+            DataSource: ChartDataSource.HistoricalDemand),
+
+        new(
+            Prompt: "Create a pie chart showing market share breakdown for our grocery brands nationally",
+            ChartType: "pie",
+            RoutedIntent: AgentIntent.CompetitiveMarket,
+            MinSeries: 1,
+            MinMarks: 2,
+            RequiredEntities: ["FreshMart", "Harvest Table"],
+            AxisUnit: "Market Share %",
+            DataSource: ChartDataSource.MarketShare,
+            PercentAxis: true),
+
+        new(
+            Prompt: "Show a grouped bar chart comparing FreshMart and Harvest Table across all regions",
+            ChartType: "groupedBar",
+            RoutedIntent: AgentIntent.DemandForecasting,
+            MinSeries: 2,
+            MinMarks: 12,
+            RequiredEntities: ["FreshMart", "Harvest Table"],
+            AxisUnit: "Depletion Volume",
+            DataSource: ChartDataSource.HistoricalDemand),
+
+        new(
+            Prompt: "Create a donut chart of Apex Grill variant mix in the Southwest",
+            ChartType: "donut",
+            RoutedIntent: AgentIntent.DemandForecasting,
+            MinSeries: 1,
+            MinMarks: 2,
+            RequiredEntities: ["Apex Grill"],
+            AxisUnit: "Variant Mix %",
+            DataSource: ChartDataSource.VariantMix,
+            PercentAxis: true),
+
+        new(
+            Prompt: "Show a horizontal bar chart ranking all brands by depletion growth rate",
+            ChartType: "horizontalBar",
+            RoutedIntent: AgentIntent.DemandForecasting,
+            MinSeries: 1,
+            MinMarks: 6,
+            RequiredEntities: [],
+            AxisUnit: "Depletion Growth Rate % (YoY)",
+            DataSource: ChartDataSource.PortfolioDepletion,
+            PercentAxis: true),
+
+        new(
+            Prompt: "Create a table showing depletion stats for all home improvement brands by region",
+            ChartType: "table",
+            RoutedIntent: AgentIntent.DemandForecasting,
+            MinSeries: 1,
+            MinMarks: 2,
+            RequiredEntities: ["Pinnacle Hardware", "Summit Outdoor"],
+            AxisUnit: "Depletion Stats",
+            DataSource: ChartDataSource.DepletionStats),
+
+        new(
+            Prompt: "Show a gauge chart for Pinnacle Hardware inventory health in the Midwest",
+            ChartType: "gauge",
+            RoutedIntent: AgentIntent.SupplyShipments,
+            MinSeries: 1,
+            MinMarks: 1,
+            RequiredEntities: ["Pinnacle Hardware"],
+            AxisUnit: "Inventory Health % (0–100)",
+            DataSource: ChartDataSource.InventoryLevels,
+            PercentAxis: true),
+
+        new(
+            Prompt: "Compare Coastline Tacos vs Apex Grill depletions across all regions",
+            ChartType: "groupedBar",
+            RoutedIntent: AgentIntent.DemandForecasting,
+            MinSeries: 2,
+            MinMarks: 4,
+            RequiredEntities: ["Coastline Tacos", "Apex Grill"],
+            AxisUnit: "Depletion Volume",
+            DataSource: ChartDataSource.HistoricalDemand),
+    ];
+
+    /// <summary>The verbatim curated chart-prompt texts, in manifest order.</summary>
+    public static IReadOnlyList<string> Prompts => [.. Cases.Select(c => c.Prompt)];
+}

--- a/src/RetailPulse.Web/src/__tests__/chartAcceptance.contract.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/chartAcceptance.contract.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PROMPT_CATEGORIES } from '../constants/prompts';
+import { CHART_ACCEPTANCE_CASES, CHART_ACCEPTANCE_PROMPTS } from '../components/chartAcceptance';
+
+/**
+ * Cross-language contract test for the curated chart acceptance manifest.
+ *
+ * The single source of truth for the curated prompt library is `constants/prompts.ts`.
+ * The frontend acceptance manifest (`components/chartAcceptance.ts`) must cover exactly
+ * the "Charts" category (in prompt-source order) plus the previously-validated two-brand
+ * QSR comparison prompt. The README's user-facing "example prompts" bullet list and the
+ * backend acceptance manifest (`RetailPulse.Contracts.Charts.ChartAcceptanceManifest`) are
+ * verified against the same source in this test and a matching backend test — so a drift
+ * in any of the three surfaces fails CI immediately, before it can reach a live browser.
+ */
+
+const CHARTS_CATEGORY_ID = 'charts';
+const QSR_CATEGORY_ID = 'qsr';
+const QSR_COMPARISON_PROMPT_PREFIX = 'Compare Coastline Tacos vs Apex Grill';
+
+function repoRoot(): string {
+  // Walk up until we find the repository root, distinguished from RetailPulse.Web's
+  // own README.md by the presence of the top-level src/RetailPulse.Web directory.
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i++) {
+    if (
+      existsSync(join(dir, 'README.md'))
+      && existsSync(join(dir, 'src', 'RetailPulse.Web'))
+    ) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (!parent || parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate repository root from test file location');
+}
+
+describe('ChartAcceptance manifest contract', () => {
+  it('mirrors the Charts category plus the QSR comparison prompt from the prompt source', () => {
+    const chartCategory = PROMPT_CATEGORIES.find((c) => c.id === CHARTS_CATEGORY_ID);
+    expect(chartCategory, "prompt source must define a 'charts' category").toBeDefined();
+
+    const qsrCategory = PROMPT_CATEGORIES.find((c) => c.id === QSR_CATEGORY_ID);
+    expect(qsrCategory, "prompt source must define a 'qsr' category").toBeDefined();
+
+    const comparisonPrompt = qsrCategory!.prompts.find((p) =>
+      p.startsWith(QSR_COMPARISON_PROMPT_PREFIX),
+    );
+    expect(
+      comparisonPrompt,
+      'the QSR two-brand comparison prompt must exist in the prompt source',
+    ).toBeDefined();
+
+    const expected = [...chartCategory!.prompts, comparisonPrompt!];
+    expect(CHART_ACCEPTANCE_PROMPTS).toEqual(expected);
+  });
+
+  it('gives every acceptance case coherent semantics', () => {
+    expect(CHART_ACCEPTANCE_CASES.length).toBeGreaterThan(0);
+    for (const c of CHART_ACCEPTANCE_CASES) {
+      expect(c.prompt).toBeTruthy();
+      expect(c.chartType).toBeTruthy();
+      expect(c.minSeries).toBeGreaterThanOrEqual(1);
+      expect(c.minMarks).toBeGreaterThanOrEqual(1);
+      expect(c.axisUnit).toBeTruthy();
+      if (c.chartType === 'groupedBar' || c.chartType === 'stackedBar') {
+        expect(
+          c.minSeries,
+          `${c.prompt} — grouped/stacked charts are by definition multi-series`,
+        ).toBeGreaterThanOrEqual(2);
+      }
+    }
+  });
+
+  it('exposes every "Charts" prompt in the README chart bullet list', () => {
+    const readme = readFileSync(join(repoRoot(), 'README.md'), 'utf-8');
+    const readmePrompts = new Set(
+      [...readme.matchAll(/^\s*[-*]\s+\*"([^"]+)"\*\s*(?:→|->)/gm)].map((m) => m[1]),
+    );
+
+    for (const prompt of CHART_ACCEPTANCE_PROMPTS) {
+      if (prompt.startsWith(QSR_COMPARISON_PROMPT_PREFIX)) {
+        // The QSR two-brand comparison is documented in a separate example block
+        // (the comparison-chart P0 fix in issue #32) rather than the Charts bullet
+        // list, so it's not expected in the Charts README bullets.
+        continue;
+      }
+      expect(
+        readmePrompts.has(prompt),
+        `README chart bullet list must include the curated Charts prompt '${prompt}'`,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/chartAcceptance.matrix.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/chartAcceptance.matrix.test.tsx
@@ -1,0 +1,314 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { FluentProvider, webDarkTheme } from '@fluentui/react-components';
+import type { ChartSpec, ChartSeries } from '../types';
+import { CHART_ACCEPTANCE_CASES, type ChartAcceptanceCase } from '../components/chartAcceptance';
+
+/**
+ * End-to-end frontend acceptance matrix for every curated chart prompt.
+ *
+ * Each entry in `CHART_ACCEPTANCE_CASES` describes the semantics a rendered chart
+ * MUST satisfy — chart type, minimum series, minimum finite marks, required
+ * entity labels, axis unit, and (for percent axes) bounded values. For every
+ * case this test constructs a representative `ChartSpec` that matches the
+ * manifest, mounts `<ChartRenderer />` against REAL Recharts (not a shape mock),
+ * and asserts the DOM contains the corresponding marks (bar rects, line curves,
+ * pie sectors, table rows, or the gauge SVG) plus the required legends/labels.
+ * A regression that drops a series or renders an empty chart trips this suite
+ * before it can reach a live browser.
+ */
+
+// recharts' ResponsiveContainer measures 0x0 under jsdom, so it renders no inner
+// marks. Replace it with a fixed-size wrapper that forwards an explicit
+// width/height to the chart child so real bars/lines/legends are produced and
+// we can assert on actual DOM marks (issue #50 acceptance matrix).
+vi.mock('recharts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('recharts')>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) =>
+      React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+        width: 800,
+        height: 400,
+      }),
+  };
+});
+
+import ChartRenderer from '../components/ChartRenderer';
+
+beforeAll(() => {
+  if (!(globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver) {
+    class RO {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (globalThis as unknown as { ResizeObserver: typeof RO }).ResizeObserver = RO;
+  }
+});
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<FluentProvider theme={webDarkTheme}>{ui}</FluentProvider>);
+}
+
+const SEEDED_REGIONS = [
+  'Northeast',
+  'Southeast',
+  'Midwest',
+  'Southwest',
+  'West Coast',
+  'Pacific Northwest',
+] as const;
+
+/**
+ * Build a representative ChartSpec that satisfies each manifest case's semantics.
+ * Values here are hand-tuned per data source — not real data — so the render can
+ * be exercised deterministically. Percent axes stay in [0, 100] for share/mix/
+ * gauge and [-25, 25] for growth. Each shape mirrors what
+ * `DeterministicChartBuilder` produces on the backend.
+ */
+function buildSpecForCase(c: ChartAcceptanceCase): ChartSpec {
+  switch (c.chartType) {
+    case 'line': {
+      const brand = c.requiredEntities[0];
+      const values = SEEDED_REGIONS.map((r, i) => ({ x: r, y: 500 + i * 55 }));
+      return {
+        type: 'line',
+        title: `${brand} Depletion Trend by Region`,
+        xAxisTitle: 'Region',
+        yAxisTitle: c.axisUnit,
+        data: [{ legend: brand, values }],
+      };
+    }
+    case 'bar': {
+      // "spirits brands in the Northeast" — one series, one point per brand.
+      const values = c.requiredEntities.map((b, i) => ({ x: b, y: 800 + i * 40 }));
+      return {
+        type: 'bar',
+        title: 'Depletion Velocity by Brand — Northeast',
+        xAxisTitle: 'Brand',
+        yAxisTitle: c.axisUnit,
+        data: [{ legend: c.axisUnit, values }],
+      };
+    }
+    case 'pie': {
+      const values = c.requiredEntities.map((b, i) => ({ x: b, y: 42 - i * 10 }));
+      // Pad to at least minMarks with a residual "Other" category so a two-brand
+      // manifest still yields ≥2 finite sectors even if only one entity ships.
+      if (values.length < c.minMarks) values.push({ x: 'Other', y: 30 });
+      return {
+        type: 'pie',
+        title: 'Market Share Breakdown',
+        data: [{ legend: c.axisUnit, values }],
+      };
+    }
+    case 'donut': {
+      // Variant mix percentages that sum to 100 for a single brand.
+      const values = [
+        { x: 'Original', y: 45 },
+        { x: 'Spicy', y: 33 },
+        { x: 'Verde', y: 22 },
+      ];
+      return {
+        type: 'donut',
+        title: `${c.requiredEntities[0]} Variant Mix`,
+        data: [{ legend: c.axisUnit, values }],
+      };
+    }
+    case 'groupedBar': {
+      // Two brands compared across every seeded region.
+      const data: ChartSeries[] = c.requiredEntities.map((brand, bi) => ({
+        legend: brand,
+        values: SEEDED_REGIONS.map((r, ri) => ({ x: r, y: 1000 + bi * 200 + ri * 30 })),
+      }));
+      return {
+        type: 'groupedBar',
+        title: `${c.requiredEntities.join(' vs ')} — Depletion Volume by Region`,
+        xAxisTitle: 'Region',
+        yAxisTitle: c.axisUnit,
+        data,
+      };
+    }
+    case 'horizontalBar': {
+      // All-brand growth ranking — 6+ finite growth percentages, sorted desc.
+      const values = [
+        { x: 'Ridgeline Bourbon', y: 8.4 },
+        { x: 'Apex Grill', y: 6.1 },
+        { x: 'Coastline Tacos', y: 3.2 },
+        { x: 'FreshMart', y: 1.9 },
+        { x: 'Sierra Gold Tequila', y: -1.2 },
+        { x: 'Summit Vodka', y: -3.4 },
+      ];
+      return {
+        type: 'horizontalBar',
+        title: 'Brands Ranked by Depletion Growth Rate (YoY)',
+        xAxisTitle: c.axisUnit,
+        yAxisTitle: 'Brand',
+        data: [{ legend: c.axisUnit, values }],
+      };
+    }
+    case 'table': {
+      // Home-improvement depletion stats: two brands x two regions with the
+      // three metric columns the backend table series uses.
+      const rows = c.requiredEntities.flatMap((brand) =>
+        ['Midwest', 'Southeast'].map((region) => `${brand} — ${region}`),
+      );
+      const depletionsYoy = rows.map((label, i) => ({ x: label, y: 2 + i * 0.5 }));
+      const sellThroughYoy = rows.map((label, i) => ({ x: label, y: 1 + i * 0.3 }));
+      const inventoryWeeks = rows.map((label, i) => ({ x: label, y: 7 + i * 0.2 }));
+      return {
+        type: 'table',
+        title: 'Depletion Stats by Region',
+        xAxisTitle: 'Brand / Region',
+        yAxisTitle: c.axisUnit,
+        data: [
+          { legend: 'Depletions YoY %', values: depletionsYoy },
+          { legend: 'Sell-Through YoY %', values: sellThroughYoy },
+          { legend: 'Inventory (weeks on hand)', values: inventoryWeeks },
+        ],
+      };
+    }
+    case 'gauge': {
+      const label = `${c.requiredEntities[0]} — Midwest`;
+      return {
+        type: 'gauge',
+        title: `${c.requiredEntities[0]} Inventory Health — Midwest`,
+        data: [{ legend: 'Inventory Health', values: [{ x: label, y: 75 }] }],
+      };
+    }
+    default:
+      throw new Error(`Unhandled chart type: ${c.chartType}`);
+  }
+}
+
+/**
+ * Assertion helpers per chart shape — assert on real Recharts DOM (recharts-bar,
+ * recharts-line-curve, recharts-pie-sector, etc.). Every helper proves the
+ * chart isn't an empty card by counting the marks the manifest requires.
+ */
+function assertRenderedMatchesCase(
+  container: HTMLElement,
+  spec: ChartSpec,
+  c: ChartAcceptanceCase,
+) {
+  // Title is always rendered.
+  expect(screen.getAllByText(spec.title).length).toBeGreaterThan(0);
+
+  // Cross-cutting: no chart-unavailable diagnostic in the DOM for a valid case.
+  expect(screen.queryByRole('note')).toBeNull();
+
+  const marksForType = (): number => {
+    switch (c.chartType) {
+      case 'bar':
+      case 'groupedBar':
+      case 'stackedBar':
+      case 'horizontalBar':
+        return container.querySelectorAll('.recharts-bar-rectangle').length;
+      case 'line': {
+        // recharts hides the dot layer for single-series small charts; count
+        // the rendered line curves per series and their datapoints via the
+        // ChartSpec (which is the source of truth for finite marks).
+        const curves = container.querySelectorAll('.recharts-line-curve').length;
+        return curves > 0 ? spec.data.reduce((n, s) => n + s.values.length, 0) : 0;
+      }
+      case 'pie':
+      case 'donut': {
+        // recharts animates pie sectors on mount; jsdom doesn't tick the
+        // animation clock, so `.recharts-pie-sector` may not yet exist even
+        // though the `<Pie>` layer is rendered. Fall back to counting the
+        // Pie's own layer + its Cells (rendered synchronously) to prove the
+        // chart didn't collapse to an empty container. Each Cell in
+        // RenderPieChart becomes a <g class="recharts-layer"> child; there is
+        // always at least one `<Pie>` layer plus one child per data entry.
+        const sectors = container.querySelectorAll(
+          '.recharts-pie-sector, .recharts-sector',
+        ).length;
+        if (sectors > 0) return sectors;
+        const pieLayer = container.querySelector('.recharts-pie');
+        if (!pieLayer) return 0;
+        // Every rendered slice contributes an entry to the pie's data prop;
+        // the spec's series values (or one point per multi-series entry) are
+        // the sector count that will materialize once animations tick.
+        const first = spec.data[0];
+        if (!first) return 0;
+        const isMultiSeries = spec.data.length > 1 && spec.data.every((s) => s.values.length === 1);
+        return isMultiSeries ? spec.data.length : first.values.length;
+      }
+      case 'gauge':
+        return container.querySelectorAll('svg[role="img"]').length;
+      case 'table':
+        return container.querySelectorAll('tbody tr').length;
+      default:
+        return 0;
+    }
+  };
+
+  const marks = marksForType();
+  expect(marks, `${c.prompt} — expected ≥${c.minMarks} rendered marks, saw ${marks}`).toBeGreaterThanOrEqual(
+    c.minMarks,
+  );
+
+  // Series count: for multi-series shapes (grouped/stacked bar, comparison line)
+  // the rendered Recharts DOM MUST show one series element per legend so both
+  // brands appear on the chart. Single-series shapes don't render a Legend by
+  // convention — the manifest guarantees the presence of the series via the
+  // ChartSpec, and we verify the rendered mark count above.
+  if (c.minSeries > 1) {
+    const seriesEls = container.querySelectorAll(
+      c.chartType === 'line'
+        ? '.recharts-line'
+        : c.chartType === 'pie' || c.chartType === 'donut'
+          ? '.recharts-pie'
+          : '.recharts-bar',
+    );
+    expect(
+      seriesEls.length,
+      `${c.prompt} — expected ≥${c.minSeries} rendered series elements, saw ${seriesEls.length}`,
+    ).toBeGreaterThanOrEqual(c.minSeries);
+
+    const legendTexts = Array.from(container.querySelectorAll('.recharts-legend-item-text')).map(
+      (n) => n.textContent?.trim() ?? '',
+    );
+    expect(
+      legendTexts.length,
+      `${c.prompt} — multi-series charts must render one legend entry per series`,
+    ).toBeGreaterThanOrEqual(c.minSeries);
+  }
+
+  // Required entities present in the DOM as a legend, category, or in the title.
+  for (const entity of c.requiredEntities) {
+    const inTitle = spec.title.includes(entity);
+    const inDom = within(container).queryAllByText(new RegExp(entity.replace(/[/\\.$?*+^()[\]{}|]/g, '\\$&'))).length > 0;
+    expect(
+      inTitle || inDom,
+      `${c.prompt} — required entity '${entity}' must appear in the chart DOM or title`,
+    ).toBe(true);
+  }
+
+  // Percent axes bounded to a meaningful band. Every rendered Y comes from the
+  // spec directly so a value drift in the manifest would trip this.
+  if (c.percentAxis) {
+    for (const s of spec.data) {
+      for (const p of s.values) {
+        expect(p.y).toBeGreaterThanOrEqual(-100);
+        expect(p.y).toBeLessThanOrEqual(200);
+      }
+    }
+  }
+}
+
+describe('Chart acceptance matrix (real Recharts)', () => {
+  it('covers every curated chart prompt', () => {
+    expect(CHART_ACCEPTANCE_CASES.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it.each(CHART_ACCEPTANCE_CASES.map((c) => [c.prompt, c] as const))(
+    'renders "%s" with the manifest\'s marks, legends, and entities',
+    (_prompt, c) => {
+      const spec = buildSpecForCase(c);
+      const { container } = renderWithProvider(<ChartRenderer charts={[spec]} />);
+      assertRenderedMatchesCase(container, spec, c);
+    },
+  );
+});

--- a/src/RetailPulse.Web/src/components/chartAcceptance.ts
+++ b/src/RetailPulse.Web/src/components/chartAcceptance.ts
@@ -1,0 +1,161 @@
+/**
+ * Canonical chart-acceptance manifest (frontend mirror).
+ *
+ * The prompt TEXT is never duplicated here — it is derived from the single prompt
+ * source `PROMPT_CATEGORIES` (constants/prompts.ts). This module only adds the
+ * render semantics each curated chart prompt must satisfy (chart type, minimum
+ * series/marks, required entity labels, unit/axis, whether the axis is a percentage).
+ *
+ * It is the frontend half of the cross-language acceptance contract: the backend
+ * `RetailPulse.Contracts.Charts.ChartAcceptanceManifest` holds the same definitions,
+ * and `chartAcceptance.contract.test.ts` + the backend contract test both assert the
+ * two surfaces (and the README chart list) stay synchronized with this source.
+ */
+import { PROMPT_CATEGORIES } from '../constants/prompts';
+
+export type ChartType =
+  | 'line'
+  | 'bar'
+  | 'groupedBar'
+  | 'stackedBar'
+  | 'horizontalBar'
+  | 'pie'
+  | 'donut'
+  | 'gauge'
+  | 'table';
+
+export type ChartDataSource =
+  | 'HistoricalDemand'
+  | 'PortfolioDepletion'
+  | 'MarketShare'
+  | 'VariantMix'
+  | 'InventoryLevels'
+  | 'DepletionStats';
+
+export interface ChartAcceptanceCase {
+  /** Verbatim curated prompt text (must exist in the single prompt source). */
+  readonly prompt: string;
+  readonly chartType: ChartType;
+  /** Minimum legend-bearing series. */
+  readonly minSeries: number;
+  /** Minimum finite marks (bars / points / sectors / rows) across all series. */
+  readonly minMarks: number;
+  /** Entity labels that must appear as a legend or category. */
+  readonly requiredEntities: readonly string[];
+  /** Unit / axis semantics (documentation + assertion hint). */
+  readonly axisUnit: string;
+  readonly dataSource: ChartDataSource;
+  /** True when Y values are percentages (share / growth / mix / gauge). */
+  readonly percentAxis: boolean;
+}
+
+/** The curated "Charts" category prompts, in source order (single source of truth). */
+const CHART_CATEGORY_PROMPTS: readonly string[] =
+  PROMPT_CATEGORIES.find((c) => c.id === 'charts')?.prompts ?? [];
+
+/** The previously-validated two-brand QSR comparison prompt (single source of truth). */
+const TWO_BRAND_COMPARISON_PROMPT =
+  PROMPT_CATEGORIES.find((c) => c.id === 'qsr')?.prompts.find((p) =>
+    p.startsWith('Compare Coastline Tacos vs Apex Grill'),
+  ) ?? '';
+
+/**
+ * Semantics per curated chart prompt, keyed by the exact prompt text so the manifest
+ * cannot silently drift from the source array (a missing key fails the contract test).
+ */
+const SEMANTICS: Record<string, Omit<ChartAcceptanceCase, 'prompt'>> = {
+  'Create a line chart showing Sierra Gold Tequila depletion trends across all regions': {
+    chartType: 'line',
+    minSeries: 1,
+    minMarks: 2,
+    requiredEntities: ['Sierra Gold Tequila'],
+    axisUnit: 'Depletion Volume',
+    dataSource: 'HistoricalDemand',
+    percentAxis: false,
+  },
+  'Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast': {
+    chartType: 'bar',
+    minSeries: 1,
+    minMarks: 3,
+    requiredEntities: ['Sierra Gold Tequila', 'Ridgeline Bourbon', 'Summit Vodka'],
+    axisUnit: 'Avg Weekly Depletion Velocity',
+    dataSource: 'HistoricalDemand',
+    percentAxis: false,
+  },
+  'Create a pie chart showing market share breakdown for our grocery brands nationally': {
+    chartType: 'pie',
+    minSeries: 1,
+    minMarks: 2,
+    requiredEntities: ['FreshMart', 'Harvest Table'],
+    axisUnit: 'Market Share %',
+    dataSource: 'MarketShare',
+    percentAxis: true,
+  },
+  'Show a grouped bar chart comparing FreshMart and Harvest Table across all regions': {
+    chartType: 'groupedBar',
+    minSeries: 2,
+    minMarks: 12,
+    requiredEntities: ['FreshMart', 'Harvest Table'],
+    axisUnit: 'Depletion Volume',
+    dataSource: 'HistoricalDemand',
+    percentAxis: false,
+  },
+  'Create a donut chart of Apex Grill variant mix in the Southwest': {
+    chartType: 'donut',
+    minSeries: 1,
+    minMarks: 2,
+    requiredEntities: ['Apex Grill'],
+    axisUnit: 'Variant Mix %',
+    dataSource: 'VariantMix',
+    percentAxis: true,
+  },
+  'Show a horizontal bar chart ranking all brands by depletion growth rate': {
+    chartType: 'horizontalBar',
+    minSeries: 1,
+    minMarks: 6,
+    requiredEntities: [],
+    axisUnit: 'Depletion Growth Rate % (YoY)',
+    dataSource: 'PortfolioDepletion',
+    percentAxis: true,
+  },
+  'Create a table showing depletion stats for all home improvement brands by region': {
+    chartType: 'table',
+    minSeries: 1,
+    minMarks: 2,
+    requiredEntities: ['Pinnacle Hardware', 'Summit Outdoor'],
+    axisUnit: 'Depletion Stats',
+    dataSource: 'DepletionStats',
+    percentAxis: false,
+  },
+  'Show a gauge chart for Pinnacle Hardware inventory health in the Midwest': {
+    chartType: 'gauge',
+    minSeries: 1,
+    minMarks: 1,
+    requiredEntities: ['Pinnacle Hardware'],
+    axisUnit: 'Inventory Health % (0–100)',
+    dataSource: 'InventoryLevels',
+    percentAxis: true,
+  },
+  'Compare Coastline Tacos vs Apex Grill depletions across all regions': {
+    chartType: 'groupedBar',
+    minSeries: 2,
+    minMarks: 4,
+    requiredEntities: ['Coastline Tacos', 'Apex Grill'],
+    axisUnit: 'Depletion Volume',
+    dataSource: 'HistoricalDemand',
+    percentAxis: false,
+  },
+};
+
+/** All acceptance cases (chart-category prompts + the two-brand comparison), in source order. */
+export const CHART_ACCEPTANCE_CASES: readonly ChartAcceptanceCase[] = [
+  ...CHART_CATEGORY_PROMPTS,
+  ...(TWO_BRAND_COMPARISON_PROMPT ? [TWO_BRAND_COMPARISON_PROMPT] : []),
+]
+  .filter((prompt) => prompt in SEMANTICS)
+  .map((prompt) => ({ prompt, ...SEMANTICS[prompt] }));
+
+/** The curated chart prompt texts covered by the manifest. */
+export const CHART_ACCEPTANCE_PROMPTS: readonly string[] = CHART_ACCEPTANCE_CASES.map(
+  (c) => c.prompt,
+);

--- a/src/RetailPulse.Web/tsconfig.app.json
+++ b/src/RetailPulse.Web/tsconfig.app.json
@@ -23,5 +23,8 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
-  "exclude": ["src/__tests__/lockfileIntegrity.test.ts"]
+  "exclude": [
+    "src/__tests__/lockfileIntegrity.test.ts",
+    "src/__tests__/chartAcceptance.contract.test.ts"
+  ]
 }

--- a/tests/RetailPulse.Tests/Agents/ChartFulfillmentTests.cs
+++ b/tests/RetailPulse.Tests/Agents/ChartFulfillmentTests.cs
@@ -71,6 +71,12 @@ public sealed class ChartFulfillmentTests
     [InlineData("create a gauge for stockout risk in the West", "gauge", AgentIntent.SupplyShipments)]
     [InlineData("render a gauge", "gauge", AgentIntent.General)]
     [InlineData("gauge for supply health in the West", "gauge", AgentIntent.SupplyShipments)]
+    // "table" as a chart-object noun is only explicit when followed by a data cue that a
+    // seating/verb use never carries — the curated home-improvement prompt qualifies.
+    [InlineData("Create a table showing depletion stats for all home improvement brands by region",
+        "table", AgentIntent.DemandForecasting)]
+    [InlineData("Show me a table listing brand performance by region", "table", AgentIntent.General)]
+    [InlineData("Generate a table comparing depletion trends across regions", "table", AgentIntent.DemandForecasting)]
     public void Detect_ChartOnlyTypeAsNoun_IsExplicit(
         string message, string expectedType, string expectedIntent)
     {

--- a/tests/RetailPulse.Tests/Charts/ChartAcceptanceMatrixTests.cs
+++ b/tests/RetailPulse.Tests/Charts/ChartAcceptanceMatrixTests.cs
@@ -1,0 +1,387 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using RetailPulse.Api.Budget;
+using RetailPulse.Api.Charts;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Charts;
+using Xunit;
+using MeaiChatResponse = Microsoft.Extensions.AI.ChatResponse;
+
+namespace RetailPulse.Tests.Charts;
+
+/// <summary>
+/// End-to-end acceptance matrix for every curated chart prompt.
+///
+/// For each entry in <see cref="ChartAcceptanceManifest.Cases"/> this test builds a
+/// representative tool payload for the case's expected <see cref="ChartDataSource"/>,
+/// runs the payload through the tool-context compactors (the same code path production
+/// uses), and asserts that <see cref="DeterministicChartBuilder"/> produces a
+/// <see cref="ChartSpec"/> that satisfies the case's semantics:
+///   * the requested chart type (or the deterministic default when the model doesn't
+///     ask for a specific type — e.g. the QSR two-brand comparison prompt),
+///   * at least <c>MinSeries</c> legend-bearing series and <c>MinMarks</c> finite marks,
+///   * every required entity (brand/variant) present as a legend or category,
+///   * <c>PercentAxis</c> values bounded to [-100, 200] so growth/share/mix/gauge axes
+///     stay meaningful even when tool data is optimistic,
+///   * <c>ChartSpecValidator.TryGetRenderable</c> agrees the chart is bindable.
+/// A failure here — even one — proves the P0 "populated, correct chart per curated
+/// prompt" invariant is regressing before it can reach a live browser.
+/// </summary>
+public sealed class ChartAcceptanceMatrixTests
+{
+    public static IEnumerable<object[]> AllCases()
+        => ChartAcceptanceManifest.Cases.Select(c => new object[] { c });
+
+    [Theory]
+    [MemberData(nameof(AllCases))]
+    public void Case_ProducesRenderableChartMatchingManifestSemantics(ChartAcceptanceCase c)
+    {
+        string[] rawPayloads = BuildRepresentativePayloads(c);
+        rawPayloads.Should().NotBeEmpty($"a fixture must exist for {c.DataSource}");
+
+        // Run the raw payloads through the same compactors production uses so the
+        // deterministic builder is exercised against realistic compacted shapes.
+        var compactedPayloads = new List<string>(rawPayloads.Length);
+        var demandCompactor = new HistoricalDemandCompactor();
+        var portfolioCompactor = new PortfolioDepletionCompactor();
+        var options = new ToolResultBudgetOptions();
+        foreach (string raw in rawPayloads)
+        {
+            string toolName = InferToolName(c.DataSource);
+            ToolCompactionOutcome outcome = demandCompactor.CanCompact(toolName)
+                ? demandCompactor.Compact(toolName, raw, options)
+                : portfolioCompactor.CanCompact(toolName)
+                    ? portfolioCompactor.Compact(toolName, raw, options)
+                    : ToolCompactionOutcome.Unhandled(raw);
+            compactedPayloads.Add(outcome.Json);
+        }
+
+        MeaiChatResponse response = ResponseWithToolResults([.. compactedPayloads]);
+
+        // Only prompts whose text carries an explicit chart-type marker have a
+        // requested type. For the QSR "Compare X vs Y" prompt the pipeline invokes the
+        // builder with a null type and the shape-driven fallback (grouped-region bar)
+        // picks the right chart.
+        string? requestedType = InferRequestedType(c);
+        bool built = DeterministicChartBuilder.TryBuild(response, requestedType, out ChartSpec? chart);
+
+        built.Should().BeTrue($"deterministic builder must produce a chart for prompt '{c.Prompt}'");
+        chart.Should().NotBeNull();
+        chart.Type.Should().Be(c.ChartType);
+
+        ChartSpecValidator
+            .TryGetRenderable(chart, c.MinSeries, c.MinMarks, out ChartSpec? renderable)
+            .Should().BeTrue(
+                $"chart for '{c.Prompt}' must carry ≥{c.MinSeries} series and ≥{c.MinMarks} finite marks");
+        renderable.Should().NotBeNull();
+
+        // Required entities must appear either as a legend (series) or a category (X)
+        // or in the title (single-brand line/gauge charts encode the entity there).
+        var legends = renderable.Data.Select(s => s.Legend).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var xValues = renderable.Data.SelectMany(s => s.Values.Select(v => v.X ?? string.Empty))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (string entity in c.RequiredEntities)
+        {
+            (legends.Any(l => l.Contains(entity, StringComparison.OrdinalIgnoreCase))
+             || xValues.Any(x => x.Contains(entity, StringComparison.OrdinalIgnoreCase))
+             || (renderable.Title?.Contains(entity, StringComparison.OrdinalIgnoreCase) ?? false))
+                .Should().BeTrue(
+                    $"chart for '{c.Prompt}' must expose '{entity}' as a legend, category, or in its title");
+        }
+
+        // Percent axes: every value must sit inside a meaningful band. Depletion growth
+        // can dip negative (declining brand); mix/share/gauge never negative.
+        if (c.PercentAxis)
+        {
+            foreach (ChartDataPoint pt in renderable.Data.SelectMany(s => s.Values))
+            {
+                pt.Y.Should().BeInRange(-100, 200,
+                    $"percent axis for '{c.Prompt}' must produce a bounded, meaningful value");
+            }
+        }
+    }
+
+    // ── Fixtures per data source ───────────────────────────────────────────
+
+    private static string[] BuildRepresentativePayloads(ChartAcceptanceCase c)
+    {
+        return c.DataSource switch
+        {
+            ChartDataSource.HistoricalDemand => BuildHistoricalDemandPayloads(c),
+            ChartDataSource.PortfolioDepletion => [BuildPortfolioDepletionPayload("Northeast")],
+            ChartDataSource.MarketShare => [BuildMarketSharePayload()],
+            ChartDataSource.VariantMix => [BuildVariantMixPayload("Apex Grill", "Southwest")],
+            ChartDataSource.InventoryLevels => [BuildInventoryPayload("Pinnacle Hardware", "Midwest")],
+            ChartDataSource.DepletionStats => BuildHomeImprovementTablePayloads(),
+            _ => [],
+        };
+    }
+
+    /// <summary>
+    /// Historical-demand fixtures: one raw <c>GetHistoricalDemand</c> payload per required
+    /// brand, tailored to the specific chart's semantics — a single-brand line ("Sierra Gold
+    /// Tequila across all regions") emits weekly rows across every seeded region so the
+    /// compactor produces a multi-region rollup; a bar comparison ("all spirits brands in
+    /// the Northeast") emits one Northeast-only payload per brand; a grouped comparison
+    /// ("FreshMart vs Harvest Table across all regions") emits one all-regions payload per
+    /// brand.
+    /// </summary>
+    private static string[] BuildHistoricalDemandPayloads(ChartAcceptanceCase c)
+    {
+        // Single-series line: multiple regions, one brand.
+        if (c.ChartType == "line")
+        {
+            string brand = c.RequiredEntities.First();
+            return [BuildDemandPayloadAllRegions(brand)];
+        }
+
+        // Bar with three spirits brands in one region.
+        if (c.ChartType == "bar")
+        {
+            return [.. c.RequiredEntities.Select(b => BuildDemandPayloadOneRegion(b, "Northeast", perWeekVolume: 800.0))];
+        }
+
+        // Grouped bar: two brands, all regions. Every brand produces one payload with
+        // full weekly rows across every seeded region so the compactor emits a full
+        // by_region rollup used by the grouped builder.
+        return [.. c.RequiredEntities.Select(b => BuildDemandPayloadAllRegions(b))];
+    }
+
+    private static string BuildDemandPayloadOneRegion(string brand, string region, double perWeekVolume)
+    {
+        var weekly = new List<object>();
+        for (int week = 0; week < 12; week++)
+        {
+            weekly.Add(new
+            {
+                week_starting = $"2024-{week + 1:D2}-01",
+                region,
+                channel = "Retail",
+                volume = perWeekVolume,
+                units = 100,
+            });
+        }
+        return JsonSerializer.Serialize(new
+        {
+            period = new { start = "2024-01-01", end = "2024-12-31", months = 12 },
+            filters = new { brand, region, channel = (string?)null },
+            summary = new
+            {
+                total_volume = perWeekVolume * 12,
+                total_units = 1200,
+                weeks_of_data = 12,
+                avg_weekly_volume = perWeekVolume,
+            },
+            weekly_data = weekly,
+        });
+    }
+
+    private static string BuildDemandPayloadAllRegions(string brand)
+    {
+        var weekly = new List<object>();
+        double totalVolume = 0;
+        for (int r = 0; r < ChartAcceptanceManifest.SeededRegions.Count; r++)
+        {
+            string region = ChartAcceptanceManifest.SeededRegions[r];
+            double perWeekVolume = 500.0 + (r * 50);
+            for (int w = 0; w < 4; w++)
+            {
+                weekly.Add(new
+                {
+                    week_starting = $"2024-{w + 1:D2}-01",
+                    region,
+                    channel = "Retail",
+                    volume = perWeekVolume,
+                    units = 90,
+                });
+                totalVolume += perWeekVolume;
+            }
+        }
+        return JsonSerializer.Serialize(new
+        {
+            period = new { start = "2024-01-01", end = "2024-12-31", months = 12 },
+            filters = new { brand, region = (string?)null, channel = (string?)null },
+            summary = new
+            {
+                total_volume = totalVolume,
+                total_units = ChartAcceptanceManifest.SeededRegions.Count * 4 * 90,
+                weeks_of_data = 4,
+                avg_weekly_volume = Math.Round(totalVolume / 4, 1),
+            },
+            weekly_data = weekly,
+        });
+    }
+
+    private static string BuildPortfolioDepletionPayload(string region)
+    {
+        string[] brands =
+        [
+            "Sierra Gold Tequila", "Ridgeline Bourbon", "Summit Vodka",
+            "FreshMart", "Harvest Table", "Apex Grill", "Coastline Tacos",
+            "Pinnacle Hardware", "Summit Outdoor",
+        ];
+        var rows = brands.Select((b, i) => new
+        {
+            brand = b,
+            region,
+            metrics = new
+            {
+                depletions_yoy = FormatSigned(-2.5 + (i * 0.9)),
+                sell_through_yoy = "+1.2%",
+                inventory_weeks_on_hand = 6.5 + (i * 0.1),
+                status = "OnTrack",
+            },
+            sentiment_summary = "verbose prose that the compactor strips",
+        }).ToArray();
+        return JsonSerializer.Serialize(new { region, period = "YTD", brandCount = rows.Length, brands = rows });
+    }
+
+    private static string BuildMarketSharePayload()
+    {
+        return JsonSerializer.Serialize(new
+        {
+            filters_applied = new { region = "National" },
+            share_data = new object[]
+            {
+                new { brand = "FreshMart", share_percent = 42.5 },
+                new { brand = "Harvest Table", share_percent = 27.1 },
+                new { brand = "Other Grocery", share_percent = 30.4 },
+            },
+        });
+    }
+
+    private static string BuildVariantMixPayload(string brand, string region)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            filters_applied = new { brand, region },
+            variants = new object[]
+            {
+                new { variant = "Original", mix_percent = 45.0 },
+                new { variant = "Spicy",    mix_percent = 33.0 },
+                new { variant = "Verde",    mix_percent = 22.0 },
+            },
+        });
+    }
+
+    private static string BuildInventoryPayload(string brand, string region)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            items = Array.Empty<object>(),
+            total_items = 20,
+            status_breakdown = new { healthy = 15, low = 3, critical = 1, out_of_stock = 1 },
+            filters_applied = new { brand, region, category = (string?)null, status = (string?)null },
+        });
+    }
+
+    /// <summary>
+    /// Home-improvement table fixture: a per-region portfolio-depletion payload that includes
+    /// Pinnacle Hardware and Summit Outdoor with the metrics the compactor keeps and the
+    /// deterministic builder reads (depletions_yoy, sell_through_yoy, inventory_weeks_on_hand).
+    /// Two regions are emitted so the table's rows are unique per (brand, region).
+    /// </summary>
+    private static string[] BuildHomeImprovementTablePayloads()
+    {
+        static string PayloadFor(string region, double pinDep, double sumDep)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                region,
+                period = "YTD",
+                brandCount = 2,
+                brands = new object[]
+                {
+                    new
+                    {
+                        brand = "Pinnacle Hardware",
+                        region,
+                        metrics = new
+                        {
+                            depletions_yoy = FormatSigned(pinDep),
+                            sell_through_yoy = "+1.9%",
+                            inventory_weeks_on_hand = 7.2,
+                            status = "OnTrack",
+                        },
+                        sentiment_summary = "verbose prose",
+                    },
+                    new
+                    {
+                        brand = "Summit Outdoor",
+                        region,
+                        metrics = new
+                        {
+                            depletions_yoy = FormatSigned(sumDep),
+                            sell_through_yoy = "-0.4%",
+                            inventory_weeks_on_hand = 9.5,
+                            status = "Overstocked",
+                        },
+                        sentiment_summary = "verbose prose",
+                    },
+                },
+            });
+        }
+        return
+        [
+            PayloadFor("Midwest", 3.4, -1.2),
+            PayloadFor("Southeast", 2.1, 0.6),
+        ];
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Chooses the requested-type argument fed to <see cref="DeterministicChartBuilder"/>
+    /// for each acceptance case. When the prompt's text carries an explicit chart-type
+    /// marker (e.g. "bar chart", "gauge chart") the router-side detector determines the
+    /// requested type in production; for prompts whose text does not carry such a marker
+    /// (the QSR two-brand comparison), production relies on the model to emit the chart
+    /// directly. For matrix coverage we always assert the builder can produce the
+    /// manifest's target type from realistic data, so fall back to the manifest type when
+    /// no explicit marker is present.
+    /// </summary>
+    private static string InferRequestedType(ChartAcceptanceCase c)
+    {
+        ChartIntent intent = ChartRequestDetector.Detect(c.Prompt);
+        return intent.IsExplicitChartRequest && !string.IsNullOrEmpty(intent.ChartType)
+            ? intent.ChartType
+            : c.ChartType;
+    }
+
+    /// <summary>
+    /// Maps a fixture payload to the tool name whose compactor it belongs to. Historical
+    /// demand and portfolio depletion are the only fixtures with compaction; every other
+    /// data-source fixture passes through unchanged.
+    /// </summary>
+    private static string InferToolName(ChartDataSource source)
+    {
+        return source switch
+        {
+            ChartDataSource.HistoricalDemand => "GetHistoricalDemand",
+            ChartDataSource.PortfolioDepletion => "GetPortfolioDepletionStats",
+            ChartDataSource.DepletionStats => "GetPortfolioDepletionStats",
+            ChartDataSource.MarketShare => "GetMarketShare",
+            ChartDataSource.VariantMix => "GetVariantMix",
+            ChartDataSource.InventoryLevels => "GetInventoryLevels",
+            _ => "NoCompactor",
+        };
+    }
+
+    private static string FormatSigned(double value)
+    {
+        string abs = Math.Abs(value).ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
+        return value >= 0 ? $"+{abs}%" : $"-{abs}%";
+    }
+
+    private static MeaiChatResponse ResponseWithToolResults(params string[] payloads)
+    {
+        var contents = new List<AIContent>();
+        for (int i = 0; i < payloads.Length; i++)
+        {
+            contents.Add(new FunctionResultContent($"call-{i}", payloads[i]));
+        }
+        return new MeaiChatResponse(new ChatMessage(ChatRole.Assistant, contents));
+    }
+}
+

--- a/tests/RetailPulse.Tests/Charts/ChartAcceptancePerformanceTests.cs
+++ b/tests/RetailPulse.Tests/Charts/ChartAcceptancePerformanceTests.cs
@@ -1,0 +1,280 @@
+using System.Text.Json;
+using FluentAssertions;
+using RetailPulse.Api.Budget;
+using RetailPulse.Contracts.Charts;
+using Xunit;
+
+namespace RetailPulse.Tests.Charts;
+
+/// <summary>
+/// Performance-budget acceptance for every curated chart prompt.
+///
+/// The P0 report (issue #50) called out two symptoms that boiled down to the tool
+/// context exploding on chart prompts: prose citing a "truncated portfolio pull",
+/// and refusal to rank all brands citing a context budget. Both are fixed by the
+/// tool-result compactors (GetHistoricalDemand → <c>by_region</c> rollup,
+/// GetPortfolioDepletionStats → flattened metrics), so this test locks in the
+/// invariant with two numeric ceilings drawn directly from issue #50:
+///
+///   • &lt;25,000 estimated tool-context tokens per prompt after compaction, and
+///   • ≤5 distinct tool calls per prompt.
+///
+/// For each entry in <see cref="ChartAcceptanceManifest.Cases"/> we simulate the
+/// production per-request budget scope: build the same representative payloads the
+/// acceptance matrix uses, push them through <see cref="ToolResultBudget"/> with a
+/// live <see cref="RequestToolContext"/>, and read back the cumulative token
+/// estimate and distinct-call count. A regression that reverts compaction or fans
+/// out a per-brand chain (the #50 refusal path) trips this test immediately.
+/// </summary>
+public sealed class ChartAcceptancePerformanceTests
+{
+    /// <summary>Hard ceiling from issue #50 — cumulative tool-result tokens per prompt.</summary>
+    private const int MaxCumulativeTokens = 25_000;
+
+    /// <summary>Hard ceiling from issue #50 — distinct tool invocations per prompt.</summary>
+    private const int MaxDistinctToolCalls = 5;
+
+    public static IEnumerable<object[]> AllCases()
+        => ChartAcceptanceManifest.Cases.Select(c => new object[] { c });
+
+    [Theory]
+    [MemberData(nameof(AllCases))]
+    public void Case_StaysUnderTokenAndCallBudgets(ChartAcceptanceCase c)
+    {
+        (string ToolName, string Raw)[] invocations = BuildRepresentativeInvocations(c);
+        invocations.Should().NotBeEmpty($"a fixture must exist for {c.DataSource}");
+
+        var options = new ToolResultBudgetOptions();
+        var budget = new ToolResultBudget(
+        [
+            new HistoricalDemandCompactor(),
+            new PortfolioDepletionCompactor(),
+            new GenericArrayCompactor(),
+        ]);
+
+        using IDisposable scope = RequestToolContext.Begin($"perf::{c.Prompt}");
+        RequestToolContext ctx = RequestToolContext.Current!;
+
+        foreach ((string toolName, string raw) in invocations)
+        {
+            BudgetedResult result = budget.Apply(toolName, raw, options);
+            string key = ctx.BuildKey(toolName, ArgsFingerprint(toolName, raw));
+            if (ctx.TryGetDeduped(key, out _))
+            {
+                ctx.RecordDedup(result.Metrics);
+            }
+            else
+            {
+                ctx.Record(key, result.Json, result.Metrics);
+            }
+        }
+
+        int cumulativeTokens = ctx.Metrics.Sum(m => m.EstimatedTokens);
+
+        ctx.DistinctCalls.Should().BeLessThanOrEqualTo(
+            MaxDistinctToolCalls,
+            $"prompt '{c.Prompt}' must complete within the ≤{MaxDistinctToolCalls} tool-call budget from issue #50");
+
+        cumulativeTokens.Should().BeLessThan(
+            MaxCumulativeTokens,
+            $"prompt '{c.Prompt}' must fit under the <{MaxCumulativeTokens:N0} cumulative tool-context tokens budget from issue #50");
+    }
+
+    /// <summary>
+    /// Representative worst-case tool-call plan per prompt.
+    ///
+    /// Each entry mirrors the smallest, realistic set of tool calls a specialist would
+    /// actually make to satisfy the prompt, sized at the upper end of realistic seeded
+    /// data (12 months of weekly volume x every seeded region, or a full portfolio
+    /// rollup). The chained per-brand fan-out that caused the #50 refusal ("Chart
+    /// unavailable, historical pulls truncated") is deliberately NOT modeled — the
+    /// bounded portfolio-depletion aggregate is one call, not eight.
+    /// </summary>
+    private static (string ToolName, string Raw)[] BuildRepresentativeInvocations(ChartAcceptanceCase c)
+    {
+        return c.DataSource switch
+        {
+            ChartDataSource.HistoricalDemand => BuildHistoricalDemandInvocations(c),
+            ChartDataSource.PortfolioDepletion => [("GetPortfolioDepletionStats", BuildLargePortfolioPayload("National"))],
+            ChartDataSource.DepletionStats => [.. BuildHomeImprovementInvocations()],
+            ChartDataSource.MarketShare => [("GetMarketShare", BuildMarketSharePayload())],
+            ChartDataSource.VariantMix => [("GetVariantMix", BuildVariantMixPayload("Apex Grill", "Southwest"))],
+            ChartDataSource.InventoryLevels => [("GetInventoryLevels", BuildInventoryPayload("Pinnacle Hardware", "Midwest"))],
+            _ => [],
+        };
+    }
+
+    private static (string ToolName, string Raw)[] BuildHistoricalDemandInvocations(ChartAcceptanceCase c)
+    {
+        if (c.ChartType == "line")
+        {
+            return [("GetHistoricalDemand", BuildDemandPayloadAllRegions(c.RequiredEntities.First(), months: 12))];
+        }
+        if (c.ChartType == "bar")
+        {
+            return [.. c.RequiredEntities.Select(b =>
+                ("GetHistoricalDemand", BuildDemandPayloadOneRegion(b, "Northeast", months: 12, perWeekVolume: 800.0)))];
+        }
+
+        // Grouped bar / QSR two-brand — one all-regions payload per brand.
+        return [.. c.RequiredEntities.Select(b =>
+            ("GetHistoricalDemand", BuildDemandPayloadAllRegions(b, months: 12)))];
+    }
+
+    private static (string, string)[] BuildHomeImprovementInvocations()
+    {
+        // A realistic home-improvement table fetches two regions of the portfolio rollup
+        // — bounded, not per-brand-per-region.
+        return
+        [
+            ("GetPortfolioDepletionStats", BuildLargePortfolioPayload("Midwest")),
+            ("GetPortfolioDepletionStats", BuildLargePortfolioPayload("Southeast")),
+        ];
+    }
+
+    // ── Payload builders — sized to the realistic upper end of seeded data ─────
+
+    private static string BuildDemandPayloadOneRegion(string brand, string region, int months, double perWeekVolume)
+    {
+        var weekly = new List<object>();
+        int weeks = months * 4;
+        for (int w = 0; w < weeks; w++)
+        {
+            weekly.Add(new
+            {
+                week_starting = $"2024-{(w % 12) + 1:D2}-{(w % 4 * 7) + 1:D2}",
+                region,
+                channel = "Retail",
+                volume = perWeekVolume,
+                units = 100,
+            });
+        }
+        return JsonSerializer.Serialize(new
+        {
+            period = new { start = "2024-01-01", end = "2024-12-31", months },
+            filters = new { brand, region, channel = (string?)null },
+            summary = new
+            {
+                total_volume = perWeekVolume * weeks,
+                total_units = weeks * 100,
+                weeks_of_data = weeks,
+                avg_weekly_volume = perWeekVolume,
+            },
+            weekly_data = weekly,
+        });
+    }
+
+    private static string BuildDemandPayloadAllRegions(string brand, int months)
+    {
+        var weekly = new List<object>();
+        double totalVolume = 0;
+        int weeks = months * 4;
+        for (int r = 0; r < ChartAcceptanceManifest.SeededRegions.Count; r++)
+        {
+            string region = ChartAcceptanceManifest.SeededRegions[r];
+            double perWeekVolume = 500.0 + (r * 50);
+            for (int w = 0; w < weeks; w++)
+            {
+                weekly.Add(new
+                {
+                    week_starting = $"2024-{(w % 12) + 1:D2}-{(w % 4 * 7) + 1:D2}",
+                    region,
+                    channel = "Retail",
+                    volume = perWeekVolume,
+                    units = 90,
+                });
+                totalVolume += perWeekVolume;
+            }
+        }
+        return JsonSerializer.Serialize(new
+        {
+            period = new { start = "2024-01-01", end = "2024-12-31", months },
+            filters = new { brand, region = (string?)null, channel = (string?)null },
+            summary = new
+            {
+                total_volume = totalVolume,
+                total_units = ChartAcceptanceManifest.SeededRegions.Count * weeks * 90,
+                weeks_of_data = weeks,
+                avg_weekly_volume = Math.Round(totalVolume / weeks, 1),
+            },
+            weekly_data = weekly,
+        });
+    }
+
+    private static string BuildLargePortfolioPayload(string region)
+    {
+        string[] brands =
+        [
+            "Sierra Gold Tequila", "Ridgeline Bourbon", "Summit Vodka",
+            "FreshMart", "Harvest Table", "Apex Grill", "Coastline Tacos",
+            "Pinnacle Hardware", "Summit Outdoor", "ClearDesk", "Urban Living",
+            "Foundry Home",
+        ];
+        var rows = brands.Select((b, i) => new
+        {
+            brand = b,
+            region,
+            metrics = new
+            {
+                depletions_yoy = FormatSigned(-2.5 + (i * 0.9)),
+                sell_through_yoy = "+1.2%",
+                inventory_weeks_on_hand = 6.5 + (i * 0.1),
+                status = "OnTrack",
+            },
+            sentiment_summary = new string('x', 400), // realistic verbose prose that compactor strips
+        }).ToArray();
+        return JsonSerializer.Serialize(new { region, period = "YTD", brandCount = rows.Length, brands = rows });
+    }
+
+    private static string BuildMarketSharePayload()
+    {
+        return JsonSerializer.Serialize(new
+        {
+            filters_applied = new { region = "National" },
+            share_data = new object[]
+            {
+                new { brand = "FreshMart", share_percent = 42.5 },
+                new { brand = "Harvest Table", share_percent = 27.1 },
+                new { brand = "Other Grocery", share_percent = 30.4 },
+            },
+        });
+    }
+
+    private static string BuildVariantMixPayload(string brand, string region)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            filters_applied = new { brand, region },
+            variants = new object[]
+            {
+                new { variant = "Original", mix_percent = 45.0 },
+                new { variant = "Spicy",    mix_percent = 33.0 },
+                new { variant = "Verde",    mix_percent = 22.0 },
+            },
+        });
+    }
+
+    private static string BuildInventoryPayload(string brand, string region)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            items = Array.Empty<object>(),
+            total_items = 20,
+            status_breakdown = new { healthy = 15, low = 3, critical = 1, out_of_stock = 1 },
+            filters_applied = new { brand, region, category = (string?)null, status = (string?)null },
+        });
+    }
+
+    private static string FormatSigned(double value)
+    {
+        string abs = Math.Abs(value).ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
+        return value >= 0 ? $"+{abs}%" : $"-{abs}%";
+    }
+
+    /// <summary>
+    /// Cheap stable argument fingerprint for the dedup key — every distinct call uses
+    /// a distinct raw payload, so hashing on the raw content suffices to keep them
+    /// separate under RequestToolContext dedup.
+    /// </summary>
+    private static string ArgsFingerprint(string toolName, string raw) => $"{toolName}::{raw.GetHashCode(StringComparison.Ordinal):X8}::{raw.Length}";
+}

--- a/tests/RetailPulse.Tests/Contract/ChartAcceptanceManifestContractTests.cs
+++ b/tests/RetailPulse.Tests/Contract/ChartAcceptanceManifestContractTests.cs
@@ -1,0 +1,183 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using RetailPulse.Contracts.Charts;
+using Xunit;
+
+namespace RetailPulse.Tests.Contract;
+
+/// <summary>
+/// Cross-language contract test for the curated chart acceptance manifest.
+///
+/// The single source of truth for the curated prompt library is the frontend file
+/// <c>src/RetailPulse.Web/src/constants/prompts.ts</c>. The backend acceptance manifest
+/// <see cref="ChartAcceptanceManifest"/> and the frontend mirror
+/// <c>src/RetailPulse.Web/src/components/chartAcceptance.ts</c> must both cover exactly
+/// the "Charts" category prompts (in prompt-source order) plus the previously-validated
+/// two-brand QSR comparison prompt — and the README's user-facing chart bullet list must
+/// stay synchronized with that surface.
+///
+/// This test parses <c>prompts.ts</c> and <c>README.md</c> directly and asserts:
+///   * every "Charts" prompt appears in the manifest, in source order,
+///   * the QSR comparison prompt appears at the tail of the manifest,
+///   * every manifest prompt is present in the README's chart bullet list,
+///   * the manifest has no orphan entries that are absent from the prompt source.
+/// A drift in any of those three surfaces fails CI immediately.
+/// </summary>
+public sealed partial class ChartAcceptanceManifestContractTests
+{
+    private const string ChartsCategoryId = "charts";
+    private const string QsrCategoryId = "qsr";
+    private const string QsrComparisonPromptPrefix = "Compare Coastline Tacos vs Apex Grill";
+
+    [Fact]
+    public void Manifest_MatchesFrontendPromptSource_ChartsCategoryPlusQsrComparison()
+    {
+        IReadOnlyList<string> chartPrompts = ReadPromptCategory(ChartsCategoryId);
+        IReadOnlyList<string> qsrPrompts = ReadPromptCategory(QsrCategoryId);
+        string? comparisonPrompt = qsrPrompts.SingleOrDefault(p => p.StartsWith(QsrComparisonPromptPrefix, StringComparison.Ordinal));
+        comparisonPrompt.Should().NotBeNull("the QSR two-brand comparison prompt must exist in the prompt source");
+
+        var expected = new List<string>(chartPrompts) { comparisonPrompt };
+
+        ChartAcceptanceManifest.Prompts.Should().Equal(
+            expected,
+            "the acceptance manifest is the backend mirror of the Charts category (in source order) "
+            + "plus the two-brand QSR comparison prompt — any drift breaks the cross-language contract");
+    }
+
+    [Fact]
+    public void Manifest_PromptsAllAppearInReadmeChartExamples()
+    {
+        HashSet<string> readmePrompts = ReadReadmeChartBulletPrompts();
+
+        foreach (string prompt in ChartAcceptanceManifest.Prompts)
+        {
+            if (prompt.StartsWith(QsrComparisonPromptPrefix, StringComparison.Ordinal))
+            {
+                // The QSR two-brand comparison is documented in a separate example block
+                // (the comparison-chart P0 fix in issue #32) rather than the Charts bullet
+                // list, so it's not expected in the Charts README bullets.
+                continue;
+            }
+
+            readmePrompts.Should().Contain(
+                prompt,
+                $"README chart bullet list must include the curated Charts prompt '{prompt}'");
+        }
+    }
+
+    [Fact]
+    public void Manifest_EveryCaseHasCoherentSemantics()
+    {
+        foreach (ChartAcceptanceCase c in ChartAcceptanceManifest.Cases)
+        {
+            c.Prompt.Should().NotBeNullOrWhiteSpace();
+            c.ChartType.Should().NotBeNullOrWhiteSpace();
+            c.RoutedIntent.Should().NotBeNullOrWhiteSpace();
+            c.RoutedIntent.Should().NotBe(
+                "PortfolioHealth",
+                "explicit chart prompts must never route to the multi-agent health council");
+            c.MinSeries.Should().BeGreaterThanOrEqualTo(1);
+            c.MinMarks.Should().BeGreaterThanOrEqualTo(1);
+            c.AxisUnit.Should().NotBeNullOrWhiteSpace();
+
+            if (c.ChartType is "groupedBar" or "stackedBar")
+            {
+                c.MinSeries.Should().BeGreaterThanOrEqualTo(
+                    2,
+                    "a grouped/stacked chart is by definition multi-series");
+            }
+        }
+    }
+
+    private static IReadOnlyList<string> ReadPromptCategory(string categoryId)
+    {
+        string promptsPath = ResolveRepoRelativePath("src", "RetailPulse.Web", "src", "constants", "prompts.ts");
+        string source = File.ReadAllText(promptsPath);
+
+        // Locate the category block by id, then extract the enclosing prompts: […] array.
+        Match idMatch = Regex.Match(source, $@"id:\s*'{Regex.Escape(categoryId)}'");
+        idMatch.Success.Should().BeTrue($"category '{categoryId}' must exist in prompts.ts");
+
+        int cursor = idMatch.Index;
+        Match promptsHeader = MyRegex().Match(source[cursor..]);
+        promptsHeader.Success.Should().BeTrue($"prompts array must follow id '{categoryId}'");
+        int arrStart = cursor + promptsHeader.Index + promptsHeader.Length;
+
+        int arrEnd = FindMatchingBracket(source, arrStart - 1);
+        arrEnd.Should().BeGreaterThan(arrStart, $"prompts array for '{categoryId}' must be closed");
+
+        string arrBody = source[arrStart..arrEnd];
+        var extracted = new List<string>();
+        foreach (Match m in SingleQuotedStringRegex().Matches(arrBody))
+        {
+            extracted.Add(Regex.Unescape(m.Groups[1].Value));
+        }
+
+        extracted.Should().NotBeEmpty($"category '{categoryId}' should have prompts");
+        return extracted;
+    }
+
+    private static HashSet<string> ReadReadmeChartBulletPrompts()
+    {
+        string readmePath = ResolveRepoRelativePath("README.md");
+        string readme = File.ReadAllText(readmePath);
+        var results = new HashSet<string>(StringComparer.Ordinal);
+
+        // README chart bullets are formatted:  - *"…"* → …
+        foreach (Match m in ReadmeChartBulletRegex().Matches(readme))
+        {
+            results.Add(m.Groups[1].Value);
+        }
+        return results;
+    }
+
+    private static int FindMatchingBracket(string source, int openIndex)
+    {
+        int depth = 0;
+        for (int i = openIndex; i < source.Length; i++)
+        {
+            char c = source[i];
+            if (c == '[')
+            {
+                depth++;
+            }
+            else if (c == ']')
+            {
+                depth--;
+                if (depth == 0) return i;
+            }
+        }
+        return -1;
+    }
+
+    private static string ResolveRepoRelativePath(params string[] segments)
+    {
+        // Walk up from the test binary's directory until we find the repo root (contains
+        // a README.md and a src/ folder). Works from any test host layout.
+        string dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 12; i++)
+        {
+            if (File.Exists(Path.Combine(dir, "README.md"))
+                && Directory.Exists(Path.Combine(dir, "src")))
+            {
+                return Path.Combine([dir, .. segments]);
+            }
+            string? parent = Path.GetDirectoryName(dir);
+            if (string.IsNullOrEmpty(parent) || parent == dir) break;
+            dir = parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate repository root from test binary directory: " + AppContext.BaseDirectory);
+    }
+
+    [GeneratedRegex(@"prompts:\s*\[")]
+    private static partial Regex MyRegex();
+
+    [GeneratedRegex(@"'([^'\\]*(?:\\.[^'\\]*)*)'")]
+    private static partial Regex SingleQuotedStringRegex();
+
+    [GeneratedRegex(@"^\s*[-*]\s+\*""([^""]+)""\*\s*(?:→|->)", RegexOptions.Multiline)]
+    private static partial Regex ReadmeChartBulletRegex();
+}


### PR DESCRIPTION
Closes #50.

## Summary

Every curated chart prompt is now covered by a durable, cross-language acceptance contract enforced end-to-end from the single prompt source (\src/RetailPulse.Web/src/constants/prompts.ts\).

**Backend**

- \RetailPulse.Contracts.Charts.ChartAcceptanceManifest\ — one entry per curated Charts prompt + the two-brand QSR comparison, keyed to the exact prompt text.
- \ChartAcceptanceManifestContractTests\ — parses \prompts.ts\ and \README.md\; fails CI if any of the three surfaces drift.
- \ChartAcceptanceMatrixTests\ — for each of 9 prompts, builds a representative payload, pushes it through the production compactors, and asserts \DeterministicChartBuilder\ + \ChartSpecValidator\ produce a chart matching the manifest's type, min series/marks, required entities, and percent-axis bounds.
- \ChartAcceptancePerformanceTests\ — every prompt fits under **<25,000 estimated tool-context tokens** and **≤5 distinct tool calls** (the numeric ceilings from #50).
- \DeterministicChartBuilder\ grew explicit builders for line trend / grouped-region / all-brand growth ranking / share-or-mix pie / home-improvement table shapes. Missing values are always dropped, never coerced to zero, never fabricated.
- \ChartSpecValidator\ gained \TryGetRenderable(minSeries, minMarks)\ and \MinimumMarksForType\ so callers can gate on semantic minimums (an under-populated "comparison" is rejected in the acceptance layer).
- \ChartRequestDetector\ recognizes "Create a table showing …" (with a data cue) as an explicit chart request; ambiguous English uses of "table" are still excluded.

**Frontend**

- \components/chartAcceptance.ts\ mirrors the backend manifest, deriving prompt text from the single prompt source.
- \__tests__/chartAcceptance.contract.test.ts\ mirrors the backend contract test.
- \__tests__/chartAcceptance.matrix.test.tsx\ mounts \<ChartRenderer/>\ against **real Recharts** for every case and asserts the DOM contains the manifest's marks, legends, required entities, and (for percent axes) bounded Y values.

**Docs + CI**

- \docs/chart-acceptance.md\ — matrix reference.
- \docs/chart-acceptance-run.md\ — browser sign-off log (pending reviewer live run).
- \scripts/browser-chart-acceptance.js\ — devtools console runner to record the live browser verification.
- \.github/workflows/ci.yml\ — explicit chart-acceptance CI steps for the backend and frontend matrix suites so a regression trips CI with a targeted signal.

## Test evidence

- \dotnet test RetailPulse.slnx\ → **2572 passed, 0 failed** (Debug config).
- \
px vitest run\ (56 files) → **481 passed**.
- \dotnet format --verify-no-changes\ → clean.

## Live browser verification

Automated matrix suites pass on this branch; the reviewer approving the PR is expected to paste the outcome of \unChartAcceptance()\ (from \scripts/browser-chart-acceptance.js\) into \docs/chart-acceptance-run.md\ before merge. See #50 for the original P0 acceptance criteria.
