### PR TITLE
fix: stop APIM inference endpoint from doubling the /openai path segment

### DIFF
--- a/infra/modules/apim-openai-api.bicep
+++ b/infra/modules/apim-openai-api.bicep
@@ -204,7 +204,17 @@ resource subscription 'Microsoft.ApiManagement/service/subscriptions@2024-06-01-
 
 output inferenceApiName string = api.name
 output inferenceApiPath string = api.properties.path
-output inferenceEndpoint string = '${apim.properties.gatewayUrl}/${api.properties.path}'
+// NOTE: The Azure OpenAI SDK (AzureOpenAIClient) appends '/openai/deployments/{id}/...'
+// to whatever endpoint it is given. The APIM API path already ends in '/openai'
+// (see `path: '${inferenceApiPath}/openai'` above) purely so the OpenAPI import
+// matches the real AOAI '/openai/deployments/...' route shape. If this output
+// included that trailing '/openai' segment, the SDK would double it up into
+// '.../inference/openai/openai/deployments/...', which APIM rejects with 404
+// OperationNotFound (root cause of the 2026-08-11 production incident — see
+// .squad/decisions/inbox/kroger-incident-*.md). Emit only the base path
+// ('.../inference') so the SDK's own '/openai/deployments/...' suffix lands on
+// the API's actual registered path.
+output inferenceEndpoint string = '${apim.properties.gatewayUrl}/${inferenceApiPath}'
 output subscriptionName string = subscription.name
 
 // Live APIM subscription primary key, resolved at Bicep deploy time via

--- a/tests/RetailPulse.Tests/Deployment/DeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/DeploymentContractTests.cs
@@ -215,6 +215,32 @@ public partial class DeploymentContractTests
     }
 
     [Fact]
+    public void ApimOpenAiApiBicep_InferenceEndpointOutputDoesNotDoubleAppendOpenAiSegment()
+    {
+        // Root cause of the 2026-08-11 production incident: the APIM API's registered
+        // path is '{inferenceApiPath}/openai' (so its OpenAPI import matches AOAI's real
+        // '/openai/deployments/...' route shape), but Azure.AI.OpenAI's AzureOpenAIClient
+        // itself appends '/openai/deployments/{id}/...' to whatever endpoint it is given.
+        // If `inferenceEndpoint` echoed the API's full registered path (including the
+        // trailing '/openai'), the SDK would double it up into
+        // '.../inference/openai/openai/deployments/...', which APIM rejects as 404
+        // OperationNotFound before any agent/tool execution starts. The output must use
+        // only the base `inferenceApiPath` (e.g. '.../inference'), never
+        // `api.properties.path` (e.g. '.../inference/openai').
+        string apimApi = File.ReadAllText(Path.Combine(
+            RepoRoot, "infra", "modules", "apim-openai-api.bicep"));
+
+        apimApi.Should().Contain(
+            "output inferenceEndpoint string = '${apim.properties.gatewayUrl}/${inferenceApiPath}'",
+            "inferenceEndpoint must be built from the base inferenceApiPath param, not api.properties.path, " +
+            "so the AzureOpenAIClient's own '/openai/deployments/...' suffix does not get doubled");
+        apimApi.Should().NotMatchRegex(
+            @"output\s+inferenceEndpoint\s+string\s*=\s*'\$\{apim\.properties\.gatewayUrl\}/\$\{api\.properties\.path\}'",
+            "inferenceEndpoint must not be derived from api.properties.path (that path already ends in " +
+            "'/openai', which combined with the SDK's own suffix produces a double '/openai/openai/' segment)");
+    }
+
+    [Fact]
     public void MainBicep_PipesApimAndSwaOutputsThroughToContainerApps()
     {
         // Ordering matters: staticWebApp + apimOpenAiApi must run BEFORE containerApps so


### PR DESCRIPTION
## Summary
Fixes the P0 production incident where every AI prompt failed fast with "Something went wrong while contacting the AI service" (0 tokens/spans/tool calls, ~299ms -- failure before agent execution started).

Closes #55. References PR #52 (61323c7), PR #53 (8ed3561), issues #51, #50.

## Root cause
`infra/modules/apim-openai-api.bicep` built `inferenceEndpoint` from `api.properties.path` (`.../inference/openai`). The deployed `AzureOpenAIClient` SDK independently appends `/openai/deployments/{id}/chat/completions` to whatever endpoint it is given, so the actual outbound request became `.../inference/openai/openai/deployments/...` -- a double `/openai` segment that APIM rejected with `404 OperationNotFound`.

Confirmed live against APIM:
- `.../inference/openai/openai/deployments/...` → `404`
- `.../inference/openai/deployments/...` → `200` with a valid chat completion

## Fix
- `infra/modules/apim-openai-api.bicep`: `inferenceEndpoint` now derives from the base `inferenceApiPath` param instead of `api.properties.path`.
- `tests/RetailPulse.Tests/Deployment/DeploymentContractTests.cs`: new regression test `ApimOpenAiApiBicep_InferenceEndpointOutputDoesNotDoubleAppendOpenAiSegment` locks the correct output expression in and rejects the buggy one.

## Live mitigation (already applied to restore prod immediately)
```
az containerapp update -n ca-retailpulse-api -g rg-retailpulse-demo-eus-001 \
  --set-env-vars "OpenAI__Endpoint=https://apim-5aldk7aotqods.azure-api.net/inference"
```
New revision `ca-retailpulse-api--0000018` Healthy at 100% traffic. This PR lands the durable Bicep fix so `azd provision` cannot reintroduce the bug on the next deploy.

## Validation
- `dotnet test --filter FullyQualifiedName~DeploymentContractTests` -- 53/53 passed (incl. new test).
- `dotnet format --verify-no-changes` -- clean.
- Live APIM call with corrected URL shape -- `200 OK` with real chat completion.

## Follow-up required before merge
- Publix: execute full live acceptance run against production with this fix applied and attach PASS/FAIL evidence.
- Kroger: final architecture/approval sign-off pending Publix evidence (per standing incident-response protocol).

⚠️ This is a P0 incident fix -- please expedite review.