### PR TITLE
P1: Prompt-ideas frontend acceptance contract + drift tests (26 prompts)

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/ChartRenderer.acceptance.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChartRenderer.acceptance.test.tsx
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FluentProvider, webDarkTheme } from '@fluentui/react-components';
+import type { ChartSpec, ChartSeries } from '../types';
+import {
+  PROMPT_ACCEPTANCE_CASES,
+  type PromptAcceptanceCase,
+} from '../components/promptAcceptance';
+
+/**
+ * Chart-prompt render acceptance keyed off the extended prompt manifest.
+ *
+ * `chartAcceptance.matrix.test.tsx` already renders every chart case through
+ * real Recharts and asserts marks/legends/entities. This suite is complementary
+ * and locks in the acceptance-behavior contract added in issue #58:
+ *
+ *   • Stable `data-testid` structural selectors (never Griffel class
+ *     substrings) — `chart-card`, `chart-title`, `chart-gauge`, `chart-table`.
+ *   • `data-chart-type` attribute matches the manifest's expectedVisualization.
+ *   • Rendered DOM contains no JSON leakage (no `"type": "bar"` or
+ *     `"chart_spec":` blocks).
+ *   • Rendered DOM contains no "Chart unavailable" fallback (no `role=note`).
+ *   • Render completes under a per-case performance ceiling.
+ *
+ * Each case builds a representative ChartSpec that satisfies the manifest,
+ * mounts `<ChartRenderer />` against real Recharts, and asserts the above.
+ */
+
+// Same ResponsiveContainer shim as the matrix test — jsdom measures 0x0 so
+// Recharts renders no inner marks unless we forward an explicit size.
+vi.mock('recharts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('recharts')>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) =>
+      React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+        width: 800,
+        height: 400,
+      }),
+  };
+});
+
+import ChartRenderer from '../components/ChartRenderer';
+
+beforeAll(() => {
+  if (!(globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver) {
+    class RO {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (globalThis as unknown as { ResizeObserver: typeof RO }).ResizeObserver = RO;
+  }
+});
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<FluentProvider theme={webDarkTheme}>{ui}</FluentProvider>);
+}
+
+const SEEDED_REGIONS = [
+  'Northeast',
+  'Southeast',
+  'Midwest',
+  'Southwest',
+  'West Coast',
+  'Pacific Northwest',
+] as const;
+
+/**
+ * Build a representative ChartSpec that satisfies the manifest case's shape.
+ * Mirrors the fixture shapes used by `chartAcceptance.matrix.test.tsx` so both
+ * suites exercise the same production-plausible payloads.
+ */
+function buildSpec(c: PromptAcceptanceCase): ChartSpec {
+  const type = c.expectedVisualization;
+  switch (type) {
+    case 'line': {
+      const brand = c.expectedEntities[0];
+      return {
+        type: 'line',
+        title: `${brand} Depletion Trend by Region`,
+        xAxisTitle: 'Region',
+        yAxisTitle: 'Depletion Volume',
+        data: [
+          {
+            legend: brand,
+            values: SEEDED_REGIONS.map((r, i) => ({ x: r, y: 500 + i * 55 })),
+          },
+        ],
+      };
+    }
+    case 'bar': {
+      return {
+        type: 'bar',
+        title: 'Depletion Velocity by Brand — Northeast',
+        xAxisTitle: 'Brand',
+        yAxisTitle: 'Avg Weekly Depletion Velocity',
+        data: [
+          {
+            legend: 'Avg Weekly Depletion Velocity',
+            values: c.expectedEntities.map((b, i) => ({ x: b, y: 800 + i * 40 })),
+          },
+        ],
+      };
+    }
+    case 'pie': {
+      const values = c.expectedEntities.map((b, i) => ({ x: b, y: 42 - i * 10 }));
+      if (values.length < c.expectedCategories) values.push({ x: 'Other', y: 30 });
+      return {
+        type: 'pie',
+        title: 'Market Share Breakdown',
+        data: [{ legend: 'Market Share %', values }],
+      };
+    }
+    case 'donut': {
+      return {
+        type: 'donut',
+        title: `${c.expectedEntities[0]} Variant Mix`,
+        data: [
+          {
+            legend: 'Variant Mix %',
+            values: [
+              { x: 'Original', y: 45 },
+              { x: 'Spicy', y: 33 },
+              { x: 'Verde', y: 22 },
+            ],
+          },
+        ],
+      };
+    }
+    case 'groupedBar': {
+      const data: ChartSeries[] = c.expectedEntities.map((brand, bi) => ({
+        legend: brand,
+        values: SEEDED_REGIONS.map((r, ri) => ({ x: r, y: 1000 + bi * 200 + ri * 30 })),
+      }));
+      return {
+        type: 'groupedBar',
+        title: `${c.expectedEntities.join(' vs ')} — Depletion Volume by Region`,
+        xAxisTitle: 'Region',
+        yAxisTitle: 'Depletion Volume',
+        data,
+      };
+    }
+    case 'horizontalBar': {
+      return {
+        type: 'horizontalBar',
+        title: 'Brands Ranked by Depletion Growth Rate (YoY)',
+        xAxisTitle: 'Depletion Growth Rate % (YoY)',
+        yAxisTitle: 'Brand',
+        data: [
+          {
+            legend: 'Depletion Growth Rate % (YoY)',
+            values: [
+              { x: 'Ridgeline Bourbon', y: 8.4 },
+              { x: 'Apex Grill', y: 6.1 },
+              { x: 'Coastline Tacos', y: 3.2 },
+              { x: 'FreshMart', y: 1.9 },
+              { x: 'Sierra Gold Tequila', y: -1.2 },
+              { x: 'Summit Vodka', y: -3.4 },
+            ],
+          },
+        ],
+      };
+    }
+    case 'table': {
+      const rows = c.expectedEntities.flatMap((brand) =>
+        ['Midwest', 'Southeast'].map((region) => `${brand} — ${region}`),
+      );
+      return {
+        type: 'table',
+        title: 'Depletion Stats by Region',
+        xAxisTitle: 'Brand / Region',
+        yAxisTitle: 'Depletion Stats',
+        data: [
+          { legend: 'Depletions YoY %', values: rows.map((label, i) => ({ x: label, y: 2 + i * 0.5 })) },
+          { legend: 'Sell-Through YoY %', values: rows.map((label, i) => ({ x: label, y: 1 + i * 0.3 })) },
+          { legend: 'Inventory (weeks on hand)', values: rows.map((label, i) => ({ x: label, y: 7 + i * 0.2 })) },
+        ],
+      };
+    }
+    case 'gauge': {
+      return {
+        type: 'gauge',
+        title: `${c.expectedEntities[0]} Inventory Health — Midwest`,
+        data: [
+          {
+            legend: 'Inventory Health',
+            values: [{ x: `${c.expectedEntities[0]} — Midwest`, y: 75 }],
+          },
+        ],
+      };
+    }
+    default:
+      throw new Error(`Unhandled chart visualization: ${type}`);
+  }
+}
+
+const CHART_CASES = PROMPT_ACCEPTANCE_CASES.filter((c) => c.responseClass === 'chart');
+
+// Chart-spec JSON leakage sentinels — a leak looks like the shape emitted by
+// the model in issue #15 (canonical or Chart.js-style). None must ever survive
+// to the rendered assistant DOM.
+const JSON_LEAKAGE_PATTERNS = [
+  /"chart_spec"\s*:/,
+  /"type"\s*:\s*"(?:line|bar|groupedBar|horizontalBar|pie|donut|gauge|table)"/i,
+  /"labels"\s*:\s*\[/,
+  /"series"\s*:\s*\[\s*\{/,
+];
+
+// Per-case render ceiling: pure jsdom + real Recharts, no network, one card.
+// Ships with a generous ceiling so the assertion catches order-of-magnitude
+// regressions (e.g. an infinite render loop) without becoming a flake vector.
+const RENDER_CEILING_MS = 1500;
+
+describe('Chart prompt render acceptance (testids + no leakage + ceilings)', () => {
+  it('covers every chart-class prompt from the manifest', () => {
+    expect(CHART_CASES.length).toBe(9);
+  });
+
+  it.each(CHART_CASES.map((c) => [c.prompt, c] as const))(
+    'renders "%s" with stable testids, no leakage, no fallback, under the perf ceiling',
+    (_prompt, c) => {
+      const spec = buildSpec(c);
+      const t0 = performance.now();
+      const { container } = renderWithProvider(<ChartRenderer charts={[spec]} />);
+      const elapsed = performance.now() - t0;
+
+      // ── Structural selectors (never Griffel classes) ─────────────────
+      const card = container.querySelector('[data-testid="chart-card"]');
+      expect(card, `${c.prompt} — chart-card testid`).not.toBeNull();
+      expect(card!.getAttribute('data-chart-type')).toBe(c.expectedVisualization.toLowerCase());
+
+      const title = container.querySelector('[data-testid="chart-title"]');
+      expect(title, `${c.prompt} — chart-title testid`).not.toBeNull();
+      expect(title!.textContent).toBe(spec.title);
+
+      // Shape-specific structural anchor.
+      switch (c.expectedVisualization) {
+        case 'gauge':
+          expect(container.querySelector('[data-testid="chart-gauge"]')).not.toBeNull();
+          expect(container.querySelector('[data-testid="chart-gauge-svg"]')).not.toBeNull();
+          break;
+        case 'table':
+          expect(container.querySelector('[data-testid="chart-table"]')).not.toBeNull();
+          expect(container.querySelectorAll('[data-testid="chart-table"] tbody tr').length)
+            .toBeGreaterThanOrEqual(c.expectedCategories);
+          break;
+        default:
+          // Recharts SVG anchor — a real chart always emits a <svg class="recharts-surface">.
+          expect(container.querySelector('svg.recharts-surface')).not.toBeNull();
+      }
+
+      // ── No JSON leakage ──────────────────────────────────────────────
+      const rendered = container.textContent ?? '';
+      for (const rx of JSON_LEAKAGE_PATTERNS) {
+        expect(
+          rendered,
+          `${c.prompt} — rendered DOM must not leak chart-spec JSON (${rx})`,
+        ).not.toMatch(rx);
+      }
+
+      // ── No fallback error text ───────────────────────────────────────
+      expect(
+        screen.queryByRole('note'),
+        `${c.prompt} — 'Chart unavailable' fallback must NOT be rendered for a bindable spec`,
+      ).toBeNull();
+      expect(container.querySelector('[data-testid="chart-unavailable"]')).toBeNull();
+
+      // ── Entity presence (title OR body) ──────────────────────────────
+      for (const entity of c.expectedEntities) {
+        const inTitle = spec.title.includes(entity);
+        const inDom = rendered.includes(entity);
+        expect(
+          inTitle || inDom,
+          `${c.prompt} — required entity '${entity}' must appear somewhere in the chart DOM`,
+        ).toBe(true);
+      }
+
+      // ── Performance ceiling ──────────────────────────────────────────
+      expect(
+        elapsed,
+        `${c.prompt} — rendered in ${elapsed.toFixed(0)}ms, ceiling ${RENDER_CEILING_MS}ms`,
+      ).toBeLessThan(RENDER_CEILING_MS);
+    },
+  );
+
+  it('surfaces the "chart-unavailable" fallback (never silent) when a spec has no bindable data', () => {
+    // Regression guard for the acceptance-behavior promise: `noFallbackErrorText`
+    // holds ONLY when the spec is bindable. This test verifies the opposite side
+    // of the invariant — a truly unbindable spec MUST use the testid-anchored
+    // fallback, not an empty card.
+    const { container } = renderWithProvider(
+      <ChartRenderer
+        charts={[
+          {
+            type: 'bar',
+            title: 'Unbindable regression fixture',
+            data: [{ legend: 'x', values: [] }],
+          },
+        ]}
+      />,
+    );
+    expect(container.querySelector('[data-testid="chart-unavailable"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="chart-card"]')).toBeNull();
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/PromptLibrary.browser.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/PromptLibrary.browser.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentProvider, webDarkTheme } from '@fluentui/react-components';
+import { PromptLibrary } from '../components/PromptLibrary';
+import { PROMPT_CATEGORIES } from '../constants/prompts';
+import { PROMPT_ACCEPTANCE_CASES } from '../components/promptAcceptance';
+
+/**
+ * Production-capable "browser" style acceptance for the Prompt Ideas popover.
+ *
+ * "Browser-style" here means:
+ *   • Selectors are stable `data-testid` anchors and role/name pairs — never
+ *     Griffel class name substrings (which change on every Fluent release and
+ *     across build modes).
+ *   • Assertions poll with `waitFor` / `findBy*` instead of racing on
+ *     synchronous DOM, so the test survives Fluent's portal-mount timing and
+ *     tabster's aria-hidden dance under jsdom, and would translate cleanly to
+ *     a real browser runner (Playwright / Cypress) if wired up.
+ *   • Every one of the 27 curated Prompt Ideas is proven discoverable through
+ *     the popover's own UX — trigger click, category filter click, prompt
+ *     click — with no back-door selector into private component state.
+ *
+ * This test is intentionally exhaustive: an editor change that hides a prompt
+ * behind a broken category filter, or a Fluent version that reworks the popover
+ * portal, will trip a specific failing case pointing at the offending prompt.
+ */
+
+function renderLibrary(props: Partial<React.ComponentProps<typeof PromptLibrary>> = {}) {
+  const onSelect = props.onSelect ?? vi.fn();
+  const utils = render(
+    <FluentProvider theme={webDarkTheme}>
+      <PromptLibrary categories={PROMPT_CATEGORIES} onSelect={onSelect} {...props} />
+    </FluentProvider>,
+  );
+  return { onSelect, ...utils };
+}
+
+/** Poll until the popover panel is mounted, then return its DOM node. */
+async function openPanel(user: ReturnType<typeof userEvent.setup>): Promise<HTMLElement> {
+  const trigger = document.querySelector('[data-testid="prompt-library-trigger"]') as HTMLElement | null;
+  expect(trigger, 'prompt-library-trigger testid must exist').not.toBeNull();
+  await user.click(trigger!);
+  const panel = await waitFor(
+    () => {
+      const el = document.querySelector('[data-testid="prompt-library-panel"]');
+      if (!el) throw new Error('panel not mounted yet');
+      return el as HTMLElement;
+    },
+    { timeout: 5000 },
+  );
+  return panel;
+}
+
+describe('Prompt Ideas — production-style browser acceptance', () => {
+  it('exposes exactly the 27 acceptance-manifest prompts through the popover (all-categories view)', async () => {
+    const user = userEvent.setup();
+    renderLibrary();
+    const panel = await openPanel(user);
+
+    // Wait for the "All" category items list to fully mount.
+    await waitFor(() => {
+      const items = panel.querySelectorAll('[data-testid="prompt-library-item"]');
+      // "All" view mounts every prompt.
+      expect(items.length).toBe(PROMPT_ACCEPTANCE_CASES.length);
+    });
+
+    const items = Array.from(
+      panel.querySelectorAll<HTMLButtonElement>('[data-testid="prompt-library-item"]'),
+    );
+    const textInOrder = items.map((el) => el.textContent?.trim() ?? '');
+    const expected = PROMPT_ACCEPTANCE_CASES.map((c) => c.prompt);
+    expect(textInOrder).toEqual(expected);
+  });
+
+  it.each(PROMPT_CATEGORIES.map((c) => [c.id, c.label] as const))(
+    'filters to only the "%s" category prompts when its chip is clicked',
+    async (categoryId) => {
+      const user = userEvent.setup();
+      renderLibrary();
+      const panel = await openPanel(user);
+
+      const chip = panel.querySelector(
+        `[data-testid="prompt-library-category-${categoryId}"]`,
+      ) as HTMLButtonElement | null;
+      expect(chip, `category chip for '${categoryId}' must exist`).not.toBeNull();
+      await user.click(chip!);
+
+      const categoryPrompts = PROMPT_ACCEPTANCE_CASES.filter((c) => c.categoryId === categoryId).map(
+        (c) => c.prompt,
+      );
+
+      await waitFor(() => {
+        const items = panel.querySelectorAll<HTMLButtonElement>(
+          '[data-testid="prompt-library-item"]',
+        );
+        expect(items.length).toBe(categoryPrompts.length);
+        expect(Array.from(items).map((el) => el.textContent?.trim())).toEqual(categoryPrompts);
+      });
+
+      // aria-pressed state on the active chip is the ARIA contract; testid+state
+      // both must move together.
+      expect(chip!.getAttribute('aria-pressed')).toBe('true');
+    },
+  );
+
+  it.each(PROMPT_ACCEPTANCE_CASES.map((c) => [c.id, c.prompt] as const))(
+    'dispatches "%s" (%s) through the popover selection flow',
+    async (id, promptText) => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+      renderLibrary({ onSelect });
+      const panel = await openPanel(user);
+
+      // Find the button whose textContent exactly matches the featured prompt.
+      const button = await waitFor(() => {
+        const items = Array.from(
+          panel.querySelectorAll<HTMLButtonElement>('[data-testid="prompt-library-item"]'),
+        );
+        const hit = items.find((el) => el.textContent?.trim() === promptText);
+        if (!hit) throw new Error(`prompt '${promptText}' (${id}) not yet mounted`);
+        return hit;
+      });
+
+      await user.click(button);
+
+      await waitFor(() => {
+        expect(onSelect).toHaveBeenCalledWith(promptText);
+      });
+    },
+  );
+
+  it('never leaks a raw chart-spec JSON block into the popover DOM', async () => {
+    const user = userEvent.setup();
+    renderLibrary();
+    const panel = await openPanel(user);
+    // Every rendered item text must be plain prompt prose — no JSON payloads
+    // from a curated string masquerading as a prompt. Defense against a future
+    // author pasting a JSON-shaped prompt into `constants/prompts.ts`.
+    const items = panel.querySelectorAll('[data-testid="prompt-library-item"]');
+    for (const el of Array.from(items)) {
+      const text = el.textContent ?? '';
+      expect(text).not.toMatch(/"type"\s*:\s*"(?:line|bar|pie|donut|gauge|table)"/i);
+      expect(text).not.toMatch(/"chart_spec"\s*:/);
+    }
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/promptAcceptance.contract.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/promptAcceptance.contract.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PROMPT_CATEGORIES } from '../constants/prompts';
+import {
+  PROMPT_ACCEPTANCE_CASES,
+  FEATURED_PROMPTS,
+  findAcceptanceCase,
+} from '../components/promptAcceptance';
+import { CHART_ACCEPTANCE_CASES } from '../components/chartAcceptance';
+
+/**
+ * Bidirectional drift contract for the complete Prompt Ideas surface.
+ *
+ * The chart-only manifest already asserts the 9 chart prompts + README chart
+ * bullets stay in sync. This suite widens the guarantee to every one of the
+ * 27 curated Prompt Ideas: every featured prompt has an acceptance case, and
+ * every acceptance case is still a featured prompt. A rename, deletion, or
+ * silent addition on either side fails CI before it can reach the demo.
+ *
+ * The suite also detects intentional mirror disagreement across README /
+ * docs / frontend prompt source / backend chart manifest, so a chart prompt
+ * removed from the frontend can't quietly linger in the backend manifest or
+ * the README bullet list.
+ */
+
+function repoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i++) {
+    if (
+      existsSync(join(dir, 'README.md'))
+      && existsSync(join(dir, 'src', 'RetailPulse.Web'))
+    ) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (!parent || parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate repository root from test file location');
+}
+
+describe('Prompt Ideas — bidirectional drift', () => {
+  it('the frontend prompt source exposes exactly the expected 27 curated prompts across 7 categories', () => {
+    // Regression guard: `PROMPT_CATEGORIES` is the single source of truth and
+    // its shape drives every dependent surface. This is not a lockdown on
+    // adding prompts — it is a deliberate step that forces a squad decision
+    // (and this test update) when the surface count changes, so drift can
+    // never happen silently.
+    const totalPrompts = PROMPT_CATEGORIES.reduce((n, c) => n + c.prompts.length, 0);
+    expect(PROMPT_CATEGORIES).toHaveLength(7);
+    expect(totalPrompts).toBe(26);
+  });
+
+  it('every featured prompt has exactly one acceptance case', () => {
+    for (const prompt of FEATURED_PROMPTS) {
+      const match = PROMPT_ACCEPTANCE_CASES.filter((c) => c.prompt === prompt);
+      expect(
+        match.length,
+        `featured prompt '${prompt}' must have exactly one acceptance case (found ${match.length})`,
+      ).toBe(1);
+    }
+  });
+
+  it('every acceptance case is still a featured prompt', () => {
+    const featured = new Set(FEATURED_PROMPTS);
+    for (const c of PROMPT_ACCEPTANCE_CASES) {
+      expect(
+        featured.has(c.prompt),
+        `acceptance case '${c.prompt}' is orphaned — no longer in PROMPT_CATEGORIES`,
+      ).toBe(true);
+    }
+  });
+
+  it('acceptance cases preserve the source prompt order per category', () => {
+    // A demo-driven ordering guarantee: the popover, the New Chat welcome, and
+    // the manifest must all iterate prompts in the same order so tests are
+    // deterministic regardless of which surface they hit.
+    let sourceIndex = 0;
+    for (const cat of PROMPT_CATEGORIES) {
+      for (const prompt of cat.prompts) {
+        expect(PROMPT_ACCEPTANCE_CASES[sourceIndex].prompt).toBe(prompt);
+        expect(PROMPT_ACCEPTANCE_CASES[sourceIndex].categoryId).toBe(cat.id);
+        expect(PROMPT_ACCEPTANCE_CASES[sourceIndex].id).toBe(`${cat.id}:${cat.prompts.indexOf(prompt)}`);
+        sourceIndex++;
+      }
+    }
+    expect(sourceIndex).toBe(PROMPT_ACCEPTANCE_CASES.length);
+  });
+
+  it('classifies every chart-category prompt as responseClass=chart with a real visualization', () => {
+    const chartCategory = PROMPT_CATEGORIES.find((c) => c.id === 'charts');
+    expect(chartCategory).toBeDefined();
+    for (const prompt of chartCategory!.prompts) {
+      const c = findAcceptanceCase(prompt);
+      expect(c, `chart-category prompt '${prompt}' must have an acceptance case`).toBeDefined();
+      expect(c!.responseClass).toBe('chart');
+      expect(c!.expectedVisualization).not.toBe('none');
+      expect(c!.expectedSeries).toBeGreaterThanOrEqual(1);
+      expect(c!.expectedCategories).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('classifies every non-chart-category prompt as responseClass=prose with expectedVisualization=none (except the QSR chart mirror)', () => {
+    for (const cat of PROMPT_CATEGORIES) {
+      if (cat.id === 'charts') continue;
+      for (const prompt of cat.prompts) {
+        const c = findAcceptanceCase(prompt)!;
+        // Single documented exception: the QSR two-brand comparison is a
+        // grouped-bar CHART prompt lifted into the chart acceptance manifest.
+        const isQsrChartMirror = prompt.startsWith('Compare Coastline Tacos vs Apex Grill');
+        if (isQsrChartMirror) {
+          expect(c.responseClass).toBe('chart');
+          expect(c.expectedVisualization).toBe('groupedBar');
+          continue;
+        }
+        expect(c.responseClass, `${prompt} — non-chart category prompt`).toBe('prose');
+        expect(c.expectedVisualization, `${prompt} — prose prompt visualization`).toBe('none');
+        expect(c.expectedSeries).toBe(0);
+      }
+    }
+  });
+
+  it('gives every chart acceptance case a matching prompt-manifest entry with the same chart type', () => {
+    // Detect drift the other direction: if the chart manifest gains a case
+    // that the prompt manifest hasn't inherited (via CHART_ACCEPTANCE_CASES),
+    // the two mirrors are out of sync.
+    for (const chart of CHART_ACCEPTANCE_CASES) {
+      const c = findAcceptanceCase(chart.prompt);
+      expect(c, `chart case '${chart.prompt}' must appear in the prompt manifest`).toBeDefined();
+      expect(c!.responseClass).toBe('chart');
+      expect(c!.expectedVisualization).toBe(chart.chartType);
+      expect(c!.expectedSeries).toBe(chart.minSeries);
+      expect(c!.expectedCategories).toBe(chart.minMarks);
+      expect(c!.expectedEntities).toEqual(chart.requiredEntities);
+    }
+  });
+
+  it('README chart bullet list mirrors every chart-category acceptance case', () => {
+    const readme = readFileSync(join(repoRoot(), 'README.md'), 'utf-8');
+    const readmePrompts = new Set(
+      [...readme.matchAll(/^\s*[-*]\s+\*"([^"]+)"\*\s*(?:→|->)/gm)].map((m) => m[1]),
+    );
+    for (const c of PROMPT_ACCEPTANCE_CASES) {
+      if (c.categoryId !== 'charts') continue;
+      expect(
+        readmePrompts.has(c.prompt),
+        `README chart bullet list must include chart-category prompt '${c.prompt}'`,
+      ).toBe(true);
+    }
+  });
+
+  it('no README chart bullet references a prompt that isn\'t in the frontend manifest', () => {
+    const readme = readFileSync(join(repoRoot(), 'README.md'), 'utf-8');
+    const readmePrompts = [...readme.matchAll(/^\s*[-*]\s+\*"([^"]+)"\*\s*(?:→|->)/gm)].map(
+      (m) => m[1],
+    );
+    const featured = new Set(FEATURED_PROMPTS);
+    for (const prompt of readmePrompts) {
+      expect(
+        featured.has(prompt),
+        `README documents chart prompt '${prompt}' but PROMPT_CATEGORIES no longer features it — README/frontend mirror disagreement`,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/promptAcceptance.nonChart.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/promptAcceptance.nonChart.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { PROMPT_ACCEPTANCE_CASES } from '../components/promptAcceptance';
+
+/**
+ * Non-chart (prose) prompt acceptance contract.
+ *
+ * The chart matrix (`chartAcceptance.matrix.test.tsx`) covers the 9 chart
+ * prompts against real Recharts. Prose prompts don't render a chart, but the
+ * demo still contracts a shape:
+ *
+ *   • Every prose case declares the entities its response must reference.
+ *   • Every prose case shares the same hard performance ceilings as the chart
+ *     matrix (≤5 tool calls, <25K cumulative tool-context tokens) — a prose
+ *     lookup must NEVER cost more than a chart fulfillment.
+ *   • Every prose case explicitly promises no JSON leakage and no fallback
+ *     error text in the rendered assistant DOM (asserted by the render suite
+ *     and by `sanitizeMessage` — this test locks the promise into the
+ *     manifest itself so a future edit can't quietly relax it).
+ *
+ * Coupled with the bidirectional drift test, this contract guarantees that
+ * every non-chart prompt in the popover / welcome / library / README has a
+ * defined behavior; no orphan prompts, no silently-broken ceilings.
+ */
+describe('Prompt Ideas — non-chart (prose) contract', () => {
+  const proseCases = PROMPT_ACCEPTANCE_CASES.filter((c) => c.responseClass === 'prose');
+
+  it('covers every non-chart prompt with at least one expected entity mention', () => {
+    // 26 total prompts, 9 chart cases (8 chart-category + QSR mirror) → 17 prose.
+    expect(proseCases.length).toBe(17);
+    for (const c of proseCases) {
+      expect(c.expectedEntities.length, `${c.prompt} — must declare ≥1 expected entity`).toBeGreaterThanOrEqual(1);
+      expect(c.expectedCategories, `${c.prompt} — must declare ≥1 expected mention`).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('every non-chart entity string is non-empty and free of markup', () => {
+    for (const c of proseCases) {
+      for (const entity of c.expectedEntities) {
+        expect(entity.trim(), `${c.prompt} — empty entity`).not.toBe('');
+        expect(entity, `${c.prompt} — entity '${entity}' must not contain markup`).not.toMatch(/[<>]/);
+      }
+    }
+  });
+
+  it('every non-chart prompt honors the hard tool-call and token-budget ceilings', () => {
+    for (const c of proseCases) {
+      expect(c.maxToolCalls, `${c.prompt} — tool-call ceiling`).toBeLessThanOrEqual(5);
+      expect(c.maxTokenBudget, `${c.prompt} — token budget`).toBeLessThanOrEqual(25_000);
+    }
+  });
+
+  it('every non-chart prompt explicitly promises no JSON leakage and no fallback error text', () => {
+    for (const c of proseCases) {
+      expect(c.noJsonLeakage, `${c.prompt} — noJsonLeakage`).toBe(true);
+      expect(c.noFallbackErrorText, `${c.prompt} — noFallbackErrorText`).toBe(true);
+      // Prose prompts never render a chart, so expectedVisualization must be explicit 'none'.
+      expect(c.expectedVisualization).toBe('none');
+    }
+  });
+
+  it('every chart prompt also honors the ceilings (chart cases mirror the same contract)', () => {
+    const chartCases = PROMPT_ACCEPTANCE_CASES.filter((c) => c.responseClass === 'chart');
+    expect(chartCases.length).toBe(9);
+    for (const c of chartCases) {
+      expect(c.maxToolCalls).toBeLessThanOrEqual(5);
+      expect(c.maxTokenBudget).toBeLessThanOrEqual(25_000);
+      expect(c.noJsonLeakage).toBe(true);
+      expect(c.noFallbackErrorText).toBe(true);
+      expect(c.expectedVisualization).not.toBe('none');
+    }
+  });
+});

--- a/src/RetailPulse.Web/src/components/ChartRenderer.tsx
+++ b/src/RetailPulse.Web/src/components/ChartRenderer.tsx
@@ -210,13 +210,14 @@ function RenderGauge({ spec }: { spec: ChartSpec }) {
   const angle = (pct / 100) * 180;
   const accessibleLabel = `${spec.title}${label ? ` — ${label}` : ''}: ${value} percent`;
   return (
-    <div className={styles.gaugeContainer}>
+    <div className={styles.gaugeContainer} data-testid="chart-gauge">
       <svg
         width={220}
         height={130}
         viewBox="0 0 220 130"
         role="img"
         aria-label={accessibleLabel}
+        data-testid="chart-gauge-svg"
       >
         <title>{accessibleLabel}</title>
         <path d="M 20 120 A 90 90 0 0 1 200 120" fill="none" stroke="rgba(255,255,255,0.1)" strokeWidth={16} strokeLinecap="round" />
@@ -246,8 +247,8 @@ function RenderTable({ spec }: { spec: ChartSpec }) {
     return m;
   }, [spec.data]);
   return (
-    <div className={styles.tableWrapper}>
-      <table className={styles.table}>
+    <div className={styles.tableWrapper} data-testid="chart-table-wrapper">
+      <table className={styles.table} data-testid="chart-table">
         <thead>
           <tr>
             <th className={styles.th}>{spec.xAxisTitle || ''}</th>
@@ -302,8 +303,8 @@ function SingleChart({ spec }: { spec: ChartSpec }) {
       break;
   }
   return (
-    <Card className={styles.chartCard} appearance="subtle">
-      <div className={styles.chartTitle}>{spec.title}</div>
+    <Card className={styles.chartCard} appearance="subtle" data-testid="chart-card" data-chart-type={t}>
+      <div className={styles.chartTitle} data-testid="chart-title">{spec.title}</div>
       {content}
     </Card>
   );
@@ -316,7 +317,7 @@ function SingleChart({ spec }: { spec: ChartSpec }) {
 function ChartUnavailable({ title }: { title?: string }) {
   const styles = useStyles();
   return (
-    <div className={styles.unavailableCard} role="note">
+    <div className={styles.unavailableCard} role="note" data-testid="chart-unavailable">
       {title ? <div className={styles.unavailableTitle}>{title}</div> : null}
       <div className={styles.unavailableNote}>
         Chart unavailable — the data returned couldn&apos;t be rendered as a chart.

--- a/src/RetailPulse.Web/src/components/PromptLibrary.tsx
+++ b/src/RetailPulse.Web/src/components/PromptLibrary.tsx
@@ -167,11 +167,12 @@ export function PromptLibrary({ categories, onSelect, disabled }: PromptLibraryP
           icon={<Lightbulb24Regular />}
           disabled={disabled}
           aria-label="Prompt ideas"
+          data-testid="prompt-library-trigger"
         >
           Prompt ideas
         </Button>
       </PopoverTrigger>
-      <PopoverSurface className={styles.surface} aria-label="Prompt library">
+      <PopoverSurface className={styles.surface} aria-label="Prompt library" data-testid="prompt-library-panel">
         <div className={styles.panel}>
           <div className={styles.header}>
             <Text as="h2" className={styles.title}>
@@ -181,11 +182,12 @@ export function PromptLibrary({ categories, onSelect, disabled }: PromptLibraryP
               Browse a category and pick a prompt to send.
             </Text>
           </div>
-          <div className={styles.categoryChips} role="group" aria-label="Prompt categories">
+          <div className={styles.categoryChips} role="group" aria-label="Prompt categories" data-testid="prompt-library-categories">
             <button
               type="button"
               className={`${styles.categoryChip} ${selectedCategory === null ? styles.categoryChipActive : ''}`}
               aria-pressed={selectedCategory === null}
+              data-testid="prompt-library-category-all"
               onClick={() => setSelectedCategory(null)}
             >
               🏪 All
@@ -196,15 +198,16 @@ export function PromptLibrary({ categories, onSelect, disabled }: PromptLibraryP
                 type="button"
                 className={`${styles.categoryChip} ${selectedCategory === cat.id ? styles.categoryChipActive : ''}`}
                 aria-pressed={selectedCategory === cat.id}
+                data-testid={`prompt-library-category-${cat.id}`}
                 onClick={() => setSelectedCategory(cat.id)}
               >
                 {cat.emoji} {cat.label}
               </button>
             ))}
           </div>
-          <div className={styles.promptList}>
+          <div className={styles.promptList} data-testid="prompt-library-list">
             {visibleCategories.map((cat) => (
-              <div key={cat.id} className={styles.promptGroup}>
+              <div key={cat.id} className={styles.promptGroup} data-testid={`prompt-library-group-${cat.id}`}>
                 {!selectedCategory && (
                   <Text className={styles.groupLabel}>
                     {cat.emoji} {cat.label}
@@ -215,6 +218,9 @@ export function PromptLibrary({ categories, onSelect, disabled }: PromptLibraryP
                     key={`${cat.id}-${i}`}
                     type="button"
                     className={styles.promptButton}
+                    data-testid="prompt-library-item"
+                    data-prompt-category={cat.id}
+                    data-prompt-index={i}
                     onClick={() => handlePromptClick(prompt)}
                     disabled={disabled}
                   >

--- a/src/RetailPulse.Web/src/components/promptAcceptance.ts
+++ b/src/RetailPulse.Web/src/components/promptAcceptance.ts
@@ -1,0 +1,241 @@
+/**
+ * Canonical acceptance manifest for EVERY curated Prompt Idea.
+ *
+ * The chart-only manifest (`chartAcceptance.ts`) covers the 9 chart-shaped
+ * prompts and drives the real-Recharts render matrix. This module extends the
+ * coverage to every prompt in `PROMPT_CATEGORIES` — including the 18 prose
+ * prompts — with a single, uniform contract shape:
+ *
+ *   • id                    — stable synthetic id (`{category}:{index}`) so
+ *                             tests can key off a symbol instead of quoting
+ *                             prompt text everywhere.
+ *   • categoryId            — the source category (`general`, `grocery`, `qsr`,
+ *                             `home-improvement`, `office-supply`, `furniture`,
+ *                             `charts`).
+ *   • prompt                — the verbatim prompt text (single source of truth,
+ *                             pulled from `PROMPT_CATEGORIES`).
+ *   • responseClass         — `'chart'` for prompts that must yield a rendered
+ *                             chart, `'prose'` for prompts that must yield a
+ *                             narrated answer with entity mentions.
+ *   • expectedVisualization — chart type for chart prompts, `'none'` for prose
+ *                             prompts (explicit — never implicit).
+ *   • expectedEntities      — entity labels (brands / regions / variants) the
+ *                             response MUST reference so the demo lands.
+ *   • expectedSeries        — chart prompts: minimum legend-bearing series.
+ *                             prose prompts: `0` (not applicable).
+ *   • expectedCategories    — chart prompts: minimum finite marks/rows.
+ *                             prose prompts: minimum distinct entity mentions.
+ *   • maxToolCalls          — hard ceiling on distinct tool invocations (matches
+ *                             the backend #50 ceiling for chart prompts).
+ *   • maxTokenBudget        — hard ceiling on cumulative tool-context tokens.
+ *   • noJsonLeakage         — rendered assistant DOM must never contain a
+ *                             chart-spec JSON block or raw tool payload.
+ *   • noFallbackErrorText   — rendered DOM must never surface the
+ *                             "Chart unavailable" diagnostic (only shown when
+ *                             a spec has no bindable data).
+ *
+ * The prompt text is NEVER duplicated in this file — every case is derived
+ * from `PROMPT_CATEGORIES` at module load, and the bidirectional drift test
+ * (`promptAcceptance.contract.test.ts`) enforces that every featured prompt
+ * has an acceptance case AND every acceptance case is still featured.
+ */
+import { PROMPT_CATEGORIES } from '../constants/prompts';
+import { CHART_ACCEPTANCE_CASES, type ChartAcceptanceCase, type ChartType } from './chartAcceptance';
+
+export type ResponseClass = 'chart' | 'prose';
+
+export type ExpectedVisualization = ChartType | 'none';
+
+export interface PromptAcceptanceCase {
+  readonly id: string;
+  readonly categoryId: string;
+  readonly prompt: string;
+  readonly responseClass: ResponseClass;
+  readonly expectedVisualization: ExpectedVisualization;
+  /** Entity labels (brands, regions, variants) that MUST appear in the response. */
+  readonly expectedEntities: readonly string[];
+  /** Minimum legend-bearing series (chart prompts) or 0 (prose prompts). */
+  readonly expectedSeries: number;
+  /** Minimum finite marks/rows (chart) or minimum entity mentions (prose). */
+  readonly expectedCategories: number;
+  /** Hard ceiling on distinct tool invocations — matches backend issue #50 ceiling. */
+  readonly maxToolCalls: number;
+  /** Hard ceiling on cumulative tool-context tokens — matches backend issue #50 ceiling. */
+  readonly maxTokenBudget: number;
+  /** True — assistant DOM must never contain a chart-spec JSON block. */
+  readonly noJsonLeakage: true;
+  /** True — assistant DOM must never surface the "Chart unavailable" fallback. */
+  readonly noFallbackErrorText: true;
+}
+
+/**
+ * Hard ceilings from issue #50 — chart prompts are the most tool-heavy demand
+ * on the tool-context budget. Prose prompts are strictly lighter (single-tool
+ * lookups, no chart fulfillment), so they share the same ceiling as a safety
+ * ceiling that they can only under-run.
+ */
+const MAX_TOOL_CALLS = 5;
+const MAX_TOKEN_BUDGET = 25_000;
+
+/**
+ * Prose-prompt semantics keyed by verbatim prompt text.
+ *
+ * A missing key trips the contract test — every non-chart featured prompt must
+ * describe the entities its response is expected to name. This is the demo
+ * bar: "field sentiment for Coastline Tacos in the West Coast" is only a
+ * successful answer if the assistant references Coastline Tacos AND the West
+ * Coast region; the same principle applies to every prose prompt.
+ */
+const PROSE_SEMANTICS: Record<
+  string,
+  { expectedEntities: readonly string[]; expectedCategories: number }
+> = {
+  // ── General Retail ──
+  'Compare depletion trends across all regions for this quarter': {
+    expectedEntities: ['depletion', 'region'],
+    expectedCategories: 2,
+  },
+  'Which brands are growing fastest year-over-year across the portfolio?': {
+    expectedEntities: ['brand', 'year-over-year'],
+    expectedCategories: 2,
+  },
+  'Show me field sentiment for our top 3 brands in the Southeast': {
+    expectedEntities: ['sentiment', 'Southeast'],
+    expectedCategories: 2,
+  },
+
+  // ── Grocery ──
+  'How are FreshMart depletions trending in the Northeast this quarter?': {
+    expectedEntities: ['FreshMart', 'Northeast'],
+    expectedCategories: 2,
+  },
+  'Compare Harvest Table vs FreshMart sell-through rates by region': {
+    expectedEntities: ['Harvest Table', 'FreshMart'],
+    expectedCategories: 2,
+  },
+  'What is the field sentiment for Harvest Table Meal Kits in the Midwest?': {
+    expectedEntities: ['Harvest Table', 'Midwest'],
+    expectedCategories: 2,
+  },
+
+  // ── Quick-Serve Restaurants ──
+  'How is Apex Grill performing in the Southwest this quarter?': {
+    expectedEntities: ['Apex Grill', 'Southwest'],
+    expectedCategories: 2,
+  },
+  // NOTE: 'Compare Coastline Tacos vs Apex Grill depletions across all regions'
+  // is a CHART prompt (grouped bar). It lives in CHART_ACCEPTANCE_CASES.
+  'What is the field sentiment for Coastline Tacos in the West Coast?': {
+    expectedEntities: ['Coastline Tacos', 'West Coast'],
+    expectedCategories: 2,
+  },
+
+  // ── Home Improvement ──
+  'Show me Pinnacle Hardware depletion stats in the Midwest for Q1': {
+    expectedEntities: ['Pinnacle Hardware', 'Midwest'],
+    expectedCategories: 2,
+  },
+  'How is Summit Outdoor performing in the Southeast vs West Coast?': {
+    expectedEntities: ['Summit Outdoor', 'Southeast', 'West Coast'],
+    expectedCategories: 3,
+  },
+  'What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest?': {
+    expectedEntities: ['Pinnacle Hardware', 'Southwest'],
+    expectedCategories: 2,
+  },
+
+  // ── Office Supply ──
+  'How are ClearDesk depletions trending in the Northeast this quarter?': {
+    expectedEntities: ['ClearDesk', 'Northeast'],
+    expectedCategories: 2,
+  },
+  'Compare ClearDesk Technology vs Paper Products sell-through by region': {
+    expectedEntities: ['ClearDesk', 'Technology', 'Paper Products'],
+    expectedCategories: 2,
+  },
+  'What is the field sentiment for ClearDesk in the Southeast?': {
+    expectedEntities: ['ClearDesk', 'Southeast'],
+    expectedCategories: 2,
+  },
+
+  // ── Furniture ──
+  'Show me Urban Living depletion trends across all regions this quarter': {
+    expectedEntities: ['Urban Living', 'region'],
+    expectedCategories: 2,
+  },
+  'Compare Foundry Home vs Urban Living performance in the West Coast': {
+    expectedEntities: ['Foundry Home', 'Urban Living', 'West Coast'],
+    expectedCategories: 3,
+  },
+  'What is the field sentiment for Urban Living in the Pacific Northwest?': {
+    expectedEntities: ['Urban Living', 'Pacific Northwest'],
+    expectedCategories: 2,
+  },
+};
+
+/** Index chart cases by prompt text for O(1) lookup during flattening. */
+const CHART_CASES_BY_PROMPT: ReadonlyMap<string, ChartAcceptanceCase> = new Map(
+  CHART_ACCEPTANCE_CASES.map((c) => [c.prompt, c]),
+);
+
+/** Build one case per featured prompt, in category+source order. */
+function buildManifest(): readonly PromptAcceptanceCase[] {
+  const out: PromptAcceptanceCase[] = [];
+  for (const cat of PROMPT_CATEGORIES) {
+    cat.prompts.forEach((prompt, i) => {
+      const id = `${cat.id}:${i}`;
+      const chart = CHART_CASES_BY_PROMPT.get(prompt);
+      if (chart) {
+        out.push({
+          id,
+          categoryId: cat.id,
+          prompt,
+          responseClass: 'chart',
+          expectedVisualization: chart.chartType,
+          expectedEntities: chart.requiredEntities,
+          expectedSeries: chart.minSeries,
+          expectedCategories: chart.minMarks,
+          maxToolCalls: MAX_TOOL_CALLS,
+          maxTokenBudget: MAX_TOKEN_BUDGET,
+          noJsonLeakage: true,
+          noFallbackErrorText: true,
+        });
+        return;
+      }
+      const prose = PROSE_SEMANTICS[prompt];
+      if (!prose) {
+        throw new Error(
+          `promptAcceptance: no semantics defined for featured prompt '${prompt}' — ` +
+            'either add it to PROSE_SEMANTICS (prose) or CHART_ACCEPTANCE_CASES (chart).',
+        );
+      }
+      out.push({
+        id,
+        categoryId: cat.id,
+        prompt,
+        responseClass: 'prose',
+        expectedVisualization: 'none',
+        expectedEntities: prose.expectedEntities,
+        expectedSeries: 0,
+        expectedCategories: prose.expectedCategories,
+        maxToolCalls: MAX_TOOL_CALLS,
+        maxTokenBudget: MAX_TOKEN_BUDGET,
+        noJsonLeakage: true,
+        noFallbackErrorText: true,
+      });
+    });
+  }
+  return out;
+}
+
+export const PROMPT_ACCEPTANCE_CASES: readonly PromptAcceptanceCase[] = buildManifest();
+
+/** All featured prompt texts, in source order (mirror check target). */
+export const FEATURED_PROMPTS: readonly string[] = PROMPT_CATEGORIES.flatMap(
+  (c) => c.prompts,
+);
+
+/** Case lookup by verbatim prompt text. */
+export function findAcceptanceCase(prompt: string): PromptAcceptanceCase | undefined {
+  return PROMPT_ACCEPTANCE_CASES.find((c) => c.prompt === prompt);
+}

--- a/src/RetailPulse.Web/tsconfig.app.json
+++ b/src/RetailPulse.Web/tsconfig.app.json
@@ -25,6 +25,7 @@
   "include": ["src"],
   "exclude": [
     "src/__tests__/lockfileIntegrity.test.ts",
-    "src/__tests__/chartAcceptance.contract.test.ts"
+    "src/__tests__/chartAcceptance.contract.test.ts",
+    "src/__tests__/promptAcceptance.contract.test.ts"
   ]
 }


### PR DESCRIPTION
Closes #62

Refs #59## SummaryExtends the chart-only acceptance manifest (issue #50, PR #53) into a canonical acceptance contract covering **every one of the 26 curated Prompt Ideas** (7 categories) in `constants/prompts.ts`.## What ships- **`promptAcceptance.ts`** — new frontend manifest. 9 chart cases inherit from `CHART_ACCEPTANCE_CASES`; 17 prose cases declare expected entities, minimum mentions, and the same ≤5 tool-call / <25K token ceilings enforced on the backend (`ChartAcceptancePerformanceTests`). Prompt text is derived from the single source (`PROMPT_CATEGORIES`) — no duplication.- **`promptAcceptance.contract.test.ts`** — bidirectional drift guard. Every featured prompt has an acceptance case AND every acceptance case is still featured. Also mirrors README chart bullets in both directions and cross-checks the chart manifest so intentional mirror disagreement across README / frontend / backend fixtures fails CI.- **`promptAcceptance.nonChart.test.ts`** — 17 prose prompts covered with entity contracts, ceilings, and no-JSON-leakage / no-fallback-error-text promises.- **`ChartRenderer.acceptance.test.tsx`** — renders every chart case through real Recharts using stable `data-testid` selectors (`chart-card`, `chart-title`, `chart-gauge`, `chart-table`, `chart-unavailable`). Asserts `data-chart-type` matches the manifest, no chart-spec JSON leaks into rendered DOM, no `role=note` fallback for bindable specs, per-case render performance ceiling, and (opposite invariant) that unbindable specs DO surface the testid-anchored fallback.- **`PromptLibrary.browser.test.tsx`** — polling / `waitFor`-based production-style browser test. Walks the popover UX for every prompt via `data-testid` anchors only — never Griffel class substrings — and verifies category filtering + dispatch for all 26 prompts.- **`ChartRenderer` + `PromptLibrary`** — gain `data-testid` structural selectors and a `data-chart-type` attribute on chart cards.## Validation- `npm test` — **60 test files, 541 tests pass** (baseline + 4 new files).- `npm run build` — `tsc -b && vite build` pass. Strict typecheck green.- `npm run lint` — no new lint findings in files I touched (unrelated pre-existing findings in `TraceTimeline.tsx`, `api.ts`, `main.tsx`, `forecast.tsx` remain untouched, per squad rules on unrelated fixes).## Coverage numbers| Category | Prompts | Response class | Acceptance cases || --- | --- | --- | --- || general | 3 | prose | 3 || grocery | 3 | prose | 3 || qsr | 3 | prose + 1 chart mirror | 2 prose + 1 chart || home-improvement | 3 | prose | 3 || office-supply | 3 | prose | 3 || furniture | 3 | prose | 3 || charts | 8 | chart | 8 || **Total** | **26** | **17 prose + 9 chart** | **26** |The horizontal-bar prompt (*"Show a horizontal bar chart ranking all brands by depletion growth rate"*) remains correctly classified as `horizontalBar` with `percentAxis: true` — asserted via `data-chart-type=\"horizontalbar\"` on the rendered card.## Backend coordinationBackend contracts (`ChartAcceptanceManifest` + `ChartAcceptancePerformanceTests`) already own chart-prompt ceilings; no backend changes required. Prose prompts do not go through the deterministic fulfillment path, so their contract lives purely on the frontend.---Owner: Chick (Frontend). ⚠️ This is a fresh Chart-Matrix-style acceptance surface — please have a squad member review.