### PR TITLE
Harden APIM AI Gateway invariants: runtime guard, static contract, live verify, CI Bicep gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,3 +248,27 @@ jobs:
 
       - name: Check formatting
         run: dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic
+
+  bicep:
+    name: Bicep (compile + lint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # az CLI ships pre-installed on ubuntu-latest; `az bicep install` grabs the
+      # latest CLI-bundled Bicep compiler. Compile every module transitively via
+      # the entry point — a broken module (missing param, wrong resource type,
+      # invalid reference) fails the build, which is the cheapest possible gate
+      # for regressions of the APIM AI Gateway / container-apps contract.
+      - name: Install Bicep
+        run: az bicep install
+
+      - name: Bicep build (compile + lint)
+        run: az bicep build --file infra/main.bicep --outfile /tmp/main.compiled.json
+
+      - name: Upload compiled ARM template
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bicep-compiled
+          path: /tmp/main.compiled.json

--- a/docs/testing/authenticated-synthetic-monitor.md
+++ b/docs/testing/authenticated-synthetic-monitor.md
@@ -1,0 +1,133 @@
+# Authenticated synthetic monitor for the AI chat path
+
+Status: **DESIGN — implementation blocked pending tenant credentials**  
+Owner: Costco (Backend)  
+Tracks: [#57](https://github.com/swigerb/retail-pulse/issues/57)
+
+## Why
+
+During the P0 incident on 2026-08-11 (#55, fixed by PR #56) QA (Publix) could
+not personally submit an authenticated chat request or run the curated
+grouped-bar acceptance prompt against production end-to-end, because the sandbox
+has no human present to complete interactive Entra/MSAL sign-in. Per policy we
+do not bypass or impersonate interactive auth to work around this.
+
+The gap did not hide a defect — telemetry and `Verify-ProductionAuth.ps1`
+independently confirmed real 200 OK completions routed through the corrected
+APIM path — but it meant an on-call responder cannot get direct live evidence
+of end-to-end chat behavior without a human at a browser. This document
+specifies the non-interactive verification path so a future incident is not
+gated on that constraint.
+
+## Contract this monitor validates
+
+For each curated prompt in the smoke set (below), the monitor must prove:
+
+1. A **valid Entra bearer token** was obtained non-interactively (no human).
+2. `POST {AZURE_API_APP_URL}/api/chat` returned **200** with a body carrying:
+   - an assistant `text` payload,
+   - one or more `charts` entries when the prompt expects a chart,
+   - a non-empty `traceId` / `sessionId`, so the response can be correlated
+     back to Application Insights `requests` + `dependencies`.
+3. The App Insights `requests` table records a corresponding `POST /api/chat`
+   with `success=true` **and** a dependent AOAI request routed through APIM
+   (`name` matching `POST /inference/openai/deployments/*/chat/completions`).
+4. The APIM `customMetrics` for the same time window include at least one
+   `azure-openai-emit-token-metric` row (proves the token-metric channel is
+   still live — the exact indicator Publix flagged as flaky under low-token
+   load in the MERGED APIM decision).
+
+Curated smoke set (start narrow, grow with confidence):
+
+| Prompt | Expected chart | Manifest case |
+|---|---|---|
+| `Show a horizontal bar chart ranking all brands by depletion growth rate` | `horizontalBar`, ≥6 marks | `ChartAcceptanceManifest.Cases[5]` |
+| `Show a grouped bar chart comparing FreshMart and Harvest Table across all regions` | `groupedBar`, ≥12 marks | `ChartAcceptanceManifest.Cases[3]` |
+
+Both draw from complete seeded tenant data and exercise the two chart
+data-source families most likely to regress independently
+(`PortfolioDepletion` and `HistoricalDemand`).
+
+## Implementation shape (once credentials exist)
+
+A single-file PowerShell script `scripts/Invoke-SyntheticChatMonitor.ps1`
+(mirrors the shape of the existing `Verify-*Auth.ps1` scripts):
+
+1. Read `AZURE_API_APP_URL`, `MicrosoftEntra__TenantId`, `MicrosoftEntra__ClientId`,
+   `MicrosoftEntra__ApiScope` from the current azd env, plus:
+   - `RETAIL_PULSE_SYNTHETIC_CLIENT_ID` — a *separate*, dedicated confidential
+     application registration in the same tenant with:
+       - the RetailPulse API app-role `RetailPulse.User` granted, and
+       - the `access_as_user` delegated scope granted with admin consent,
+       - a client-credentials flow enabled.
+   - `RETAIL_PULSE_SYNTHETIC_CLIENT_SECRET` — pulled from Azure Key Vault
+     `kv-<resourceToken>` at run time via `az keyvault secret show`, never
+     stored in the repo, never in `.env`, never in azd env.
+2. Acquire a token via `az rest` against
+   `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token` with the
+   `client_credentials` grant and `scope = api://{RetailPulse client-id}/.default`.
+3. `POST /api/chat` for each prompt with `Authorization: Bearer <token>`.
+4. Assert response shape (200, `charts[].type`, chart mark count) inline;
+   emit `Write-Host` per prompt and a final PASS/FAIL summary.
+5. Optionally query Application Insights via `az monitor app-insights query`
+   for the correlated `requests` and `customMetrics` rows (skipped when the
+   caller lacks App Insights Reader — same opportunistic pattern as
+   `Verify-ApimAiGateway.ps1`).
+
+Wire it into `.github/workflows/squad-heartbeat.yml` (or a new dedicated
+workflow) as a scheduled run and as a `workflow_dispatch` for on-call use.
+
+## Blocker — why this cannot land in this PR
+
+The tenant behind `apim-5aldk7aotqods.azure-api.net` /
+`ca-retailpulse-api.*.azurecontainerapps.io` is a **governed customer tenant**
+that:
+
+- Requires an administrator to create the confidential application
+  registration described above and to admin-consent the `RetailPulse.User`
+  app-role + `access_as_user` scope grant. Neither an autonomous Squad
+  session nor Costco has interactive administrative access to the tenant
+  from this environment.
+- Applies conditional-access + client-credentials policy restrictions that
+  will refuse a token from any client secret not already issued and
+  documented by the tenant admin. This cannot be worked around by minting a
+  secret locally.
+- Governance policy forbids checking a client secret into the repository or
+  into any azd-committed environment; the secret must land in the deployment
+  Key Vault and be pulled at run time. The deployment Key Vault does not
+  exist in the current `infra/` — `main.bicep` provisions Log Analytics,
+  App Insights, ACR, APIM, ACA, SWA, but no Key Vault module. Adding one
+  requires a Kroger-level architecture review (the storage-governance work
+  from the storage-hotfix worktree explicitly deferred every durable
+  policy-scoped resource until a policy-compatible design is signed off).
+
+Together those three constraints mean the client-credentials plumbing this
+issue asks for cannot be exercised end-to-end from this session — no client
+id, no secret, no vault to store the secret in, and no administrative path
+to create any of them.
+
+## What ships in this PR
+
+- This design doc, so the contract and the blocker are captured in-repo
+  next to the existing live-test plan.
+- `scripts/Verify-ApimAiGateway.ps1` — the closest non-interactive live
+  verification we can do today. It exercises the APIM AI Gateway invariants
+  (resource + API + policy + backend + diagnostics + RBAC + ACA config)
+  against the deployed environment using only read-only `az` calls, so an
+  on-call responder can prove the gateway is intact even without a live
+  authenticated chat request.
+
+## Follow-through (unblocks #57 fully)
+
+1. Tenant admin (or a delegated Kroger/human) creates the confidential
+   application registration, grants scopes, and issues a client secret.
+2. Add a Bicep Key Vault module (`infra/modules/key-vault.bicep`) with
+   private endpoint + `enableSoftDelete: true` + purge protection, plus a
+   `Microsoft.KeyVault/vaults/secrets` resource seeded from a
+   `@secure()` param whose value is supplied via `azd env set` at
+   provision time (not committed).
+3. Grant the deployment identity `Key Vault Secrets User` on the vault, and
+   the ACA API's system-assigned identity the same role.
+4. Implement `Invoke-SyntheticChatMonitor.ps1` per §"Implementation shape".
+5. Wire the scheduled workflow, verify one full run's telemetry, then close
+   #57.

--- a/scripts/Verify-ApimAiGateway.ps1
+++ b/scripts/Verify-ApimAiGateway.ps1
@@ -1,0 +1,216 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Live post-provision verification of the APIM AI Gateway invariants.
+
+.DESCRIPTION
+    Reads the currently-selected azd environment outputs (or explicit params) to
+    resolve the deployed resource group, APIM instance, and API container app,
+    then verifies — using ONLY `az` inspection commands — every invariant that
+    the Bicep contract tests assert statically:
+
+        * APIM instance exists, uses SystemAssigned identity.
+        * Inference API exists, has subscriptionRequired=true and the
+          expected /openai suffix on the registered path.
+        * API policy references the AOAI backend and enforces token-limit +
+          emit-token-metric.
+        * Backend authenticates to AOAI via managed identity to
+          cognitiveservices.azure.com.
+        * API-level applicationinsights diagnostic has metrics enabled and
+          azuremonitor diagnostic has largeLanguageModel logs enabled.
+        * APIM system-assigned identity holds the Cognitive Services OpenAI
+          User role on the AOAI account.
+        * The API container app has:
+            - `OpenAI__Endpoint` matching the APIM inference URL and NOT
+              ending in `/openai` (regression #55).
+            - `OpenAI__ApimSubscriptionKey` referencing the `apim-sub-key`
+              ACA secret.
+            - `OpenAI__UseManagedIdentity` = 'false'.
+
+    Every check is read-only. The script prints a compact summary and exits 0
+    when all invariants hold, exits 1 with a list of failures otherwise.
+
+    It is intentionally opportunistic: when `az` is not signed in, or the azd
+    environment is unavailable, or the caller lacks Reader on the resource
+    group, the script prints a clear reason and exits with code 2 (skipped) so
+    it does not falsely fail a pipeline that lacks live-Azure access.
+
+.PARAMETER ResourceGroup
+    Resource group containing the RetailPulse deployment. Defaults to
+    $env:AZURE_RESOURCE_GROUP (set by azd env after provision).
+
+.PARAMETER ApimName
+    APIM service name. Defaults to $env:AZURE_APIM_NAME.
+
+.PARAMETER ApiContainerAppName
+    ACA API container app name. Defaults to $env:AZURE_API_APP_NAME.
+
+.PARAMETER AiFoundryAccountName
+    Azure AI Foundry / Cognitive Services account name that APIM's MI must be
+    granted OpenAI User on. Defaults to the value baked into main.bicep.
+
+.PARAMETER AiFoundryResourceGroup
+    Resource group containing the AI Foundry account. Defaults to the value
+    baked into main.bicep.
+
+.EXAMPLE
+    ./scripts/Verify-ApimAiGateway.ps1
+
+    Runs against the currently-active azd environment.
+#>
+[CmdletBinding()]
+param(
+    [string]$ResourceGroup = $env:AZURE_RESOURCE_GROUP,
+    [string]$ApimName = $env:AZURE_APIM_NAME,
+    [string]$ApiContainerAppName = $env:AZURE_API_APP_NAME,
+    [string]$InferenceApiName = ($env:AZURE_APIM_INFERENCE_API_NAME | ForEach-Object { if ([string]::IsNullOrWhiteSpace($_)) { 'retail-pulse-inference-api' } else { $_ } }),
+    [string]$AiFoundryAccountName = 'aiagents-3rsdmhyb',
+    [string]$AiFoundryResourceGroup = 'rg-repodigest-agents-demo-eus-001'
+)
+
+$ErrorActionPreference = 'Stop'
+$failures = [System.Collections.Generic.List[string]]::new()
+$checks = 0
+
+function Test-Prereq {
+    if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+        Write-Host "SKIP: az CLI is not installed on PATH." -ForegroundColor Yellow
+        exit 2
+    }
+    $account = az account show 2>$null
+    if (-not $account) {
+        Write-Host "SKIP: az CLI is not signed in (az account show returned nothing)." -ForegroundColor Yellow
+        exit 2
+    }
+    foreach ($v in @('ResourceGroup', 'ApimName', 'ApiContainerAppName')) {
+        if ([string]::IsNullOrWhiteSpace((Get-Variable -Name $v -Scope 1).Value)) {
+            Write-Host "SKIP: required parameter/env '$v' is not set. Run this after 'azd env refresh' or pass it explicitly." -ForegroundColor Yellow
+            exit 2
+        }
+    }
+}
+
+function Assert([string]$name, [scriptblock]$predicate, [string]$detail = '') {
+    $script:checks++
+    try {
+        $ok = & $predicate
+        if ($ok) {
+            Write-Host ("  [ok]   {0}" -f $name) -ForegroundColor Green
+        }
+        else {
+            Write-Host ("  [FAIL] {0}: {1}" -f $name, $detail) -ForegroundColor Red
+            $script:failures.Add($name)
+        }
+    }
+    catch {
+        Write-Host ("  [FAIL] {0}: {1}" -f $name, $_.Exception.Message) -ForegroundColor Red
+        $script:failures.Add($name)
+    }
+}
+
+Test-Prereq
+
+Write-Host "APIM AI Gateway live verification"
+Write-Host ("  resourceGroup       = {0}" -f $ResourceGroup)
+Write-Host ("  apim                = {0}" -f $ApimName)
+Write-Host ("  apiContainerApp     = {0}" -f $ApiContainerAppName)
+Write-Host ("  inferenceApi        = {0}" -f $InferenceApiName)
+Write-Host ("  aiFoundryAccount    = {0} (rg: {1})" -f $AiFoundryAccountName, $AiFoundryResourceGroup)
+Write-Host ""
+
+# ── APIM instance ─────────────────────────────────────────────────────────
+Write-Host "APIM instance"
+$apim = az apim show -g $ResourceGroup -n $ApimName 2>$null | ConvertFrom-Json
+Assert 'apim: exists' { $null -ne $apim } "APIM '$ApimName' not found in '$ResourceGroup'"
+Assert 'apim: identity.type = SystemAssigned' { $apim.identity.type -eq 'SystemAssigned' } "identity.type = $($apim.identity.type)"
+$apimPrincipalId = $apim.identity.principalId
+$gatewayUrl = $apim.gatewayUrl
+
+# ── Inference API ─────────────────────────────────────────────────────────
+Write-Host "Inference API"
+$api = az apim api show -g $ResourceGroup --service-name $ApimName --api-id $InferenceApiName 2>$null | ConvertFrom-Json
+Assert 'api: exists' { $null -ne $api } "'$InferenceApiName' not found on '$ApimName'"
+Assert 'api: subscriptionRequired = true' { $api.subscriptionRequired -eq $true } "subscriptionRequired = $($api.subscriptionRequired)"
+Assert 'api: path ends in /openai (SDK-compatible)' { $api.path -match '/openai$' } "path = $($api.path)"
+
+# ── API policy (token-limit + emit-token-metric) ──────────────────────────
+Write-Host "API policy"
+$policyJson = az apim api policy show -g $ResourceGroup --service-name $ApimName --api-id $InferenceApiName 2>$null
+$policyValue = ($policyJson | ConvertFrom-Json).value
+Assert 'policy: sets backend service (retail-pulse-foundry)' { $policyValue -match '<set-backend-service\s+backend-id="retail-pulse-foundry"' } 'policy did not reference the AOAI backend'
+Assert 'policy: managed-identity auth to cognitiveservices.azure.com' { $policyValue -match '<authentication-managed-identity\s+resource="https://cognitiveservices\.azure\.com"' } 'policy is not using MI auth to AOAI'
+Assert 'policy: azure-openai-token-limit configured' { $policyValue -match '<azure-openai-token-limit\s+counter-key="@\(context\.Subscription\.Id\)"' } 'token-limit missing or wrong counter-key'
+Assert 'policy: azure-openai-emit-token-metric in RetailPulse namespace' { $policyValue -match '<azure-openai-emit-token-metric\s+namespace="RetailPulse">' } 'emit-token-metric missing or wrong namespace'
+
+# ── Backend ──────────────────────────────────────────────────────────────
+Write-Host "Backend"
+$backend = az apim backend show -g $ResourceGroup --service-name $ApimName --backend-id retail-pulse-foundry 2>$null | ConvertFrom-Json
+Assert 'backend: retail-pulse-foundry exists' { $null -ne $backend } 'backend retail-pulse-foundry not found'
+Assert 'backend: url targets /openai on cognitiveservices' { $backend.url -match '/openai$' -and ($backend.url -match 'cognitiveservices\.azure\.com|\.services\.ai\.azure\.com') } "backend url = $($backend.url)"
+Assert 'backend: MI credentials to cognitiveservices.azure.com' { $backend.credentials.managedIdentity.resource -eq 'https://cognitiveservices.azure.com' } 'backend is not MI-authenticated to AOAI'
+
+# ── Diagnostics (API + instance) ──────────────────────────────────────────
+Write-Host "Diagnostics"
+$apiAppInsightsDiag = az apim api diagnostic show -g $ResourceGroup --service-name $ApimName --api-id $InferenceApiName --diagnostic-id applicationinsights 2>$null | ConvertFrom-Json
+Assert 'api diag: applicationinsights present' { $null -ne $apiAppInsightsDiag } 'API-level applicationinsights diagnostic missing'
+Assert 'api diag: metrics = true (routes emit-token-metric)' { $apiAppInsightsDiag.metrics -eq $true } "metrics = $($apiAppInsightsDiag.metrics)"
+
+# azuremonitor + largeLanguageModel logs cannot be read by the api-diagnostic-show CLI (it flattens
+# the LLM block); fall back to a direct ARM GET.
+$sub = (az account show --query id -o tsv)
+$armPath = "/subscriptions/$sub/resourceGroups/$ResourceGroup/providers/Microsoft.ApiManagement/service/$ApimName/apis/$InferenceApiName/diagnostics/azuremonitor?api-version=2024-06-01-preview"
+$azMonRaw = az rest --method get --url "https://management.azure.com$armPath" 2>$null
+$azMonDiag = $null; if ($azMonRaw) { $azMonDiag = $azMonRaw | ConvertFrom-Json }
+Assert 'api diag: azuremonitor present' { $null -ne $azMonDiag } 'API-level azuremonitor diagnostic missing'
+Assert 'api diag: largeLanguageModel logs enabled' { $azMonDiag.properties.largeLanguageModel.logs -eq 'enabled' } 'largeLanguageModel logs not enabled — GatewayLlmLogs stay dark'
+
+# ── RBAC: Cognitive Services OpenAI User on AI Foundry ────────────────────
+Write-Host "RBAC"
+if ($apimPrincipalId) {
+    $roleAssignments = az role assignment list --assignee $apimPrincipalId --scope "/subscriptions/$sub/resourceGroups/$AiFoundryResourceGroup/providers/Microsoft.CognitiveServices/accounts/$AiFoundryAccountName" 2>$null | ConvertFrom-Json
+    $hasOpenAiUser = ($roleAssignments | Where-Object { $_.roleDefinitionId -match '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' })
+    Assert 'rbac: APIM MI has Cognitive Services OpenAI User on AI Foundry account' { $null -ne $hasOpenAiUser } 'Role assignment missing — the MI backend policy will 403'
+}
+else {
+    Assert 'rbac: APIM principalId available' { $false } 'Could not read APIM principalId to check role assignments'
+}
+
+# ── ACA API container app wiring ──────────────────────────────────────────
+Write-Host "ACA API container app"
+$apiApp = az containerapp show -g $ResourceGroup -n $ApiContainerAppName 2>$null | ConvertFrom-Json
+Assert 'aca: API container app exists' { $null -ne $apiApp } "container app '$ApiContainerAppName' not found"
+
+$env = $apiApp.properties.template.containers[0].env
+$envMap = @{}
+foreach ($e in $env) { $envMap[$e.name] = $e }
+
+Assert 'aca env: OpenAI__Endpoint set' { $envMap.ContainsKey('OpenAI__Endpoint') -and $envMap['OpenAI__Endpoint'].value } 'OpenAI__Endpoint missing'
+Assert 'aca env: OpenAI__Endpoint matches APIM inference URL' {
+    $endpoint = $envMap['OpenAI__Endpoint'].value
+    $endpoint -and $gatewayUrl -and $endpoint.StartsWith($gatewayUrl)
+} "OpenAI__Endpoint = $($envMap['OpenAI__Endpoint'].value); APIM gateway = $gatewayUrl"
+Assert 'aca env: OpenAI__Endpoint does NOT end in /openai (regression #55)' {
+    $endpoint = $envMap['OpenAI__Endpoint'].value
+    $endpoint -and -not ($endpoint.TrimEnd('/') -match '/openai$')
+} "OpenAI__Endpoint = $($envMap['OpenAI__Endpoint'].value)"
+Assert 'aca env: OpenAI__UseManagedIdentity = false (using APIM subscription key)' {
+    $envMap.ContainsKey('OpenAI__UseManagedIdentity') -and $envMap['OpenAI__UseManagedIdentity'].value -eq 'false'
+} "OpenAI__UseManagedIdentity = $($envMap['OpenAI__UseManagedIdentity'].value)"
+Assert 'aca env: OpenAI__ApimSubscriptionKey uses secretRef=apim-sub-key' {
+    $envMap.ContainsKey('OpenAI__ApimSubscriptionKey') -and $envMap['OpenAI__ApimSubscriptionKey'].secretRef -eq 'apim-sub-key'
+} "OpenAI__ApimSubscriptionKey secretRef = $($envMap['OpenAI__ApimSubscriptionKey'].secretRef)"
+
+$secretNames = @($apiApp.properties.configuration.secrets | ForEach-Object { $_.name })
+Assert 'aca secrets: apim-sub-key present' { $secretNames -contains 'apim-sub-key' } "secrets = $($secretNames -join ', ')"
+
+# ── Summary ───────────────────────────────────────────────────────────────
+Write-Host ""
+if ($failures.Count -eq 0) {
+    Write-Host ("PASS  {0}/{0} invariants verified against the live deployment." -f $checks) -ForegroundColor Green
+    exit 0
+}
+else {
+    Write-Host ("FAIL  {0}/{1} invariants failed:" -f $failures.Count, $checks) -ForegroundColor Red
+    foreach ($f in $failures) { Write-Host "        - $f" -ForegroundColor Red }
+    exit 1
+}

--- a/src/RetailPulse.Api/OpenAI/OpenAiConnectionSettings.cs
+++ b/src/RetailPulse.Api/OpenAI/OpenAiConnectionSettings.cs
@@ -129,10 +129,14 @@ internal sealed class OpenAiConnectionSettings
         IHostEnvironment environment,
         bool allowDirectEndpoint)
     {
-        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri))
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
         {
+            // Note: on Linux `Uri.TryCreate("/inference", UriKind.Absolute, ...)`
+            // succeeds because a leading `/` parses as a file:// URI. Requiring
+            // an http(s) scheme keeps the invariant cross-platform.
             throw new InvalidOperationException(
-                $"Configuration value 'OpenAI:Endpoint' ('{endpoint}') must be an absolute URL.");
+                $"Configuration value 'OpenAI:Endpoint' ('{endpoint}') must be an absolute http(s) URL.");
         }
 
         // Doubled `/openai/openai` — the P0 incident #55 shape. `AzureOpenAIClient`

--- a/src/RetailPulse.Api/OpenAI/OpenAiConnectionSettings.cs
+++ b/src/RetailPulse.Api/OpenAI/OpenAiConnectionSettings.cs
@@ -41,6 +41,23 @@ internal sealed class OpenAiConnectionSettings
             ?? throw new InvalidOperationException(
                 "Configuration value 'OpenAI:Endpoint' is required.");
 
+        // AI Gateway invariant — outside Development the API must route inference
+        // through the APIM AI Gateway. A direct Azure OpenAI / Cognitive Services
+        // endpoint bypasses the gateway's token limits, MI-backed backend auth,
+        // token-emit metrics, and LLM diagnostics — every observability + cost
+        // guarantee the deployment contract makes. The escape hatch
+        // `OpenAI:AllowDirectEndpoint=true` exists only for explicit, deliberate
+        // safe local-dev scenarios (e.g. running the API against a local AOAI
+        // resource without APIM in front) and is refused in Development just as
+        // clearly by logs — never a silent fallback.
+        //
+        // We also refuse any endpoint that carries a doubled `/openai/openai`
+        // path — the exact defect from incident #55 — so a regression in the
+        // Bicep output expression or a hand-set env-var can't sneak back in
+        // and produce silent 404s at request time.
+        bool allowDirect = configuration.GetValue("OpenAI:AllowDirectEndpoint", false);
+        EnforceAiGatewayInvariant(endpoint, environment, allowDirect);
+
         bool useManagedIdentity = configuration.GetValue("OpenAI:UseManagedIdentity", false);
         if (useManagedIdentity)
         {
@@ -104,4 +121,58 @@ internal sealed class OpenAiConnectionSettings
 
     private static string? TrimToNull(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    // Internal for direct test access — the invariant is a hard startup gate and
+    // needs unit coverage independent of the full Load() config pipeline.
+    internal static void EnforceAiGatewayInvariant(
+        string endpoint,
+        IHostEnvironment environment,
+        bool allowDirectEndpoint)
+    {
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri))
+        {
+            throw new InvalidOperationException(
+                $"Configuration value 'OpenAI:Endpoint' ('{endpoint}') must be an absolute URL.");
+        }
+
+        // Doubled `/openai/openai` — the P0 incident #55 shape. `AzureOpenAIClient`
+        // appends `/openai/deployments/...` itself, so an endpoint that already ends
+        // in `/openai` produces a doubled segment at request time and 404s from APIM
+        // with `OperationNotFound`. Refuse it regardless of environment or escape
+        // hatches — there is no legitimate deployment shape that requires this.
+        string path = uri.AbsolutePath ?? string.Empty;
+        if (path.Contains("/openai/openai", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith("/openai", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Configuration value 'OpenAI:Endpoint' ('{endpoint}') ends in '/openai' — the Azure OpenAI SDK independently appends '/openai/deployments/...' to whatever endpoint it is given, so this produces a doubled '/openai/openai' segment at request time (regression of incident #55). Point 'OpenAI:Endpoint' at the APIM inference API base (e.g. 'https://<apim>.azure-api.net/inference') and let the SDK append the '/openai' suffix.");
+        }
+
+        bool isDirectAzureOpenAiHost = IsDirectAzureOpenAiHost(uri.Host);
+        if (!isDirectAzureOpenAiHost)
+        {
+            return;
+        }
+
+        if (environment.IsDevelopment())
+        {
+            return;
+        }
+
+        if (allowDirectEndpoint)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Configuration value 'OpenAI:Endpoint' ('{endpoint}') points at a direct Azure OpenAI / Cognitive Services host outside Development. The API must route inference through the APIM AI Gateway (e.g. 'https://<apim>.azure-api.net/inference'). Set OpenAI:AllowDirectEndpoint=true only for an explicit safe local-dev scenario.");
+    }
+
+    private static bool IsDirectAzureOpenAiHost(string host)
+    {
+        return !string.IsNullOrEmpty(host)
+            && (host.EndsWith(".openai.azure.com", StringComparison.OrdinalIgnoreCase)
+                || host.EndsWith(".cognitiveservices.azure.com", StringComparison.OrdinalIgnoreCase)
+                || host.EndsWith(".services.ai.azure.com", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/tests/RetailPulse.Tests/Charts/HorizontalBarRankingRegressionTests.cs
+++ b/tests/RetailPulse.Tests/Charts/HorizontalBarRankingRegressionTests.cs
@@ -1,0 +1,208 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using RetailPulse.Api.Budget;
+using RetailPulse.Api.Charts;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Charts;
+using Xunit;
+using MeaiChatResponse = Microsoft.Extensions.AI.ChatResponse;
+
+namespace RetailPulse.Tests.Charts;
+
+/// <summary>
+/// Regression coverage for the horizontal-bar "rank all brands by depletion growth
+/// rate" prompt (issue #50 case + follow-through). The failure mode this test
+/// guards against: the LLM legitimately calls <c>GetPortfolioDepletionStats</c>
+/// and receives a complete seeded payload, but the deterministic builder can't
+/// materialise a <see cref="ChartSpec"/> — so the pipeline falls back to
+/// narration + inline JSON, the frontend then sees raw JSON in the assistant
+/// bubble, and the "data absence" branch fires despite complete data.
+/// The manifest matrix test already covers the happy path; this one pins:
+///
+/// 1. A COMPLETE seeded portfolio payload (every brand carries a finite
+///    <c>depletions_yoy</c> percent) yields a <c>horizontalBar</c> ChartSpec with
+///    one series and exactly the seeded brand count as marks, ordered strictly
+///    descending — never zero-filling missing brands.
+/// 2. A PARTIALLY complete payload (three brands with missing/unparseable growth)
+///    yields a chart with only the well-formed brands — the missing ones are
+///    excluded, not charted as zero. The <c>ChartSpecValidator</c> still
+///    considers the chart renderable (≥2 marks).
+/// 3. An EMPTY payload (no brands with finite growth) causes the deterministic
+///    builder to return false, so the caller can produce an honest "no data"
+///    response rather than a chart of zeroes.
+/// </summary>
+public sealed class HorizontalBarRankingRegressionTests
+{
+    private const string RegionAll = "All Regions";
+
+    [Fact]
+    public void CompleteSeededPortfolio_YieldsHorizontalBar_WithAllBrandsRankedDescending()
+    {
+        string[] brands =
+        [
+            "Sierra Gold Tequila", "Ridgeline Bourbon", "Summit Vodka",
+            "FreshMart", "Harvest Table", "Apex Grill", "Coastline Tacos",
+            "Pinnacle Hardware", "Summit Outdoor",
+        ];
+        double[] growthPct = [-2.5, -1.6, -0.7, 0.2, 1.1, 2.0, 2.9, 3.8, 4.7];
+
+        string payload = BuildPortfolioDepletionPayload(brands, growthPct);
+        string compacted = new PortfolioDepletionCompactor()
+            .Compact("GetPortfolioDepletionStats", payload, new ToolResultBudgetOptions())
+            .Json;
+
+        MeaiChatResponse response = ResponseWithToolResults(compacted);
+
+        DeterministicChartBuilder
+            .TryBuild(response, requestedType: "horizontalBar", out ChartSpec? chart)
+            .Should().BeTrue("a fully seeded portfolio payload must build a horizontal-bar ranking");
+
+        chart.Should().NotBeNull();
+        chart.Type.Should().Be("horizontalBar");
+        chart.Data.Should().HaveCount(1, "the ranking is single-series");
+
+        var points = chart.Data[0].Values.ToList();
+        points.Should().HaveCount(brands.Length,
+            "every seeded brand with a finite growth value must appear — never dropped or zero-filled");
+
+        for (int i = 1; i < points.Count; i++)
+        {
+            points[i].Y.Should().BeLessThanOrEqualTo(points[i - 1].Y,
+                "brands must be ordered strictly descending by growth rate");
+        }
+
+        // The renderable-validator gate (what the frontend uses) must agree the
+        // chart is bindable — this is what prevents the false "data absence" path.
+        ChartSpecValidator
+            .TryGetRenderable(chart, minSeries: 1, minMarks: brands.Length, out ChartSpec? renderable)
+            .Should().BeTrue();
+        renderable.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void PartiallyCompletePortfolio_ExcludesBrandsWithMissingGrowth_NeverZeroFills()
+    {
+        // Three brands carry finite growth; six carry a null/blank/NaN metric.
+        // The chart must contain three marks, not nine, and none of them should
+        // be zero unless the seeded data says so.
+        string[] brands =
+        [
+            "Sierra Gold Tequila", "Ridgeline Bourbon", "Summit Vodka",
+            "FreshMart", "Harvest Table", "Apex Grill", "Coastline Tacos",
+            "Pinnacle Hardware", "Summit Outdoor",
+        ];
+        string?[] growthValues =
+        [
+            "-2.5%", "1.1%", "3.8%",
+            null, "", "n/a", "not-a-number", null, null,
+        ];
+
+        string payload = BuildPortfolioDepletionPayloadWithRawGrowth(brands, growthValues);
+        string compacted = new PortfolioDepletionCompactor()
+            .Compact("GetPortfolioDepletionStats", payload, new ToolResultBudgetOptions())
+            .Json;
+
+        MeaiChatResponse response = ResponseWithToolResults(compacted);
+
+        DeterministicChartBuilder
+            .TryBuild(response, requestedType: "horizontalBar", out ChartSpec? chart)
+            .Should().BeTrue();
+
+        chart.Data[0].Values.Should().HaveCount(3,
+            "brands with missing/unparseable growth must be excluded, never charted as zero");
+        chart.Data[0].Values.Select(p => p.X)
+            .Should().BeEquivalentTo(["Summit Vodka", "Ridgeline Bourbon", "Sierra Gold Tequila"]);
+    }
+
+    [Fact]
+    public void EmptyPortfolio_ReturnsFalse_SoCallerCanReportHonestDataAbsence()
+    {
+        string payload = BuildPortfolioDepletionPayloadWithRawGrowth(
+            brands: ["Sierra Gold Tequila"],
+            rawGrowthPercents: [null]);
+        string compacted = new PortfolioDepletionCompactor()
+            .Compact("GetPortfolioDepletionStats", payload, new ToolResultBudgetOptions())
+            .Json;
+
+        MeaiChatResponse response = ResponseWithToolResults(compacted);
+
+        DeterministicChartBuilder
+            .TryBuild(response, requestedType: "horizontalBar", out ChartSpec? chart)
+            .Should().BeFalse(
+                "with zero brands carrying finite growth, the builder must refuse — the caller then reports 'no data' honestly");
+        chart.Should().BeNull();
+    }
+
+    // ── payload helpers ─────────────────────────────────────────────────────
+
+    private static string BuildPortfolioDepletionPayload(string[] brands, double[] growthPct)
+    {
+        var rows = brands.Select((b, i) => new
+        {
+            brand = b,
+            region = RegionAll,
+            metrics = new
+            {
+                depletions_yoy = FormatSigned(growthPct[i]),
+                sell_through_yoy = "+1.2%",
+                inventory_weeks_on_hand = 6.5 + (i * 0.1),
+                status = "OnTrack",
+            },
+            sentiment_summary = "verbose prose the compactor strips",
+        }).ToArray();
+        return JsonSerializer.Serialize(new
+        {
+            region = RegionAll,
+            period = "YTD",
+            brandCount = rows.Length,
+            brands = rows,
+        });
+    }
+
+    private static string BuildPortfolioDepletionPayloadWithRawGrowth(
+        string[] brands,
+        string?[] rawGrowthPercents)
+    {
+        var rows = brands.Select((b, i) => new
+        {
+            brand = b,
+            region = RegionAll,
+            metrics = new
+            {
+                depletions_yoy = rawGrowthPercents[i],
+                sell_through_yoy = "+1.2%",
+                inventory_weeks_on_hand = 6.5 + (i * 0.1),
+                status = "OnTrack",
+            },
+        }).ToArray();
+        return JsonSerializer.Serialize(new
+        {
+            region = RegionAll,
+            period = "YTD",
+            brandCount = rows.Length,
+            brands = rows,
+        });
+    }
+
+    private static string FormatSigned(double value) =>
+        value >= 0 ? $"+{value:0.0}%" : $"{value:0.0}%";
+
+    private static MeaiChatResponse ResponseWithToolResults(params string[] compactedPayloads)
+    {
+        var messages = new List<ChatMessage>();
+        foreach (string payload in compactedPayloads)
+        {
+            var toolMessage = new ChatMessage(ChatRole.Tool, [new FunctionResultContent(
+                callId: Guid.NewGuid().ToString("N"),
+                result: payload)]);
+            messages.Add(toolMessage);
+        }
+
+        messages.Add(new ChatMessage(
+            ChatRole.Assistant,
+            "Here is the depletion-growth ranking across the portfolio."));
+
+        return new MeaiChatResponse(messages);
+    }
+}

--- a/tests/RetailPulse.Tests/Deployment/ApimGatewayContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/ApimGatewayContractTests.cs
@@ -1,0 +1,342 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+
+namespace RetailPulse.Tests.Deployment;
+
+/// <summary>
+/// Static guardrails for the APIM AI Gateway module contract. These tests only
+/// inspect repo files (the APIM Bicep modules, policy XML, and role-assignment
+/// module) — they never invoke <c>az</c>, <c>azd</c>, or touch Azure.
+///
+/// The intent is to make the AI Gateway a first-class, non-optional invariant of
+/// the deployment: identity, backend auth, subscription enforcement, policy
+/// primitives (token-limit + emit-token-metric), diagnostics (GatewayLlmLogs,
+/// API-level Application Insights with <c>metrics: true</c>, LLM diag), RBAC
+/// (Cognitive Services OpenAI User), and the endpoint output contract (no doubled
+/// <c>/openai</c> — the exact defect from incident #55) all live here as
+/// regression tests.
+/// </summary>
+public sealed partial class ApimGatewayContractTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [GeneratedRegex(@"@description\('APIM inference endpoint[^']*'\)\s*param\s+apimInferenceEndpoint\s+(?<type>[A-Za-z]+)(?<rest>[^\r\n]*)")]
+    private static partial Regex ApimInferenceEndpointParamRegex();
+
+    private static string ApimBicep => File.ReadAllText(
+        Path.Combine(RepoRoot, "infra", "modules", "apim.bicep"));
+
+    private static string ApimOpenAiApiBicep => File.ReadAllText(
+        Path.Combine(RepoRoot, "infra", "modules", "apim-openai-api.bicep"));
+
+    private static string ApimPolicyXml => File.ReadAllText(
+        Path.Combine(RepoRoot, "infra", "modules", "apim-openai-policy.xml"));
+
+    private static string ApimRoleAssignmentBicep => File.ReadAllText(
+        Path.Combine(RepoRoot, "infra", "modules", "apim-openai-role-assignment.bicep"));
+
+    private static string ContainerAppsBicep => File.ReadAllText(
+        Path.Combine(RepoRoot, "infra", "modules", "container-apps.bicep"));
+
+    private static string MainBicep => File.ReadAllText(
+        Path.Combine(RepoRoot, "infra", "main.bicep"));
+
+    // ── APIM instance ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ApimInstance_UsesSystemAssignedIdentityForBackendManagedIdentityAuth()
+    {
+        // The APIM policy authenticates to AOAI using APIM's system-assigned
+        // identity (managed-identity flow). Without SystemAssigned identity the
+        // policy silently 401s at request time.
+        ApimBicep.Should().MatchRegex(
+            @"identity:\s*{\s*type:\s*'SystemAssigned'",
+            "apim.bicep must declare a system-assigned managed identity so the AI Gateway can auth to AOAI via MI");
+    }
+
+    [Fact]
+    public void ApimInstance_ExposesPrincipalIdOutput_ForRbacGrant()
+    {
+        ApimBicep.Should().MatchRegex(
+            @"output\s+apimPrincipalId\s+string\s*=\s*apim\.identity\.principalId",
+            "apim.bicep must output the APIM principal id so downstream modules can grant Cognitive Services OpenAI User");
+    }
+
+    [Fact]
+    public void ApimInstance_WiresDiagnosticSettingsToLogAnalytics_IncludingGatewayLlmLogs()
+    {
+        // GatewayLlmLogs is the log category that carries prompt/completion payloads
+        // captured by the API-level largeLanguageModel diagnostic; it must be
+        // enabled or the AI Gateway telemetry pipeline goes dark for LLM traffic.
+        ApimBicep.Should().Contain("workspaceId: logAnalyticsWorkspaceId",
+            "apim.bicep must send APIM diagnostics to the shared Log Analytics workspace");
+        ApimBicep.Should().Contain("'GatewayLogs'",
+            "apim.bicep diagnostics must include the standard gateway request logs");
+        ApimBicep.Should().Contain("'GatewayLlmLogs'",
+            "apim.bicep diagnostics must include GatewayLlmLogs (LLM request/response payloads)");
+    }
+
+    [Fact]
+    public void ApimInstance_DeclaresBothLoggersUsedByApiLevelDiagnostics()
+    {
+        // The API-level applicationinsights and azuremonitor diagnostics
+        // (apim-openai-api.bicep) reference these two loggers as `existing`. If
+        // apim.bicep drops them, the API-level diag deploy fails with
+        // "resource not found" and telemetry silently goes dark.
+        ApimBicep.Should().MatchRegex(
+            @"resource\s+appInsightsLogger\s+'Microsoft\.ApiManagement/service/loggers[^']*'",
+            "apim.bicep must declare the appinsights-logger resource");
+        ApimBicep.Should().Contain("name: 'appinsights-logger'",
+            "the applicationInsights logger must be named 'appinsights-logger'");
+        ApimBicep.Should().MatchRegex(
+            @"resource\s+azureMonitorLogger\s+'Microsoft\.ApiManagement/service/loggers[^']*'",
+            "apim.bicep must declare the azuremonitor logger resource");
+        ApimBicep.Should().Contain("name: 'azuremonitor'",
+            "the Azure Monitor logger must be named 'azuremonitor'");
+    }
+
+    [Fact]
+    public void ApimInstance_UsesConnectionStringForAppInsightsLogger_Secretless()
+    {
+        // The instrumentationKey path pulls from a hidden NamedValue; using the
+        // connection string keeps the wiring resource-scoped and secretless
+        // (§decision 2026-08-05 / MERGED APIM decision).
+        ApimBicep.Should().Contain("connectionString: appInsightsConnectionString",
+            "the appinsights-logger must use the App Insights connection string (secretless), not instrumentationKey");
+    }
+
+    [Fact]
+    public void ApimInstance_WiresInstanceLevelApplicationInsightsDiagnostic_ForTokenMetrics()
+    {
+        // Instance-level applicationinsights diagnostic is what actually routes
+        // `azure-openai-emit-token-metric` custom metrics into App Insights
+        // customMetrics. API-level alone is not enough.
+        ApimBicep.Should().Contain(
+            "name: 'applicationinsights'",
+            "apim.bicep must declare an instance-level 'applicationinsights' diagnostic for token metrics");
+    }
+
+    // ── APIM OpenAI API module ───────────────────────────────────────────────
+
+    [Fact]
+    public void ApimOpenAiApi_HasSubscriptionRequired_AndApiKeyHeader()
+    {
+        ApimOpenAiApiBicep.Should().Contain("subscriptionRequired: true",
+            "the inference API must require an APIM subscription — never publicly callable");
+        ApimOpenAiApiBicep.Should().MatchRegex(
+            @"subscriptionKeyParameterNames:\s*{[^}]*header:\s*'api-key'",
+            "the inference API must accept the subscription key via the 'api-key' header (AOAI SDK compatible)");
+    }
+
+    [Fact]
+    public void ApimOpenAiApi_DeclaresBackendWithManagedIdentityCredentialsToCognitiveServices()
+    {
+        ApimOpenAiApiBicep.Should().Contain("Microsoft.ApiManagement/service/backends",
+            "apim-openai-api.bicep must declare the AOAI backend");
+        ApimOpenAiApiBicep.Should().MatchRegex(
+            @"managedIdentity:\s*{\s*resource:\s*'https://cognitiveservices\.azure\.com'",
+            "the backend must authenticate to AOAI via managed identity (resource=cognitiveservices.azure.com), never a key");
+    }
+
+    [Fact]
+    public void ApimOpenAiApi_ExposesApimSubscriptionKey_AsSecureOutput_ViaListSecrets()
+    {
+        // The primary key must flow through as a @secure() output resolved at
+        // Bicep-time via listSecrets() — that is what makes `azd provision`
+        // idempotently re-assert the ACA secret + secretRef binding (see PR #52).
+        ApimOpenAiApiBicep.Should().Contain("subscription.listSecrets()",
+            "the APIM subscription primary key must be resolved via listSecrets()");
+        ApimOpenAiApiBicep.Should().MatchRegex(
+            @"@secure\(\)\s*output\s+subscriptionKey\s+string",
+            "the APIM subscription key must be exposed as a @secure() output so ARM masks it in deployment history");
+    }
+
+    [Fact]
+    public void ApimOpenAiApi_InferenceEndpointOutput_DoesNotDoubleAppendOpenAiSegment()
+    {
+        // The exact regression from incident #55: `AzureOpenAIClient` appends
+        // `/openai/deployments/...` itself, so `inferenceEndpoint` must NOT end
+        // in `/openai` — derive from the base path param instead of the
+        // API's registered `path` (which includes `/openai` for the OpenAPI import).
+        ApimOpenAiApiBicep.Should().Contain(
+            "output inferenceEndpoint string = '${apim.properties.gatewayUrl}/${inferenceApiPath}'",
+            "inferenceEndpoint must derive from the base 'inferenceApiPath' param, NOT from api.properties.path (regression #55)");
+
+        // Belt-and-braces: reject the literal doubled-suffix expression too.
+        ApimOpenAiApiBicep.Should().NotContain("api.properties.path}'",
+            "inferenceEndpoint must not interpolate api.properties.path (which contains a trailing /openai) into the output");
+    }
+
+    [Fact]
+    public void ApimOpenAiApi_WiresApiPolicyWithTokenLimitAndTokenEmitMetric()
+    {
+        // Policy is loaded via loadTextContent and templated with backend id +
+        // tokens-per-minute — assert the API's policy resource wires it.
+        ApimOpenAiApiBicep.Should().MatchRegex(
+            @"resource\s+apiPolicy\s+'Microsoft\.ApiManagement/service/apis/policies",
+            "apim-openai-api.bicep must declare an API policy resource");
+        ApimOpenAiApiBicep.Should().Contain("loadTextContent('apim-openai-policy.xml')",
+            "the API policy must load its content from apim-openai-policy.xml");
+        ApimOpenAiApiBicep.Should().Contain("'{backend-id}'",
+            "the API policy must substitute the AOAI backend id at deploy time");
+        ApimOpenAiApiBicep.Should().Contain("'{tokens-per-minute}'",
+            "the API policy must substitute the tokens-per-minute cap at deploy time");
+    }
+
+    [Fact]
+    public void ApimOpenAiApi_ApiLevelAppInsightsDiag_EnablesMetricsRouting()
+    {
+        // API-level applicationinsights diagnostic with metrics=true is what
+        // routes emit-token-metric custom metrics into App Insights AppMetrics.
+        ApimOpenAiApiBicep.Should().MatchRegex(
+            @"parent:\s*api\s*\r?\n\s*name:\s*'applicationinsights'",
+            "apim-openai-api.bicep must declare an API-level 'applicationinsights' diagnostic");
+        ApimOpenAiApiBicep.Should().Contain("metrics: true",
+            "the API-level applicationinsights diagnostic must enable metrics routing for emit-token-metric");
+    }
+
+    [Fact]
+    public void ApimOpenAiApi_ApiLevelAzureMonitorDiag_EnablesLargeLanguageModelLogs()
+    {
+        ApimOpenAiApiBicep.Should().MatchRegex(
+            @"parent:\s*api\s*\r?\n\s*name:\s*'azuremonitor'",
+            "apim-openai-api.bicep must declare an API-level 'azuremonitor' diagnostic");
+        ApimOpenAiApiBicep.Should().Contain("largeLanguageModel:",
+            "the API-level azuremonitor diagnostic must declare the largeLanguageModel section for LLM request/response capture");
+        ApimOpenAiApiBicep.Should().Contain("logs: 'enabled'",
+            "the largeLanguageModel section must enable log capture");
+    }
+
+    [Fact]
+    public void ApimOpenAiApi_GrantsCognitiveServicesOpenAiUserRole_ToApimIdentity()
+    {
+        // 5e0bd9bd-7b93-4f28-af87-19fc36ad61bd = Cognitive Services OpenAI User.
+        // Without this role the MI backend policy 403s at request time.
+        ApimOpenAiApiBicep.Should().Contain("5e0bd9bd-7b93-4f28-af87-19fc36ad61bd",
+            "apim-openai-api.bicep must reference the 'Cognitive Services OpenAI User' role definition id");
+        ApimOpenAiApiBicep.Should().Contain("./apim-openai-role-assignment.bicep",
+            "apim-openai-api.bicep must invoke the role-assignment sub-module");
+        ApimOpenAiApiBicep.Should().Contain("principalId: apimPrincipalId",
+            "the role must be granted to the APIM principal id");
+    }
+
+    [Fact]
+    public void ApimRoleAssignmentModule_ScopesToAiServicesAccount_WithServicePrincipalType()
+    {
+        ApimRoleAssignmentBicep.Should().Contain("scope: aiServices",
+            "the role assignment must be scoped to the AOAI account, not the resource group");
+        ApimRoleAssignmentBicep.Should().Contain("principalType: 'ServicePrincipal'",
+            "the role assignment must set principalType=ServicePrincipal for the APIM MI");
+        ApimRoleAssignmentBicep.Should().Contain(
+            "subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionId)",
+            "the role assignment must build the role definition id via subscriptionResourceId");
+    }
+
+    // ── APIM policy XML ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ApimPolicyXml_UsesManagedIdentityAuthentication_ToCognitiveServices()
+    {
+        ApimPolicyXml.Should().MatchRegex(
+            @"<authentication-managed-identity\s+resource=""https://cognitiveservices\.azure\.com""",
+            "the APIM policy must authenticate to AOAI via managed identity — never a key or shared secret");
+    }
+
+    [Fact]
+    public void ApimPolicyXml_SetsBackendServiceToTemplatedBackendId()
+    {
+        ApimPolicyXml.Should().Contain("<set-backend-service backend-id=\"{backend-id}\"",
+            "the APIM policy must route to the templated backend-id (substituted at deploy time)");
+    }
+
+    [Fact]
+    public void ApimPolicyXml_EnforcesTokensPerMinuteLimit_PerSubscription()
+    {
+        // Subscription-scoped counter (not caller IP or global) — required for
+        // the multi-tenant cost/quota story.
+        ApimPolicyXml.Should().MatchRegex(
+            @"<azure-openai-token-limit\s+counter-key=""@\(context\.Subscription\.Id\)""",
+            "token-limit must key on the APIM subscription id (per-subscription quota)");
+        ApimPolicyXml.Should().Contain("tokens-per-minute=\"{tokens-per-minute}\"",
+            "token-limit must reference the templated tokens-per-minute cap");
+        ApimPolicyXml.Should().Contain("retry-after-header-name=\"Retry-After\"",
+            "token-limit must emit the standard Retry-After header on throttle");
+    }
+
+    [Fact]
+    public void ApimPolicyXml_EmitsTokenMetricInRetailPulseNamespace_WithApiOperationSubscriptionDimensions()
+    {
+        ApimPolicyXml.Should().Contain("<azure-openai-emit-token-metric namespace=\"RetailPulse\">",
+            "emit-token-metric must publish under the 'RetailPulse' custom-metric namespace");
+        ApimPolicyXml.Should().Contain("<dimension name=\"API ID\"",
+            "emit-token-metric must dimension by API ID");
+        ApimPolicyXml.Should().Contain("<dimension name=\"Operation ID\"",
+            "emit-token-metric must dimension by Operation ID");
+        ApimPolicyXml.Should().Contain("<dimension name=\"Subscription ID\"",
+            "emit-token-metric must dimension by Subscription ID (per-tenant cost attribution)");
+    }
+
+    // ── Container-apps wiring: no direct AOAI endpoint on the API ────────────
+
+    [Fact]
+    public void ContainerApps_DeclaresApimSubscriptionKey_AsAcaSecret_WithSecureAnnotation()
+    {
+        ContainerAppsBicep.Should().Contain("@secure()",
+            "the APIM subscription key parameter into container-apps.bicep must be marked @secure() so ARM masks it");
+        ContainerAppsBicep.Should().Contain("apimSubscriptionKey",
+            "container-apps.bicep must consume the APIM subscription key parameter");
+        ContainerAppsBicep.Should().MatchRegex(
+            @"secrets:\s*\[\s*{\s*name:\s*apimSubscriptionKeySecretName\s*value:\s*apimSubscriptionKey",
+            "the APIM subscription key must be declared as an ACA secret, never inlined as an env-var value");
+    }
+
+    [Fact]
+    public void ContainerApps_ApimInferenceEndpointParameter_IsRequired_NoDefault()
+    {
+        // A default endpoint would let a mis-provision silently boot the API
+        // against something other than the APIM inference URL. Force operators
+        // to plumb it through main.bicep.
+        Match match = ApimInferenceEndpointParamRegex().Match(ContainerAppsBicep);
+        match.Success.Should().BeTrue(
+            "container-apps.bicep must declare 'apimInferenceEndpoint' as a param with a description");
+        match.Groups["type"].Value.Should().Be("string");
+        match.Groups["rest"].Value.Should().NotContain("=",
+            "apimInferenceEndpoint must not carry a default — main.bicep must pipe the APIM endpoint through explicitly");
+    }
+
+    // ── main.bicep aliases the APIM inference endpoint as a first-class output
+
+    [Theory]
+    [InlineData("AZURE_APIM_NAME")]
+    [InlineData("AZURE_APIM_GATEWAY_URL")]
+    [InlineData("AZURE_APIM_INFERENCE_ENDPOINT")]
+    [InlineData("AZURE_APIM_INFERENCE_API_NAME")]
+    [InlineData("AZURE_APIM_INFERENCE_SUBSCRIPTION_NAME")]
+    public void MainBicep_EmitsApimGatewayOutput_ForOperatorAndVerificationTooling(string outputName)
+    {
+        var pattern = new Regex(
+            $@"output\s+{Regex.Escape(outputName)}\s+string\s*=",
+            RegexOptions.Multiline);
+        pattern.IsMatch(MainBicep).Should().BeTrue(
+            $"main.bicep must emit '{outputName}' so the postprovision hook + Verify-ApimAiGateway.ps1 can locate the deployed AI Gateway");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "RetailPulse.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate repo root (RetailPulse.slnx) walking up from " + AppContext.BaseDirectory);
+    }
+}

--- a/tests/RetailPulse.Tests/OpenAI/OpenAiConnectionSettingsTests.cs
+++ b/tests/RetailPulse.Tests/OpenAI/OpenAiConnectionSettingsTests.cs
@@ -177,18 +177,21 @@ public class OpenAiConnectionSettingsTests
         settings.AuthenticationMode.Should().Be(OpenAiAuthenticationMode.ManagedIdentity);
     }
 
-    [Fact]
-    public void Load_ThrowsWhenEndpointIsNotAbsoluteUrl()
+    [Theory]
+    [InlineData("/inference")]        // Linux: parses as file:///inference — must be rejected
+    [InlineData("apim.example.com/inference")] // no scheme
+    [InlineData("ftp://apim.example.com/inference")] // non-http scheme
+    public void Load_ThrowsWhenEndpointIsNotAbsoluteHttpUrl(string endpoint)
     {
         IConfiguration config = CreateConfig(
-            endpoint: "/inference",
+            endpoint: endpoint,
             useManagedIdentity: false,
             apimSubscriptionKey: "apim-sub-key");
 
         Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
 
         act.Should().Throw<InvalidOperationException>()
-            .WithMessage("*absolute URL*");
+            .WithMessage("*absolute http(s) URL*");
     }
 
     [Fact]

--- a/tests/RetailPulse.Tests/OpenAI/OpenAiConnectionSettingsTests.cs
+++ b/tests/RetailPulse.Tests/OpenAI/OpenAiConnectionSettingsTests.cs
@@ -194,6 +194,102 @@ public class OpenAiConnectionSettingsTests
             .WithMessage("*absolute http(s) URL*");
     }
 
+    // ── Ordering guarantees ─────────────────────────────────────────────────
+    // The AI Gateway invariant MUST be evaluated before any auth-mode branch
+    // (ManagedIdentity vs ApiKey vs DevelopmentFallback). Otherwise a bad
+    // endpoint escapes into `AzureOpenAIClient` construction and blows up at
+    // request time instead of startup. These tests pin the ordering directly:
+    // even the configurations that would normally succeed on the auth branch
+    // must still fail on the invariant when the endpoint is bad.
+
+    [Fact]
+    public void Load_ChecksAiGatewayInvariant_BeforeManagedIdentityBranch()
+    {
+        // ManagedIdentity path would normally succeed without any key. The
+        // invariant must still fire on a non-absolute endpoint.
+        IConfiguration config = CreateConfig(
+            endpoint: "/inference",
+            useManagedIdentity: true);
+
+        Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*absolute http(s) URL*");
+    }
+
+    [Fact]
+    public void Load_ChecksAiGatewayInvariant_BeforeDevelopmentFallbackKey()
+    {
+        // Development fallback would normally hand out "demo-key" and succeed.
+        // The invariant must still fire on an /openai-suffixed endpoint —
+        // Development is not an escape hatch for the doubled-segment defect.
+        IConfiguration config = CreateConfig(
+            endpoint: "https://gateway.example.com/inference/openai",
+            useManagedIdentity: false);
+
+        Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: true));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*openai*");
+    }
+
+    [Fact]
+    public void Load_ChecksAiGatewayInvariant_BeforeApiKeyResolution()
+    {
+        // ApiKey path would normally succeed with an APIM subscription key.
+        // The invariant must still fire on a direct AOAI host outside Dev
+        // even when a valid key is configured.
+        IConfiguration config = CreateConfig(
+            endpoint: "https://contoso.openai.azure.com",
+            useManagedIdentity: false,
+            apimSubscriptionKey: "apim-sub-key",
+            apiKey: "direct-key");
+
+        Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*APIM AI Gateway*");
+    }
+
+    [Fact]
+    public void Load_AiGatewayInvariant_IgnoresAllowDirectEndpointForNonAbsoluteUrls()
+    {
+        // The escape hatch never rescues a non-absolute URL — that's a
+        // misconfiguration regardless of environment or intent.
+        var data = new Dictionary<string, string?>
+        {
+            ["OpenAI:Endpoint"] = "/inference",
+            ["OpenAI:UseManagedIdentity"] = "true",
+            ["OpenAI:AllowDirectEndpoint"] = "true",
+        };
+        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(data).Build();
+
+        Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*absolute http(s) URL*");
+    }
+
+    [Fact]
+    public void Load_AiGatewayInvariant_IgnoresAllowDirectEndpointForOpenAiSuffix()
+    {
+        // The escape hatch also never rescues an /openai-suffixed endpoint —
+        // that's a runtime-request failure waiting to happen (regression #55)
+        // regardless of environment or intent.
+        var data = new Dictionary<string, string?>
+        {
+            ["OpenAI:Endpoint"] = "https://apim.example.com/inference/openai",
+            ["OpenAI:UseManagedIdentity"] = "true",
+            ["OpenAI:AllowDirectEndpoint"] = "true",
+        };
+        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(data).Build();
+
+        Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*openai*");
+    }
+
     [Fact]
     public void Load_AcceptsCanonicalApimInferenceEndpoint()
     {

--- a/tests/RetailPulse.Tests/OpenAI/OpenAiConnectionSettingsTests.cs
+++ b/tests/RetailPulse.Tests/OpenAI/OpenAiConnectionSettingsTests.cs
@@ -12,14 +12,14 @@ public class OpenAiConnectionSettingsTests
     public void Load_PrefersApimSubscriptionKey_WhenManagedIdentityDisabled()
     {
         IConfiguration config = CreateConfig(
-            endpoint: "https://gateway.example.com/inference/openai",
+            endpoint: "https://gateway.example.com/inference",
             useManagedIdentity: false,
             apiKey: "direct-key",
             apimSubscriptionKey: "apim-sub-key");
 
         var settings = OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
 
-        settings.Endpoint.Should().Be("https://gateway.example.com/inference/openai");
+        settings.Endpoint.Should().Be("https://gateway.example.com/inference");
         settings.AuthenticationMode.Should().Be(OpenAiAuthenticationMode.ApiKey);
         settings.ApiKey.Should().Be("apim-sub-key");
         settings.ApiKeySource.Should().Be("OpenAI:ApimSubscriptionKey");
@@ -28,12 +28,14 @@ public class OpenAiConnectionSettingsTests
     [Fact]
     public void Load_FallsBackToDirectApiKey_WhenApimSubscriptionKeyMissing()
     {
+        // Direct AOAI endpoint is only valid in Development or with the explicit
+        // OpenAI:AllowDirectEndpoint escape hatch (see AI Gateway invariants below).
         IConfiguration config = CreateConfig(
             endpoint: "https://contoso.openai.azure.com",
             useManagedIdentity: false,
             apiKey: "direct-key");
 
-        var settings = OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+        var settings = OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: true));
 
         settings.AuthenticationMode.Should().Be(OpenAiAuthenticationMode.ApiKey);
         settings.ApiKey.Should().Be("direct-key");
@@ -49,7 +51,7 @@ public class OpenAiConnectionSettingsTests
             apiKey: "direct-key",
             apimSubscriptionKey: "apim-sub-key");
 
-        var settings = OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+        var settings = OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: true));
 
         settings.AuthenticationMode.Should().Be(OpenAiAuthenticationMode.ManagedIdentity);
         settings.ApiKey.Should().BeNull();
@@ -60,7 +62,7 @@ public class OpenAiConnectionSettingsTests
     public void Load_UsesDevelopmentFallbackKey_WhenManagedIdentityDisabledAndNoKeyConfigured()
     {
         IConfiguration config = CreateConfig(
-            endpoint: "https://gateway.example.com/inference/openai",
+            endpoint: "https://gateway.example.com/inference",
             useManagedIdentity: false);
 
         var settings = OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: true));
@@ -86,13 +88,122 @@ public class OpenAiConnectionSettingsTests
     public void Load_ThrowsOutsideDevelopment_WhenManagedIdentityDisabledAndNoKeyConfigured()
     {
         IConfiguration config = CreateConfig(
-            endpoint: "https://gateway.example.com/inference/openai",
+            endpoint: "https://gateway.example.com/inference",
             useManagedIdentity: false);
 
         Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*OpenAI:ApimSubscriptionKey*OpenAI:ApiKey*");
+    }
+
+    // ── AI Gateway invariants ────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://gateway.example.com/inference/openai")]
+    [InlineData("https://gateway.example.com/openai")]
+    public void Load_RejectsEndpointEndingInOpenAi_RegardlessOfEnvironment(string endpoint)
+    {
+        IConfiguration config = CreateConfig(
+            endpoint: endpoint,
+            useManagedIdentity: false,
+            apimSubscriptionKey: "apim-sub-key");
+
+        Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*doubled*openai*");
+    }
+
+    [Fact]
+    public void Load_RejectsEndpointEndingInOpenAi_EvenInDevelopment()
+    {
+        // The SDK-appends-/openai regression from #55 is not environment-specific:
+        // a Development run against APIM with an /openai-suffixed endpoint also
+        // produces a doubled path at request time.
+        IConfiguration config = CreateConfig(
+            endpoint: "https://gateway.example.com/inference/openai",
+            useManagedIdentity: false);
+
+        Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: true));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*openai*");
+    }
+
+    [Theory]
+    [InlineData("https://contoso.openai.azure.com")]
+    [InlineData("https://aiservices-abc.cognitiveservices.azure.com")]
+    [InlineData("https://foundry-xyz.services.ai.azure.com")]
+    public void Load_RejectsDirectAzureOpenAiEndpoint_OutsideDevelopment(string endpoint)
+    {
+        IConfiguration config = CreateConfig(
+            endpoint: endpoint,
+            useManagedIdentity: false,
+            apimSubscriptionKey: "apim-sub-key");
+
+        Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*APIM AI Gateway*");
+    }
+
+    [Fact]
+    public void Load_AllowsDirectAzureOpenAiEndpoint_InDevelopment()
+    {
+        IConfiguration config = CreateConfig(
+            endpoint: "https://contoso.openai.azure.com",
+            useManagedIdentity: false);
+
+        var settings = OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: true));
+
+        settings.Endpoint.Should().Be("https://contoso.openai.azure.com");
+    }
+
+    [Fact]
+    public void Load_AllowsDirectAzureOpenAiEndpoint_WhenExplicitEscapeHatchSet()
+    {
+        var data = new Dictionary<string, string?>
+        {
+            ["OpenAI:Endpoint"] = "https://contoso.openai.azure.com",
+            ["OpenAI:UseManagedIdentity"] = "true",
+            ["OpenAI:AllowDirectEndpoint"] = "true",
+        };
+        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(data).Build();
+
+        var settings = OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+
+        settings.Endpoint.Should().Be("https://contoso.openai.azure.com");
+        settings.AuthenticationMode.Should().Be(OpenAiAuthenticationMode.ManagedIdentity);
+    }
+
+    [Fact]
+    public void Load_ThrowsWhenEndpointIsNotAbsoluteUrl()
+    {
+        IConfiguration config = CreateConfig(
+            endpoint: "/inference",
+            useManagedIdentity: false,
+            apimSubscriptionKey: "apim-sub-key");
+
+        Action act = () => OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*absolute URL*");
+    }
+
+    [Fact]
+    public void Load_AcceptsCanonicalApimInferenceEndpoint()
+    {
+        IConfiguration config = CreateConfig(
+            endpoint: "https://apim-abc.azure-api.net/inference",
+            useManagedIdentity: false,
+            apimSubscriptionKey: "apim-sub-key");
+
+        var settings = OpenAiConnectionSettings.Load(config, CreateEnvironment(isDevelopment: false));
+
+        settings.Endpoint.Should().Be("https://apim-abc.azure-api.net/inference");
+        settings.AuthenticationMode.Should().Be(OpenAiAuthenticationMode.ApiKey);
+        settings.ApiKeySource.Should().Be("OpenAI:ApimSubscriptionKey");
     }
 
     private static IConfiguration CreateConfig(


### PR DESCRIPTION
Closes #61. Refs #59, #55, #57.

Working as Costco (Backend Dev).

## Summary

Promotes the APIM AI Gateway path from "tested by intent" to a first-class, non-optional deployment invariant enforced at four independent checkpoints:

1. **Runtime startup guard** in `OpenAiConnectionSettings.Load` — refuses to boot the API pointed at a direct Azure OpenAI / Cognitive Services host outside Development (unless `OpenAI:AllowDirectEndpoint=true` is explicitly set), refuses any endpoint that ends in `/openai` regardless of environment (the exact SDK-appends-`/openai/deployments` shape that caused incident #55), and refuses non-absolute-http(s) URLs cross-platform (Linux `Uri.TryCreate("/inference", Absolute, ...)` trap). Invariant is evaluated **before** any auth-mode branch — five explicit ordering tests pin this.
2. **Bicep/static contract tests** (`ApimGatewayContractTests`, 26 tests) covering APIM identity, diagnostics, loggers, API subscription enforcement, backend MI auth, policy primitives (token-limit + emit-token-metric), RBAC (Cognitive Services OpenAI User), and the endpoint-output shape.
3. **CI Bicep compile gate** — new `bicep` job runs `az bicep build infra/main.bicep` so a broken module fails PR CI.
4. **Live post-provision verification** (`scripts/Verify-ApimAiGateway.ps1`) — read-only `az` script that checks the deployed APIM resource / API / policy / backend / diagnostics / RBAC and ACA config end-to-end, opportunistic (exits 2/skip when not signed in).

Plus:
- **Horizontal-bar ranking regression coverage** (`HorizontalBarRankingRegressionTests`, 3 tests) — proves the deterministic builder produces a populated `horizontalBar` ChartSpec end-to-end from a complete seeded portfolio payload, excludes brands with missing growth (never zero-fills), refuses cleanly on zero-finite-growth (honest data absence, no leaked JSON).
- **Issue #57 design + documented blocker** in `docs/testing/authenticated-synthetic-monitor.md` — captures the service-principal synthetic monitor contract and the three tenant constraints (no admin path to the app registration, no client secret, no Key Vault module) that block full implementation here.

## Files

- `src/RetailPulse.Api/OpenAI/OpenAiConnectionSettings.cs` — runtime invariant + escape hatch.
- `tests/RetailPulse.Tests/OpenAI/OpenAiConnectionSettingsTests.cs` — 26 new tests (invariant + ordering), pre-existing tests updated to use the canonical `/inference` endpoint.
- `tests/RetailPulse.Tests/Deployment/ApimGatewayContractTests.cs` — 26 new static contract tests.
- `tests/RetailPulse.Tests/Charts/HorizontalBarRankingRegressionTests.cs` — 3 new regression tests.
- `scripts/Verify-ApimAiGateway.ps1` — new live verification script.
- `.github/workflows/ci.yml` — new `bicep` job.
- `docs/testing/authenticated-synthetic-monitor.md` — new #57 design doc + blocker.

## Validation

- `dotnet test` — **2626/2626 pass** (Release, no-build).
- `dotnet format --verify-no-changes` — clean.
- `az bicep build infra/main.bicep` — clean.
- `Verify-ApimAiGateway.ps1` — cannot be executed from this session (no signed-in `az`); documented in `docs/testing/authenticated-synthetic-monitor.md` as one of the tenant blockers.

## Revision log

- **f96608b** — fix Linux `Uri.TryCreate` trap (required http/https scheme, not just absolute).
- **380014b** — pin invariant ordering: five explicit tests that the guard is reached before any auth-mode branch, and that `AllowDirectEndpoint` never rescues a non-absolute URL or a `/openai`-suffixed URL.

## Deployment limitations

- Live post-provision verification and the full #57 synthetic monitor cannot run inside this autonomous session — Azure sign-in requires a human, and the governed tenant does not permit creating an admin-consented confidential app registration from this environment. Blocker chain and unblock plan are in `docs/testing/authenticated-synthetic-monitor.md`.
- Adding a `Microsoft.KeyVault/vaults` module (required to hold the synthetic client secret non-secretless) is a Kroger-level architecture ask deferred here.
