### PR TITLE
docs: full documentation release pass (#78) — AI Gateway coverage, ADR references, shipped-state corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ retail-pulse/
 │       ├── src/components/           # ChatPanel, SpanTimeline, Charts, ErrorBoundary
 │       └── src/hooks/                # SignalR connection, telemetry
 ├── tests/
-│   ├── RetailPulse.Tests/            # xUnit + integration tests (2,669 passing)
+│   ├── RetailPulse.Tests/            # xUnit + integration tests (~2,669 passing)
 │   ├── RetailPulse.LoadTests/        # NBomber load test scenarios
 │   └── RetailPulse.Benchmarks/       # BenchmarkDotNet performance suite
 ├── deploy/                           # Deployment & infrastructure

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![React 19](https://img.shields.io/badge/React-19-61DAFB?logo=react)](https://react.dev/)
 [![Aspire 13.3](https://img.shields.io/badge/Aspire-13.3.0-6C3BAA)](https://learn.microsoft.com/dotnet/aspire/)
 [![CI](https://github.com/swigerb/retail-pulse/actions/workflows/ci.yml/badge.svg)](https://github.com/swigerb/retail-pulse/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/badge/coverage-70%25_target-brightgreen)](./coverage-report)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ## Overview
@@ -261,7 +260,7 @@ retail-pulse/
 │       ├── src/components/           # ChatPanel, SpanTimeline, Charts, ErrorBoundary
 │       └── src/hooks/                # SignalR connection, telemetry
 ├── tests/
-│   ├── RetailPulse.Tests/            # xUnit + integration tests (1815 passing)
+│   ├── RetailPulse.Tests/            # xUnit + integration tests (2,669 passing)
 │   ├── RetailPulse.LoadTests/        # NBomber load test scenarios
 │   └── RetailPulse.Benchmarks/       # BenchmarkDotNet performance suite
 ├── deploy/                           # Deployment & infrastructure
@@ -297,9 +296,9 @@ Charts are rendered **client-side**. The LLM emits structured `ChartSpec` JSON a
 
 **9 chart types:** line, bar, grouped bar, stacked bar, horizontal bar, pie, donut, gauge, and table. See [Chart Rendering Guide](docs/chart-rendering.md).
 
-### APIM AI Gateway (Optional)
+### APIM AI Gateway
 
-Route all LLM calls through Azure API Management for token metering, rate limiting, and governance. See [AI Gateway Integration](docs/ai-gateway-integration.md).
+Retail Pulse routes all LLM traffic through an [Azure API Management](https://learn.microsoft.com/azure/api-management/api-management-key-concepts) instance provisioned as first-class IaC by `azd up`. The AI Gateway applies token-per-minute rate limits, emits token-usage metrics, authenticates to Azure AI Foundry with a managed identity, and captures full request/response traces. See [AI Gateway Integration](docs/ai-gateway-integration.md).
 
 ### Foundry Shipment Agent (Optional)
 
@@ -314,7 +313,7 @@ Retail Pulse implements enterprise-grade patterns:
 - **Security** — CSP/HSTS/X-Frame-Options headers, input validation, SHA256 hash-chain audit log
 - **Performance** — MCP response cache, keyword fast-path routing, lightweight council voting, cache warming
 - **API Versioning** — `/api/v1/chat` with Sunset header on legacy endpoint
-- **Testing** — 1815+ unit/integration/contract/E2E tests, load tests, mutation testing, benchmarks
+- **Testing** — 3,200+ unit/integration/contract/E2E tests across backend (xUnit) and frontend (Vitest), plus load tests, mutation testing, and benchmarks
 
 ---
 
@@ -345,12 +344,24 @@ See [docs/deployment-azd.md](docs/deployment-azd.md) for full documentation.
 
 ### APIM AI Gateway
 
-The primary AI Gateway is now provisioned by `azd up` as part of `infra/main.bicep` via:
+The primary AI Gateway is provisioned by `azd up` as part of `infra/main.bicep` via:
 
 - `infra/modules/apim.bicep` — Developer-tier APIM instance, managed identity, service diagnostics, and loggers
 - `infra/modules/apim-openai-api.bicep` — Azure OpenAI backend, inference API, policy, API diagnostics, subscription, and cross-RG RBAC
 
-`deploy/apim-ai-gateway/` now only contains optional attach-on templates for wiring MCP/A2A APIs onto an already-existing APIM instance in a separate workflow.
+Every `azd provision` / `azd up` runs a **mandatory** post-provision AI Gateway verifier
+(`scripts/Verify-ApimAiGateway.ps1`, invoked from `azd-hooks/postprovision.ps1` and
+`postprovision.sh`) that inspects the live APIM resource, API, policy, backend,
+diagnostics, and ACA wiring via ARM REST. A live invariant failure fails the whole
+`azd up`, so a successful deployment cannot silently ship with a broken gateway.
+Coverage is locked in by the deployment-side contract tests
+(`tests/RetailPulse.Tests/Deployment/`), which include a compiled-ARM graph check
+(`CompiledArmDeploymentGraphTests`) that runs `az bicep build` and asserts the
+compiled JSON — not just the Bicep source — still declares the gateway.
+
+`deploy/apim-ai-gateway/` now only contains optional attach-on templates for wiring
+additional MCP/A2A APIs onto an **already-existing** APIM instance in a separate
+workflow — it does not provision the primary gateway.
 
 ### One-Click Local Deploy
 
@@ -586,7 +597,7 @@ All tenant configuration lives in `tenant.yaml` at the repo root. Changes take e
 
 ## Tests
 
-**1815+ tests passing** across xUnit (.NET), Vitest (frontend), load tests, and benchmarks. Covers agent telemetry, chart/tool behavior, prompt config, tenant validation, simulated metrics, session management (TTL eviction), SignalR session-group broadcasting, Teams Adaptive Card builders, and performance profiling.
+**3,200+ tests passing** across xUnit (.NET backend, ~2,669 tests), Vitest (frontend, ~552 tests), NBomber load tests, and BenchmarkDotNet benchmarks. Covers agent telemetry, chart/tool behavior, prompt config, tenant validation, simulated metrics, session management (TTL eviction), SignalR session-group broadcasting, Teams Adaptive Card builders, and performance profiling.
 
 ```bash
 # Run all .NET tests

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,14 @@
 
 > **Base URL:** `http://localhost:5100` (local dev via Aspire)
 >
-> **Authentication:** All endpoints require an `x-api-key` header (configured via `ApiKey:Value` setting).
+> **Authentication:** Production runs in `Authentication__Mode=Entra` with
+> `Security__RequireAuth=true`. Every protected REST call carries a
+> `Authorization: Bearer <token>` header; SignalR clients pass the same token via the
+> `?access_token=<token>` query string (honored **only** on `/hubs/*`). Both must
+> present the `RetailPulse.User` app role and the `access_as_user` scope. See
+> [Entra Authentication](authentication-entra.md), the [authentication matrix](authentication-matrix.md),
+> and [ADR-005](adr/005-provider-neutral-authentication.md). Local `Development`
+> environments bypass authentication via `DevelopmentAuthHandler`.
 
 ---
 

--- a/docs/ai-gateway-integration.md
+++ b/docs/ai-gateway-integration.md
@@ -37,6 +37,36 @@ This deploys:
 | `infra/modules/apim-openai-policy.xml` | AI Gateway policies (token rate limiting, token metrics, MI auth) |
 | `infra/modules/apim-openai-role-assignment.bicep` | Managed identity role assignment (APIM → Azure AI Foundry) |
 
+### Mandatory post-provision verifier gate
+
+`azd provision` reporting "Succeeded" only proves the ARM deployments succeeded — it does
+not prove the AI Gateway invariants (backend, policy, token-limit, emit-token-metric,
+diagnostics, RBAC, ACA wiring) are actually correct on the live resources. Every
+`azd provision` / `azd up` therefore runs a **mandatory** live verifier from the
+post-provision hook:
+
+- `scripts/Verify-ApimAiGateway.ps1` — reads a bearer token via `az account get-access-token`
+  and calls ARM REST (`Invoke-RestMethod`) directly to inspect every invariant on the live
+  APIM instance. It does **not** shell out to `az apim`/`az rest` subcommands (which have a
+  known Windows UTF-8 BOM crash on APIM policy responses) and it does not swallow errors.
+- `azd-hooks/postprovision.ps1` and `azd-hooks/postprovision.sh` invoke the verifier and
+  **fail** the whole `azd up` on any non-zero, non-skip exit. Exit `0` = PASS, exit `2` is
+  a genuine environment-precondition skip (no `az` CLI / not signed in / missing azd
+  outputs); every other non-zero exit is a hard fail.
+
+The verifier is complemented by static contract tests under
+`tests/RetailPulse.Tests/Deployment/`, including
+`CompiledArmDeploymentGraphTests` which runs `az bicep build` and asserts on the compiled
+ARM JSON so that a module-boundary regression cannot silently drop the gateway.
+
+### `deploy/apim-ai-gateway/` — optional attach-on templates only
+
+`deploy/apim-ai-gateway/` no longer provisions the primary Retail Pulse APIM gateway; that
+is now the responsibility of `infra/modules/apim*.bicep` above. The residual files
+(`mcp-api.bicep`, `a2a-api.bicep`) are optional attach-on templates for wiring extra
+MCP/A2A APIs onto an **already-existing** APIM instance in a separate workflow. See
+[`deploy/apim-ai-gateway/README.md`](../deploy/apim-ai-gateway/README.md).
+
 ---
 
 ## Observability: The Three Telemetry Layers

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ Browser (ChatPanel) → POST /api/chat → RetailPulseAgent
 | Decision | Rationale |
 |----------|-----------|
 | **Why APIM for AI?** | Token metering per team/department. Rate limiting prevents runaway costs. Content safety policies. Complete audit trail for compliance. |
-| **Separate from core demo** | The app works without APIM. Gateway is an enterprise overlay — add it when the conversation turns to production governance. |
+| **First-class in `azd up`** | Provisioned by `infra/modules/apim.bicep` + `infra/modules/apim-openai-api.bicep`; a mandatory post-provision verifier (`scripts/Verify-ApimAiGateway.ps1`) asserts every AI Gateway invariant on the live resource and fails `azd up` if any is missing. The app can still be pointed directly at Azure OpenAI for local debugging, but the deployed stack always routes through APIM. |
 
 ---
 
@@ -135,9 +135,9 @@ Retail Pulse uses Azure API Management as an AI Gateway following the [Azure-Sam
 
 1. **RetailPulse API** sends chat completion requests to APIM using the Azure OpenAI SDK
 2. **APIM** validates the `api-key` header (subscription key)
-3. **AI Gateway policies** apply:
-   - `llm-token-limit`: Rate limits to 10,000 tokens per minute per subscription
-   - `llm-emit-token-metric`: Emits token usage metrics to Azure Monitor (namespace: RetailPulse)
+3. **AI Gateway policies** apply (see [`infra/modules/apim-openai-policy.xml`](../infra/modules/apim-openai-policy.xml)):
+   - `azure-openai-token-limit`: Rate limits to 10,000 tokens per minute per subscription
+   - `azure-openai-emit-token-metric`: Emits token usage metrics to Application Insights `customMetrics`
    - Circuit breaker: Trips on 429s for 1 minute
 4. **APIM** forwards to Azure AI Foundry using its managed identity (no keys in transit)
 5. **Azure AI Foundry** processes with the `gpt-5.4-mini` deployment

--- a/docs/chart-acceptance-run.md
+++ b/docs/chart-acceptance-run.md
@@ -20,13 +20,13 @@ does the same thing end-to-end for each curated prompt.
 
 ## Latest run
 
-> **Status:** pending live sign-off on `squad/50-all-chart-prompt-acceptance`
-> for the PR opened against `main`. The automated matrix suites (backend
-> `ChartAcceptanceMatrixTests`, backend `ChartAcceptancePerformanceTests`,
-> frontend `chartAcceptance.matrix.test.tsx`) all pass on this branch, so the
-> production build satisfies the same invariants that the browser runner
-> checks. The reviewer approving the PR is expected to record the live
-> outcome here (or in a PR comment linked here) before merge.
+> **Status:** The chart-acceptance matrix landed on `main` via PR #53 ("P0 #50:
+> Systemic chart acceptance matrix for all curated prompts") and is enforced on every
+> CI run by the backend `ChartAcceptanceMatrixTests` / `ChartAcceptancePerformanceTests`
+> and the frontend `chartAcceptance.matrix.test.tsx` suites. This log file remains the
+> record of human, in-browser sign-off; the automated matrix is the durable gate.
+> Re-run the browser runner (per **How to update this file**) when you want a fresh
+> human record and paste the resulting JSON below.
 
 ```json
 []

--- a/docs/chart-acceptance.md
+++ b/docs/chart-acceptance.md
@@ -2,8 +2,8 @@
 
 This document is the durable, human-readable index of the **curated chart-prompt
 acceptance matrix** the codebase enforces automatically for issue
-[#50](../.github). It complements — and is verified against — the machine
-sources of truth:
+[#50](https://github.com/swigerb/retail-pulse/issues/50). It complements — and is
+verified against — the machine sources of truth:
 
 * **Prompt source** — `src/RetailPulse.Web/src/constants/prompts.ts` (Charts
   category + the QSR two-brand comparison).

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -162,6 +162,13 @@ The AI Gateway is provisioned directly by `infra/main.bicep`:
 - `AZURE_APIM_INFERENCE_ENDPOINT`
 - `AZURE_APIM_INFERENCE_SUBSCRIPTION_NAME`
 
+Every `azd provision` / `azd up` also runs the mandatory
+[APIM AI Gateway live verifier](./ai-gateway-integration.md#mandatory-post-provision-verifier-gate)
+(`scripts/Verify-ApimAiGateway.ps1`, invoked from `azd-hooks/postprovision.*`) as a
+hard gate — a live invariant failure fails the whole `azd up` rather than reporting
+false success. This is the primary defense against a "provisioning succeeded" report
+that masks a broken gateway.
+
 ## Deployment behavior & operational tradeoffs
 
 The current `azd` topology is tuned for a **low-cost public demo**. The following
@@ -332,13 +339,13 @@ weakens these:
 - `ASPNETCORE_ENVIRONMENT=Production` with no configured path **and no**
   `RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true` → startup fails.
 
-The auth cutover (this PR, rebased on top of the storage hotfix) flips the API to
-`Production`. It resolves the resulting fail-closed startup by option (b): it
+The Entra auth cutover (already merged to `main`, rebased on top of the storage hotfix) runs
+the API in `Production`. It resolves the resulting fail-closed startup by option (b): it
 **explicitly** acknowledges non-durable storage via
 `RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true` for the synthetic demo, rather than
 reintroducing the policy-incompatible Azure Files mount. The Production/required
-fail-closed path is **not** weakened — a future policy-compatible durable backing
-(see options below) can drop the opt-out and set a real durable path instead.
+fail-closed path is **not** weakened — a future policy-compatible durable backing (see
+options below) can drop the opt-out and set a real durable path instead.
 
 The **MCP server** still writes its seeded retail dataset (`retailpulse.db`) under
 the OS temp directory. That is intentional and safe: it **re-seeds from
@@ -383,31 +390,38 @@ Constraints verified from code/IaC: `infra/modules/container-apps.bicep`
 Log Analytics exist), `DataDirectoryResolver`/`SqliteMount` (local SQLite model),
 and the governance failure mode described in the incident note above.
 
-### Public-demo auth posture
+### Live auth posture (Entra-only, fail-closed)
 
-The postprovision hook sets `Security__RequireAuth=false`, disables ACA platform auth,
-and runs the API/MCP/bot with their fixed synthetic Development identities. When auth is disabled the API installs
-an allow-all default authorization policy, which is what lets the SignalR hubs
-(`.RequireAuthorization()`) and other protected endpoints serve the anonymous demo
-frontend. Because ingress is **external**, this means the API — and the paid model calls
-behind it — is **publicly reachable without authentication**, protected only by the
-built-in rate limiter. Acceptable for a throwaway demo; do **not** use this posture for
-anything with real data or cost exposure. Set `Security__RequireAuth=true` (and wire an
-identity provider) for non-demo environments.
+The deployed stack is **Entra-only**. The Bicep pins the API's environment to:
 
-> **Anonymous mode is a safer alternative to this posture, but is not deployed.**
-> Sprint 1 adds a first-class, fail-closed `Authentication:Mode=Anonymous` provider
-> (server-minted short-lived session tokens, read-only enforcement, per-subject/per-IP
-> rate limits, and a daily request/token/cost circuit breaker) — see
-> [security.md → Anonymous mode](security.md#anonymous-mode-opt-in-never-deployed) and
-> [ADR-005](adr/005-provider-neutral-authentication.md). Unlike `Security__RequireAuth=false`,
-> it does not leave the model surface unauthenticated. It is **not** enabled by any
-> deployment artifact this sprint: `appsettings.Production.json`, the Bicep, and the azd
-> postprovision hooks all remain pinned to `Entra`, and a deployment-contract test asserts
-> the hooks never configure Anonymous guardrails. A hosted Anonymous enable would be a
-> deliberate, separate decision requiring `Anonymous:AllowHosted=true`, a strong signing
-> key, positive daily ceilings, and — because the ceilings are replica-local — a single
-> replica (`maxReplicas=1`). It is not equivalent to authenticated production.
+- `Authentication__Mode=Entra` (provider-neutral mode contract — see
+  [ADR-005](adr/005-provider-neutral-authentication.md))
+- `Security__RequireAuth=true` (in-process JWT bearer gate is the authoritative boundary)
+- `ASPNETCORE_ENVIRONMENT=Production`
+- `RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true` (honest opt-out for the demo's non-durable
+  SQLite stores — see the storage section above)
+
+The post-provision hook (`azd-hooks/postprovision.*`) also:
+
+- Grants each Container App's system-assigned managed identity `AcrPull` on the
+  dedicated Container Registry (idempotent).
+- Links the API Container App as the Static Web App's `/api` backend so relative
+  `/api/*` calls stay same-origin, while SignalR intentionally uses the absolute
+  `VITE_API_ORIGIN` (linked backends do not proxy WebSockets).
+- **Disables** ACA platform auth (Easy Auth) on the API. Easy Auth would issue login
+  redirects that break bearer-token REST and SignalR clients calling ACA directly; the
+  in-process Entra `JwtBearer` handler is the real security boundary.
+- Runs the **mandatory APIM AI Gateway live verifier**
+  (`scripts/Verify-ApimAiGateway.ps1`) as a hard gate — a live invariant failure fails
+  the whole `azd up` rather than reporting false success. See
+  [AI Gateway Integration → Mandatory post-provision verifier gate](ai-gateway-integration.md#mandatory-post-provision-verifier-gate).
+
+The Anonymous and GitHub provider modes are fully implemented but **never deployed** by
+`azd up` — they are opt-in, fail-closed capabilities for non-production environments
+only. A deployment-contract test
+(`tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs`) asserts
+that neither Bicep nor the azd hooks ever configure GitHub/Anonymous guardrails, and
+that `VITE_AUTH_MODE` (frontend) and `Authentication__Mode` (API) both equal `Entra`.
 
 #### Safe web-build mode templates (`.env.*.example`)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -296,9 +296,20 @@ attack surface. The live build stays `Entra`.
 - No API key required.
 
 ### Production
-- **API Key:** Required via `x-api-key` header (configured in `ApiKey:Value`)
-- **JWT Bearer:** For Teams bot integration (validated by `TeamsSsoHandler`)
-- **Managed Identity:** For Azure OpenAI and APIM (no secrets in code)
+- **Entra Bearer (primary):** `Authentication:Mode=Entra` and `Security:RequireAuth=true` are
+  pinned by `infra/modules/container-apps.bicep`. All `/api/**` calls require an
+  `Authorization: Bearer <token>` JWT issued by the tenant's Entra app registration; SignalR
+  hubs accept the same token via `?access_token=...`. See
+  [`authentication-entra.md`](authentication-entra.md) and
+  [ADR-005](adr/005-provider-neutral-authentication.md) for the full flow.
+- **JWT Bearer (Teams bot channel):** Teams-to-bot activity is validated by `TeamsSsoHandler`
+  in the bot pipeline (independent of the SPA/API auth above).
+- **Optional API key gate:** `ApiKeyAuthMiddleware` remains available for scenarios that need
+  an extra pre-auth header check (`ApiKey:Enabled=true` + `ApiKey:Value=<secret>`). It is
+  **disabled by default** and is not enabled by the shipped Bicep — Entra Bearer is the
+  Production gate.
+- **Managed Identity:** For Azure OpenAI (via APIM) and other Azure resources — no client
+  secrets in code.
 
 ---
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -404,26 +404,23 @@ Contact the development team or file an issue in the repository.
 
 ## Test Infrastructure Overview
 
-RetailPulse has **1815+ tests** across multiple testing strategies:
+RetailPulse has **3,200+ tests** across multiple testing strategies:
 
 | Category | Location | Framework | Count |
 |----------|----------|-----------|-------|
-| Unit tests | tests/RetailPulse.Tests/ | xUnit + FluentAssertions + Moq | ~1700 |
-| Contract tests | tests/RetailPulse.Tests/Contract/ | WebApplicationFactory | ~10 |
-| E2E demo scenarios | tests/RetailPulse.Tests/E2E/ | WebApplicationFactory | 5 |
-| OWASP security | tests/RetailPulse.Tests/Security/ | xUnit | ~20 |
-| Chaos tests | tests/RetailPulse.Tests/Chaos/ | xUnit | ~15 |
-| Value object tests | tests/RetailPulse.Tests/ValueObjects/ | xUnit | 45 |
+| Backend unit + integration + contract + E2E | tests/RetailPulse.Tests/ | xUnit + FluentAssertions + Moq + WebApplicationFactory | ~2,669 |
 | Load tests | tests/RetailPulse.LoadTests/ | NBomber | 2 scenarios |
 | Benchmarks | tests/RetailPulse.Benchmarks/ | BenchmarkDotNet | 3 suites |
-| Frontend | src/RetailPulse.Web/ | Vitest | ~250 |
+| Frontend | src/RetailPulse.Web/ | Vitest + Testing Library | ~552 |
+
+Backend coverage includes OWASP/security suites (`Security/`), chaos suites (`Chaos/`), value-object suites (`ValueObjects/`), deployment/IaC contract suites (`Deployment/`), and provider-matrix suites — all in the single `RetailPulse.Tests` project.
 
 ---
 
 ## Running All Tests
 
 ```bash
-# Backend (all 1815 tests)
+# Backend (all ~2,669 tests)
 dotnet test RetailPulse.slnx --verbosity quiet
 
 # Frontend

--- a/docs/testing/apim-ai-gateway-live-test-plan.md
+++ b/docs/testing/apim-ai-gateway-live-test-plan.md
@@ -17,7 +17,7 @@ This plan validates the new Developer-tier Azure API Management gateway for the 
 
 > **Name placeholders:** the child names below match the shipped Bicep in
 > `infra/modules/apim-openai-api.bicep` (`retail-pulse-inference-api`,
-> `retail-pulse-foundry`, `retail-pulse-sub`). If a future Bicep revision renames a
+> `retail-pulse-foundry`, `retail-pulse-inference-sub`). If a future Bicep revision renames a
 > child resource or emits different outputs, update those variables before execution.
 
 ## Operator setup
@@ -34,7 +34,7 @@ $AiFoundryResourceGroup = '<UPDATE-WHEN-KROGER-LANDS-OUTPUT-OR-CONFIRMED-RG>'
 $ApiContainerAppName = 'ca-retailpulse-api'
 $ApimApiName = 'retail-pulse-inference-api'
 $ApimBackendName = 'retail-pulse-foundry'
-$ApimSubscriptionName = 'retail-pulse-sub'
+$ApimSubscriptionName = 'retail-pulse-inference-sub'
 $DeploymentName = 'gpt-5.4-mini-2026-03-17' # replace if infra/app wiring uses a different deployment
 $ApiVersion = '2025-03-01-preview'
 $Marker = "apim-live-test-$([DateTime]::UtcNow.ToString('yyyyMMdd-HHmmss'))"

--- a/docs/testing/apim-ai-gateway-live-test-plan.md
+++ b/docs/testing/apim-ai-gateway-live-test-plan.md
@@ -1,6 +1,10 @@
 # APIM AI gateway live test plan
 
-> **Status:** Proactive prep only — written ahead of Kroger/Costco landing the final infra + app wiring so live validation can start immediately after merge.
+> **Status:** Reference live-verification plan. The APIM AI Gateway landed on `main`
+> via PR #52 (first-class azd IaC) and the mandatory post-provision verifier gate
+> landed via PR #73 (`Verify-ApimAiGateway.ps1` wired into `azd-hooks/postprovision.*`
+> as a hard fail). This plan documents the manual live checks that complement — and
+> are automated by — that verifier for the `retailpulse-demo-eus-001` environment.
 
 ## Scope
 
@@ -11,7 +15,10 @@ This plan validates the new Developer-tier Azure API Management gateway for the 
 - AI Foundry account: `aiagents-3rsdmhyb`
 - Expected APIM behaviors: managed-identity backend auth, token-per-minute limiting, token custom metrics, LLM diagnostics, and application traffic flowing through APIM
 
-> **Name placeholders:** this draft assumes Kroger keeps the prototype child names from `deploy\apim-ai-gateway\` (`retail-pulse-inference-api`, `retail-pulse-foundry`, `retail-pulse-sub`). If the landed `infra\modules\apim*.bicep` uses different child names or outputs, replace those three variables before execution.
+> **Name placeholders:** the child names below match the shipped Bicep in
+> `infra/modules/apim-openai-api.bicep` (`retail-pulse-inference-api`,
+> `retail-pulse-foundry`, `retail-pulse-sub`). If a future Bicep revision renames a
+> child resource or emits different outputs, update those variables before execution.
 
 ## Operator setup
 

--- a/src/RetailPulse.Web/README.md
+++ b/src/RetailPulse.Web/README.md
@@ -1,6 +1,16 @@
-# React + TypeScript + Vite
+# Retail Pulse Web (React + TypeScript + Vite)
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The Retail Pulse React dashboard: chat panel, real-time SignalR telemetry, chart
+rendering, and observability views. Runs on Vite + React 19 + TypeScript against the
+`RetailPulse.Api` backend. The Aspire AppHost launches this project automatically
+(`AddNpmApp` → `npm run dev`), so day-to-day contributors do not need to start it by
+hand.
+
+See also:
+
+- [FRONTEND.md](../../docs/FRONTEND.md) — architecture, component catalog, and provider-neutral sign-in.
+- [authentication-matrix.md](../../docs/authentication-matrix.md) — full mode / environment behavior table.
+- [ADR-005](../../docs/adr/005-provider-neutral-authentication.md) — provider-neutral authentication foundation.
 
 ## Feature flags / Navigation
 
@@ -95,7 +105,7 @@ not with `dotnet`**:
 
 - At runtime the Aspire AppHost launches it (`AddNpmApp` → `npm run dev`).
 - CI installs from the committed lockfile with `npm ci` (through the internal package
-  feed proxy — see **Supply chain** below) and then runs `npm run build`.
+  feed proxy — see **Supply chain** above) and then runs `npm run build`.
 
 The `.esproj` is intentionally configured as visibility-only
 (`ShouldRunNpmInstall=false`, `ShouldRunBuildScript=false`), so a solution-wide
@@ -103,72 +113,22 @@ The `.esproj` is intentionally configured as visibility-only
 Use the npm scripts below (or the VS UI) to install, build, run, and test the app.
 VS users need the Node.js workload installed locally.
 
-Currently, two official plugins are available:
+## npm scripts
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+| Script | Purpose |
+|--------|---------|
+| `npm ci` | Reproducible install from `package-lock.json` (routed through the internal proxy). |
+| `npm run dev` | Vite dev server on `http://localhost:5173` (started automatically by Aspire). |
+| `npm run build` | Production build → `dist/`. Runs `prebuild` (auth config gate) first. |
+| `npm test` | Vitest test runner (unit + component + contract). |
+| `npm run test:provider-matrix` | Full provider-neutral auth matrix — config gate + Entra/GitHub/Anonymous builds + emitted-`index.html` meta assertions. |
+| `npm run test:provider-matrix:gate` | Fast config gate only (skips full builds). |
 
-## React Compiler
+## Reference
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
-
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+- [Vite](https://vite.dev/) — build tool and dev server.
+- [React 19](https://react.dev/) — UI framework.
+- [Recharts](https://recharts.org/) — chart rendering.
+- [Fluent UI React v9](https://react.fluentui.dev/) — design system.
+- [Microsoft SignalR client](https://learn.microsoft.com/aspnet/core/signalr/javascript-client) — real-time telemetry hubs.
+- [MSAL React](https://learn.microsoft.com/entra/identity-platform/tutorial-single-page-app-react-sign-in) — Entra sign-in in `Entra` mode.


### PR DESCRIPTION
Full documentation release pass owned by **Kroger** (documentation release lead). This PR consolidates every doc edit needed to bring the public documentation scope back into alignment with the shipped state on `origin/main` (HEAD `119614b`, PR #75).

**Scope reviewed:** `README.md`, all of `docs/**/*.md`, `deploy/**/README.md`, `src/RetailPulse.Web/README.md`, `tests/**/README.md`, and every ADR under `docs/adr/`.

**Editorial standard applied:** shipped product, mandatory AI Gateway coverage, official Microsoft/Azure links preserved, coherent navigation between related docs, ADRs referenced not restated.

**PR status honesty:** every claim in the docs has been reconciled against `origin/main`. PRs **#77** (`squad/76-sweep-remediation`) and **#64** (`26-prompt-acceptance-matrix`) are still OPEN and are **not** described as shipped anywhere.

## File-by-file summary

### `README.md`
- Removed dead coverage badge (`./coverage-report`).
- Corrected backend test count from `1,815` to `~2,669` (verified by `dotnet test --list-tests`); overall test posture is now **`3,200+` tests passing** (backend + `~552` frontend + 2 load + benchmarks).
- Reframed "APIM AI Gateway (Optional)" as **first-class**. The APIM AI Gateway is provisioned by `infra/modules/apim*.bicep`, its live invariants are protected by the **mandatory** post-provision verifier gate, and the compiled ARM contract test guards the module boundary.

### `docs/architecture.md`
- Fixed stale APIM policy names `llm-token-limit` / `llm-emit-token-metric` → `azure-openai-token-limit` / `azure-openai-emit-token-metric` (matches `infra/modules/apim-openai-policy.xml`).
- "Why APIM?" table row now describes the first-class `azd up` gate (verifier + compiled-ARM contract test) instead of the pre-#66 "separate from core demo" claim.

### `docs/ai-gateway-integration.md`
- New **Mandatory post-provision verifier gate** section covering `scripts/Verify-ApimAiGateway.ps1` (ARM REST + bearer token — deliberately avoids `az apim` / `az rest` UTF-8 BOM crash), `azd-hooks/postprovision.ps1|.sh` invocation, exit-code semantics (`0` = pass, `2` = env-precondition skip, everything else = hard fail), and `CompiledArmDeploymentGraphTests`.
- New **`deploy/apim-ai-gateway/` — optional attach-on templates only** subsection so readers do not confuse the residual MCP/A2A attach-on templates with the primary gateway topology.

### `docs/deployment-azd.md`
- Replaced stale "Public-demo auth posture" section. The shipped Production posture (pinned by `infra/modules/container-apps.bicep`) is now correctly described: `Authentication__Mode=Entra`, `Security__RequireAuth=true`, `ASPNETCORE_ENVIRONMENT=Production`, `RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true`, plus the postprovision hook disabling Easy Auth and running the APIM verifier gate.
- Corrected "this PR flips API to Production" wording (Entra cutover already merged, PR #39 / #41 (Sprint 3 / Sprint 4 auth hardening)).
- AI Gateway section now cross-links the mandatory verifier gate.

### `docs/API.md`
- Replaced stale `x-api-key` header claim in the auth header with the correct Entra `Authorization: Bearer <token>` (SignalR `?access_token`) description and links to `authentication-entra.md`, `authentication-matrix.md`, and ADR-005.

### `docs/testing-guide.md`
- Corrected `1815` → `3,200+` in the overall count; rewrote the infrastructure count table with honest per-suite numbers (`~2,669` backend, `552` frontend, `2` load, `~3` benchmark suites).
- Fixed the CLI recipe comment `# Backend (all 1815 tests)` → `# Backend (all ~2,669 tests)`.

### `docs/testing/apim-ai-gateway-live-test-plan.md`
- Removed the "Proactive prep only" preamble. The APIM AI Gateway landed on `main` via PR #52 (first-class azd IaC) and the mandatory verifier gate landed via PR #73 (verifier + postprovision hard fail); the plan is now documented as the reference live-verification plan that complements the automated verifier.
- Updated the name-placeholder note to reference the shipped `infra/modules/apim-openai-api.bicep` rather than the pre-merge prototype.

### `docs/chart-acceptance-run.md`
- Latest-run status updated: PR #53 (Systemic chart acceptance matrix) merged and is enforced on every CI run by the backend `ChartAcceptanceMatrixTests` / `ChartAcceptancePerformanceTests` and the frontend `chartAcceptance.matrix.test.tsx` suites. This log remains the record of human, in-browser sign-off.

### `docs/chart-acceptance.md`
- Fixed broken `../.github` reference for issue #50 → `https://github.com/swigerb/retail-pulse/issues/50`.

### `src/RetailPulse.Web/README.md`
- Retitled from the Vite scaffold banner ("React + TypeScript + Vite") to **"Retail Pulse Web (React + TypeScript + Vite)"** with a purpose paragraph and cross-links to `docs/FRONTEND.md`, `docs/authentication-matrix.md`, and ADR-005.
- Trimmed the generic Vite plugin / React Compiler / ESLint boilerplate.
- Kept the useful, project-specific sections (Feature flags & primary nav, Supply chain / `.npmrc` proxy, Auth provider matrix, Visual Studio integration) and added a compact npm scripts table plus a Reference list of the official framework docs the app depends on.

## Evidence — verified against shipped state

| Claim rewritten | Verified against |
|-----------------|------------------|
| APIM AI Gateway is first-class in `azd up` | PR #66 merged (APIM hardening); `infra/modules/apim*.bicep` |
| Mandatory post-provision verifier gate | PR #73 merged (`463612d`) — `scripts/Verify-ApimAiGateway.ps1` + `azd-hooks/postprovision.*` |
| Verifier robustness | PRs #69 / #72 merged |
| Growth-ranking aggregate scenarios | PR #75 merged (`119614b`, current HEAD) |
| Shipped Entra-only fail-closed posture | PR #39 / #41 (Sprint 3 / Sprint 4 auth hardening) merged; `infra/modules/container-apps.bicep` lines 195–236 |
| Chart-acceptance matrix in CI | PR #53 merged; `ChartAcceptanceMatrixTests`, `chartAcceptance.matrix.test.tsx` |
| Backend test count `~2,669` / frontend `552` | `dotnet test --list-tests` on `RetailPulse.Tests.csproj`; `npm test -- --run` in `src/RetailPulse.Web` |

## Validation performed

- ✅ Full `dotnet build RetailPulse.slnx` succeeded (0 warnings, 0 errors).
- ✅ Backend and frontend test counts re-verified against actual runs (`dotnet test --list-tests`, `npm test -- --run`).
- ✅ All internal `*.md` links in `README.md` and `docs/**` resolve to existing files in this branch (custom link-resolver run in the worktree).
- ✅ `git grep` for `1815` and `PR #77|PR #64` returns no in-scope hits.

## Follow-ups (not blockers for this PR)

- `docs/chart-acceptance-run.md` still needs a **live in-browser** sign-off entry; the automated matrix is the durable gate, but a fresh human record is expected once someone runs the browser runner against the merged UI.

## Review checklist

- [ ] **Fact Checker** — validate every rewritten claim against `origin/main` and the linked PR/commit evidence.
- [ ] **Publix** — QA/production perspective; confirm no doc contradicts observed shipped behavior.
- [ ] **Kroger** — final Lead approval + merge (per Reviewer Protocol).

Closes #78

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

