### PR TITLE
docs: Fact Checker hotfix — 80,000 TPM default, Bicep-pinned runtime env, APIM subscription-key path, versioned model name

### DIFF
--- a/docs/ai-gateway-integration.md
+++ b/docs/ai-gateway-integration.md
@@ -201,7 +201,7 @@ The policies in `infra/modules/apim-openai-policy.xml`:
 |--------|---------|-------------|
 | `set-backend-service` | inbound | Routes to the Azure AI Foundry backend |
 | `authentication-managed-identity` | inbound | Authenticates to backend via APIM managed identity |
-| `azure-openai-token-limit` | inbound | Rate limits to 10,000 TPM per subscription |
+| `azure-openai-token-limit` | inbound | Rate limits to **80,000 TPM** per subscription (default; `tokensPerMinute` param in `infra/modules/apim-openai-api.bicep`) |
 | `azure-openai-emit-token-metric` | inbound | Emits token usage to App Insights `customMetrics` |
 | Circuit breaker (on backend) | — | Trips on 429 responses for 1 minute |
 
@@ -243,7 +243,7 @@ POST {apim_gateway}/inference/openai/deployments/{model}/chat/completions?api-ve
 
 Example:
 ```
-POST https://<your-apim-gateway>.azure-api.net/inference/openai/deployments/gpt-5.4-mini/chat/completions?api-version=2025-03-01-preview
+POST https://<your-apim-gateway>.azure-api.net/inference/openai/deployments/gpt-5.4-mini-2026-03-17/chat/completions?api-version=2025-03-01-preview
 ```
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ Browser (ChatPanel) → POST /api/chat → RetailPulseAgent
 |------|-----------|-------------|
 | **1. User sends message** | `ChatPanel.tsx` | Frontend sends `POST /api/chat` with `{ message, sessionId, history }`. Conversation history (up to 10 turns) is included for context continuity. |
 | **2. Agent builds prompt** | `RetailPulseAgent.cs` | Assembles a message array: system prompt (from `prompts.yaml`) + conversation history + current user message. Starts a `Stopwatch` to measure wall-clock duration. |
-| **3. Model inference** | Azure OpenAI via APIM | The `IChatClient` (backed by `AzureOpenAIClient`) sends the messages to APIM. APIM applies token limiting (10k TPM), emits metrics, and forwards to Azure OpenAI using managed identity. Model: `gpt-5.4-mini`. |
+| **3. Model inference** | Azure OpenAI via APIM | The `IChatClient` (backed by `AzureOpenAIClient`) sends the messages to APIM. APIM applies token limiting (default **80,000 TPM** per subscription — configurable via the `tokensPerMinute` param in `infra/modules/apim-openai-api.bicep`), emits metrics, and forwards to Azure OpenAI using managed identity. Model: `gpt-5.4-mini` (shipped deployment `gpt-5.4-mini-2026-03-17`). |
 | **4. Tool selection** | Azure OpenAI | The model examines the user's question and the available tool schemas, then decides which tools to call and with what parameters. For a portfolio-wide question, it may call `GetPortfolioDepletionStats`; for a single brand, `GetDepletionStats`. |
 | **5. Tool execution loop** | MAF (`UseFunctionInvocation`) | Microsoft.Extensions.AI middleware intercepts each tool call. It invokes the registered `AITool` implementation, captures the result, and sends it back to the model. The model may call additional tools or generate its final response. Tools execute sequentially within a single turn. |
 | **6. API proxy call** | e.g., `DepletionStatsTool.cs` | Each tool is an HTTP proxy. It calls the MCP Server's REST endpoint (e.g., `GET /api/depletion-stats?brand=X&region=Y&period=Z`). If the MCP Server is unreachable, the tool returns hardcoded fallback data and logs a warning. |
@@ -136,7 +136,7 @@ Retail Pulse uses Azure API Management as an AI Gateway following the [Azure-Sam
 1. **RetailPulse API** sends chat completion requests to APIM using the Azure OpenAI SDK
 2. **APIM** validates the `api-key` header (subscription key)
 3. **AI Gateway policies** apply (see [`infra/modules/apim-openai-policy.xml`](../infra/modules/apim-openai-policy.xml)):
-   - `azure-openai-token-limit`: Rate limits to 10,000 tokens per minute per subscription
+   - `azure-openai-token-limit`: Rate limits to **80,000 tokens per minute** per subscription by default (`tokensPerMinute` param in `infra/modules/apim-openai-api.bicep`)
    - `azure-openai-emit-token-metric`: Emits token usage metrics to Application Insights `customMetrics`
    - Circuit breaker: Trips on 429s for 1 minute
 4. **APIM** forwards to Azure AI Foundry using its managed identity (no keys in transit)
@@ -150,7 +150,7 @@ POST {apim_gateway}/inference/openai/deployments/{model}/chat/completions?api-ve
 
 Example:
 ```
-POST ${AZURE_APIM_INFERENCE_ENDPOINT}/openai/deployments/gpt-5.4-mini/chat/completions?api-version=2025-03-01-preview
+POST ${AZURE_APIM_INFERENCE_ENDPOINT}/openai/deployments/gpt-5.4-mini-2026-03-17/chat/completions?api-version=2025-03-01-preview
 ```
 
 Retrieve `AZURE_APIM_INFERENCE_ENDPOINT` from `azd env get-values` after `azd provision`; there is no longer a repo-wide hardcoded APIM hostname.

--- a/docs/authentication-entra.md
+++ b/docs/authentication-entra.md
@@ -52,8 +52,9 @@ so the token rides the `?access_token` query string the API honours **only** on 
 **Local dev / not‑yet‑provisioned:** when `VITE_ENTRA_TENANT_ID` / `_CLIENT_ID`
 are empty, `isConfigured` is `false` — no MSAL is loaded, `AuthGate` renders its
 children directly, and the API's Development auth handler stamps a local identity.
-There is **no anonymous fallback in Production**: the azd hooks set
-`Security__RequireAuth=true` and `ASPNETCORE_ENVIRONMENT=Production`.
+There is **no anonymous fallback in Production**: `infra/modules/container-apps.bicep`
+pins `Security__RequireAuth=true` and `ASPNETCORE_ENVIRONMENT=Production` directly on
+the API Container App.
 
 ---
 
@@ -106,7 +107,9 @@ Resolution is deterministic and never auto-detects a provider:
   startup — the app fails closed**.
 
 Production pins `Authentication__Mode=Entra` explicitly in
-`appsettings.Production.json` and the azd hooks; it never merely defaults to it.
+`appsettings.Production.json` and in the shipped Bicep
+(`infra/modules/container-apps.bicep` sets the env var on the API Container App); it
+never merely defaults to it.
 The normalized principal seam (`IPrincipalNormalizer` / `NormalizedPrincipal`)
 maps Entra claims to a provider-neutral identity for future providers without
 changing the `RetailPulse.User` + `access_as_user` requirement.
@@ -126,9 +129,11 @@ changing the `RetailPulse.User` + `access_as_user` requirement.
 - `infra/main.bicepparam` reads the `RETAIL_PULSE_ENTRA_*` env vars; `infra/main.bicep`
   round‑trips them as `VITE_ENTRA_*` outputs, which azd exposes to the Static Web
   App (Vite) build — exactly like `VITE_API_ORIGIN`.
-- The API values are injected at runtime by the `azd-hooks/postprovision.*` hooks
-  (which also set `Security__RequireAuth=true`, `ASPNETCORE_ENVIRONMENT=Production`,
-  and **disable ACA Easy Auth** so it can't interfere with the in‑process JWT boundary).
+- The API values are pinned directly on the Container App revision template by
+  `infra/modules/container-apps.bicep` (which also sets `Security__RequireAuth=true`
+  and `ASPNETCORE_ENVIRONMENT=Production`). The `azd-hooks/postprovision.*` hooks
+  then **disable ACA Easy Auth** so it can't interfere with the in-process JWT
+  boundary.
 - All of these are **public identifiers — never secrets**.
 
 ---
@@ -171,7 +176,8 @@ azd env set RETAIL_PULSE_ENTRA_CLIENT_ID <clientId>
 azd env set RETAIL_PULSE_ENTRA_API_SCOPE access_as_user
 azd env set RETAIL_PULSE_ENTRA_AUDIENCE api://<clientId>
 
-# Provision (postprovision hook flips RequireAuth on + disables Easy Auth) then deploy
+# Provision (Bicep pins Authentication__Mode=Entra + RequireAuth=true directly on
+# the API Container App; the postprovision hook disables Easy Auth) then deploy
 azd provision
 azd deploy
 

--- a/docs/demo-walkthrough.md
+++ b/docs/demo-walkthrough.md
@@ -68,7 +68,7 @@ Before the first demo run, provision the APIM AI Gateway infrastructure:
    # Test the endpoint directly
    $endpoint = (azd env get-values | Select-String "AZURE_APIM_INFERENCE_ENDPOINT" | ForEach-Object { ($_ -split "=", 2)[1].Trim('"') })
    $key = dotnet user-secrets list --project src/RetailPulse.Api | Select-String "OpenAI:ApimSubscriptionKey" | ForEach-Object { ($_ -split " = ")[1] }
-   curl "$endpoint/openai/deployments/gpt-5.4-mini/chat/completions?api-version=2025-03-01-preview" `
+   curl "$endpoint/openai/deployments/gpt-5.4-mini-2026-03-17/chat/completions?api-version=2025-03-01-preview" `
      -H "api-key: $key" `
      -H "Content-Type: application/json" `
      -d '{"messages":[{"role":"user","content":"Hello"}]}'

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -14,7 +14,7 @@ Retail Pulse supports one-command deployment to Azure using the [Azure Developer
 | Monitoring | Application Insights + Log Analytics | Full OpenTelemetry pipeline |
 | App data storage | Container-local temp (no durable volume) | The API's SQLite stores (cost/audit/memory/approvals/alerts) live in the replica's temp dir. **No Azure Files mount** — tenant governance forbids account-key CIFS mounts (see the incident note below), so observability history is per-replica and resets on replacement. |
 | AI Gateway | Azure API Management | First-class azd IaC in `infra/modules/apim*.bicep` |
-| Authentication | Microsoft Entra ID | Single-tenant SPA/API app registration (MSAL PKCE). See [authentication-entra.md](./authentication-entra.md). Set `RETAIL_PULSE_ENTRA_*` before `azd provision`; the postprovision hook flips `RequireAuth` on, pins `Authentication__Mode=Entra` (provider-neutral mode contract — see [ADR-005](./adr/005-provider-neutral-authentication.md)), and disables Easy Auth. |
+| Authentication | Microsoft Entra ID | Single-tenant SPA/API app registration (MSAL PKCE). See [authentication-entra.md](./authentication-entra.md). Set `RETAIL_PULSE_ENTRA_*` before `azd provision`; `infra/modules/container-apps.bicep` pins `Authentication__Mode=Entra`, `Security__RequireAuth=true`, and `ASPNETCORE_ENVIRONMENT=Production` directly on the API Container App (provider-neutral mode contract — see [ADR-005](./adr/005-provider-neutral-authentication.md)), and the postprovision hook then disables ACA platform (Easy Auth) so it can't double-wrap the in-process JWT boundary. |
 
 ## Prerequisites
 
@@ -41,13 +41,13 @@ azd up
 ```
 
 This single command will:
-1. Provision all Azure resources (Container Registry, Container Apps Environment, Container Apps, Static Web App, App Insights, Log Analytics, Azure API Management). Provisioning captures the API and frontend origins as azd environment values (`VITE_API_ORIGIN`, `RETAIL_PULSE_FRONTEND_ORIGIN`, `MCP_SERVER_BASE_URL`), the dedicated registry coordinates (`AZURE_CONTAINER_REGISTRY_ENDPOINT`, `AZURE_CONTAINER_REGISTRY_NAME`, `AZURE_CONTAINER_REGISTRY_RESOURCE_ID`), and the APIM gateway coordinates (`AZURE_APIM_NAME`, `AZURE_APIM_GATEWAY_URL`, `AZURE_APIM_INFERENCE_ENDPOINT`, `AZURE_APIM_INFERENCE_SUBSCRIPTION_NAME`). A **postprovision hook** then binds each Container App's system-assigned identity to `AcrPull`, applies the synthetic-demo runtime environment, and disables ACA platform auth on the demo API.
+1. Provision all Azure resources (Container Registry, Container Apps Environment, Container Apps, Static Web App, App Insights, Log Analytics, Azure API Management). Provisioning captures the API and frontend origins as azd environment values (`VITE_API_ORIGIN`, `RETAIL_PULSE_FRONTEND_ORIGIN`, `MCP_SERVER_BASE_URL`), the dedicated registry coordinates (`AZURE_CONTAINER_REGISTRY_ENDPOINT`, `AZURE_CONTAINER_REGISTRY_NAME`, `AZURE_CONTAINER_REGISTRY_RESOURCE_ID`), and the APIM gateway coordinates (`AZURE_APIM_NAME`, `AZURE_APIM_GATEWAY_URL`, `AZURE_APIM_INFERENCE_ENDPOINT`, `AZURE_APIM_INFERENCE_SUBSCRIPTION_NAME`). The API's runtime env (model/APIM endpoint, subscription-key ref, CORS origin, MCP base URL, Entra identifiers, `Authentication__Mode=Entra`, `Security__RequireAuth=true`, `ASPNETCORE_ENVIRONMENT=Production`, `RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true`) is asserted directly on the Container App by `infra/modules/container-apps.bicep`. A **postprovision hook** then binds each Container App's system-assigned identity to `AcrPull` on the registry, links the Static Web App to the API backend, and disables ACA platform (Easy Auth) on the API.
 2. Build the .NET services and containerize them (pushed to the dedicated Container Registry)
-3. Deploy backend containers to Azure Container Apps (the postprovision hook has already applied the API's model, CORS, auth, and MCP settings)
+3. Deploy backend containers to Azure Container Apps (Bicep has already pinned the API's model, CORS, auth-mode, and MCP settings on the Container App revision template)
 4. Build the React frontend (`npm run build`) **with `VITE_API_ORIGIN` injected from the provisioned API origin** and deploy `dist/` to Azure Static Web Apps
 5. Output the frontend URL and connection strings
 
-Because provisioning runs first, both the API-origin injection into the frontend build and the frontend-origin injection into API CORS happen automatically in a single `azd up` — no manual two-pass step is required. Runtime settings are asserted by the postprovision hook rather than relying on `azure.yaml` service environment-variable updates, which are not consistently applied to pre-existing ACA targets. See [Build-time API origin injection](#build-time-api-origin-injection-vite_api_origin) for the one ordering caveat.
+Because provisioning runs first, both the API-origin injection into the frontend build and the frontend-origin injection into API CORS happen automatically in a single `azd up` — no manual two-pass step is required. Runtime settings are asserted directly by `infra/modules/container-apps.bicep` on the Container App revision template, rather than by `azure.yaml` service environment-variable updates (which are not consistently applied to pre-existing ACA targets); the postprovision hook then layers the identity/RBAC glue and disables Easy Auth. See [Build-time API origin injection](#build-time-api-origin-injection-vite_api_origin) for the one ordering caveat.
 
 ## Environment Configuration
 
@@ -109,9 +109,9 @@ so azd's `${...}` substitution and Vite's `import.meta.env` resolve them:
 
 **Frontend/API mode parity.** `VITE_AUTH_MODE` (frontend) **must equal**
 `Authentication__Mode` (API) so the rendered sign-in UX matches the boundary the API
-enforces. The live Bicep emits `output VITE_AUTH_MODE = 'Entra'` and the postprovision
-hook pins `Authentication__Mode=Entra`, so the deployed pair is always `Entra`. A
-deployment contract test
+enforces. The live Bicep emits `output VITE_AUTH_MODE = 'Entra'` and
+`infra/modules/container-apps.bicep` pins `Authentication__Mode=Entra` directly on
+the API Container App, so the deployed pair is always `Entra`. A deployment contract test
 (`tests/RetailPulse.Tests/Deployment/ProviderNeutralDeploymentContractTests.cs`)
 asserts this parity and that the Bicep/hooks never emit `GitHub`/`Anonymous`. Non-live
 web builds can be produced from the secret-free templates
@@ -231,17 +231,25 @@ pull happens later during deploy, there is normally enough delay for propagation
 If a very first deploy ever races propagation, simply re-run `azd deploy` (or
 `azd up`) — the hook is idempotent and the grant will already be in place.
 
-### Managed identity → Azure OpenAI requires an out-of-band role assignment
+### Managed identity → Azure OpenAI via APIM subscription key (shipped) or direct MI (opt-in)
 
 Each Container App (`api`, `mcpserver`, `teamsbot`) is provisioned with a
-**system-assigned managed identity** (`infra/modules/container-apps.bicep`), and the
-`api` service sets `OpenAI__UseManagedIdentity=true` (`azure.yaml`), so the API
-authenticates to the model endpoint with `DefaultAzureCredential` instead of an API key.
+**system-assigned managed identity** (`infra/modules/container-apps.bicep`). In the
+shipped topology the API talks to Azure OpenAI **through APIM**, not directly:
+`infra/modules/container-apps.bicep` pins `OpenAI__UseManagedIdentity=false` and passes
+`OpenAI__ApimSubscriptionKey` (an ACA secret referencing the APIM subscription's primary
+key) so the API authenticates to APIM with an `Ocp-Apim-Subscription-Key` header. APIM
+itself then uses **its own** managed identity (via `<authentication-managed-identity>` in
+`infra/modules/apim-openai-policy.xml`) to call the Azure AI Foundry backend — no AI-model
+keys are stored in or transit through the API. This is the mode the shipped Bicep and the
+mandatory verifier gate enforce.
 
-**The model endpoint is external to this Bicep** — it is supplied via
+**If you point `OpenAI__Endpoint` at a direct Azure OpenAI resource** (bypassing APIM),
+set `OpenAI__UseManagedIdentity=true` so the API authenticates with `DefaultAzureCredential`
+instead. The direct model endpoint is **external to this Bicep** — it is supplied via
 `AZURE_OPENAI_ENDPOINT` and is not provisioned here — so the infra **cannot** create the
 required RBAC. After `azd up` you must grant the API's principal access on the target
-resource, e.g. for a direct Azure OpenAI resource:
+resource:
 
 ```bash
 az role assignment create \
@@ -251,10 +259,9 @@ az role assignment create \
 ```
 
 The API's principal id is exposed as the `apiPrincipalId` output of the container-apps
-module. **If you point `AZURE_OPENAI_ENDPOINT` at the APIM AI Gateway instead of a direct
-Azure OpenAI resource**, `DefaultAzureCredential` bearer tokens will only work if APIM is
-configured to accept AAD tokens (or to inject the upstream key itself); otherwise set
-`OpenAI__UseManagedIdentity=false` and provide a subscription key via `OpenAI__ApiKey`.
+module. To go the other direction — bypass APIM AND use a raw API key — set
+`OpenAI__UseManagedIdentity=false` and provide the key via `OpenAI__ApiKey` instead of
+`OpenAI__ApimSubscriptionKey`.
 
 ### Scale-to-zero (cold start) and in-memory state loss
 
@@ -523,9 +530,13 @@ build azd already performs.
 
 The **postprovision** hook (`azd-hooks/postprovision.ps1` / `azd-hooks/postprovision.sh`,
 same per-OS selection) wires secretless ACR pull for the three Container Apps,
-idempotently links SWA `/api` traffic to ACA, and applies the synthetic-demo runtime
-settings (managed-identity model endpoint, MCP/API URLs, CORS origin, demo auth mode,
-and Teams bot API URL).
+idempotently links SWA `/api` traffic to ACA, disables ACA platform (Easy Auth) on
+the API, and runs the mandatory APIM AI Gateway live verifier as a hard gate. The
+API's runtime env (model endpoint, APIM subscription key ref, MCP/API URLs, CORS
+origin, `Authentication__Mode=Entra`, `Security__RequireAuth=true`,
+`ASPNETCORE_ENVIRONMENT=Production`, Teams bot API URL) is pinned directly on the
+Container App revision template by `infra/modules/container-apps.bicep` — not by the
+hook — so a re-provision re-asserts the same env.
 
 The prompt model remains `gpt-5.4-mini`; Azure deployment selection is separate:
 `OpenAI__Deployment=gpt-5.4-mini-2026-03-17`. Versioned deployment names make

--- a/docs/diagram-ai-gateway-arch.html
+++ b/docs/diagram-ai-gateway-arch.html
@@ -198,7 +198,7 @@
     <ul>
       <li><code>set-backend-service</code> - route to AI Foundry</li>
       <li><code>authentication-managed-identity</code> - MI auth</li>
-      <li><code>azure-openai-token-limit</code> - 10K TPM rate limit</li>
+      <li><code>azure-openai-token-limit</code> - 80K TPM rate limit (default)</li>
       <li><code>azure-openai-emit-token-metric</code> - token metrics</li>
     </ul>
     <div class="sec-title">Backend Protection</div>

--- a/docs/diagram-ai-gateway-pipeline.html
+++ b/docs/diagram-ai-gateway-pipeline.html
@@ -378,7 +378,7 @@
           <span class="step">3</span>
           <div>
             <span class="policy-name">azure-openai-token-limit</span>
-            <div class="policy-desc">Enforces 10,000 tokens-per-minute rate limit per subscription. Returns 429 if exceeded.</div>
+            <div class="policy-desc">Enforces 80,000 tokens-per-minute rate limit per subscription (default). Returns 429 if exceeded.</div>
           </div>
         </div>
         <div class="policy-step">
@@ -407,7 +407,7 @@
           <span class="step">6</span>
           <div>
             <span style="font-size:12px;color:#e8f5e9;font-weight:600">Forward to Azure AI Foundry</span>
-            <div class="policy-desc">POST /openai/deployments/gpt-5.4-mini/chat/completions - authenticated via managed identity</div>
+            <div class="policy-desc">POST /openai/deployments/gpt-5.4-mini-2026-03-17/chat/completions - authenticated via managed identity</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fact Checker hotfix for the documentation release pass (#78 / PR #79). Fact Checker's independent verification against the shipped Bicep found four categories of factually incorrect claims that landed in PR #79. This PR brings the docs back into alignment with `infra/` before the release is treated as complete.

## Findings addressed

### 1. TPM default — 10,000 → 80,000

`infra/modules/apim-openai-api.bicep` line 23 sets `param tokensPerMinute int = 80000`.

- `docs/architecture.md` line 48 — "APIM applies token limiting (10k TPM)" → "80,000 TPM per subscription (default; `tokensPerMinute` param in `infra/modules/apim-openai-api.bicep`)"
- `docs/architecture.md` line 139 — "10,000 tokens per minute" → "80,000 tokens per minute"
- `docs/ai-gateway-integration.md` line 204 — "10,000 TPM per subscription" → "80,000 TPM per subscription"
- `docs/diagram-ai-gateway-arch.html` line 201 — "10K TPM rate limit" → "80K TPM rate limit (default)"
- `docs/diagram-ai-gateway-pipeline.html` line 381 — "10,000 tokens-per-minute" → "80,000 tokens-per-minute"

### 2. AI Gateway URL example uses versioned deployment name

`infra/main.bicep` and `infra/modules/container-apps.bicep` both default `openAiDeployment` to `gpt-5.4-mini-2026-03-17`.

- `docs/ai-gateway-integration.md` line 246 — POST URL now `.../gpt-5.4-mini-2026-03-17/chat/completions`
- `docs/architecture.md` line 153 — same URL corrected
- `docs/demo-walkthrough.md` line 71 — curl example corrected
- `docs/diagram-ai-gateway-pipeline.html` line 410 — pipeline diagram POST path corrected

(Conceptual "Model: `gpt-5.4-mini`" references remain — that is the model family name; only the URL/deployment path needed to match the versioned name.)

### 3. Runtime env is pinned by Bicep, not by the postprovision hook

`infra/modules/container-apps.bicep` (lines ~160–236) declares the full API runtime env directly on the Container App revision template. The `azd-hooks/postprovision.*` hook **only** does:

1. `az role assignment create ... --role AcrPull` for each of the three Container Apps' system-assigned identities against the dedicated ACR.
2. `az staticwebapp backends link` between the SWA and the API ACA.
3. `az containerapp auth update` to **disable** ACA platform auth (Easy Auth) on the API.
4. Run `scripts/Verify-ApimAiGateway.ps1` as the mandatory live-invariant gate.

Corrected in:
- `docs/deployment-azd.md` line 17 header table row for Authentication
- `docs/deployment-azd.md` lines 44–46 (numbered `azd up` flow)
- `docs/deployment-azd.md` line 50 (rationale paragraph)
- `docs/deployment-azd.md` line ~112 (mode-parity paragraph)
- `docs/deployment-azd.md` line ~533 (postprovision hook description)
- `docs/authentication-entra.md` lines 55–56 (Production RequireAuth pin)
- `docs/authentication-entra.md` lines 129–131 (API values injection paragraph)
- `docs/authentication-entra.md` line 174 (Cutover comment)
- `docs/authentication-entra.md` lines 108–109 (Production pins paragraph)

### 4. Shipped topology uses APIM subscription-key path, not direct MI to Foundry

`infra/modules/container-apps.bicep` line 182 pins `OpenAI__UseManagedIdentity=false` and line 186 wires `OpenAI__ApimSubscriptionKey` from an ACA secret. In the shipped topology the API talks to APIM via `Ocp-Apim-Subscription-Key`, and **APIM's own managed identity** authenticates upstream to Azure AI Foundry (via `<authentication-managed-identity>` in `infra/modules/apim-openai-policy.xml`).

Rewrote the "Managed identity → Azure OpenAI" section of `docs/deployment-azd.md` (lines ~234–260, retitled "Managed identity → Azure OpenAI via APIM subscription key (shipped) or direct MI (opt-in)") to:

- Describe the actual shipped path first (`OpenAI__UseManagedIdentity=false`, `OpenAI__ApimSubscriptionKey`, APIM's MI upstream to Foundry).
- Preserve the direct-AOAI bypass instructions as an opt-in path with the required `Cognitive Services OpenAI User` role assignment.

## Evidence

| Corrected claim | Ground truth |
|-----------------|--------------|
| 80,000 TPM default | `infra/modules/apim-openai-api.bicep:23` — `param tokensPerMinute int = 80000` |
| Bicep pins Entra/RequireAuth/Production | `infra/modules/container-apps.bicep:202–235` (`Security__RequireAuth=true`, `Authentication__Mode=Entra`, `ASPNETCORE_ENVIRONMENT=Production`) |
| Hook only does AcrPull/SWA link/Easy Auth disable + verifier | `azd-hooks/postprovision.ps1` and `.sh` — the four steps listed above are the entire hook |
| Shipped API-to-APIM path is subscription key | `infra/modules/container-apps.bicep:182` (`OpenAI__UseManagedIdentity=false`) and `:186` (`OpenAI__ApimSubscriptionKey`) |
| APIM MI → Foundry | `infra/modules/apim-openai-policy.xml:5` (`<authentication-managed-identity resource="https://cognitiveservices.azure.com" />`) |
| Versioned deployment name | `infra/main.bicep:38` (`openAiDeployment = 'gpt-5.4-mini-2026-03-17'`) |

## Validation

- ✅ All modified files rebuild the internal `*.md` link graph cleanly.
- ✅ `git grep` post-fix for the four failure patterns (`10,000 (tokens|TPM)`, `flips.*RequireAuth`, `synthetic-demo runtime`, `OpenAI__UseManagedIdentity=true.*azure\.yaml`) returns no in-scope hits.

Refs: PR #79 (previous docs release pass), Issue #78 (closed by PR #79 — reopened for
tracking is not required; this is a follow-up correction).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
