### PR TITLE
docs: Chick FE audit hotfix (9 defects) — 9-chart list, POST knowledge, cost 4-endpoint fanout, real SignalR events, Fluent icons, actual palette, base-URL semantics

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -95,17 +95,21 @@ The header bar contains toggle buttons that switch the main content area between
 
 | Tab | Icon | What It Shows |
 |-----|------|---------------|
-| Approvals | Badge | Pending human-in-the-loop approvals for promotions and campaigns |
-| Campaign Planner | 🎯 | Promotion planning workspace with ROI modeling and approval gates |
-| Competitive | 🛡️ | Competitive intelligence — threats, market share, pricing alerts |
-| Knowledge Base | 📚 | RAG-indexed documents the agent uses for grounded answers |
-| Health Council | 💓 | Multi-agent consensus scoring for brand/portfolio health |
-| Security | ✅ | Guardrails dashboard — blocked requests, PII redaction, jailbreak stats |
-| Cards | 🃏 | Adaptive Cards for structured agent responses (voting, sign-offs) |
-| Observability | 👁️ | Token usage, cost tracking, audit log, conversation export |
-| Stores | 🏢 | Store operations — heatmap, stockout risks, planograms, performance |
-| Financials | 💰 | P&L waterfall chart and margin driver analysis |
-| Portfolio | ⭐ | Portfolio Scorecard — weighted brand scoring with drill-down explainability |
+| Approvals | Fluent UI `Badge` (count) | Pending human-in-the-loop approvals for promotions and campaigns |
+| Campaign Planner | `TargetArrow24Regular` | Promotion planning workspace with ROI modeling and approval gates |
+| Competitive | `Shield24Regular` | Competitive intelligence — threats, market share, pricing alerts |
+| Knowledge Base | `Library24Regular` | RAG-indexed documents the agent uses for grounded answers |
+| Health Council | `HeartPulse24Regular` | Multi-agent consensus scoring for brand/portfolio health |
+| Security | `ShieldCheckmark24Regular` | Guardrails dashboard — blocked requests, PII redaction, jailbreak stats |
+| Cards | `CardUi24Regular` | Adaptive Cards for structured agent responses (voting, sign-offs) |
+| Observability | `Eye24Regular` | Token usage, cost tracking, audit log, conversation export |
+| Stores | `Building24Regular` | Store operations — heatmap, stockout risks, planograms, performance |
+| Financials | `Money24Regular` | P&L waterfall chart and margin driver analysis |
+| Portfolio | `Star24Regular` | Portfolio Scorecard — weighted brand scoring with drill-down explainability |
+
+Icons are imported from `@fluentui/react-icons`; the "New Chat" button uses
+`Add24Regular` and the telemetry drawer toggle uses `DataUsage24Regular` (open) /
+`Dismiss24Regular` (close).
 
 ### Tab Details
 
@@ -231,10 +235,12 @@ Inline "⚡ Cached" pill badge with tooltip showing time saved and TTL remaining
 - **Props:** `cacheInfo: CacheInfo`
 
 #### `ChartRenderer`
-Polymorphic chart renderer — takes a `ChartSpec` array and renders line, bar, pie, donut, gauge, or table charts via Recharts. Also supports forecast chart variant when `forecastData` is provided.
+Polymorphic chart renderer — takes a `ChartSpec` array and dispatches on the spec's
+`type` field to render one of nine supported chart shapes via Recharts. Also supports
+the forecast chart variant when `forecastData` is provided.
 
 - **Props:** `charts: ChartSpec[]`, `forecastData?: ForecastData`
-- **Chart types:** line, bar, pie, donut, gauge, table
+- **Chart types (9):** `line`, `bar`, `groupedbar`, `stackedbar`, `horizontalbar`, `pie`, `donut`, `gauge`, `table`
 
 ### Agent Routing
 
@@ -332,13 +338,13 @@ Modal-style detail panel for a single competitor with charts and a close button.
 RAG document manager with search, upload, delete, and stats sections.
 
 - **State:** `docs`, `query`, `results`, `loading`
-- **Services:** `fetchDocuments()` → `GET /api/knowledge/documents`; `deleteDocument()` → `DELETE /api/knowledge/documents/{id}`; `searchKnowledgeBase()` → `GET /api/knowledge/search?q=`
+- **Services:** `fetchDocuments()` → `GET /api/knowledge/documents`; `deleteDocument()` → `DELETE /api/knowledge/documents/{id}`; `searchKnowledgeBase()` → `POST /api/knowledge/search` (JSON body)
 
 #### `DocumentUpload`
 Drag-and-drop upload interface for `.md` and `.txt` documents.
 
 - **Props:** `onUploadComplete: () => void`
-- **Services:** `uploadDocument()` → `POST /api/knowledge/documents`
+- **Services:** `uploadDocument()` → `POST /api/knowledge/upload` (JSON body)
 
 #### `CitationBadge`
 Inline citation pill with hover tooltip previewing the source document passage.
@@ -522,10 +528,12 @@ Tabbed container for the three observability views: Cost Dashboard, Audit Log, a
 - **State:** `activeTab`
 
 #### `CostDashboard`
-Token usage and cost charts with period selector (24h / 7d / 30d). Shows metric summary cards, trend line chart, agent cost breakdown bar chart, and tool usage table.
+Token usage and cost charts with a **Today / This Week / This Month** period selector.
+Shows metric summary cards, trend area/line chart, agent cost breakdown bar chart, and
+tool usage table.
 
 - **State:** `selectedPeriod`, `data`, `loading`
-- **Services:** `fetchCostDashboard()` → `GET /api/observability/costs?period=`
+- **Services:** `fetchCostDashboard(period)` fans out to four `/api/observability` endpoints in parallel: `GET /api/observability/costs?period=`, `GET /api/observability/costs/agents?period=`, `GET /api/observability/costs/trend?days=`, `GET /api/observability/costs/tools?period=`. The summary endpoint is required; the other three fall back to empty sections on 404 so partial telemetry still renders.
 
 #### `AuditLogViewer`
 Filterable, paginated audit log table with expandable detail rows. Supports text search, action type, and date range filters.
@@ -621,7 +629,15 @@ Visual list of telemetry spans with type icon, duration bar, token count, timest
 
 ## API Service Layer
 
-All services live in `src/services/` and wrap `fetch()` calls with typed responses. Base URL defaults to the Vite dev server proxy or production origin.
+All services live in `src/services/` and wrap `fetch()` calls with typed responses. Base URL resolution is centralized in `src/config/apiOrigin.ts` and `src/config/telemetryHubUrl.ts`, and is deliberately **different for REST vs SignalR**:
+
+- **REST `/api/**`** — services call same-origin paths (e.g. `fetch('/api/chat')`) and pass them through `resolveApiUrl(path)`. `resolveApiUrl` returns the path unchanged unless `VITE_API_ORIGIN` is set to a bare HTTP(S) origin at build time, in which case it prefixes that origin. This lets a single build cover three deploy topologies:
+  - **Vite dev** (`npm run dev` on `http://localhost:5173`) — `VITE_API_ORIGIN` is unset; the browser hits the SPA origin and the app-host / dev workflow serves API and SPA under the same origin.
+  - **Azure Static Web Apps with a linked backend** (the shipped `azd up` topology) — `VITE_API_ORIGIN` is left unset so `/api/*` calls stay on the SWA origin and are proxied to the linked Container App backend. This is what the `azd-hooks/postprovision.*` `az staticwebapp backends link` step configures.
+  - **Cross-origin SPA host** (e.g. a static bundle served from a different origin than the API) — set `VITE_API_ORIGIN=https://api.example.com` at build time; `resolveApiUrl` then rewrites REST calls to absolute URLs and CORS at the API takes over.
+- **SignalR `/hubs/telemetry`** — the SPA-linked backend proxy on SWA does **not** proxy WebSockets, so `resolveTelemetryHubUrl(VITE_API_ORIGIN)` always prefers the absolute API origin when one is available and only falls back to the relative `/hubs/telemetry` path in dev. The Container App is public and validates the bearer token itself (`?access_token=<jwt>` for hubs), so the direct WebSocket handshake works without the SWA proxy.
+
+A malformed `VITE_API_ORIGIN` (path, query, credentials, non-http protocol) is rejected — `resolveApiOrigin` returns `null` and callers stay on the same-origin default. This behavior is contract-tested by `apiOrigin.test.ts`, `telemetryHubUrl.test.ts`, and `authorizedFetch.test.ts`.
 
 | Service | Endpoints | Used By |
 |---------|-----------|---------|
@@ -631,10 +647,10 @@ All services live in `src/services/` and wrap `fetch()` calls with typed respons
 | `competitiveApi.ts` | `GET /api/competitive/pricing`, `GET /api/competitive/market-share`, `GET /api/competitive/threats`, `GET /api/competitive/competitor/{name}`, `POST /api/competitive/threats/{threatId}/response-plan` | CompetitiveDashboard, ThreatCards |
 | `councilApi.ts` | `POST /api/council/convene`, `GET /api/council/history` | CouncilPanel, CouncilHistory |
 | `guardrailsApi.ts` | `GET /api/guardrails/stats`, `GET /api/guardrails/config`, `PUT /api/guardrails/config`, `POST /api/guardrails/config/reset` | GuardrailsDashboard, GuardrailsConfig |
-| `knowledgeApi.ts` | `GET /api/knowledge/documents`, `POST /api/knowledge/documents`, `DELETE /api/knowledge/documents/{id}`, `GET /api/knowledge/search`, `GET /api/knowledge/stats` | KnowledgeBasePanel, DocumentUpload, KnowledgeStats |
+| `knowledgeApi.ts` | `GET /api/knowledge/documents`, `POST /api/knowledge/upload`, `DELETE /api/knowledge/documents/{id}`, `POST /api/knowledge/search`, `GET /api/knowledge/stats` | KnowledgeBasePanel, DocumentUpload, KnowledgeStats |
 | `marginApi.ts` | `GET /api/margin/waterfall`, `GET /api/margin/drivers`, `GET /api/escalation/{traceId}` | MarginWaterfall, MarginDrivers, EscalationPath |
 | `memoryApi.ts` | `GET /api/memory`, `DELETE /api/memory/{id}`, `DELETE /api/memory` | MemoryPanel |
-| `observabilityApi.ts` | `GET /api/observability/costs`, `GET /api/observability/audit`, `GET /api/observability/export/sessions`, `GET /api/observability/export/{sessionId}/preview`, `POST /api/observability/export/{sessionId}` | CostDashboard, AuditLogViewer, ConversationExport |
+| `observabilityApi.ts` | `GET /api/observability/costs`, `GET /api/observability/costs/agents`, `GET /api/observability/costs/trend`, `GET /api/observability/costs/tools`, `GET /api/observability/audit`, `GET /api/observability/export/sessions`, `GET /api/observability/export/{sessionId}/preview`, `POST /api/observability/export/{sessionId}` | CostDashboard, AuditLogViewer, ConversationExport |
 | `promoApi.ts` | `POST /api/taskmodule/promo`, `GET /api/campaigns`, `POST /api/taskmodule/promo/submit` | PromoTaskModule |
 | `scorecardApi.ts` | `GET /api/portfolio/scorecard`, `GET /api/portfolio/brand/{brandName}`, `GET /api/explain/{traceId}` | PortfolioScorecard, BrandScoreCard, ExplanationPanel |
 | `storeApi.ts` | `GET /api/stores/performance`, `GET /api/stores/{storeId}/planogram`, `GET /api/stores/stockout-risks` | StoreHeatmap, PlanogramDiagram, StockoutAlert, StorePerformanceTable |
@@ -642,16 +658,28 @@ All services live in `src/services/` and wrap `fetch()` calls with typed respons
 
 ## Real-Time (SignalR)
 
-The app maintains one SignalR connection to `/hubs/telemetry`:
+The app maintains one SignalR connection to `/hubs/telemetry`. Two client methods are
+invoked (`JoinSession`, plus the connection lifecycle handshake); the hub then dispatches
+the following server-to-client events (verified against
+`src/RetailPulse.Web/src/services/telemetryHub.ts`,
+`src/RetailPulse.Web/src/components/Dashboard.tsx`, and
+`src/RetailPulse.Web/src/components/cards/AdaptiveCardPanel.tsx`):
 
-| Event | Direction | Used By |
-|-------|-----------|---------|
-| `ReceiveSpan` | Server → Client | Dashboard (live spans) |
-| `ReceiveTotalDuration` | Server → Client | Dashboard (total ms) |
-| `ReceiveTokenUsage` | Server → Client | Dashboard (token counts) |
-| `approval_requested` | Server → Client | Dashboard (pending approvals) |
-| `approval_resolved` | Server → Client | Dashboard (approval status) |
-| `card_updated` | Server → Client | AdaptiveCardPanel (live card sync) |
+| Event | Direction | Handler | Used By |
+|-------|-----------|---------|---------|
+| `Connected` | Server → Client | Startup handshake — session banner + reconnect logging | telemetryHub |
+| `SpanReceived` | Server → Client | Push a single agent/tool span onto the live-spans list | Dashboard (`liveSpans`) |
+| `progress` | Server → Client | Per-turn progress ticks (phase, duration, tokens if available) | Dashboard (streaming progress) |
+| `approval_requested` | Server → Client | New pending approval | Dashboard (`pendingApprovals`) |
+| `approval_resolved` | Server → Client | Approval decided (`id`, `status`, `decidedBy`, `decidedAt`) | Dashboard (`approvalHistory`) |
+| `alert_fired` | Server → Client | Guardrails / operational alert | Dashboard (`alerts`) |
+| `trace_started` | Server → Client | New trace opened for a chat turn | Dashboard (`traces`) |
+| `span_completed` | Server → Client | Span closed with duration/tokens | Dashboard (`traces`) |
+| `trace_completed` | Server → Client | Trace closed — final totals | Dashboard (`traces`) |
+| `card:action` | Server → Client | Adaptive Card action (vote, comment, sign-off) | AdaptiveCardPanel |
+| `card:lifecycle` | Server → Client | Adaptive Card lifecycle change (created, resolved, expired) | AdaptiveCardPanel |
+
+The client calls `connection.invoke('JoinSession', sessionId)` after every connect / reconnect so the hub can broadcast events to the correct SignalR group.
 
 ## Constants & Theming
 

--- a/docs/chart-acceptance-run.md
+++ b/docs/chart-acceptance-run.md
@@ -12,11 +12,21 @@ does the same thing end-to-end for each curated prompt.
 
 1. Start the API (via `RetailPulse.AppHost` or `dotnet run` per project) and
    the frontend (`cd src/RetailPulse.Web && npm run dev`).
-2. Sign in (Anonymous is fine for this record) and land on the empty chat.
-3. Open DevTools → Console; paste the contents of
+2. **Sign in with a provider that permits chat** (`Entra` in Production, or
+   `Anonymous` / `GitHub` in a non-live dev build with the matching example env
+   template). `Anonymous` disables the SignalR realtime hub by capability, so
+   `progress`/`SpanReceived`/`trace_*` events won't fire during the run — the
+   chart-acceptance runner still passes because it only inspects the rendered
+   `ChartRenderer` output, but note it in the entry if you want the telemetry
+   pane populated. Do **not** run this in an unauthenticated build: the API's
+   `RequireAuth=true` production posture returns 401 for `/api/chat` and no
+   chart will ever render.
+3. Land on the empty chat.
+4. Open DevTools → Console; paste the contents of
    `scripts/browser-chart-acceptance.js`; run `await runChartAcceptance()`.
-4. Copy the resulting JSON from the `COPY-TO-DOCS:` log line into the
-   "Latest run" section below with the date and the app version (git SHA).
+5. Copy the resulting JSON from the `COPY-TO-DOCS:` log line into the
+   "Latest run" section below with the date, provider mode, and app version
+   (git SHA).
 
 ## Latest run
 
@@ -25,8 +35,10 @@ does the same thing end-to-end for each curated prompt.
 > CI run by the backend `ChartAcceptanceMatrixTests` / `ChartAcceptancePerformanceTests`
 > and the frontend `chartAcceptance.matrix.test.tsx` suites. This log file remains the
 > record of human, in-browser sign-off; the automated matrix is the durable gate.
-> Re-run the browser runner (per **How to update this file**) when you want a fresh
-> human record and paste the resulting JSON below.
+>
+> The `[]` block below is an intentional **empty-log placeholder**, not a failed run —
+> no live browser sign-off has been recorded since the matrix landed on `main`. Paste
+> your run's `COPY-TO-DOCS` JSON here when you exercise the browser runner.
 
 ```json
 []

--- a/docs/chart-rendering.md
+++ b/docs/chart-rendering.md
@@ -52,9 +52,9 @@ public record ChartDataPoint
 |------|-----|----------------|-------------------|
 | Line | `line` | `LineChart` | `Chart.Line` |
 | Bar | `bar` | `BarChart` | `Chart.HorizontalBar` |
-| Grouped Bar | `groupedBar` | `BarChart` (multi-series) | `Chart.HorizontalBar` |
-| Stacked Bar | `stackedBar` | `BarChart` (stacked) | `Chart.HorizontalBar` |
-| Horizontal Bar | `horizontalBar` | `BarChart` (horizontal) | `Chart.HorizontalBar` |
+| Grouped Bar | `groupedbar` | `BarChart` (multi-series) | `Chart.HorizontalBar` |
+| Stacked Bar | `stackedbar` | `BarChart` (stacked) | `Chart.HorizontalBar` |
+| Horizontal Bar | `horizontalbar` | `BarChart` (horizontal) | `Chart.HorizontalBar` |
 | Pie | `pie` | `PieChart` | `Chart.Donut` |
 | Donut | `donut` | `PieChart` (inner radius) | `Chart.Donut` |
 | Gauge | `gauge` | Custom `PieChart` | `Chart.Donut` (partial) |
@@ -64,20 +64,48 @@ public record ChartDataPoint
 
 ## Default Chart Colors
 
-Default palette applied when no explicit `Color` is set on a series:
+Default palette applied when no explicit `Color` is set on a series (the `BRAND_COLORS`
+array in `src/RetailPulse.Web/src/components/ChartRenderer.tsx`) — a blue-forward
+sequence with two supporting greens/blue-greens:
 
-| Swatch | Hex | Name |
-|--------|-----|------|
-| 🔵 | `#1B4D7A` | Primary Blue |
-| 🟡 | `#E8A838` | Accent Gold |
-| 🔵 | `#4682B4` | Steel Blue |
-| 🟢 | `#2E8B57` | Sea Green |
-| 🟤 | `#CD853F` | Peru |
-| 🟠 | `#B8860B` | Dark Goldenrod |
-| 🩵 | `#5F9EA0` | Cadet Blue |
-| 🧡 | `#D2691E` | Chocolate |
+| Order | Hex | Name |
+|-------|-----|------|
+| 1 | `#1565C0` | Primary Blue |
+| 2 | `#42A5F5` | Sky Blue |
+| 3 | `#4682B4` | Steel Blue |
+| 4 | `#2E8B57` | Sea Green |
+| 5 | `#1E88E5` | Primary Blue 500 |
+| 6 | `#64B5F6` | Light Sky Blue |
+| 7 | `#5F9EA0` | Cadet Blue |
+| 8 | `#0D47A1` | Deep Blue |
 
-Background: `#111111` · Accent: `#E8A838` · Text: `#F5F5F0`
+Recharts axes/legend/tooltip pull from a fixed dark-mode set: axis ticks and legend
+labels `#A0A0A0`, tooltip background `#1A1A1A` with `rgba(66,165,245,0.3)` border, and
+tooltip label `#42A5F5`. The gauge chart's active arc is `#42A5F5`.
+
+The application shell in `src/RetailPulse.Web/src/App.css` defines the semantic CSS
+variables the rest of the UI (surfaces, borders, scrollbars, accents) is built from:
+
+| CSS variable | Value |
+|--------------|-------|
+| `--brand-primary` | `#1565C0` |
+| `--brand-primary-light` | `#1E88E5` |
+| `--brand-accent` | `#42A5F5` |
+| `--brand-accent-light` | `#64B5F6` |
+| `--brand-deep-black` | `#080808` |
+| `--color-bg` | `#080808` |
+| `--color-bg-elevated` | `#0D0D0D` |
+| `--color-surface` | `#1A1A1A` |
+| `--color-surface-hover` | `#242424` |
+| `--color-surface-alt` | `#111111` |
+| `--color-text` | `#F5F5F0` |
+| `--color-text-muted` | `#A0A0A0` |
+| `--color-text-subtle` | `#666666` |
+
+Domain-specific palettes (`FORECAST_COLORS`, `AGENT_ROUTING_CONFIG`, `PROMO_COLORS`,
+`SEASONAL_COLORS`, `COUNCIL_COLORS`, `CARD_COLORS`, `OBSERVABILITY_COLORS`,
+`STORE_COLORS`, `MARGIN_COLORS`, `SCORECARD_COLORS`) live in
+`src/RetailPulse.Web/src/constants/agentRouting.ts` — see [Constants & Theming](#constants--theming) in FRONTEND.md for the full breakdown.
 
 ---
 


### PR DESCRIPTION
## Summary

Chick (frontend maintainer) audited the shipped docs against the live frontend and reported 9 factual defects that survived PR #79/#80. This hotfix corrects them in `docs/FRONTEND.md`, `docs/chart-rendering.md`, and `docs/chart-acceptance-run.md`. All corrections verified against the actual source in `src/RetailPulse.Web/src/` and against a fresh local `npx vitest run`.

Closes #78 follow-up (Chick FE audit). Follows PR #79 (initial release pass) and PR #80 (Fact Checker hotfix). This is a docs-only PR — no code, config, deploy, or `.squad/*` files touched.

## Defect Matrix

| # | Defect (Chick) | Source of Truth | Fix |
|---|----------------|-----------------|-----|
| 1 | `FRONTEND.md` lists only 6 chart types | `ChartRenderer.tsx` switch renders 9 types | Chart list rewritten to `line, bar, groupedbar, stackedbar, horizontalbar, pie, donut, gauge, table`; `chart-rendering.md` type keys normalized to lowercase |
| 2 | Knowledge upload/search wrong verb+path | `KnowledgeEndpoints.cs` + `knowledgeApi.ts` use `POST /api/knowledge/upload` and `POST /api/knowledge/search` (JSON body) | Sections and service table updated to POST with JSON body |
| 3 | CostDashboard shown as single endpoint w/ 24h/7d/30d selector | `observabilityApi.ts` `fetchCostDashboard` fans out to 4 endpoints via `Promise.all`; `CostDashboard.tsx` labels are `Today / This Week / This Month` | Rewrote CostDashboard component paragraph + service-table row to list all 4 endpoints (summary required, others fail-soft) and correct period labels |
| 4 | SignalR event table is stale (missing real events, invents `ReceiveTotalDuration`, `ReceiveTokenUsage`, `card_updated`) | `telemetryHub.ts` (`SpanReceived`, `progress`, `Connected`), `Dashboard.tsx` (`approval_requested`, `approval_resolved`, `alert_fired`, `trace_started`, `span_completed`, `trace_completed`), `AdaptiveCardPanel.tsx` (`card:action`, `card:lifecycle`) | Full event table replaced; phantom events removed; noted client → server `JoinSession` invoke |
| 5 | Chart palette table lists gold/peru/chocolate — wrong | `ChartRenderer.tsx` `BRAND_COLORS = ['#1565C0','#42A5F5','#4682B4','#2E8B57','#1E88E5','#64B5F6','#5F9EA0','#0D47A1']`; `App.css` `--brand-primary #1565C0`, `--brand-accent #42A5F5`, `--color-bg #080808` | Palette table replaced with actual `BRAND_COLORS`; semantic CSS variable table added referencing `App.css`; Recharts axis/tooltip colors documented |
| 6 | `testing-guide.md` claims ~250 frontend tests | Fresh `npx vitest run` = **552 tests / 63 files** in this worktree | Not changed — docs already say `~552`. Chick's `~540` figure is stale; the actual count is `552`. Dismissal documented here and in the coordinator report. |
| 7 | Tab icons documented as emoji, ship as Fluent UI | `Dashboard.tsx` imports `TargetArrow24Regular`, `Shield24Regular`, `Library24Regular`, `HeartPulse24Regular`, `ShieldCheckmark24Regular`, `CardUi24Regular`, `Eye24Regular`, `Building24Regular`, `Money24Regular`, `Star24Regular` from `@fluentui/react-icons` | Tab-icon table now shows the shipped Fluent icon names; note added about `Add24Regular` / `DataUsage24Regular` / `Dismiss24Regular` for chrome affordances |
| 8 | Base URL wording ("Vite dev server proxy or production origin") misses SPA / SWA linked backend / SignalR distinction | `apiOrigin.ts` `resolveApiUrl` + `telemetryHubUrl.ts` `resolveTelemetryHubUrl` | Rewrote paragraph to describe the three deploy topologies (Vite dev, SWA linked backend, cross-origin) and call out that SWA does not proxy WebSockets so SignalR uses the absolute API origin; cross-referenced the contract tests |
| 9 | `chart-acceptance-run.md` still shows `[]` placeholder + omits provider/auth gates | Same file | Framed `[]` as an intentional empty-log placeholder awaiting fresh browser sign-off; added provider/auth-gate context (Entra prod, Anonymous/GitHub dev; Anonymous disables the SignalR realtime hub so `progress`/`trace_*` won't fire during that run) |

## Evidence Files (source of truth)

- `src/RetailPulse.Web/src/components/ChartRenderer.tsx` — `BRAND_COLORS`, 9-type switch
- `src/RetailPulse.Web/src/components/Dashboard.tsx` — Fluent icon imports, SignalR handlers, telemetry state
- `src/RetailPulse.Web/src/components/cards/AdaptiveCardPanel.tsx` — `card:action`, `card:lifecycle`
- `src/RetailPulse.Web/src/components/CostDashboard.tsx` — period labels
- `src/RetailPulse.Web/src/services/telemetryHub.ts` — `SpanReceived`, `progress`, `Connected`, `JoinSession`
- `src/RetailPulse.Web/src/services/observabilityApi.ts` — `fetchCostDashboard` 4-endpoint fan-out
- `src/RetailPulse.Web/src/services/knowledgeApi.ts` — POST upload/search JSON body
- `src/RetailPulse.Web/src/config/apiOrigin.ts` + `src/config/telemetryHubUrl.ts` — base URL semantics
- `src/RetailPulse.Web/src/App.css` — `:root` CSS variables
- `src/RetailPulse.Api/Endpoints/KnowledgeEndpoints.cs` — REST contracts

## Validation

- Fresh `npx vitest run` in `src/RetailPulse.Web` → **552 tests / 63 files passed** (used to confirm defect #6 dismissal and to rule out unintended code drift).
- `git grep` sweep for stale strings (`ReceiveTotalDuration|ReceiveTokenUsage|ReceiveSpan|card_updated`, `POST /api/knowledge/documents`, old palette hex codes) → 0 in-scope hits; remaining matches are in `.squad/decisions-archive.md`, `docs/code-review-report.md` (historical audit), and `docs/tenant-configuration.md` (tenant-branding example colors, not the default palette) — all correctly out of scope.
- All edits are Markdown-only; docs-only PR does not require `dotnet build` or a link-resolver run beyond the normal CI docs job.

## Coordinator Report

Filed as `.squad/decisions/inbox/kroger-78-docs-fe-hotfix.md` after merge (per Squad process). Prior PRs in the docs release chain: PR #79 (initial release pass, merged as `db311dc`), PR #80 (Fact Checker hotfix, merged as `cf02074`).

## Notes for Reviewers

- Chick's `~540 frontend tests` figure is dismissed with evidence: the live count is 552 (see `chart-acceptance-run.md` and this PR body). Docs already stated `~552` and were not changed for defect #6.
- Tenant-branding example colors (`#1B4D7A`, `#E8A838`) in `README.md` and `docs/tenant-configuration.md` are legitimate example configurations for the multi-tenant customization surface — not claims about the shipped default chart palette — and are intentionally left in place.

---

Working as **Kroger** (documentation release lead)
Reviews requested: **Fact Checker** (release gate) and **Publix** (editorial)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
