### PR TITLE
docs: add official Microsoft AI Gateway resource links (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ Charts are rendered **client-side**. The LLM emits structured `ChartSpec` JSON a
 
 Retail Pulse routes all LLM traffic through an [Azure API Management](https://learn.microsoft.com/azure/api-management/api-management-key-concepts) instance provisioned as first-class IaC by `azd up`. The AI Gateway applies token-per-minute rate limits, emits token-usage metrics, authenticates to Azure AI Foundry with a managed identity, and captures full request/response traces. See [AI Gateway Integration](docs/ai-gateway-integration.md).
 
+See [Official Microsoft resources](docs/ai-gateway-integration.md#official-microsoft-resources) for canonical links, including [AI gateway capabilities in Azure API Management](https://learn.microsoft.com/en-us/azure/api-management/genai-gateway-capabilities) and the [Azure-Samples/AI-Gateway](https://github.com/Azure-Samples/AI-Gateway) sample repo.
+
 ### Foundry Shipment Agent (Optional)
 
 Deploy a specialist agent to Azure AI Foundry for Three-Tier Distribution pipeline analysis. Disabled by default - the app runs fully without it using a local analyzer. See [Architecture](docs/architecture.md).

--- a/docs/ai-gateway-integration.md
+++ b/docs/ai-gateway-integration.md
@@ -12,6 +12,18 @@ Retail Pulse routes all LLM calls through Azure API Management (APIM) configured
 
 The AI Gateway pattern places APIM between the Retail Pulse API and Azure AI Foundry, giving operators visibility and control over every LLM interaction.
 
+## Official Microsoft resources
+
+Azure AI Gateway is a capability set within Azure API Management (APIM) — not a separate Azure product or service.
+
+- [Azure API Management overview](https://learn.microsoft.com/en-us/azure/api-management/)
+- [AI gateway capabilities in Azure API Management (canonical)](https://learn.microsoft.com/en-us/azure/api-management/genai-gateway-capabilities)
+- [Sample repo: Azure-Samples/AI-Gateway](https://github.com/Azure-Samples/AI-Gateway)
+- [Policy reference — authentication-managed-identity](https://learn.microsoft.com/en-us/azure/api-management/authentication-managed-identity-policy)
+- [Policy reference — azure-openai-token-limit (canonical id: llm-token-limit)](https://learn.microsoft.com/en-us/azure/api-management/llm-token-limit-policy)
+- [Policy reference — azure-openai-emit-token-metric (canonical id: llm-emit-token-metric)](https://learn.microsoft.com/en-us/azure/api-management/llm-emit-token-metric-policy)
+- [Monitor / diagnostics / LLM logging](https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-use-azure-monitor)
+
 ## Architecture
 
 ![Retail Pulse AI Gateway Architecture](retail-pulse-ai-gateway.png)


### PR DESCRIPTION
Closes #84

Adds a concise 'Official Microsoft resources' section to docs/ai-gateway-integration.md and a compact pointer in README.md's APIM AI Gateway section.

Canonical links added (all verified HTTP 200):
- https://learn.microsoft.com/en-us/azure/api-management/
- https://learn.microsoft.com/en-us/azure/api-management/genai-gateway-capabilities
- https://github.com/Azure-Samples/AI-Gateway
- https://learn.microsoft.com/en-us/azure/api-management/authentication-managed-identity-policy
- https://learn.microsoft.com/en-us/azure/api-management/llm-token-limit-policy
- https://learn.microsoft.com/en-us/azure/api-management/llm-emit-token-metric-policy
- https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-use-azure-monitor

Explicitly states AI Gateway is a capability set within Azure API Management, not a separate Azure product.

Reviews:
- Fact Checker (Publix): ✅ Verified — all links live, content accurate, no duplicated prose
- Approval (Kroger): ✅ Approved for merge

Working as Chick (docs).