### PR TITLE
build: upgrade Microsoft Agent Framework to 1.18.0 and add Workflows package (#88)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,9 +14,10 @@
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
     <!-- Microsoft Agents Framework -->
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.9.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.Abstractions" Version="1.9.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.9.0" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.18.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Abstractions" Version="1.18.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.18.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.18.0" />
     <PackageVersion Include="Microsoft.Agents.Authentication.Msal" Version="1.5.184" />
     <PackageVersion Include="Microsoft.Agents.Builder" Version="1.5.184" />
     <PackageVersion Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.5.184" />
@@ -30,7 +31,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,24 @@ Browser (ChatPanel) → POST /api/chat → RetailPulseAgent
 | **Why GPT-5.4-mini?** | Best balance of reasoning quality, speed, and cost for tool-calling scenarios. Architecture is model-agnostic — swap via `prompts.yaml`. |
 | **Prompt configuration in YAML** | Separates prompt engineering from code. Non-developers can iterate on prompts without touching C#. Supports multiple agent definitions. |
 
+#### MAF & Microsoft.Extensions.AI package versions
+
+Central package management (`Directory.Packages.props`) pins the MAF stack to the
+following floors. A contract test (`MafPackageVersionContractTests`) fails CI on
+any accidental downgrade.
+
+| Package | Version |
+|---------|---------|
+| `Microsoft.Agents.AI` | 1.18.0 |
+| `Microsoft.Agents.AI.Abstractions` | 1.18.0 |
+| `Microsoft.Agents.AI.OpenAI` | 1.18.0 |
+| `Microsoft.Agents.AI.Workflows` | 1.18.0 |
+| `Microsoft.Extensions.AI` | 10.9.0 |
+
+`Microsoft.Agents.AI.Workflows` is referenced by `RetailPulse.Api` so the workflow
+primitives resolve alongside the existing `AIAgent` / `ChatClientAgent` surface;
+behavioural adoption of the workflow APIs lands in a separate issue.
+
 ### Model Context Protocol (MCP) — Tool Access
 
 | Decision | Rationale |

--- a/src/RetailPulse.Api/RetailPulse.Api.csproj
+++ b/src/RetailPulse.Api/RetailPulse.Api.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Agents.AI" />
     <PackageReference Include="Microsoft.Agents.AI.Abstractions" />
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Agents.AI.Workflows" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.Data.Sqlite" />

--- a/tests/RetailPulse.Tests/Deployment/MafPackageVersionContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/MafPackageVersionContractTests.cs
@@ -38,8 +38,8 @@ public class MafPackageVersionContractTests
     [InlineData("Microsoft.Extensions.AI")]
     public void DirectoryPackagesProps_PinsPackageAtOrAboveFloor(string packageId)
     {
-        var floor = RequiredFloors.Single(f => f.PackageId == packageId).Floor;
-        var pins = LoadCentralPackagePins();
+        Version floor = RequiredFloors.Single(f => f.PackageId == packageId).Floor;
+        Dictionary<string, Version> pins = LoadCentralPackagePins();
 
         pins.Should().ContainKey(packageId,
             $"Directory.Packages.props must pin {packageId} centrally");
@@ -55,11 +55,11 @@ public class MafPackageVersionContractTests
         // Issue #88 explicitly requires the API project to reference
         // Microsoft.Agents.AI.Workflows so the workflow primitives resolve
         // even before behavioural migration in #89 begins.
-        var csprojPath = Path.Combine(RepoRoot, "src", "RetailPulse.Api", "RetailPulse.Api.csproj");
+        string csprojPath = Path.Combine(RepoRoot, "src", "RetailPulse.Api", "RetailPulse.Api.csproj");
         File.Exists(csprojPath).Should().BeTrue("RetailPulse.Api.csproj must exist");
 
         var project = XDocument.Load(csprojPath);
-        var referencedPackages = project
+        IEnumerable<string> referencedPackages = project
             .Descendants("PackageReference")
             .Select(e => (string?)e.Attribute("Include") ?? string.Empty);
 

--- a/tests/RetailPulse.Tests/Deployment/MafPackageVersionContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/MafPackageVersionContractTests.cs
@@ -1,0 +1,113 @@
+using System.Xml.Linq;
+using FluentAssertions;
+
+namespace RetailPulse.Tests.Deployment;
+
+/// <summary>
+/// Contract guardrail pinning the Microsoft Agent Framework (MAF) and
+/// Microsoft.Extensions.AI package floors declared in
+/// <c>Directory.Packages.props</c>. Any accidental downgrade below the versions
+/// established by issue #88 fails CI before it can regress the rest of the
+/// codebase.
+///
+/// Follows the file-inspection style of <see cref="DeploymentContractTests"/> —
+/// this test never restores or executes packages, it only parses the central
+/// package-management file.
+/// </summary>
+public class MafPackageVersionContractTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    // Floors set by issue #88 (Wave 0 MAF upgrade). Bumps are allowed; downgrades
+    // are not — behavioural migration to newer MAF primitives happens in #89 and
+    // beyond, and those follow-ups must not silently regress the floor.
+    private static readonly (string PackageId, Version Floor)[] RequiredFloors =
+    [
+        ("Microsoft.Agents.AI", new Version(1, 18, 0)),
+        ("Microsoft.Agents.AI.Abstractions", new Version(1, 18, 0)),
+        ("Microsoft.Agents.AI.OpenAI", new Version(1, 18, 0)),
+        ("Microsoft.Agents.AI.Workflows", new Version(1, 18, 0)),
+        ("Microsoft.Extensions.AI", new Version(10, 9, 0)),
+    ];
+
+    [Theory]
+    [InlineData("Microsoft.Agents.AI")]
+    [InlineData("Microsoft.Agents.AI.Abstractions")]
+    [InlineData("Microsoft.Agents.AI.OpenAI")]
+    [InlineData("Microsoft.Agents.AI.Workflows")]
+    [InlineData("Microsoft.Extensions.AI")]
+    public void DirectoryPackagesProps_PinsPackageAtOrAboveFloor(string packageId)
+    {
+        var floor = RequiredFloors.Single(f => f.PackageId == packageId).Floor;
+        var pins = LoadCentralPackagePins();
+
+        pins.Should().ContainKey(packageId,
+            $"Directory.Packages.props must pin {packageId} centrally");
+
+        pins[packageId].Should().BeGreaterThanOrEqualTo(floor,
+            $"{packageId} must stay at or above {floor} (issue #88 floor); a lower version " +
+            "is an accidental downgrade of the Microsoft Agent Framework upgrade");
+    }
+
+    [Fact]
+    public void RetailPulseApi_ReferencesMicrosoftAgentsAiWorkflows()
+    {
+        // Issue #88 explicitly requires the API project to reference
+        // Microsoft.Agents.AI.Workflows so the workflow primitives resolve
+        // even before behavioural migration in #89 begins.
+        var csprojPath = Path.Combine(RepoRoot, "src", "RetailPulse.Api", "RetailPulse.Api.csproj");
+        File.Exists(csprojPath).Should().BeTrue("RetailPulse.Api.csproj must exist");
+
+        var project = XDocument.Load(csprojPath);
+        var referencedPackages = project
+            .Descendants("PackageReference")
+            .Select(e => (string?)e.Attribute("Include") ?? string.Empty);
+
+        referencedPackages.Should().Contain("Microsoft.Agents.AI.Workflows",
+            "RetailPulse.Api must reference Microsoft.Agents.AI.Workflows (issue #88)");
+    }
+
+    private static Dictionary<string, Version> LoadCentralPackagePins()
+    {
+        string path = Path.Combine(RepoRoot, "Directory.Packages.props");
+        File.Exists(path).Should().BeTrue("Directory.Packages.props must exist at repo root");
+
+        var doc = XDocument.Load(path);
+        var pins = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (XElement element in doc.Descendants("PackageVersion"))
+        {
+            string? id = (string?)element.Attribute("Include");
+            string? version = (string?)element.Attribute("Version");
+            if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(version))
+            {
+                continue;
+            }
+
+            if (Version.TryParse(version, out Version? parsed))
+            {
+                pins[id] = parsed;
+            }
+        }
+
+        return pins;
+    }
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "RetailPulse.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate repo root (RetailPulse.slnx) walking up from " +
+            AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
Closes #88

Working as Costco (Backend Dev)

> Revision by Publix (Tester): Kroger rejected the initial commit `a011d3d` for a failing Lint (dotnet format) CI check and an inaccurate "Warnings: 0 new" claim. Revision commit `1df684c` fixes both. Package versions, runtime code, and architecture docs are unchanged from the original commit.

## Summary

Wave 0 mechanical upgrade of the Microsoft Agent Framework (MAF) package floor. No runtime behavior change — behavioral migration to the MAF 1.18 primitives (AIAgent, ChatClientAgent, workflow APIs) is explicitly out of scope and is tracked as issue #89.

## Package changes (Directory.Packages.props)

| Package | From | To |
|---------|------|----|
| Microsoft.Agents.AI | 1.9.0 | **1.18.0** |
| Microsoft.Agents.AI.Abstractions | 1.9.0 | **1.18.0** |
| Microsoft.Agents.AI.OpenAI | 1.9.0 | **1.18.0** |
| Microsoft.Agents.AI.Workflows | — | **1.18.0** (new; referenced by RetailPulse.Api) |
| Microsoft.Extensions.AI | 10.6.0 | **10.9.0** |

All five versions verified present on the `azure-default` feed. `nuget.org` remained disabled throughout (`dotnet nuget list source` confirmed).

## What changed

- `Directory.Packages.props` — bumped the three MAF packages, added `Microsoft.Agents.AI.Workflows`, bumped `Microsoft.Extensions.AI` to 10.9.0.
- `src/RetailPulse.Api/RetailPulse.Api.csproj` — added `PackageReference` for `Microsoft.Agents.AI.Workflows` so the workflow primitives restore cleanly for #89 to consume.
- `tests/RetailPulse.Tests/Deployment/MafPackageVersionContractTests.cs` — new contract test (follows the file-inspection pattern of `DeploymentContractTests`) pinning the five MAF/M.E.AI floors so any accidental downgrade fails CI, and asserting that `RetailPulse.Api` still references `Microsoft.Agents.AI.Workflows`.
- `docs/architecture.md` — added a technology version subsection under **Microsoft Agent Framework (MAF)** with the pinned versions and a pointer to the new contract test.

## Breaking changes between MAF 1.9.0 and 1.18.0

Grounded strictly in direct compilation and test observation of this repository against 1.18.0:

- **No source-level break observed** in the surface that RetailPulse.Api uses today: `AIAgent`, `ChatClientAgent`, tool auto-invocation via `UseFunctionInvocation`, and `Microsoft.Extensions.AI` chat client / `ChatResponse` / `AITool` types all compile unchanged.
- **No behavioural break observed** — the full `dotnet test` suite (2,689 tests) is green on the bump.
- `Microsoft.Agents.AI.Workflows` is a new package in this family; adopting it is deferred to #89.

Any additional breaking-change details from the official MAF changelog beyond what the codebase directly exercises are out of scope for a mechanical bump and belong with the #89 primitives migration.

## Validation

- `dotnet nuget list source` — Nuget.org **Disabled**, `azure-default` **Enabled**.
- `dotnet build -c Debug` — **Build succeeded. 0 Errors. 1 Warning.** The single warning is `tests/RetailPulse.Tests/Charts/HorizontalBarRankingRegressionTests.cs(112,9): CS8602`, which is **pre-existing on `main` and unchanged by this PR** (empty `git diff main...HEAD` for that file). This PR itself introduces **0 new `dotnet build` warnings**.
- **Lint (dotnet format) — PR-introduced diagnostics fixed in revision commit `1df684c`.** The initial commit `a011d3d` introduced four IDE0008 style diagnostics in the new `MafPackageVersionContractTests.cs` that the `dotnet format RetailPulse.slnx --verify-no-changes` CI gate surfaces (but `dotnet build` alone does not). These are **not** counted as `dotnet build` warnings — they are style analyzer diagnostics enforced by the Lint job. The revision:
  - `floor` → explicit `Version`
  - `pins` → explicit `Dictionary<string, Version>`
  - `csprojPath` → explicit `string`
  - `referencedPackages` → explicit `IEnumerable<string>` (this is the true owner of the IDE0008 at line 62; the initial reject comment attributed line 62 to `project`, but `project = XDocument.Load(...)` is classified as *type-apparent* by the analyzer and must stay `var` to avoid an IDE0007 warning under `csharp_style_var_when_type_is_apparent = true:warning`).
  Local `dotnet format RetailPulse.slnx --verify-no-changes` now exits **0**. The CI Lint check is expected to go green on the revision.
- `dotnet test --no-build -c Debug` — **Passed 2,689, Failed 0, Skipped 0** (`RetailPulse.Tests`). `RetailPulse.LoadTests` — **Skipped 2, Failed 0, Passed 0** (its normal state; requires a live endpoint).
- New contract test rows: 5 `DirectoryPackagesProps_PinsPackageAtOrAboveFloor` cases + 1 `RetailPulseApi_ReferencesMicrosoftAgentsAiWorkflows` — all green.

### Aspire AppHost full-stack startup

Deferred to CI on this machine. The AppHost brings up the Vite frontend which requires `npm install`, and this environment has the explicit **no-npm / no registry.npmjs.org** constraint. `dotnet build` and the full `dotnet test` suite are the validation gates used here; end-to-end Aspire startup runs in CI.

## Scope exclusions

- **Not** included: MAF primitives migration (`AIAgent`, `ChatClientAgent`, workflow usage) — that is issue #89.
- **Not** included: enabling `nuget.org` or any other feed. All packages resolved from `azure-default`.
