### PR TITLE
feat(agents): route specialists, router, and council through real MAF ChatClientAgent primitives (#89)

### DIFF
--- a/docs/adr/007-maf-agent-primitives.md
+++ b/docs/adr/007-maf-agent-primitives.md
@@ -1,0 +1,136 @@
+# ADR-007: MAF agent primitives for specialist / router / council execution
+
+## Status
+
+Accepted
+
+## Context
+
+Retail Pulse had three distinct LLM invocation surfaces:
+
+1. `AgentExecutionPipeline.ExecuteAsync` / `ExecuteWithProgressAsync` — the
+   shared execution path all 10 specialists route through.
+2. `RetailOpsRouter.ClassifyIntentAsync` — LLM-based intent classification when
+   the keyword fast-path misses.
+3. `ConsensusOrchestrator.CollectVoteAsync` and `SynthesizeVerdictAsync` — the
+   Portfolio Health Council per-agent votes and the final synthesis pass.
+
+All three called `IChatClient.GetResponseAsync` directly. Central packages already
+pin the Microsoft Agent Framework (MAF) 1.18.0 stack (`Microsoft.Agents.AI` +
+`Microsoft.Agents.AI.Abstractions` + `Microsoft.Agents.AI.OpenAI` +
+`Microsoft.Agents.AI.Workflows`), but `AIAgent` / `ChatClientAgent` were only
+referenced ceremonially: no execution path actually invoked a MAF agent
+primitive. GitHub issue #89 called this out as a durable structural gap — the
+"agent" name in the codebase did not correspond to a MAF agent object at
+runtime, which blocks future adoption of the workflow, orchestration, and
+session APIs the framework offers.
+
+Two operational constraints made this non-trivial to fix:
+
+- **The decorator stack is load-bearing.** `Program.cs` composes the production
+  `IChatClient` with `UseFunctionInvocation(client =>
+  client.MaximumIterationsPerRequest = 3)` (ADR-006), `UseOpenTelemetry(...)`,
+  the MCP HTTP retry / circuit-breaker / cache handlers, and the
+  anonymous-output cap. If a naive migration lets MAF add its own
+  `FunctionInvokingChatClient`, that cap silently doubles (or worse), spans
+  duplicate, and MCP resilience shifts one layer out.
+- **Downstream helpers depend on `Microsoft.Extensions.AI.ChatResponse`.** The
+  chart extractor, tool-span recorder, token-cost calculator, and
+  ADR-006 budget scope all read `response.Messages`, `response.Usage`, and
+  `response.Text` off the `Microsoft.Extensions.AI` type. Changing every helper
+  signature would be a large blast radius with no user-visible benefit.
+
+## Decision
+
+Introduce a single, static invocation seam,
+`RetailPulse.Api.Agents.MafAgentInvoker.RunAsync`, that every specialist,
+router, and council call site now flows through. The adapter:
+
+1. Constructs a per-invocation `ChatClientAgent(chatClient, options,
+   loggerFactory?)` with `ChatClientAgentOptions.Name` set to a stable
+   per-caller identifier (`"{AgentName}.specialist"` for specialists,
+   `"RetailOpsRouter.classifier"` for the router,
+   `"ConsensusOrchestrator.voter.{agentKey}"` and
+   `"ConsensusOrchestrator.synthesizer"` for the council).
+2. Sets `ChatClientAgentOptions.UseProvidedChatClientAsIs = true`. This is the
+   critical flag — it tells MAF **not** to re-decorate the incoming
+   `IChatClient`. The composition-root decorator stack (function-invocation with
+   ADR-006's `MaximumIterationsPerRequest = 3`, OpenTelemetry, MCP resilience,
+   caching, anonymous-output cap) is preserved end-to-end.
+3. Wraps the caller's `ChatOptions` in a `ChatClientAgentRunOptions(chatOptions)`
+   so temperature, tool list, response format, and max-output-tokens reach the
+   chat client unchanged.
+4. Invokes `ChatClientAgent.RunAsync(messages, session: null, runOptions, ct)`.
+   `session: null` yields an ephemeral in-memory MAF session per invocation —
+   Retail Pulse constructs the entire transcript (system prompt + trimmed
+   history + user message) on every call, so cross-request session persistence
+   is neither expected nor desired.
+5. Returns the real `Microsoft.Agents.AI.AgentResponse`. Callers convert to
+   `Microsoft.Extensions.AI.ChatResponse` through the documented shallow-copy
+   `AgentResponseExtensions.AsChatResponse()`, which shares the same
+   `Messages`/`Usage` list references — allocation-cheap and semantically
+   identical for every downstream helper (chart extraction, tool-span recording,
+   token cost, budget bookkeeping).
+
+`ISpecialistAgent`, `IAgentRouter`, and `IConsensusCouncil` remain unchanged;
+the migration is internal to the three implementations.
+
+## Consequences
+
+**Positive**
+
+- The three execution surfaces now genuinely run through a MAF `ChatClientAgent`
+  primitive, not just through symbols. Future adoption of `AgentSession`
+  persistence, MAF `WorkflowBuilder` orchestration, or the runtime memory APIs
+  only needs changes inside `MafAgentInvoker`, not scattered across the
+  specialists / router / council.
+- ADR-006 iteration cap, OpenTelemetry span sequence
+  (`agent.thought` → `agent.response`, tool spans nested inside), MCP HTTP
+  retry/circuit-breaker/cache, ADR-006 tool-context budget, all 9 chart types,
+  `InstrumentedToolMiddleware` timings, `StreamingProgressFeature`, blocking
+  `ApprovalTool`, `RequestToolContext` `AsyncLocal` scope, anonymous output cap,
+  cancellation/timeout paths, and per-model token cost all continue to work
+  byte-for-byte, verified by the pre-existing regression tests plus the new
+  `MafPrimitivesCharacterizationTests`.
+- A stack-frame based characterization test injects a probe `IChatClient` and
+  asserts a `Microsoft.Agents.AI.*` frame appears on every call. That means a
+  future refactor that quietly bypasses MAF and calls `IChatClient` directly
+  will fail the build.
+
+**Negative / neutral**
+
+- One additional allocation per LLM invocation (the `ChatClientAgent` +
+  `ChatClientAgentRunOptions` pair). These objects are small and per-request,
+  and MAF stores no expensive session state when constructed with
+  `session: null` and `UseProvidedChatClientAsIs = true`.
+- MAF's own emitted OpenTelemetry spans overlap with the existing
+  `RetailPulse.Agent` `agent.thought` / `agent.response` scopes. Because
+  `UseProvidedChatClientAsIs = true` prevents MAF from re-decorating the client,
+  MAF only adds a thin outer `ChatClientAgent.RunAsync` scope; no duplication of
+  the ADR-006 iteration cap or of tool-call spans occurs. Downstream span
+  parsers key on the operation names Retail Pulse already emits.
+
+## Alternatives considered
+
+- **Rename types only.** Import `AgentResponse` as a type alias and keep calling
+  `IChatClient.GetResponseAsync`. Rejected: this satisfies grep but not the
+  intent of issue #89 — no MAF primitive is on the execution path.
+- **Let MAF re-decorate the `IChatClient`.** Simpler code, but MAF would install
+  its own `FunctionInvokingChatClient` on top of ours, overriding
+  `MaximumIterationsPerRequest = 3` (ADR-006), duplicating OpenTelemetry spans,
+  and moving the MCP resilience decorators one layer away from the transport.
+  Rejected as it silently breaks contracts the existing regression suite
+  guards.
+- **Materialise a durable `AgentSession` per user session.** Requires a
+  cross-request session cache with its own lifetime and TPM implications, and
+  Retail Pulse already carries the full transcript on every request. Deferred:
+  MAF's session APIs can be adopted incrementally inside `MafAgentInvoker`
+  without any change to the three call sites.
+
+## References
+
+- Issue [#89 — Migrate agent execution onto real MAF agent primitives](https://github.com/swigerb/retail-pulse/issues/89)
+- [ADR-006: Tool-Context Budget](./006-tool-context-budget.md) — the iteration
+  cap preserved by `UseProvidedChatClientAsIs = true`.
+- `RetailPulse.Api/Agents/MafAgentInvoker.cs`
+- `RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,41 @@ any accidental downgrade.
 primitives resolve alongside the existing `AIAgent` / `ChatClientAgent` surface;
 behavioural adoption of the workflow APIs lands in a separate issue.
 
+#### MAF execution model — `MafAgentInvoker` seam
+
+Every agent-style LLM call in Retail Pulse — the 10 specialists routed through
+`AgentExecutionPipeline`, the router's LLM intent classification in
+`RetailOpsRouter`, and the consensus council's per-agent votes plus the
+synthesizer pass in `ConsensusOrchestrator` — flows through a single shared
+adapter, `RetailPulse.Api.Agents.MafAgentInvoker`. That adapter constructs a
+per-invocation MAF `ChatClientAgent`, wraps the caller-supplied `ChatOptions`
+in a `ChatClientAgentRunOptions`, and calls
+`ChatClientAgent.RunAsync(messages, session: null, runOptions, ct)`, returning
+the real MAF `AgentResponse`. Downstream helpers convert to
+`Microsoft.Extensions.AI.ChatResponse` through the documented shallow-copy
+`AgentResponseExtensions.AsChatResponse()`, so the existing chart, tool-span
+and token-cost helpers see the exact same `Messages`/`Usage` references without
+re-materialising the payload.
+
+A key invariant: `MafAgentInvoker` sets
+`ChatClientAgentOptions.UseProvidedChatClientAsIs = true`. The production DI
+container in `Program.cs` already wraps the base `IChatClient` with
+`UseFunctionInvocation(client => client.MaximumIterationsPerRequest = 3)`
+(ADR-006), `UseOpenTelemetry(...)`, and the MCP HTTP retry/circuit-breaker
+stack. Letting MAF add its own `FunctionInvokingChatClient` on top would
+silently override the ADR-006 iteration cap, duplicate OpenTelemetry spans,
+and short-circuit MCP resilience. `UseProvidedChatClientAsIs = true` keeps the
+caller's decorator stack intact end-to-end. The seam is proven by
+`MafPrimitivesCharacterizationTests`: those tests inject a probe `IChatClient`
+that walks the managed stack on every call and asserts a
+`Microsoft.Agents.AI.*` frame is present, so future refactors that quietly
+bypass MAF and go straight to `IChatClient.GetResponseAsync` will fail the
+build.
+
+The structural rationale — why `ChatClientAgent` + `UseProvidedChatClientAsIs`
+is the durable execution model, and why the alternatives were rejected — is
+captured in [`ADR-007: MAF agent primitives for specialist/router/council execution`](./adr/007-maf-agent-primitives.md).
+
 ### Model Context Protocol (MCP) — Tool Access
 
 | Decision | Rationale |

--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
@@ -2,6 +2,7 @@ using System.ClientModel;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Microsoft.Agents.AI;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.AI;
 using RetailPulse.Api.Auth;
@@ -32,6 +33,14 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
     private readonly ToolResultBudget? _toolBudget;
     private readonly ToolResultBudgetOptions _budgetOptions;
     private readonly TenantConfiguration _tenant;
+    private readonly ILoggerFactory? _loggerFactory;
+
+    /// <summary>
+    /// Distinct MAF agent name to use when invoking the shared <see cref="MafAgentInvoker"/>.
+    /// Kept internal so characterization tests can verify the pipeline actually
+    /// produces a MAF <see cref="AgentResponse"/> for every specialist run.
+    /// </summary>
+    internal const string MafSpecialistAgentSuffix = ".specialist";
 
     /// <summary>
     /// True when a tenant roster with at least one brand is wired into this pipeline.
@@ -81,7 +90,8 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         IAnonymousChatPolicy anonymousChatPolicy,
         TenantConfiguration tenant,
         ToolResultBudget? toolBudget = null,
-        ToolResultBudgetOptions? budgetOptions = null)
+        ToolResultBudgetOptions? budgetOptions = null,
+        ILoggerFactory? loggerFactory = null)
     {
         _chatClient = chatClient;
         _hubContext = hubContext;
@@ -97,6 +107,7 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         _tenant = tenant ?? throw new ArgumentNullException(nameof(tenant),
             "TenantConfiguration is required — portfolio-ranking coverage enforcement " +
             "(issue #74) fails closed without it. Production DI must resolve it from the service provider.");
+        _loggerFactory = loggerFactory;
     }
 
     /// <summary>
@@ -153,11 +164,17 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
             timestamp = DateTimeOffset.UtcNow
         }, ct);
 
-        Microsoft.Extensions.AI.ChatResponse response;
+        AgentResponse mafResponse;
 
         try
         {
-            response = await _chatClient.GetResponseAsync(messages, chatOptions, ct);
+            mafResponse = await MafAgentInvoker.RunAsync(
+                _chatClient,
+                context.AgentName + MafSpecialistAgentSuffix,
+                messages,
+                chatOptions,
+                _loggerFactory,
+                ct);
         }
         catch (ClientResultException ex) when (ex.Status == 429)
         {
@@ -184,6 +201,13 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
 
         long thoughtDurationMs = sw.ElapsedMilliseconds;
         thoughtActivity?.SetTag("agent.duration_ms", thoughtDurationMs);
+
+        // Adapt the MAF AgentResponse to a Microsoft.Extensions.AI.ChatResponse for the
+        // existing chart, tool-span, and token helpers. AgentResponseExtensions.AsChatResponse
+        // is a documented shallow copy (Messages/Usage list references are shared), so this
+        // is allocation-cheap and preserves the exact tool-call/tool-result content that the
+        // specialist span and chart extraction pipelines depend on.
+        Microsoft.Extensions.AI.ChatResponse response = mafResponse.AsChatResponse();
 
         (int inputTokens, int outputTokens, int totalTokens) = ExtractTokenCounts(response);
 
@@ -433,11 +457,17 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
             timestamp = DateTimeOffset.UtcNow
         }, ct);
 
-        Microsoft.Extensions.AI.ChatResponse response;
+        AgentResponse mafResponse;
 
         try
         {
-            response = await _chatClient.GetResponseAsync(messages, chatOptions, ct);
+            mafResponse = await MafAgentInvoker.RunAsync(
+                _chatClient,
+                context.AgentName + MafSpecialistAgentSuffix,
+                messages,
+                chatOptions,
+                _loggerFactory,
+                ct);
         }
         catch (ClientResultException ex) when (ex.Status == 429)
         {
@@ -462,6 +492,11 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
 
         long thoughtDurationMs = sw.ElapsedMilliseconds;
         thoughtActivity?.SetTag("agent.duration_ms", thoughtDurationMs);
+
+        // Adapt the MAF AgentResponse to a Microsoft.Extensions.AI.ChatResponse for the
+        // existing chart, tool-span, and token helpers (see the non-streaming path for the
+        // full rationale).
+        Microsoft.Extensions.AI.ChatResponse response = mafResponse.AsChatResponse();
 
         (int inputTokens, int outputTokens, int totalTokens) = ExtractTokenCounts(response);
 

--- a/src/RetailPulse.Api/Agents/MafAgentInvoker.cs
+++ b/src/RetailPulse.Api/Agents/MafAgentInvoker.cs
@@ -1,0 +1,93 @@
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace RetailPulse.Api.Agents;
+
+/// <summary>
+/// Centralized adapter that runs a chat request through a real Microsoft Agent
+/// Framework (MAF) <see cref="ChatClientAgent"/> primitive. Every agent-style call
+/// in Retail Pulse — the 10 specialists via <see cref="AgentExecutionPipeline"/>,
+/// the router's intent classification, and the consensus council's votes and
+/// synthesis — flows through this seam so a single, tested code path owns the
+/// MAF conversion.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The adapter is intentionally minimal: it constructs a per-invocation
+/// <see cref="ChatClientAgent"/> around the caller-provided <see cref="IChatClient"/>
+/// and invokes <see cref="ChatClientAgent.RunAsync(System.Collections.Generic.IEnumerable{ChatMessage}, AgentSession, ChatClientAgentRunOptions, System.Threading.CancellationToken)"/>.
+/// The returned <see cref="AgentResponse"/> is a genuine MAF type; callers extract
+/// text, response messages, and token usage from it directly.
+/// </para>
+/// <para>
+/// <see cref="ChatClientAgentOptions.UseProvidedChatClientAsIs"/> is set to
+/// <see langword="true"/> so MAF does <b>not</b> re-decorate the provided
+/// <see cref="IChatClient"/>. That is critical: the production DI stack already
+/// wraps the chat client with <c>UseFunctionInvocation(client =&gt;
+/// client.MaximumIterationsPerRequest = 3)</c> and <c>UseOpenTelemetry(...)</c>
+/// in <c>Program.cs</c>. Letting MAF add its own <c>FunctionInvokingChatClient</c>
+/// on top would silently override the ADR-006 iteration cap and duplicate OTel
+/// spans. Preserving the caller's decorator stack keeps the tool-context budget
+/// contract, InstrumentedToolMiddleware timings, ApprovalTool blocking behaviour,
+/// and MCP HttpClient retry/circuit-breaker/cache all working unchanged.
+/// </para>
+/// <para>
+/// The adapter is stateless and static. It intentionally does not hold session
+/// state: every Retail Pulse request builds its own message list (system prompt
+/// + trimmed history + user message) via <see cref="AgentExecutionPipeline.BuildMessages"/>,
+/// so the MAF <see cref="AgentSession"/> per run is disposable and never persisted.
+/// </para>
+/// </remarks>
+public static class MafAgentInvoker
+{
+    /// <summary>
+    /// Runs the supplied messages through a MAF <see cref="ChatClientAgent"/>
+    /// wrapping <paramref name="chatClient"/> and returns the raw
+    /// <see cref="AgentResponse"/> so callers can extract text, messages, and
+    /// usage using the same MAF surface the rest of the framework exposes.
+    /// </summary>
+    /// <param name="chatClient">The pre-decorated chat client to invoke.</param>
+    /// <param name="agentName">Human-readable agent name (used for MAF telemetry / metadata).</param>
+    /// <param name="messages">Chat messages to send to the model. Ownership stays with the caller.</param>
+    /// <param name="chatOptions">Per-invocation chat options (temperature, tools, response format).</param>
+    /// <param name="loggerFactory">Optional logger factory forwarded to <see cref="ChatClientAgent"/>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public static async Task<AgentResponse> RunAsync(
+        IChatClient chatClient,
+        string agentName,
+        IEnumerable<ChatMessage> messages,
+        ChatOptions chatOptions,
+        ILoggerFactory? loggerFactory,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(chatClient);
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentName);
+        ArgumentNullException.ThrowIfNull(messages);
+        ArgumentNullException.ThrowIfNull(chatOptions);
+
+        var agentOptions = new ChatClientAgentOptions
+        {
+            Name = agentName,
+            // Keep the caller-provided decorator stack (FunctionInvokingChatClient
+            // with MaximumIterationsPerRequest = 3, OpenTelemetry, resilience) intact.
+            UseProvidedChatClientAsIs = true,
+        };
+
+        ChatClientAgent agent = loggerFactory is null
+            ? new ChatClientAgent(chatClient, agentOptions)
+            : new ChatClientAgent(chatClient, agentOptions, loggerFactory);
+
+        var runOptions = new ChatClientAgentRunOptions(chatOptions);
+
+        // Pass session:null so MAF creates an ephemeral in-memory session per request.
+        // Retail Pulse builds the full conversation transcript into `messages` on every
+        // call (system prompt + trimmed history + user message), so cross-request
+        // session persistence is neither expected nor desired here.
+        AgentResponse response = await agent
+            .RunAsync(messages, session: null, runOptions, ct)
+            .ConfigureAwait(false);
+
+        return response;
+    }
+}

--- a/src/RetailPulse.Api/Agents/MafAgentInvoker.cs
+++ b/src/RetailPulse.Api/Agents/MafAgentInvoker.cs
@@ -16,7 +16,7 @@ namespace RetailPulse.Api.Agents;
 /// <para>
 /// The adapter is intentionally minimal: it constructs a per-invocation
 /// <see cref="ChatClientAgent"/> around the caller-provided <see cref="IChatClient"/>
-/// and invokes <see cref="ChatClientAgent.RunAsync(System.Collections.Generic.IEnumerable{ChatMessage}, AgentSession, ChatClientAgentRunOptions, System.Threading.CancellationToken)"/>.
+/// and invokes <see cref="ChatClientAgent.RunAsync(IEnumerable{ChatMessage}, AgentSession, ChatClientAgentRunOptions, CancellationToken)"/>.
 /// The returned <see cref="AgentResponse"/> is a genuine MAF type; callers extract
 /// text, response messages, and token usage from it directly.
 /// </para>

--- a/src/RetailPulse.Api/Agents/Routing/RetailOpsRouter.cs
+++ b/src/RetailPulse.Api/Agents/Routing/RetailOpsRouter.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using RetailPulse.Api.Caching;
 using RetailPulse.Api.Charts;
@@ -25,6 +26,15 @@ public partial class RetailOpsRouter : IAgentRouter
     private readonly ILogger<RetailOpsRouter> _logger;
     private readonly RetailPulseMetrics? _metrics;
     private readonly RouterClassificationCache? _classificationCache;
+    private readonly ILoggerFactory? _loggerFactory;
+
+    /// <summary>
+    /// MAF agent name used when the router classifies intent through
+    /// <see cref="MafAgentInvoker"/>. Kept as a stable, discoverable constant so
+    /// characterization tests can assert the router routes through the shared MAF
+    /// invocation path (not directly through <see cref="IChatClient"/>).
+    /// </summary>
+    internal const string MafAgentName = "RetailOpsRouter.classifier";
 
     /// <summary>
     /// Minimum confidence threshold. Below this, the router falls back to
@@ -112,13 +122,15 @@ public partial class RetailOpsRouter : IAgentRouter
         IEnumerable<ISpecialistAgent> specialists,
         ILogger<RetailOpsRouter> logger,
         RetailPulseMetrics? metrics = null,
-        RouterClassificationCache? classificationCache = null)
+        RouterClassificationCache? classificationCache = null,
+        ILoggerFactory? loggerFactory = null)
     {
         _chatClient = chatClient;
         _routerDef = routerDef;
         _logger = logger;
         _metrics = metrics;
         _classificationCache = classificationCache;
+        _loggerFactory = loggerFactory;
 
         // Build a lookup: intent → specialist (first specialist that claims it wins)
         var lookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase);
@@ -381,8 +393,19 @@ public partial class RetailOpsRouter : IAgentRouter
             ResponseFormat = ChatResponseFormat.Json
         };
 
-        Microsoft.Extensions.AI.ChatResponse response = await _chatClient.GetResponseAsync(messages, chatOptions, ct);
-        string responseText = response.Text ?? "";
+        // Route classification through a real MAF ChatClientAgent so the intent-classifier
+        // is a genuine MAF agent primitive, not a bare IChatClient call. UseProvidedChatClientAsIs
+        // (inside MafAgentInvoker) preserves the DI-wired FunctionInvokingChatClient +
+        // OpenTelemetry decorators unchanged — the router carries no tools, so no tool
+        // execution is triggered by wrapping the classifier in an agent primitive.
+        AgentResponse mafResponse = await MafAgentInvoker.RunAsync(
+            _chatClient,
+            MafAgentName,
+            messages,
+            chatOptions,
+            _loggerFactory,
+            ct);
+        string responseText = mafResponse.Text ?? "";
 
         return ParseClassification(responseText, _logger);
     }

--- a/src/RetailPulse.Api/Consensus/ConsensusOrchestrator.cs
+++ b/src/RetailPulse.Api/Consensus/ConsensusOrchestrator.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Text.Json;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using RetailPulse.Api.Agents;
 using RetailPulse.Api.Models;
 using RetailPulse.Contracts.Consensus;
 using RetailPulse.Contracts.Routing;
@@ -20,6 +22,15 @@ public class ConsensusOrchestrator : IConsensusCouncil
     private readonly AgentDefinition _synthesisDef;
     private readonly AgentDefinition _voteDef;
     private readonly ILogger<ConsensusOrchestrator> _logger;
+    private readonly ILoggerFactory? _loggerFactory;
+
+    /// <summary>MAF agent name for lightweight voter runs, so characterization tests can
+    /// verify each vote flows through <see cref="MafAgentInvoker"/> (a real
+    /// <see cref="ChatClientAgent"/>) and not directly through <see cref="IChatClient"/>.</summary>
+    internal const string MafVoterAgentName = "ConsensusOrchestrator.voter";
+
+    /// <summary>MAF agent name for the synthesis run.</summary>
+    internal const string MafSynthesizerAgentName = "ConsensusOrchestrator.synthesizer";
 
     /// <summary>Per-agent timeout for the fan-out phase. Must be long enough for
     /// agents to complete tool calls (MCP server round-trips + LLM reasoning).
@@ -42,13 +53,15 @@ public class ConsensusOrchestrator : IConsensusCouncil
         IChatClient chatClient,
         AgentDefinition synthesisDef,
         AgentDefinition voteDef,
-        ILogger<ConsensusOrchestrator> logger)
+        ILogger<ConsensusOrchestrator> logger,
+        ILoggerFactory? loggerFactory = null)
     {
         _specialists = specialists;
         _chatClient = chatClient;
         _synthesisDef = synthesisDef;
         _voteDef = voteDef;
         _logger = logger;
+        _loggerFactory = loggerFactory;
     }
 
     public async Task<CouncilVerdict> ConveneAsync(string brand, string? region, CancellationToken ct = default)
@@ -110,7 +123,15 @@ public class ConsensusOrchestrator : IConsensusCouncil
                 ResponseFormat = ChatResponseFormat.Json
             };
 
-            ChatResponse response = await _chatClient.GetResponseAsync(messages, options, timeoutCts.Token);
+            // Route through MAF: the lightweight voter is a real ChatClientAgent invocation
+            // (no tools attached; UseProvidedChatClientAsIs preserves the DI decorator stack).
+            AgentResponse response = await MafAgentInvoker.RunAsync(
+                _chatClient,
+                $"{MafVoterAgentName}.{agent.Key}",
+                messages,
+                options,
+                _loggerFactory,
+                timeoutCts.Token);
             agentSw.Stop();
 
             string responseText = response.Text ?? "";
@@ -273,7 +294,14 @@ public class ConsensusOrchestrator : IConsensusCouncil
                 Temperature = (float)_synthesisDef.Temperature
             };
 
-            ChatResponse response = await _chatClient.GetResponseAsync(messages, options, ct);
+            // Synthesis also flows through MAF for parity with the specialist / router paths.
+            AgentResponse response = await MafAgentInvoker.RunAsync(
+                _chatClient,
+                MafSynthesizerAgentName,
+                messages,
+                options,
+                _loggerFactory,
+                ct);
             string responseText = response.Text ?? "";
 
             return ParseSynthesis(brand, region, votes, responseText, convenedAt, sw);

--- a/tests/RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs
+++ b/tests/RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -8,10 +9,13 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using RetailPulse.Api.Agents;
 using RetailPulse.Api.Agents.Routing;
+using RetailPulse.Api.Agents.Specialists;
 using RetailPulse.Api.Consensus;
+using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Models;
 using RetailPulse.Contracts;
 using RetailPulse.Contracts.Consensus;
+using RetailPulse.Contracts.Memory;
 using RetailPulse.Contracts.Routing;
 using RetailPulse.Tests.Fixtures;
 using MafAgentResponse = Microsoft.Agents.AI.AgentResponse;
@@ -37,7 +41,19 @@ namespace RetailPulse.Tests.Agents;
 /// pass in, proving MAF does not silently rewrap or re-decorate the caller stack
 /// (validates <c>UseProvidedChatClientAsIs = true</c> is effective).
 /// </para>
+/// <para>
+/// This class joins the shared <c>OTel</c> xUnit collection
+/// (<see cref="RetailPulse.Tests.Fixtures.OTelCollection"/>). Its router,
+/// specialist, and span-order tests emit spans on the
+/// <c>RetailPulse.Agent</c> <see cref="ActivitySource"/> — the same source that
+/// <c>OTelRoutingSpanTests</c> subscribes to with a process-wide
+/// <see cref="ActivityListener"/>. Serializing the two classes prevents the
+/// otherwise-inevitable cross-contamination where an <c>agent.routing</c> span
+/// emitted by a MAF characterization run gets picked up as the
+/// <c>LastOrDefault</c> match by an <c>OTelRoutingSpanTests</c> assertion.
+/// </para>
 /// </summary>
+[Collection("OTel")]
 public class MafPrimitivesCharacterizationTests
 {
     #region MafAgentInvoker direct contract
@@ -214,6 +230,144 @@ public class MafPrimitivesCharacterizationTests
             "the council must issue exactly one MAF-routed vote per participant plus one MAF-routed synthesis call");
         probe.Calls.Should().OnlyContain(c => c.WasCalledFromMafFrame,
             "every voter and synthesis call must flow through the shared MafAgentInvoker path");
+    }
+
+    #endregion
+
+    #region Specialist inventory (all 10 ISpecialistAgent keys)
+
+    /// <summary>
+    /// Representative characterization for every <see cref="ISpecialistAgent"/> key
+    /// registered by production DI. For the nine LLM-backed specialists this proves
+    /// that <see cref="ISpecialistAgent.HandleAsync"/> executes exactly one chat
+    /// invocation and that the invocation originates inside a
+    /// <c>Microsoft.Agents.AI.ChatClientAgent</c> stack frame — the acceptance
+    /// contract that all real specialist inference flows through MAF. For the
+    /// single rules-only specialist (<see cref="MemoryManagementAgent"/>) it
+    /// asserts the opposite: <see cref="IChatClient"/> must NOT be called, and
+    /// the deterministic rules-only reply must reach the caller unchanged. That
+    /// keeps the characterization honest — MemoryManagement's <c>Model</c> is
+    /// documented as <c>"none"</c> and the specialist responds without an LLM.
+    /// </summary>
+    [Theory]
+    [InlineData("general",            true,  "Give me a summary of the retail landscape.")]
+    [InlineData("demand-forecasting", true,  "What is the demand forecast for Sierra Gold this quarter?")]
+    [InlineData("competitive-intel",  true,  "How is our competitive threat landscape looking this month?")]
+    [InlineData("supply-chain",       true,  "Are our supply chain shipments on track for the West region?")]
+    [InlineData("promo-planning",     true,  "Plan a summer promotion for premium spirits.")]
+    [InlineData("store-ops",          true,  "What operational issues should stores focus on this quarter?")]
+    [InlineData("planogram",          true,  "How should we adjust the planogram for the East region?")]
+    [InlineData("margin-analysis",    true,  "Analyze margin performance for tequila brands.")]
+    [InlineData("field-sentiment",    true,  "What is the field sentiment for Sierra Gold in the Northeast?")]
+    [InlineData("memory-management",  false, "Remember that I prefer premium tequila.")]
+    public async Task Specialist_HandlerBehavior_MatchesMafRoutingContract_ForEachKey(
+        string specialistKey, bool routesThroughMaf, string representativePrompt)
+    {
+        // Each specialist gets a private probe so a parallel-safe execution
+        // (the OTel collection already serializes this class, but a scoped
+        // probe per invocation also removes any latent aliasing between rows).
+        var probe = MafChatClientProbe.WithAssistantReply(
+            $"[stub reply for '{specialistKey}']");
+
+        ISpecialistAgent specialist = BuildSpecialist(specialistKey, probe);
+
+        specialist.Key.Should().Be(specialistKey,
+            "the built specialist must own the intended DI key");
+
+        RetailPulse.Contracts.ChatResponse response =
+            await specialist.HandleAsync(new ChatRequest(representativePrompt));
+
+        response.Should().NotBeNull(
+            $"specialist '{specialistKey}' must return a well-formed ChatResponse for a representative prompt");
+
+        if (routesThroughMaf)
+        {
+            probe.Calls.Should().HaveCount(1,
+                $"LLM-backed specialist '{specialistKey}' must issue exactly one chat client " +
+                "invocation through the shared MafAgentInvoker path (no tools attached, so no " +
+                "additional round-trips are expected)");
+            probe.Calls[0].WasCalledFromMafFrame.Should().BeTrue(
+                $"specialist '{specialistKey}' must reach IChatClient through the " +
+                "Microsoft.Agents.AI.ChatClientAgent primitive — the byte-equivalent " +
+                "acceptance criterion for issue #89");
+        }
+        else
+        {
+            probe.Calls.Should().BeEmpty(
+                $"specialist '{specialistKey}' is documented as rules-only (Model = \"none\") — " +
+                "any IChatClient call would prove an LLM was silently invoked and would " +
+                "contradict the specialist's contract");
+            response.Reply.Should().Contain("remember",
+                "the rules-only store path must acknowledge the user's remember request in prose");
+        }
+    }
+
+    /// <summary>
+    /// Builds a real specialist for the given key using the same constructors
+    /// production DI does. LLM-backed specialists share a pipeline that wraps
+    /// the supplied <see cref="MafChatClientProbe"/>; <see cref="MemoryManagementAgent"/>
+    /// ignores the probe and uses an in-memory fake <see cref="IConversationMemory"/>.
+    /// </summary>
+    private static ISpecialistAgent BuildSpecialist(string key, IChatClient probe)
+    {
+        IHubContext<TelemetryHub> hubContext = AgentTestFixtures.CreateMockHubContext();
+        AgentExecutionPipeline pipeline = new(
+            probe,
+            hubContext,
+            EmptyConfiguration(),
+            NullLoggerFactory.Instance.CreateLogger<AgentExecutionPipeline>());
+
+        return key switch
+        {
+            "general"            => new GeneralAgent(pipeline, Def("General"), []),
+            "demand-forecasting" => new DemandForecastAgent(pipeline, Def("Demand Forecast"), []),
+            "competitive-intel"  => new CompetitiveIntelAgent(
+                                        pipeline, Def("Competitive Intel"), [],
+                                        hubContext, Mock.Of<ILogger<CompetitiveIntelAgent>>()),
+            "supply-chain"       => new SupplyChainAgent(pipeline, Def("Supply Chain"), []),
+            "promo-planning"     => new PromoPlanningAgent(pipeline, Def("Promo Planning"), []),
+            "store-ops"          => new StoreOpsAgent(pipeline, Def("Store Ops"), []),
+            "planogram"          => new PlanogramAgent(pipeline, Def("Planogram"), []),
+            "margin-analysis"    => new MarginAgent(pipeline, Def("Margin"), []),
+            "field-sentiment"    => new FieldSentimentAgent(pipeline, Def("Field Sentiment"), []),
+            "memory-management"  => new MemoryManagementAgent(
+                                        new FakeConversationMemory(),
+                                        Mock.Of<ILogger<MemoryManagementAgent>>()),
+            _ => throw new ArgumentException(
+                     $"Unknown specialist key '{key}' — add a factory row to keep the Theory in sync with production DI",
+                     nameof(key)),
+        };
+
+        static AgentDefinition Def(string name) => new()
+        {
+            Name = name,
+            Model = "gpt-4o",
+            SystemPrompt = $"You are the {name} specialist for retail analytics.",
+            Temperature = 0.4
+        };
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IConversationMemory"/> that satisfies
+    /// <see cref="MemoryManagementAgent"/>'s store/forget code paths without any
+    /// persistence. The Theory only asserts that (a) no LLM call is issued and
+    /// (b) the rules-only reply reaches the caller; a functional memory store
+    /// is not required to make either claim.
+    /// </summary>
+    private sealed class FakeConversationMemory : IConversationMemory
+    {
+        public Task StoreAsync(string userId, MemoryEntry entry, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<IReadOnlyList<MemoryEntry>> RecallAsync(
+            string userId, string? query = null, int maxResults = 5, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+
+        public Task ForgetAsync(string userId, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task ForgetEntryAsync(string userId, string memoryId, CancellationToken ct = default)
+            => Task.CompletedTask;
     }
 
     #endregion

--- a/tests/RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs
+++ b/tests/RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs
@@ -1,0 +1,401 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RetailPulse.Api.Agents;
+using RetailPulse.Api.Agents.Routing;
+using RetailPulse.Api.Consensus;
+using RetailPulse.Api.Models;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Consensus;
+using RetailPulse.Contracts.Routing;
+using RetailPulse.Tests.Fixtures;
+using MafAgentResponse = Microsoft.Agents.AI.AgentResponse;
+
+namespace RetailPulse.Tests.Agents;
+
+/// <summary>
+/// Characterization tests for GitHub issue #89 — proves that the specialist
+/// pipeline, <see cref="RetailOpsRouter"/>, and <see cref="ConsensusOrchestrator"/>
+/// all execute through a genuine Microsoft Agent Framework (MAF) 1.18.0
+/// <c>ChatClientAgent</c> primitive, not merely through direct
+/// <see cref="IChatClient.GetResponseAsync"/> calls dressed up with MAF symbols.
+/// <para>
+/// The proof is stack-frame based: the tests inject an <see cref="IChatClient"/>
+/// wrapper that captures its own call site. If MAF is genuinely on the execution
+/// path, that call site's stack will contain a
+/// <c>Microsoft.Agents.AI.ChatClientAgent</c> frame — that frame does not exist
+/// when a caller invokes <see cref="IChatClient.GetResponseAsync"/> directly.
+/// </para>
+/// <para>
+/// Additional characterization: observed <see cref="ChatOptions"/> preserve the
+/// exact tool set, temperature, and response format the pipeline/router/council
+/// pass in, proving MAF does not silently rewrap or re-decorate the caller stack
+/// (validates <c>UseProvidedChatClientAsIs = true</c> is effective).
+/// </para>
+/// </summary>
+public class MafPrimitivesCharacterizationTests
+{
+    #region MafAgentInvoker direct contract
+
+    [Fact]
+    public async Task MafAgentInvoker_ReturnsGenuineMafAgentResponse()
+    {
+        var probe = MafChatClientProbe.WithAssistantReply("hello world");
+
+        var response = await MafAgentInvoker.RunAsync(
+            probe,
+            agentName: "test.agent",
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            chatOptions: new ChatOptions(),
+            loggerFactory: NullLoggerFactory.Instance,
+            ct: CancellationToken.None);
+
+        response.Should().NotBeNull();
+        response.Should().BeAssignableTo<MafAgentResponse>();
+        response.Text.Should().Contain("hello world");
+        response.Messages.Should().NotBeEmpty("MAF must surface at least the assistant reply message");
+    }
+
+    [Fact]
+    public async Task MafAgentInvoker_InvokesUnderlyingChatClientThroughMafFrame()
+    {
+        var probe = MafChatClientProbe.WithAssistantReply("ok");
+
+        await MafAgentInvoker.RunAsync(
+            probe,
+            agentName: "test.agent",
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            chatOptions: new ChatOptions(),
+            loggerFactory: NullLoggerFactory.Instance,
+            ct: CancellationToken.None);
+
+        probe.Calls.Should().HaveCount(1, "MAF should invoke the provided chat client exactly once for a simple, tool-less run");
+        probe.Calls[0].WasCalledFromMafFrame.Should().BeTrue(
+            "the invocation must originate inside Microsoft.Agents.AI.ChatClientAgent, proving the request " +
+            "actually flowed through a real MAF primitive rather than a direct IChatClient call");
+    }
+
+    [Fact]
+    public async Task MafAgentInvoker_PreservesChatOptions_ForToolAndResponseFormatContracts()
+    {
+        var probe = MafChatClientProbe.WithAssistantReply("{ }");
+
+        var tool = new StubAITool("stub-tool");
+        var options = new ChatOptions
+        {
+            Temperature = 0.42f,
+            Tools = [tool],
+            ResponseFormat = ChatResponseFormat.Json,
+            MaxOutputTokens = 128,
+        };
+
+        await MafAgentInvoker.RunAsync(
+            probe,
+            agentName: "test.agent",
+            messages: [new ChatMessage(ChatRole.User, "hi")],
+            chatOptions: options,
+            loggerFactory: NullLoggerFactory.Instance,
+            ct: CancellationToken.None);
+
+        probe.Calls.Should().HaveCount(1);
+        var observed = probe.Calls[0].Options;
+        observed.Should().NotBeNull();
+        observed.Temperature.Should().Be(0.42f, "MAF must forward temperature unchanged");
+        observed.ResponseFormat.Should().BeSameAs(ChatResponseFormat.Json, "response format must be preserved");
+        observed.MaxOutputTokens.Should().Be(128, "max output tokens must be preserved");
+        observed.Tools.Should().NotBeNull();
+        observed.Tools.Should().ContainSingle(t => ReferenceEquals(t, tool),
+            "the caller-provided tool list must reach the chat client unchanged (no double-wrapping)");
+    }
+
+    #endregion
+
+    #region Specialists (via AgentExecutionPipeline)
+
+    [Fact]
+    public async Task Specialist_ExecutesThroughMafChatClientAgent()
+    {
+        var probe = MafChatClientProbe.WithAssistantReply("hi from specialist");
+        var pipeline = new AgentExecutionPipeline(
+            probe,
+            AgentTestFixtures.CreateMockHubContext(),
+            EmptyConfiguration(),
+            NullLoggerFactory.Instance.CreateLogger<AgentExecutionPipeline>());
+
+        var agent = new RetailPulse.Api.Agents.Specialists.GeneralAgent(
+            pipeline,
+            new AgentDefinition
+            {
+                Name = "General",
+                Model = "gpt-4o",
+                SystemPrompt = "You are a retail analytics assistant.",
+                Temperature = 0.7
+            },
+            tools: []);
+
+        var response = await agent.HandleAsync(new ChatRequest("hello"));
+
+        response.Reply.Should().Contain("hi from specialist");
+        probe.Calls.Should().HaveCount(1, "the specialist should trigger exactly one chat client invocation via MAF");
+        probe.Calls[0].WasCalledFromMafFrame.Should().BeTrue(
+            "specialists must invoke IChatClient through the MafAgentInvoker/ChatClientAgent primitive path");
+    }
+
+    #endregion
+
+    #region Router
+
+    [Fact]
+    public async Task Router_ClassifiesIntentThroughMafChatClientAgent()
+    {
+        // Force the keyword fast-path to miss so classification actually runs through MAF.
+        // "Give me a full portfolio deep dive across every domain" avoids every keyword pattern.
+        var probe = MafChatClientProbe.WithAssistantReply(
+            "{\"intent\":\"" + AgentIntent.General + "\",\"confidence\":0.92,\"intents\":[]}");
+
+        var router = new RetailOpsRouter(
+            probe,
+            new AgentDefinition
+            {
+                Name = "Router",
+                Model = "gpt-5.4-mini",
+                SystemPrompt = "Classify user intent.",
+                Temperature = 0.1
+            },
+            specialists: [],
+            Mock.Of<ILogger<RetailOpsRouter>>());
+
+        var decision = await router.RouteAsync(
+            "Give me a full portfolio deep dive across every domain",
+            null, null, null);
+
+        decision.Should().NotBeNull();
+        probe.Calls.Should().NotBeEmpty("the router must invoke the chat client for LLM-based classification");
+        probe.Calls.Should().OnlyContain(c => c.WasCalledFromMafFrame,
+            "every router classification call must flow through the shared MafAgentInvoker path");
+    }
+
+    #endregion
+
+    #region Consensus Council
+
+    [Fact]
+    public async Task ConsensusOrchestrator_VoterAndSynthesizer_BothRouteThroughMaf()
+    {
+        var probe = MafChatClientProbe.WithAssistantReply(
+            "{\"rating\":\"Green\",\"reasoning\":\"stable performance across domain\",\"confidence\":0.85,\"tags\":[]}");
+
+        ISpecialistAgent[] specialists =
+        [
+            AgentTestFixtures.CreateMockSpecialist("demand-forecasting", [AgentIntent.DemandForecasting]),
+            AgentTestFixtures.CreateMockSpecialist("competitive-intel",  [AgentIntent.CompetitiveMarket]),
+            AgentTestFixtures.CreateMockSpecialist("supply-chain",       [AgentIntent.SupplyShipments]),
+        ];
+
+        var orchestrator = new ConsensusOrchestrator(
+            specialists,
+            probe,
+            synthesisDef: new AgentDefinition { Name = "council-synth", SystemPrompt = "Synthesize.", Temperature = 0.1 },
+            voteDef:      new AgentDefinition { Name = "council-vote",  SystemPrompt = "Vote.",       Temperature = 0.0 },
+            Mock.Of<ILogger<ConsensusOrchestrator>>());
+
+        var verdict = await orchestrator.ConveneAsync(
+            "Sierra Gold Tequila", "Southwest", CancellationToken.None);
+
+        verdict.Should().NotBeNull();
+
+        // 3 specialists vote in parallel + 1 synthesis pass = 4 MAF-routed chat calls.
+        probe.Calls.Should().HaveCount(4,
+            "the council must issue exactly one MAF-routed vote per participant plus one MAF-routed synthesis call");
+        probe.Calls.Should().OnlyContain(c => c.WasCalledFromMafFrame,
+            "every voter and synthesis call must flow through the shared MafAgentInvoker path");
+    }
+
+    #endregion
+
+    #region Span sequence characterization
+
+    /// <summary>
+    /// Locks in the outer span operation names that a specialist produces during a
+    /// standard pipeline run: agent.thought opens first (the outer thinking scope);
+    /// agent.response opens after the MAF invocation returns and closes before the
+    /// outer scope. Both spans MUST be emitted, and their <c>StartTimeUtc</c>
+    /// ordering must be preserved: agent.thought starts strictly before
+    /// agent.response. Tool spans nest inside based on tool-call activity; byte-equivalent tool
+    /// span names are covered by <c>TraceSpanTypeContractTests</c> and the
+    /// SignalR push contract.
+    /// </summary>
+    [Fact]
+    public async Task Specialist_EmitsAgentThoughtAndAgentResponseSpans_InCorrectOrder()
+    {
+        using var listener = ActivityCaptureListener.Capture(source => source.Name == "RetailPulse.Agent");
+
+        // Start a test-owned outer Activity so every span emitted while `HandleAsync`
+        // runs inherits our TraceId. That lets us filter cleanly for THIS test's spans
+        // and ignore spans emitted by other xUnit tests running in parallel.
+        using var testSource = new ActivitySource("RetailPulse.Tests.MafCharacterization");
+        using var testListener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == "RetailPulse.Tests.MafCharacterization",
+            Sample = SampleAll,
+            ActivityStopped = _ => { },
+        };
+        ActivitySource.AddActivityListener(testListener);
+        using var scopeActivity = testSource.StartActivity("test.scope");
+        scopeActivity.Should().NotBeNull("the test scope Activity is required to correlate captured spans");
+        var scopeTraceId = scopeActivity.TraceId;
+
+        var probe = MafChatClientProbe.WithAssistantReply("done");
+        var pipeline = new AgentExecutionPipeline(
+            probe,
+            AgentTestFixtures.CreateMockHubContext(),
+            EmptyConfiguration(),
+            NullLoggerFactory.Instance.CreateLogger<AgentExecutionPipeline>());
+
+        var agent = new RetailPulse.Api.Agents.Specialists.GeneralAgent(
+            pipeline,
+            new AgentDefinition
+            {
+                Name = "General",
+                Model = "gpt-4o",
+                SystemPrompt = "You are a retail analytics assistant.",
+                Temperature = 0.7
+            },
+            tools: []);
+
+        await agent.HandleAsync(new ChatRequest("hello"));
+
+        var myActivities = listener.CapturedActivities
+            .Where(a => a.TraceId == scopeTraceId)
+            .ToList();
+
+        var thoughtSpan = myActivities
+            .SingleOrDefault(a => a.OperationName == "agent.thought");
+        var responseSpan = myActivities
+            .SingleOrDefault(a => a.OperationName == "agent.response");
+
+        thoughtSpan.Should().NotBeNull("every specialist run must open an agent.thought span");
+        responseSpan.Should().NotBeNull("every specialist run must open an agent.response span");
+
+        thoughtSpan.StartTimeUtc.Should().BeOnOrBefore(responseSpan.StartTimeUtc,
+            "agent.thought (the outer thinking scope) must open before the response span; this order " +
+            "is the byte-equivalent characterization the frontend telemetry timeline relies on");
+        responseSpan.Parent?.OperationName.Should().Be("agent.thought",
+            "agent.response must be a child of agent.thought so the trace hierarchy is preserved");
+    }
+
+    private static ActivitySamplingResult SampleAll(ref ActivityCreationOptions<ActivityContext> options)
+        => ActivitySamplingResult.AllDataAndRecorded;
+
+    #endregion
+
+    #region Helpers
+
+    private static IConfiguration EmptyConfiguration()
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection([])
+            .Build();
+
+    /// <summary>
+    /// Test-only <see cref="IChatClient"/> that captures every invocation and
+    /// walks the current managed stack to prove Microsoft Agent Framework's
+    /// <c>ChatClientAgent</c> is on the caller chain.
+    /// </summary>
+    private sealed class MafChatClientProbe : IChatClient
+    {
+        public sealed record CapturedCall(
+            IReadOnlyList<ChatMessage> Messages,
+            ChatOptions? Options,
+            bool WasCalledFromMafFrame);
+
+        public List<CapturedCall> Calls { get; } = [];
+
+        private readonly Func<IReadOnlyList<ChatMessage>, ChatOptions?, Microsoft.Extensions.AI.ChatResponse> _responseFactory;
+
+        private MafChatClientProbe(Func<IReadOnlyList<ChatMessage>, ChatOptions?, Microsoft.Extensions.AI.ChatResponse> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        public static MafChatClientProbe WithAssistantReply(string reply) =>
+            new((_, _) => new Microsoft.Extensions.AI.ChatResponse(new ChatMessage(ChatRole.Assistant, reply)));
+
+        public Task<Microsoft.Extensions.AI.ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<ChatMessage> captured = [.. messages];
+            var fromMaf = IsCalledFromMafFrame(new StackTrace(fNeedFileInfo: false));
+            Calls.Add(new CapturedCall(captured, options, fromMaf));
+            return Task.FromResult(_responseFactory(captured, options));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotImplementedException("Streaming is not used by the MAF invoker path in this characterization test.");
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+
+        private static bool IsCalledFromMafFrame(StackTrace trace)
+        {
+            foreach (var frame in trace.GetFrames())
+            {
+                var declaring = frame?.GetMethod()?.DeclaringType;
+                var name = declaring?.FullName;
+                if (name is not null && name.StartsWith("Microsoft.Agents.AI.", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private sealed class StubAITool : AITool
+    {
+        public StubAITool(string name) { Name = name; }
+        public override string Name { get; }
+    }
+
+    /// <summary>
+    /// Scoped <see cref="ActivityListener"/> that captures completed activities so
+    /// tests can assert on span sequences.
+    /// </summary>
+    private sealed class ActivityCaptureListener : IDisposable
+    {
+        private readonly ActivityListener _listener;
+        public ConcurrentQueue<Activity> Completed { get; } = new();
+
+        public IReadOnlyList<Activity> CapturedActivities => [.. Completed];
+
+        private ActivityCaptureListener(Func<ActivitySource, bool> predicate)
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = predicate,
+                Sample = SampleAllData,
+                ActivityStopped = activity => Completed.Enqueue(activity),
+            };
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        private static ActivitySamplingResult SampleAllData(ref ActivityCreationOptions<ActivityContext> options)
+            => ActivitySamplingResult.AllDataAndRecorded;
+
+        public static ActivityCaptureListener Capture(Func<ActivitySource, bool> predicate) => new(predicate);
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    #endregion
+}

--- a/tests/RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs
+++ b/tests/RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs
@@ -43,7 +43,7 @@ namespace RetailPulse.Tests.Agents;
 /// </para>
 /// <para>
 /// This class joins the shared <c>OTel</c> xUnit collection
-/// (<see cref="RetailPulse.Tests.Fixtures.OTelCollection"/>). Its router,
+/// (<see cref="OTelCollection"/>). Its router,
 /// specialist, and span-order tests emit spans on the
 /// <c>RetailPulse.Agent</c> <see cref="ActivitySource"/> — the same source that
 /// <c>OTelRoutingSpanTests</c> subscribes to with a process-wide
@@ -63,7 +63,7 @@ public class MafPrimitivesCharacterizationTests
     {
         var probe = MafChatClientProbe.WithAssistantReply("hello world");
 
-        var response = await MafAgentInvoker.RunAsync(
+        MafAgentResponse response = await MafAgentInvoker.RunAsync(
             probe,
             agentName: "test.agent",
             messages: [new ChatMessage(ChatRole.User, "hi")],
@@ -119,7 +119,7 @@ public class MafPrimitivesCharacterizationTests
             ct: CancellationToken.None);
 
         probe.Calls.Should().HaveCount(1);
-        var observed = probe.Calls[0].Options;
+        ChatOptions? observed = probe.Calls[0].Options;
         observed.Should().NotBeNull();
         observed.Temperature.Should().Be(0.42f, "MAF must forward temperature unchanged");
         observed.ResponseFormat.Should().BeSameAs(ChatResponseFormat.Json, "response format must be preserved");
@@ -143,7 +143,7 @@ public class MafPrimitivesCharacterizationTests
             EmptyConfiguration(),
             NullLoggerFactory.Instance.CreateLogger<AgentExecutionPipeline>());
 
-        var agent = new RetailPulse.Api.Agents.Specialists.GeneralAgent(
+        var agent = new GeneralAgent(
             pipeline,
             new AgentDefinition
             {
@@ -154,7 +154,7 @@ public class MafPrimitivesCharacterizationTests
             },
             tools: []);
 
-        var response = await agent.HandleAsync(new ChatRequest("hello"));
+        Contracts.ChatResponse response = await agent.HandleAsync(new ChatRequest("hello"));
 
         response.Reply.Should().Contain("hi from specialist");
         probe.Calls.Should().HaveCount(1, "the specialist should trigger exactly one chat client invocation via MAF");
@@ -186,7 +186,7 @@ public class MafPrimitivesCharacterizationTests
             specialists: [],
             Mock.Of<ILogger<RetailOpsRouter>>());
 
-        var decision = await router.RouteAsync(
+        RoutingDecision decision = await router.RouteAsync(
             "Give me a full portfolio deep dive across every domain",
             null, null, null);
 
@@ -203,8 +203,10 @@ public class MafPrimitivesCharacterizationTests
     [Fact]
     public async Task ConsensusOrchestrator_VoterAndSynthesizer_BothRouteThroughMaf()
     {
+#pragma warning disable JSON002 // deliberate stub-vote payload; not produced by application code
         var probe = MafChatClientProbe.WithAssistantReply(
             "{\"rating\":\"Green\",\"reasoning\":\"stable performance across domain\",\"confidence\":0.85,\"tags\":[]}");
+#pragma warning restore JSON002
 
         ISpecialistAgent[] specialists =
         [
@@ -217,10 +219,10 @@ public class MafPrimitivesCharacterizationTests
             specialists,
             probe,
             synthesisDef: new AgentDefinition { Name = "council-synth", SystemPrompt = "Synthesize.", Temperature = 0.1 },
-            voteDef:      new AgentDefinition { Name = "council-vote",  SystemPrompt = "Vote.",       Temperature = 0.0 },
+            voteDef: new AgentDefinition { Name = "council-vote", SystemPrompt = "Vote.", Temperature = 0.0 },
             Mock.Of<ILogger<ConsensusOrchestrator>>());
 
-        var verdict = await orchestrator.ConveneAsync(
+        CouncilVerdict verdict = await orchestrator.ConveneAsync(
             "Sierra Gold Tequila", "Southwest", CancellationToken.None);
 
         verdict.Should().NotBeNull();
@@ -250,16 +252,16 @@ public class MafPrimitivesCharacterizationTests
     /// documented as <c>"none"</c> and the specialist responds without an LLM.
     /// </summary>
     [Theory]
-    [InlineData("general",            true,  "Give me a summary of the retail landscape.")]
-    [InlineData("demand-forecasting", true,  "What is the demand forecast for Sierra Gold this quarter?")]
-    [InlineData("competitive-intel",  true,  "How is our competitive threat landscape looking this month?")]
-    [InlineData("supply-chain",       true,  "Are our supply chain shipments on track for the West region?")]
-    [InlineData("promo-planning",     true,  "Plan a summer promotion for premium spirits.")]
-    [InlineData("store-ops",          true,  "What operational issues should stores focus on this quarter?")]
-    [InlineData("planogram",          true,  "How should we adjust the planogram for the East region?")]
-    [InlineData("margin-analysis",    true,  "Analyze margin performance for tequila brands.")]
-    [InlineData("field-sentiment",    true,  "What is the field sentiment for Sierra Gold in the Northeast?")]
-    [InlineData("memory-management",  false, "Remember that I prefer premium tequila.")]
+    [InlineData("general", true, "Give me a summary of the retail landscape.")]
+    [InlineData("demand-forecasting", true, "What is the demand forecast for Sierra Gold this quarter?")]
+    [InlineData("competitive-intel", true, "How is our competitive threat landscape looking this month?")]
+    [InlineData("supply-chain", true, "Are our supply chain shipments on track for the West region?")]
+    [InlineData("promo-planning", true, "Plan a summer promotion for premium spirits.")]
+    [InlineData("store-ops", true, "What operational issues should stores focus on this quarter?")]
+    [InlineData("planogram", true, "How should we adjust the planogram for the East region?")]
+    [InlineData("margin-analysis", true, "Analyze margin performance for tequila brands.")]
+    [InlineData("field-sentiment", true, "What is the field sentiment for Sierra Gold in the Northeast?")]
+    [InlineData("memory-management", false, "Remember that I prefer premium tequila.")]
     public async Task Specialist_HandlerBehavior_MatchesMafRoutingContract_ForEachKey(
         string specialistKey, bool routesThroughMaf, string representativePrompt)
     {
@@ -274,7 +276,7 @@ public class MafPrimitivesCharacterizationTests
         specialist.Key.Should().Be(specialistKey,
             "the built specialist must own the intended DI key");
 
-        RetailPulse.Contracts.ChatResponse response =
+        Contracts.ChatResponse response =
             await specialist.HandleAsync(new ChatRequest(representativePrompt));
 
         response.Should().NotBeNull(
@@ -319,18 +321,18 @@ public class MafPrimitivesCharacterizationTests
 
         return key switch
         {
-            "general"            => new GeneralAgent(pipeline, Def("General"), []),
+            "general" => new GeneralAgent(pipeline, Def("General"), []),
             "demand-forecasting" => new DemandForecastAgent(pipeline, Def("Demand Forecast"), []),
-            "competitive-intel"  => new CompetitiveIntelAgent(
+            "competitive-intel" => new CompetitiveIntelAgent(
                                         pipeline, Def("Competitive Intel"), [],
                                         hubContext, Mock.Of<ILogger<CompetitiveIntelAgent>>()),
-            "supply-chain"       => new SupplyChainAgent(pipeline, Def("Supply Chain"), []),
-            "promo-planning"     => new PromoPlanningAgent(pipeline, Def("Promo Planning"), []),
-            "store-ops"          => new StoreOpsAgent(pipeline, Def("Store Ops"), []),
-            "planogram"          => new PlanogramAgent(pipeline, Def("Planogram"), []),
-            "margin-analysis"    => new MarginAgent(pipeline, Def("Margin"), []),
-            "field-sentiment"    => new FieldSentimentAgent(pipeline, Def("Field Sentiment"), []),
-            "memory-management"  => new MemoryManagementAgent(
+            "supply-chain" => new SupplyChainAgent(pipeline, Def("Supply Chain"), []),
+            "promo-planning" => new PromoPlanningAgent(pipeline, Def("Promo Planning"), []),
+            "store-ops" => new StoreOpsAgent(pipeline, Def("Store Ops"), []),
+            "planogram" => new PlanogramAgent(pipeline, Def("Planogram"), []),
+            "margin-analysis" => new MarginAgent(pipeline, Def("Margin"), []),
+            "field-sentiment" => new FieldSentimentAgent(pipeline, Def("Field Sentiment"), []),
+            "memory-management" => new MemoryManagementAgent(
                                         new FakeConversationMemory(),
                                         Mock.Of<ILogger<MemoryManagementAgent>>()),
             _ => throw new ArgumentException(
@@ -400,9 +402,9 @@ public class MafPrimitivesCharacterizationTests
             ActivityStopped = _ => { },
         };
         ActivitySource.AddActivityListener(testListener);
-        using var scopeActivity = testSource.StartActivity("test.scope");
+        using Activity? scopeActivity = testSource.StartActivity("test.scope");
         scopeActivity.Should().NotBeNull("the test scope Activity is required to correlate captured spans");
-        var scopeTraceId = scopeActivity.TraceId;
+        ActivityTraceId scopeTraceId = scopeActivity.TraceId;
 
         var probe = MafChatClientProbe.WithAssistantReply("done");
         var pipeline = new AgentExecutionPipeline(
@@ -411,7 +413,7 @@ public class MafPrimitivesCharacterizationTests
             EmptyConfiguration(),
             NullLoggerFactory.Instance.CreateLogger<AgentExecutionPipeline>());
 
-        var agent = new RetailPulse.Api.Agents.Specialists.GeneralAgent(
+        var agent = new GeneralAgent(
             pipeline,
             new AgentDefinition
             {
@@ -428,9 +430,9 @@ public class MafPrimitivesCharacterizationTests
             .Where(a => a.TraceId == scopeTraceId)
             .ToList();
 
-        var thoughtSpan = myActivities
+        Activity? thoughtSpan = myActivities
             .SingleOrDefault(a => a.OperationName == "agent.thought");
-        var responseSpan = myActivities
+        Activity? responseSpan = myActivities
             .SingleOrDefault(a => a.OperationName == "agent.response");
 
         thoughtSpan.Should().NotBeNull("every specialist run must open an agent.thought span");
@@ -485,7 +487,7 @@ public class MafPrimitivesCharacterizationTests
             CancellationToken cancellationToken = default)
         {
             IReadOnlyList<ChatMessage> captured = [.. messages];
-            var fromMaf = IsCalledFromMafFrame(new StackTrace(fNeedFileInfo: false));
+            bool fromMaf = IsCalledFromMafFrame(new StackTrace(fNeedFileInfo: false));
             Calls.Add(new CapturedCall(captured, options, fromMaf));
             return Task.FromResult(_responseFactory(captured, options));
         }
@@ -502,10 +504,10 @@ public class MafPrimitivesCharacterizationTests
 
         private static bool IsCalledFromMafFrame(StackTrace trace)
         {
-            foreach (var frame in trace.GetFrames())
+            foreach (StackFrame frame in trace.GetFrames())
             {
-                var declaring = frame?.GetMethod()?.DeclaringType;
-                var name = declaring?.FullName;
+                Type? declaring = frame?.GetMethod()?.DeclaringType;
+                string? name = declaring?.FullName;
                 if (name is not null && name.StartsWith("Microsoft.Agents.AI.", StringComparison.Ordinal))
                 {
                     return true;

--- a/tests/RetailPulse.Tests/Charts/HorizontalBarRankingRegressionTests.cs
+++ b/tests/RetailPulse.Tests/Charts/HorizontalBarRankingRegressionTests.cs
@@ -109,6 +109,7 @@ public sealed class HorizontalBarRankingRegressionTests
             .TryBuild(response, requestedType: "horizontalBar", out ChartSpec? chart)
             .Should().BeTrue();
 
+        chart.Should().NotBeNull("TryBuild returned true and the chart must be materialised");
         chart.Data[0].Values.Should().HaveCount(3,
             "brands with missing/unparseable growth must be excluded, never charted as zero");
         chart.Data[0].Values.Select(p => p.X)

--- a/tests/RetailPulse.Tests/Fixtures/OTelCollection.cs
+++ b/tests/RetailPulse.Tests/Fixtures/OTelCollection.cs
@@ -7,8 +7,8 @@ namespace RetailPulse.Tests.Fixtures;
 /// (e.g., <c>OTelRoutingSpanTests</c>) or emits activities on that source with
 /// tag values that could satisfy another OTel test's filter
 /// (e.g., <c>MafPrimitivesCharacterizationTests</c> exercising the real
-/// <see cref="RetailPulse.Api.Agents.Routing.RetailOpsRouter"/> or
-/// <see cref="RetailPulse.Api.Agents.AgentExecutionPipeline"/>).
+/// <see cref="Api.Agents.Routing.RetailOpsRouter"/> or
+/// <see cref="Api.Agents.AgentExecutionPipeline"/>).
 /// <para>
 /// The <see cref="System.Diagnostics.ActivityListener"/> API is process-wide:
 /// once a listener is registered it captures every matching

--- a/tests/RetailPulse.Tests/Fixtures/OTelCollection.cs
+++ b/tests/RetailPulse.Tests/Fixtures/OTelCollection.cs
@@ -1,0 +1,32 @@
+namespace RetailPulse.Tests.Fixtures;
+
+/// <summary>
+/// Serialization boundary for any test that either installs a process-wide
+/// <see cref="System.Diagnostics.ActivityListener"/> against the
+/// <c>RetailPulse.Agent</c> <see cref="System.Diagnostics.ActivitySource"/>
+/// (e.g., <c>OTelRoutingSpanTests</c>) or emits activities on that source with
+/// tag values that could satisfy another OTel test's filter
+/// (e.g., <c>MafPrimitivesCharacterizationTests</c> exercising the real
+/// <see cref="RetailPulse.Api.Agents.Routing.RetailOpsRouter"/> or
+/// <see cref="RetailPulse.Api.Agents.AgentExecutionPipeline"/>).
+/// <para>
+/// The <see cref="System.Diagnostics.ActivityListener"/> API is process-wide:
+/// once a listener is registered it captures every matching
+/// <see cref="System.Diagnostics.Activity"/> from every thread until it is
+/// disposed. That means a listener installed by one xUnit test class can
+/// receive activities emitted by a different test class running in parallel,
+/// contaminating <c>LastOrDefault</c>-style span assertions that assume the
+/// captured list only contains the current test's activities.
+/// </para>
+/// <para>
+/// Joining the <c>OTel</c> collection prevents that: xUnit runs every test in
+/// this collection strictly serially, and <see cref="DisableParallelization"/>
+/// also blocks the collection from running in parallel with any other test
+/// collection, so no unrelated test can emit RetailPulse.Agent activities into
+/// the OTel window.
+/// </para>
+/// </summary>
+[CollectionDefinition("OTel", DisableParallelization = true)]
+public sealed class OTelCollection
+{
+}


### PR DESCRIPTION
Closes #89

---

## Third revision — mechanical lint correction (Chick, 2026-08-20)

**Revision owner:** Chick (Frontend Dev) — third revision author under reviewer-lockout protocol. Costco (original author, commit `578bdb5`) and Publix (second revision author, commit `f93362d`) are both locked out per `.github/skills/reviewer-protocol/SKILL.md`.

**Scope:** Mechanical format-only changes required to make `dotnet format RetailPulse.slnx --verify-no-changes --verbosity minimal` exit 0 after Kroger's rejection of head `f93362d`.

**New commit:** `a811a0f` — _fix(lint): normalize CRLF to LF, resolve IDE0001/IDE0008/JSON002 (#89)_

### Lint gate (`dotnet format RetailPulse.slnx --verify-no-changes --verbosity minimal`)

```
Format complete in ~29s.
Exit code: 0 ✅
```

### Changes made (3 files, mechanical only)

| File | Fixes applied |
|------|---------------|
| `src/RetailPulse.Api/Agents/MafAgentInvoker.cs` | CRLF → LF (93 lines); IDE0001 simplify `System.Collections.Generic.IEnumerable` and `System.Threading.CancellationToken` in doc-comment cref |
| `tests/RetailPulse.Tests/Fixtures/OTelCollection.cs` | CRLF → LF (32 lines); IDE0001 simplify `RetailPulse.Api.Agents.Routing.RetailOpsRouter` and `RetailPulse.Api.Agents.AgentExecutionPipeline` crefs |
| `tests/RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs` | CRLF → LF (555 lines); IDE0001 at 5 sites; IDE0008 explicit-type at all `var` sites (13 occurrences: `MafAgentResponse`, `ChatOptions?`, `Contracts.ChatResponse`, `RoutingDecision`, `CouncilVerdict`, `Activity?`, `ActivityTraceId`, `bool`, `StackFrame`, `Type?`, `string?`, two `Activity?` for span locals); WHITESPACE alignment in `[InlineData]` attributes and switch-expression arms; JSON002 resolved with narrow `#pragma warning disable/restore JSON002` (with explanatory comment) in place of the formatter-inserted `/*lang=json,strict*/` that left a formatter-unstable whitespace inconsistency—per Kroger's explicit approval in the revision assignment |

### JSON002 approach

Kroger's rejection explicitly approved "a narrow `#pragma warning disable JSON002` with a comment noting it is a deliberate stub-vote payload." The `/*lang=json,strict*/` comment that `dotnet format` auto-inserted during fixing left an inconsistently-indented multi-line artifact that caused a new WHITESPACE error on the next `--verify-no-changes` run (infinite formatter disagreement). The `#pragma warning disable/restore JSON002` approach is narrowly scoped to the consensus probe construction call, carries the required explanatory comment, and produces no residual whitespace errors.

### Build + tests (unchanged from f93362d)

- `dotnet build RetailPulse.slnx -c Release`: **0 Warning(s) / 0 Error(s)** ✅
- `dotnet test tests/RetailPulse.Tests -c Release --no-build`: **2706 passed / 0 failed / 0 skipped** ✅ (1m 32s)

No test assertions altered, no test coverage removed or weakened, no MAF architecture or behaviour changed.

---

Closes #89

## Architecture / execution model

Introduces a single, static invocation seam,
`RetailPulse.Api.Agents.MafAgentInvoker`, that every LLM-facing surface now
routes through. Per invocation it constructs a Microsoft Agent Framework
1.18.0 `ChatClientAgent`, wraps the caller''s `ChatOptions` in a
`ChatClientAgentRunOptions`, and calls
`ChatClientAgent.RunAsync(messages, session: null, runOptions, ct)` — returning
the real MAF `AgentResponse`. Callers convert to
`Microsoft.Extensions.AI.ChatResponse` through the documented shallow-copy
`AgentResponseExtensions.AsChatResponse()`, so downstream helpers (chart
extraction, tool-span recording, token cost, ADR-006 budget bookkeeping) see
the exact same `Messages`/`Usage` list references.

**Load-bearing invariant**: `ChatClientAgentOptions.UseProvidedChatClientAsIs
= true`. The production DI stack in `Program.cs` already wraps the base
`IChatClient` with `UseFunctionInvocation(client =>
client.MaximumIterationsPerRequest = 3)` (ADR-006), `UseOpenTelemetry(...)`,
the MCP HTTP retry/circuit-breaker/cache handlers, and the anonymous-output
cap. Letting MAF add its own `FunctionInvokingChatClient` on top would
silently override the ADR-006 iteration cap, duplicate OTel spans, and move
MCP resilience one layer out. This flag preserves the caller''s decorator
stack end-to-end.

The three call sites migrated in this PR:

- **Specialists** — `AgentExecutionPipeline.ExecuteAsync` and
  `ExecuteWithProgressAsync` (all 10 specialists inherit this path).
- **Router** — `RetailOpsRouter.ClassifyIntentAsync` (LLM classification when
  the keyword fast-path misses).
- **Council** — `ConsensusOrchestrator.CollectVoteAsync` (per-agent voter) and
  `SynthesizeVerdictAsync` (final synthesis pass).

`ISpecialistAgent`, `IAgentRouter`, and `IConsensusCouncil` stay unchanged;
the migration is internal to the three implementations.

## Preserved contracts (verified)

- ADR-006 iteration cap `MaximumIterationsPerRequest = 3`.
- OpenTelemetry span sequence: `agent.thought` → `agent.response` with tool
  spans nested inside; `Tags["span.type"]` byte-preserved.
- ADR-006 tool-context budget behaviour and tests unmodified.
- Durable model-aware input / output / total token cost.
- All 9 chart types (`DeterministicChartBuilder`, chart fulfillment gate).
- `InstrumentedToolMiddleware` timings + `ToolInvocationTimings` scope.
- `StreamingProgressFeature` progress emission.
- Blocking `ApprovalTool` pause / resume.
- MCP retry / circuit-breaker / cache HTTP handlers.
- Anonymous output caps (`IAnonymousChatPolicy`).
- Cancellation / timeouts (rate-limit 429, task-canceled, operation-canceled).
- Router / council `ChatOptions` (temperature, `ResponseFormat.Json`,
  max-output-tokens) reach the chat client unchanged — proven by
  `MafAgentInvoker_PreservesChatOptions_ForToolAndResponseFormatContracts`.
- `AsyncLocal` `RequestToolContext` and `ToolInvocationTimings` still flow
  through MAF tool calls because `UseProvidedChatClientAsIs = true` keeps the
  same decorator stack that owns them.

## Characterization tests

`tests/RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs` now
contains **17 tests** — 7 focused `[Fact]`s plus a maintainable `[Theory]`
that fans out across every one of the 10 production `ISpecialistAgent`
keys. The proof-of-MAF assertion is stack-frame based: a probe
`IChatClient` walks the managed call stack on every `GetResponseAsync`
call and asserts a `Microsoft.Agents.AI.*` frame is present. A future
refactor that quietly bypasses MAF and calls `IChatClient.GetResponseAsync`
directly will fail these tests.

| Test | What it proves |
|------|----------------|
| `MafAgentInvoker_ReturnsGenuineMafAgentResponse` | Adapter returns a real `Microsoft.Agents.AI.AgentResponse` with populated `Text` and `Messages`. |
| `MafAgentInvoker_InvokesUnderlyingChatClientThroughMafFrame` | Invocation stack contains `Microsoft.Agents.AI.*` — this is a real MAF primitive, not a symbol wrapper. |
| `MafAgentInvoker_PreservesChatOptions_ForToolAndResponseFormatContracts` | Temperature, tool list, response format, max-output-tokens reach the chat client unchanged (validates `UseProvidedChatClientAsIs = true`). |
| `Specialist_ExecutesThroughMafChatClientAgent` | End-to-end specialist run flows through MAF. |
| `Router_ClassifiesIntentThroughMafChatClientAgent` | Router LLM classification flows through MAF (keyword fast-path deliberately bypassed). |
| `ConsensusOrchestrator_VoterAndSynthesizer_BothRouteThroughMaf` | 3 parallel votes + 1 synthesis pass = exactly 4 MAF-routed calls. |
| `Specialist_EmitsAgentThoughtAndAgentResponseSpans_InCorrectOrder` | Span sequence characterization: `agent.thought` opens first, `agent.response` is a child; TraceId-scoped so parallel xUnit tests don''t contaminate. |
| `Specialist_HandlerBehavior_MatchesMafRoutingContract_ForEachKey` `[Theory: 10 rows]` | Representative prompt per specialist. Nine LLM-backed keys each prove `HandleAsync` issues exactly one chat call inside a `ChatClientAgent` frame. The tenth key (`memory-management`) is characterized honestly as rules-only. |

### Test-isolation revision (post-review)

The first head of this PR flaked `OTelRoutingSpanTests` at 1/5 full-suite
runs because `MafPrimitivesCharacterizationTests` ran in parallel with it
and emitted `agent.routing` / `agent.thought` / `agent.response` spans on
the shared `RetailPulse.Agent` `ActivitySource`. Revision fix (commit `f93362d`):
adds `[CollectionDefinition("OTel", DisableParallelization = true)]` in
`OTelCollection.cs` and applies `[Collection("OTel")]` to
`MafPrimitivesCharacterizationTests`. xUnit now runs every test in the two
classes strictly serially; cross-contamination is structurally impossible.

## Build + tests

- Full solution build (`dotnet build RetailPulse.slnx -c Release`): **0 warnings / 0 errors**.
- `dotnet format RetailPulse.slnx --verify-no-changes --verbosity minimal`: **exit 0** (added in third revision per Kroger requirement).
- Full test suite (`dotnet test tests/RetailPulse.Tests -c Release`):
  **2706 passed / 0 failed / 0 skipped** (baseline 2689 + 7 characterization Facts + 10 Theory rows).

### Post-revision convergence proof (5 consecutive full-suite runs, `--no-build`)

| Run | Failed | Passed | Skipped | Total | Elapsed_s |
| --- | ------ | ------ | ------- | ----- | --------- |
| 1   | 0      | 2706   | 0       | 2706  | 97.2 |
| 2   | 0      | 2706   | 0       | 2706  | 94.3 |
| 3   | 0      | 2706   | 0       | 2706  | 98.9 |
| 4   | 0      | 2706   | 0       | 2706  | 93.9 |
| 5   | 0      | 2706   | 0       | 2706  | 96.1 |

## Existing-test changes

Only one existing test file was modified (commits `578bdb5`/`f93362d`):
`tests/RetailPulse.Tests/Charts/HorizontalBarRankingRegressionTests.cs` — one
`chart.Should().NotBeNull(...)` added before an existing `.HaveCount(3, ...)`
check. Strict strengthening; no assertion weakened, deleted, or skipped.

## Load-test and manual telemetry blockers (honest disclosure)

- **Load tests cannot produce local p50/p95.** `RetailPulse.LoadTests` facts
  remain deliberately skipped at the baseline. No fabricated load metrics.
- **Manual Aspire dashboard / live OTel verification not possible** in this
  environment. Span-sequence, tool-invocation, and MAF routing invariants are
  validated in-process via the characterization tests.

## Unresolved risks

- The characterization tests rely on the currently-observed shape of MAF
  1.18.0''s internal stack. A future MAF patch that reorganises internals
  could change frame ordering; the assertion only checks that some
  `Microsoft.Agents.AI.*` frame exists on the call stack.

## Kroger review checklist (Reviewer)

- [ ] MAF invocation path is genuine (grep + characterization tests)
- [ ] `UseProvidedChatClientAsIs = true` rationale sound; ADR-006 iteration cap and OTel decorator stack preserved
- [ ] Router + council preserve exact `ChatOptions` (temperature, response format, max tokens)
- [ ] No `.squad/*` files staged; only intended issue #89 sources / tests / docs / ADR
- [ ] Existing tests only strengthened (`HorizontalBarRankingRegressionTests`)
- [ ] Load-test / manual-telemetry limitations honestly disclosed
- [ ] ADR-007 captures the durable execution model and rejected alternatives
- [ ] Test-isolation revision cleanly serializes MAF characterization tests with `OTelRoutingSpanTests`
- [ ] `dotnet format --verify-no-changes` exit 0 (third revision, commit `a811a0f`)
- [ ] 2706 passed / 0 failed / 0 skipped

PR remains **DRAFT** — Kroger to review before mark-ready.