### PR TITLE
feat(rag): pluggable knowledge providers with in-memory BM25 as default (#102)

### DIFF
--- a/docs/adr/009-knowledge-provider-abstraction.md
+++ b/docs/adr/009-knowledge-provider-abstraction.md
@@ -1,0 +1,199 @@
+# ADR-009: Pluggable knowledge providers (in-memory BM25 as default)
+
+## Status
+
+Accepted (Wave 5 seam - abstraction, configuration surface, degradation
+policy, and conformance suite only). Cloud implementations land in later
+issues (#103 Azure AI Search, #104 Foundry IQ) and per-agent knowledge
+binding lands in #105.
+
+## Context
+
+`InMemoryKnowledgeBase` scores documents with BM25 over a
+`ConcurrentDictionary`, capped at 100 documents and 5,000 chunks, and is
+entirely volatile. `KnowledgeBaseSeeder` reloads a sample corpus at startup,
+so the volatility is invisible until a user uploads their own document and
+then loses it on restart.
+
+The current implementation must be preserved. It has zero dependencies,
+starts instantly, and keeps `dotnet run --project src/RetailPulse.AppHost`
+working on a laptop with no cloud resources. That property is non-negotiable
+per the umbrella (#87) constraint "No new hard cloud dependencies."
+
+What we need is the ability to opt in to real semantic retrieval - Azure AI
+Search, Foundry IQ - without making cloud resources a requirement. Callers
+that consume the knowledge base (`RagContextProvider`, the message-extension
+endpoint, the future per-agent knowledge binding in #105) must be
+provider-agnostic.
+
+A configured cloud provider that is unreachable at startup or query time
+must NEVER silently return zero results. Empty results are reserved for
+"no matching documents in the corpus" and must not be conflated with "the
+backend is down". The operator must be able to opt into loud failure or
+explicit fallback - not have the platform silently limp along.
+
+## Decision
+
+Introduce a thin provider seam behind `IKnowledgeBase` selected by
+configuration. Ship only the seam in this issue; the InMemory provider is
+the default and remains unchanged.
+
+### 1. Contract extensions
+
+`IKnowledgeBase` (in `RetailPulse.Contracts.Rag`) gains two members:
+
+- `KnowledgeBaseCapabilities GetCapabilities()` - honest, static description
+  of the provider: name, relevance kind (`Lexical` / `Semantic` / `Hybrid`),
+  persistence, cloud-dependency flag, provider-enforced quotas, and a
+  `ScoreSemantics` string that always includes the reminder that scores are
+  provider-local and NOT comparable across providers.
+- `Task ProbeAsync(CancellationToken ct)` - verifies the backend is
+  reachable. The InMemory implementation is a no-op; cloud providers do a
+  cheap availability check. On unreachable backends the provider throws
+  `KnowledgeProviderUnavailableException`.
+
+`KnowledgeProviderUnavailableException` (also in `Contracts.Rag`) is the
+contract signal. Providers MUST throw it rather than returning an empty
+result to signal outage.
+
+### 2. Configuration
+
+A new `Knowledge:Provider` subsection binds to `KnowledgeProviderOptions`:
+
+```jsonc
+"Knowledge": {
+  "Provider": {
+    "Mode": "InMemory",              // or "AzureAISearch", "FoundryIQ"
+    "Degradation": "FailLoud"        // or "FallbackToInMemory"
+  }
+}
+```
+
+Resolution rules (`KnowledgeProviderSelector`):
+
+- Missing / blank `Mode` -> **InMemory** (documented default; zero cloud
+  dependency).
+- Missing / blank `Degradation` -> **FailLoud** (a cloud provider is opted
+  into deliberately; the operator should hear about outages).
+- Unknown / malformed value in either field -> **fails startup** with an
+  actionable message that names the field, echoes the offending value, and
+  lists the valid options. Bare numeric input is rejected.
+
+The existing `Knowledge` quotas (`MaxDocuments`, `MaxChunks`,
+`MaxDocumentSizeBytes`) remain in place and remain meaningful per provider.
+Each provider reports its own quotas via `GetCapabilities()`.
+
+### 3. Provider registration
+
+`KnowledgeProviderRegistry` is the reusable seam. Providers register
+factories keyed by `KnowledgeProviderMode`:
+
+```csharp
+registry.Register(KnowledgeProviderMode.InMemory,
+    sp => sp.GetRequiredService<InMemoryKnowledgeBase>());
+```
+
+`Program.cs` registers the InMemory factory automatically. Cloud modules
+(#103, #104) register their own factories from their opt-in extension
+methods. Selecting a mode that has no registered factory throws at startup
+with a message that lists the registered modes - an operator who typos
+`AzureAiSearch` or selects a mode before wiring its module gets a clear
+error, never a silent degradation.
+
+### 4. Degradation policy
+
+`DegradingKnowledgeBase` decorates the resolved primary and holds a
+reference to the always-registered in-memory instance as its fallback
+target.
+
+- **Startup probe** (`ProbeAsync`): delegates to the primary.
+  - `FailLoud`: `KnowledgeProviderUnavailableException` propagates, startup
+    aborts.
+  - `FallbackToInMemory`: logs a prominent warning and swaps the active
+    provider to the in-memory fallback for the remainder of the process
+    lifetime.
+- **Query-time** (search / ingest / list / delete):
+  - `FailLoud`: all exceptions propagate to the caller; the endpoint layer
+    surfaces a 5xx.
+  - `FallbackToInMemory`: a `KnowledgeProviderUnavailableException` from
+    the primary is re-tried against the in-memory fallback for that one
+    request; the primary remains the configured provider for future
+    requests. Any other exception still propagates.
+
+The decorator NEVER catches an exception and returns an empty result. When
+fallback is active the caller sees the fallback's genuine response; when
+fallback is disabled the caller sees the failure.
+
+### 5. Consumer wiring
+
+`RagContextProvider` and the knowledge / message-extension endpoints
+consume `IKnowledgeBase` only. They never reference `InMemoryKnowledgeBase`
+directly and never inspect the concrete provider type - the abstraction is
+the only surface.
+
+### 6. Sample-corpus seeding
+
+`KnowledgeBaseSeeder` continues to seed the InMemory instance on startup,
+but only when it is the active provider (either as the configured primary
+or because startup degradation swapped it in). A healthy cloud provider is
+never seeded from process start - its corpus is managed independently by
+#103/#104.
+
+### 7. Shared conformance suite
+
+`KnowledgeBaseConformanceTests` (abstract) codifies the invariants every
+provider must satisfy: ingest returns an id, search on an empty corpus
+returns empty, ingested content is discoverable, list surfaces ingested
+documents, delete removes documents and their chunks, capabilities report
+a non-empty provider name, scores are non-negative, and a healthy
+`ProbeAsync` completes without throwing. `InMemoryKnowledgeBaseConformanceTests`
+is the initial concrete instantiation. Future provider issues (#103, #104)
+add their own concrete instantiation of the same base class.
+
+## Consequences
+
+### Positive
+
+- The laptop demo is unchanged: default mode is InMemory, degradation
+  irrelevant, no cloud packages referenced or restored.
+- Adding a cloud provider is now a matter of implementing `IKnowledgeBase`
+  and registering a factory. No changes to `Program.cs`, endpoints, or
+  `RagContextProvider` are required.
+- Degradation behavior is honest and configurable - the operator picks
+  fail-loud (default) or explicit fallback, and empty results always mean
+  what they say.
+- The conformance suite gives every future provider a floor of contract
+  invariants without hand-rolled per-provider tests.
+
+### Negative
+
+- `IKnowledgeBase` grows two members. Any external implementer (there are
+  none in-repo besides the InMemory provider and test doubles) must
+  implement them.
+- The DI wiring gains one decorator hop (`DegradingKnowledgeBase` around
+  the primary). Overhead is a single virtual call per operation, dominated
+  by BM25 scoring or a network round-trip.
+- Providers that do not distinguish "unreachable" from "misconfigured" will
+  fail loud even under the `FallbackToInMemory` policy. This is intentional
+  - misconfiguration should not silently degrade to a different corpus.
+
+### Explicitly out of scope
+
+- No Azure AI Search implementation (#103).
+- No Foundry IQ implementation (#104).
+- No per-agent knowledge binding (#105).
+- No changes to BM25 semantics, ranking, or the InMemory quotas.
+- No changes under `src/RetailPulse.Api/Agents/` (concurrent migration).
+
+## Compliance with umbrella constraints (#87)
+
+- **No new hard cloud dependencies.** InMemory remains the default; no
+  cloud packages added.
+- **No regressions.** `IKnowledgeBase` behavior for the InMemory provider
+  is unchanged; existing InMemory tests pass unmodified.
+- **Feature-disabled test coverage.** Selection tests cover the default
+  (blank config to InMemory), unknown-mode fail-fast, unknown-degradation
+  fail-fast, and the "recognized but unregistered" case. Degradation tests
+  cover both policies against a deliberately unreachable test provider.
+- **Documentation is part of done.** This ADR, updated `appsettings.json`
+  comments, and updated inline XML docs ship in the same PR.

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -76,6 +76,7 @@ builder.Services.AddHealthChecks()
 
 // Quota configuration (IOptions pattern)
 builder.Services.Configure<KnowledgeOptions>(builder.Configuration.GetSection(KnowledgeOptions.SectionName));
+builder.Services.Configure<KnowledgeProviderOptions>(builder.Configuration.GetSection(KnowledgeProviderOptions.SectionName));
 builder.Services.Configure<ObservabilityOptions>(builder.Configuration.GetSection(ObservabilityOptions.SectionName));
 
 // Load tenant configuration
@@ -613,9 +614,38 @@ builder.Services.AddHostedService<TelemetryPushBackgroundService>();
 // ── Pre-demo cache warming (populates MCP response cache on startup) ────
 builder.Services.AddHostedService<RetailPulse.Api.Startup.CacheWarmingService>();
 
-// RAG Knowledge Base — in-memory BM25-based document store (no Azure dependency)
+// ── RAG Knowledge Base ──────────────────────────────────────────────────
+// The in-memory BM25 provider is the DEFAULT and works on a laptop with no
+// cloud dependencies. The provider abstraction lets cloud providers (#103
+// Azure AI Search, #104 Foundry IQ) opt in via configuration without changing
+// call sites. See docs/adr/009-knowledge-provider-abstraction.md.
 builder.Services.AddSingleton<InMemoryKnowledgeBase>();
-builder.Services.AddSingleton<IKnowledgeBase>(sp => sp.GetRequiredService<InMemoryKnowledgeBase>());
+builder.Services.AddSingleton<KnowledgeProviderRegistry>(sp =>
+{
+    // Every process registers the in-memory factory automatically so it is
+    // always available as the default primary and as the fallback target for
+    // KnowledgeDegradationMode.FallbackToInMemory. Cloud modules (#103/#104)
+    // register their own factories from their opt-in extension methods.
+    var registry = new KnowledgeProviderRegistry();
+    registry.Register(
+        KnowledgeProviderMode.InMemory,
+        s => s.GetRequiredService<InMemoryKnowledgeBase>());
+    return registry;
+});
+builder.Services.AddSingleton<KnowledgeProviderSelector>();
+builder.Services.AddSingleton<DegradingKnowledgeBase>(sp =>
+{
+    KnowledgeProviderSelector selector = sp.GetRequiredService<KnowledgeProviderSelector>();
+    IKnowledgeBase primary = selector.CreatePrimary(sp);
+    InMemoryKnowledgeBase fallback = sp.GetRequiredService<InMemoryKnowledgeBase>();
+    KnowledgeDegradationMode degradation = selector.ResolveDegradation();
+    return new DegradingKnowledgeBase(
+        primary,
+        fallback,
+        degradation,
+        sp.GetRequiredService<ILogger<DegradingKnowledgeBase>>());
+});
+builder.Services.AddSingleton<IKnowledgeBase>(sp => sp.GetRequiredService<DegradingKnowledgeBase>());
 builder.Services.AddSingleton<RagContextProvider>();
 
 // Response cache — in-memory with TTL expiration and LRU eviction
@@ -1008,9 +1038,29 @@ WebApplication app = builder.Build();
 
 // Seed RAG knowledge base with sample documents (idempotent)
 {
-    InMemoryKnowledgeBase kb = app.Services.GetRequiredService<InMemoryKnowledgeBase>();
+    // Run the startup probe for the configured provider. FailLoud lets a
+    // cloud outage propagate and abort startup; FallbackToInMemory swaps to
+    // the always-available in-memory instance and logs a prominent warning.
+    // The probe is a no-op for the InMemory default.
+    DegradingKnowledgeBase kb = app.Services.GetRequiredService<DegradingKnowledgeBase>();
+    await kb.ProbeAsync();
+
+    // Seed the sample corpus into the in-memory instance whenever it is the
+    // provider that will actually serve requests — either as the configured
+    // primary or because degradation swapped it in. Cloud providers manage
+    // their own corpora and are not seeded from process start.
     ILogger seedLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("KnowledgeBaseSeeder");
-    await KnowledgeBaseSeeder.SeedAsync(kb, seedLogger);
+    if (kb.ActiveProviderName == InMemoryKnowledgeBase.ProviderName)
+    {
+        InMemoryKnowledgeBase inMemory = app.Services.GetRequiredService<InMemoryKnowledgeBase>();
+        await KnowledgeBaseSeeder.SeedAsync(inMemory, seedLogger);
+    }
+    else
+    {
+        seedLogger.LogInformation(
+            "Knowledge provider '{Provider}' is active — skipping in-memory sample corpus seeding.",
+            kb.ActiveProviderName);
+    }
 }
 
 // Select CORS policy based on environment

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -620,7 +620,7 @@ builder.Services.AddHostedService<RetailPulse.Api.Startup.CacheWarmingService>()
 // Azure AI Search, #104 Foundry IQ) opt in via configuration without changing
 // call sites. See docs/adr/009-knowledge-provider-abstraction.md.
 builder.Services.AddSingleton<InMemoryKnowledgeBase>();
-builder.Services.AddSingleton<KnowledgeProviderRegistry>(sp =>
+builder.Services.AddSingleton(sp =>
 {
     // Every process registers the in-memory factory automatically so it is
     // always available as the default primary and as the fallback target for
@@ -633,7 +633,7 @@ builder.Services.AddSingleton<KnowledgeProviderRegistry>(sp =>
     return registry;
 });
 builder.Services.AddSingleton<KnowledgeProviderSelector>();
-builder.Services.AddSingleton<DegradingKnowledgeBase>(sp =>
+builder.Services.AddSingleton(sp =>
 {
     KnowledgeProviderSelector selector = sp.GetRequiredService<KnowledgeProviderSelector>();
     IKnowledgeBase primary = selector.CreatePrimary(sp);

--- a/src/RetailPulse.Api/Rag/DegradingKnowledgeBase.cs
+++ b/src/RetailPulse.Api/Rag/DegradingKnowledgeBase.cs
@@ -30,7 +30,6 @@ public sealed class DegradingKnowledgeBase : IKnowledgeBase
 {
     private readonly IKnowledgeBase _primary;
     private readonly IKnowledgeBase _fallback;
-    private readonly KnowledgeDegradationMode _degradation;
     private readonly ILogger<DegradingKnowledgeBase> _logger;
 
     // Startup-probe outcome. Until ProbeAsync has run, data-plane calls go to
@@ -45,7 +44,7 @@ public sealed class DegradingKnowledgeBase : IKnowledgeBase
     {
         _primary = primary ?? throw new ArgumentNullException(nameof(primary));
         _fallback = fallback ?? throw new ArgumentNullException(nameof(fallback));
-        _degradation = degradation;
+        DegradationMode = degradation;
         _logger = logger;
         _active = primary;
     }
@@ -64,7 +63,7 @@ public sealed class DegradingKnowledgeBase : IKnowledgeBase
     public bool PrimaryReplacedByFallback { get; private set; }
 
     /// <summary>Configured degradation policy (for observability).</summary>
-    public KnowledgeDegradationMode DegradationMode => _degradation;
+    public KnowledgeDegradationMode DegradationMode { get; }
 
     /// <inheritdoc />
     public async Task ProbeAsync(CancellationToken ct = default)
@@ -76,7 +75,7 @@ public sealed class DegradingKnowledgeBase : IKnowledgeBase
         catch (KnowledgeProviderUnavailableException ex)
         {
             string providerName = SafeProviderName(_primary);
-            if (_degradation == KnowledgeDegradationMode.FallbackToInMemory)
+            if (DegradationMode == KnowledgeDegradationMode.FallbackToInMemory)
             {
                 _logger.LogWarning(ex,
                     "Knowledge provider '{Provider}' failed startup probe — swapping to in-memory fallback " +
@@ -121,7 +120,7 @@ public sealed class DegradingKnowledgeBase : IKnowledgeBase
             return await operation(_active).ConfigureAwait(false);
         }
         catch (KnowledgeProviderUnavailableException ex)
-            when (_degradation == KnowledgeDegradationMode.FallbackToInMemory
+            when (DegradationMode == KnowledgeDegradationMode.FallbackToInMemory
                   && !ReferenceEquals(_active, _fallback))
         {
             _logger.LogWarning(ex,
@@ -139,7 +138,7 @@ public sealed class DegradingKnowledgeBase : IKnowledgeBase
             await operation(_active).ConfigureAwait(false);
         }
         catch (KnowledgeProviderUnavailableException ex)
-            when (_degradation == KnowledgeDegradationMode.FallbackToInMemory
+            when (DegradationMode == KnowledgeDegradationMode.FallbackToInMemory
                   && !ReferenceEquals(_active, _fallback))
         {
             _logger.LogWarning(ex,

--- a/src/RetailPulse.Api/Rag/DegradingKnowledgeBase.cs
+++ b/src/RetailPulse.Api/Rag/DegradingKnowledgeBase.cs
@@ -1,0 +1,158 @@
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Api.Rag;
+
+/// <summary>
+/// Decorator that applies the configured
+/// <see cref="KnowledgeDegradationMode"/> around a primary
+/// <see cref="IKnowledgeBase"/>.
+///
+/// Contract:
+/// <list type="bullet">
+///   <item><see cref="ProbeAsync"/> runs the primary's health probe. On
+///     <see cref="KnowledgeProviderUnavailableException"/>: in
+///     <see cref="KnowledgeDegradationMode.FallbackToInMemory"/> it logs a
+///     prominent warning and permanently swaps the active provider to the
+///     in-memory fallback; in <see cref="KnowledgeDegradationMode.FailLoud"/>
+///     the exception propagates and startup fails.</item>
+///   <item>Data-plane calls (search/ingest/list/delete) propagate all provider
+///     exceptions to the caller in <see cref="KnowledgeDegradationMode.FailLoud"/>.
+///     In <see cref="KnowledgeDegradationMode.FallbackToInMemory"/>, a
+///     <see cref="KnowledgeProviderUnavailableException"/> from the primary is
+///     re-tried against the fallback for that single request; other exceptions
+///     still propagate.</item>
+/// </list>
+/// The decorator NEVER swallows an exception to return an empty result. When
+/// fallback is active the caller sees the fallback's genuine response; when
+/// fallback is disabled the caller sees the failure.
+/// </summary>
+public sealed class DegradingKnowledgeBase : IKnowledgeBase
+{
+    private readonly IKnowledgeBase _primary;
+    private readonly IKnowledgeBase _fallback;
+    private readonly KnowledgeDegradationMode _degradation;
+    private readonly ILogger<DegradingKnowledgeBase> _logger;
+
+    // Startup-probe outcome. Until ProbeAsync has run, data-plane calls go to
+    // the primary; the runtime-exception fallback still applies per request.
+    private IKnowledgeBase _active;
+
+    public DegradingKnowledgeBase(
+        IKnowledgeBase primary,
+        IKnowledgeBase fallback,
+        KnowledgeDegradationMode degradation,
+        ILogger<DegradingKnowledgeBase> logger)
+    {
+        _primary = primary ?? throw new ArgumentNullException(nameof(primary));
+        _fallback = fallback ?? throw new ArgumentNullException(nameof(fallback));
+        _degradation = degradation;
+        _logger = logger;
+        _active = primary;
+    }
+
+    /// <summary>
+    /// Provider name currently serving traffic after the startup probe (either
+    /// the primary or the in-memory fallback). Prior to <see cref="ProbeAsync"/>
+    /// this is the primary's name. Useful for observability endpoints.
+    /// </summary>
+    public string ActiveProviderName => _active.GetCapabilities().ProviderName;
+
+    /// <summary>
+    /// True when the startup probe caused the primary to be permanently
+    /// replaced by the in-memory fallback for this process lifetime.
+    /// </summary>
+    public bool PrimaryReplacedByFallback { get; private set; }
+
+    /// <summary>Configured degradation policy (for observability).</summary>
+    public KnowledgeDegradationMode DegradationMode => _degradation;
+
+    /// <inheritdoc />
+    public async Task ProbeAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await _primary.ProbeAsync(ct).ConfigureAwait(false);
+        }
+        catch (KnowledgeProviderUnavailableException ex)
+        {
+            string providerName = SafeProviderName(_primary);
+            if (_degradation == KnowledgeDegradationMode.FallbackToInMemory)
+            {
+                _logger.LogWarning(ex,
+                    "Knowledge provider '{Provider}' failed startup probe — swapping to in-memory fallback " +
+                    "per configured degradation policy (FallbackToInMemory). Subsequent requests are served " +
+                    "by the in-memory BM25 corpus, not the configured backend.",
+                    providerName);
+                _active = _fallback;
+                PrimaryReplacedByFallback = true;
+                return;
+            }
+
+            _logger.LogError(ex,
+                "Knowledge provider '{Provider}' failed startup probe. FailLoud policy — startup aborted.",
+                providerName);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public KnowledgeBaseCapabilities GetCapabilities() => _active.GetCapabilities();
+
+    /// <inheritdoc />
+    public Task<string> IngestDocumentAsync(string title, string content, string source, CancellationToken ct = default) =>
+        WithFallbackAsync(kb => kb.IngestDocumentAsync(title, content, source, ct), nameof(IngestDocumentAsync));
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<SearchResult>> SearchAsync(string query, int topK = 5, CancellationToken ct = default) =>
+        WithFallbackAsync(kb => kb.SearchAsync(query, topK, ct), nameof(SearchAsync));
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<DocumentInfo>> ListDocumentsAsync(CancellationToken ct = default) =>
+        WithFallbackAsync(kb => kb.ListDocumentsAsync(ct), nameof(ListDocumentsAsync));
+
+    /// <inheritdoc />
+    public Task DeleteDocumentAsync(string documentId, CancellationToken ct = default) =>
+        WithFallbackAsync(kb => kb.DeleteDocumentAsync(documentId, ct), nameof(DeleteDocumentAsync));
+
+    private async Task<TResult> WithFallbackAsync<TResult>(Func<IKnowledgeBase, Task<TResult>> operation, string opName)
+    {
+        try
+        {
+            return await operation(_active).ConfigureAwait(false);
+        }
+        catch (KnowledgeProviderUnavailableException ex)
+            when (_degradation == KnowledgeDegradationMode.FallbackToInMemory
+                  && !ReferenceEquals(_active, _fallback))
+        {
+            _logger.LogWarning(ex,
+                "Knowledge provider '{Provider}' unavailable during {Operation} — serving this request from " +
+                "the in-memory fallback (primary remains the configured provider for future requests).",
+                ex.ProviderName, opName);
+            return await operation(_fallback).ConfigureAwait(false);
+        }
+    }
+
+    private async Task WithFallbackAsync(Func<IKnowledgeBase, Task> operation, string opName)
+    {
+        try
+        {
+            await operation(_active).ConfigureAwait(false);
+        }
+        catch (KnowledgeProviderUnavailableException ex)
+            when (_degradation == KnowledgeDegradationMode.FallbackToInMemory
+                  && !ReferenceEquals(_active, _fallback))
+        {
+            _logger.LogWarning(ex,
+                "Knowledge provider '{Provider}' unavailable during {Operation} — serving this request from " +
+                "the in-memory fallback (primary remains the configured provider for future requests).",
+                ex.ProviderName, opName);
+            await operation(_fallback).ConfigureAwait(false);
+        }
+    }
+
+    private static string SafeProviderName(IKnowledgeBase kb)
+    {
+        try { return kb.GetCapabilities().ProviderName; }
+        catch { return kb.GetType().Name; }
+    }
+}

--- a/src/RetailPulse.Api/Rag/InMemoryKnowledgeBase.cs
+++ b/src/RetailPulse.Api/Rag/InMemoryKnowledgeBase.cs
@@ -12,6 +12,9 @@ namespace RetailPulse.Api.Rag;
 /// </summary>
 public sealed class InMemoryKnowledgeBase : IKnowledgeBase
 {
+    /// <summary>Stable name reported in <see cref="GetCapabilities"/>.</summary>
+    public const string ProviderName = "InMemory";
+
     // BM25 parameters (standard values)
     private const double _k1 = 1.2;
     private const double _b = 0.75;
@@ -193,6 +196,29 @@ public sealed class InMemoryKnowledgeBase : IKnowledgeBase
 
     public int DocumentCount => _documents.Count;
     public int ChunkCount => _chunks.Count;
+
+    /// <inheritdoc />
+    public KnowledgeBaseCapabilities GetCapabilities() => new(
+        ProviderName: ProviderName,
+        Relevance: KnowledgeRelevanceKind.Lexical,
+        Persistent: false,
+        RequiresCloud: false,
+        Quotas: new KnowledgeQuotas(
+            MaxDocuments: _options.MaxDocuments,
+            MaxChunks: _options.MaxChunks,
+            MaxDocumentSizeBytes: _options.MaxDocumentSizeBytes),
+        ScoreSemantics:
+            "BM25 lexical score, normalized 0-1 within a single query response. " +
+            "Scores are provider-local and not comparable across providers.");
+
+    /// <inheritdoc />
+    public Task ProbeAsync(CancellationToken ct = default)
+    {
+        // In-memory provider has no external dependency — it is always reachable
+        // once the process is running. We honour cancellation for API parity.
+        ct.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
 
     private static string[] Tokenize(string text) =>
         [.. text.ToLowerInvariant()

--- a/src/RetailPulse.Api/Rag/KnowledgeDegradationMode.cs
+++ b/src/RetailPulse.Api/Rag/KnowledgeDegradationMode.cs
@@ -1,0 +1,30 @@
+namespace RetailPulse.Api.Rag;
+
+/// <summary>
+/// How the abstraction layer should behave when the configured
+/// <see cref="RetailPulse.Contracts.Rag.IKnowledgeBase"/> provider is
+/// unreachable — at startup or at query time.
+///
+/// The two options are the only supported policies. Silently returning an
+/// empty result set is explicitly NOT a supported behavior — an empty result
+/// means "no matching documents in the corpus" and can never be conflated with
+/// "the backend is down".
+/// </summary>
+public enum KnowledgeDegradationMode
+{
+    /// <summary>
+    /// Surface the failure. Startup fails; query-time failures propagate to the
+    /// caller (endpoints return 5xx). This is the safest default when a cloud
+    /// provider is intentionally configured — the operator wants to know it is
+    /// broken, not have the platform silently limp along.
+    /// </summary>
+    FailLoud = 0,
+
+    /// <summary>
+    /// Log a prominent warning and swap the active provider to the always-available
+    /// in-memory BM25 knowledge base. Suitable when the operator prefers
+    /// availability over cloud fidelity and understands that the corpus falls
+    /// back to whatever the local seeder loaded.
+    /// </summary>
+    FallbackToInMemory = 1,
+}

--- a/src/RetailPulse.Api/Rag/KnowledgeDegradationMode.cs
+++ b/src/RetailPulse.Api/Rag/KnowledgeDegradationMode.cs
@@ -2,7 +2,7 @@ namespace RetailPulse.Api.Rag;
 
 /// <summary>
 /// How the abstraction layer should behave when the configured
-/// <see cref="RetailPulse.Contracts.Rag.IKnowledgeBase"/> provider is
+/// <see cref="Contracts.Rag.IKnowledgeBase"/> provider is
 /// unreachable — at startup or at query time.
 ///
 /// The two options are the only supported policies. Silently returning an

--- a/src/RetailPulse.Api/Rag/KnowledgeProviderMode.cs
+++ b/src/RetailPulse.Api/Rag/KnowledgeProviderMode.cs
@@ -1,7 +1,7 @@
 namespace RetailPulse.Api.Rag;
 
 /// <summary>
-/// Selects which <see cref="RetailPulse.Contracts.Rag.IKnowledgeBase"/>
+/// Selects which <see cref="Contracts.Rag.IKnowledgeBase"/>
 /// implementation the API uses at runtime. Bound from configuration through
 /// <see cref="KnowledgeProviderOptions"/>.
 ///

--- a/src/RetailPulse.Api/Rag/KnowledgeProviderMode.cs
+++ b/src/RetailPulse.Api/Rag/KnowledgeProviderMode.cs
@@ -1,0 +1,32 @@
+namespace RetailPulse.Api.Rag;
+
+/// <summary>
+/// Selects which <see cref="RetailPulse.Contracts.Rag.IKnowledgeBase"/>
+/// implementation the API uses at runtime. Bound from configuration through
+/// <see cref="KnowledgeProviderOptions"/>.
+///
+/// Only <see cref="InMemory"/> is implemented in this repository — the cloud
+/// modes are registered by their respective opt-in packages (#103, #104) and
+/// fail loudly at startup when their configuration is selected but their
+/// registration is not present.
+/// </summary>
+public enum KnowledgeProviderMode
+{
+    /// <summary>
+    /// Volatile in-memory BM25 knowledge base. Zero cloud dependencies, works on
+    /// a laptop, ships as the default.
+    /// </summary>
+    InMemory = 0,
+
+    /// <summary>
+    /// Azure AI Search (opt-in, requires provisioning). Implementation lives in
+    /// a separate issue (#103).
+    /// </summary>
+    AzureAISearch = 1,
+
+    /// <summary>
+    /// Azure AI Foundry IQ knowledge (opt-in). Implementation lives in a
+    /// separate issue (#104).
+    /// </summary>
+    FoundryIQ = 2,
+}

--- a/src/RetailPulse.Api/Rag/KnowledgeProviderOptions.cs
+++ b/src/RetailPulse.Api/Rag/KnowledgeProviderOptions.cs
@@ -1,0 +1,40 @@
+namespace RetailPulse.Api.Rag;
+
+/// <summary>
+/// Configuration surface for selecting the active knowledge provider and its
+/// degradation policy. Bound to the <c>Knowledge:Provider</c> section.
+///
+/// A missing or empty section is a documented, deliberate default:
+/// <see cref="Mode"/> resolves to <see cref="KnowledgeProviderMode.InMemory"/>
+/// and <see cref="Degradation"/> to <see cref="KnowledgeDegradationMode.FailLoud"/>.
+/// The default keeps the platform runnable on a laptop with no cloud resources.
+///
+/// An unknown or malformed value in either field fails startup with a clear,
+/// actionable message via <see cref="KnowledgeProviderSelector"/>. This class
+/// intentionally does not attempt to auto-detect a provider from ambient
+/// signals — the choice is always explicit configuration.
+/// </summary>
+public sealed class KnowledgeProviderOptions
+{
+    /// <summary>Configuration section: <c>Knowledge:Provider</c>.</summary>
+    public const string SectionName = "Knowledge:Provider";
+
+    /// <summary>Full configuration key for the mode selector.</summary>
+    public const string ModeKey = "Knowledge:Provider:Mode";
+
+    /// <summary>Full configuration key for the degradation policy.</summary>
+    public const string DegradationKey = "Knowledge:Provider:Degradation";
+
+    /// <summary>
+    /// Raw mode value from configuration. Blank means "use the default". Kept
+    /// as a string so the selector can produce actionable error messages that
+    /// echo exactly what the operator wrote.
+    /// </summary>
+    public string? Mode { get; set; }
+
+    /// <summary>
+    /// Raw degradation value from configuration. Blank means "use the default"
+    /// (fail loud).
+    /// </summary>
+    public string? Degradation { get; set; }
+}

--- a/src/RetailPulse.Api/Rag/KnowledgeProviderRegistry.cs
+++ b/src/RetailPulse.Api/Rag/KnowledgeProviderRegistry.cs
@@ -1,0 +1,66 @@
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Api.Rag;
+
+/// <summary>
+/// Registry of <see cref="IKnowledgeBase"/> provider factories keyed by
+/// <see cref="KnowledgeProviderMode"/>. Provides the reusable seam future
+/// cloud-provider issues (#103, #104) and tests plug into without touching
+/// the selection or degradation code.
+///
+/// The registry is populated during DI configuration. The InMemory factory
+/// is registered by default. Cloud providers register themselves from their
+/// respective opt-in modules; tests register deliberately unreachable stubs
+/// to exercise the degradation policy.
+/// </summary>
+public sealed class KnowledgeProviderRegistry
+{
+    private readonly Dictionary<KnowledgeProviderMode, Func<IServiceProvider, IKnowledgeBase>> _factories = [];
+
+    /// <summary>
+    /// Registers (or replaces) the factory that materializes the provider for
+    /// <paramref name="mode"/>. The factory receives the request-scoped
+    /// <see cref="IServiceProvider"/> so it can pull its own dependencies (e.g.
+    /// options, loggers, HttpClient) from DI.
+    /// </summary>
+    public void Register(KnowledgeProviderMode mode, Func<IServiceProvider, IKnowledgeBase> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        _factories[mode] = factory;
+    }
+
+    /// <summary>
+    /// True when a factory has been registered for <paramref name="mode"/>.
+    /// </summary>
+    public bool IsRegistered(KnowledgeProviderMode mode) => _factories.ContainsKey(mode);
+
+    /// <summary>
+    /// Modes that currently have a registered factory. Useful for producing
+    /// actionable error messages when the selected mode is not available.
+    /// </summary>
+    public IReadOnlyCollection<KnowledgeProviderMode> RegisteredModes => _factories.Keys;
+
+    /// <summary>
+    /// Resolves the provider for <paramref name="mode"/> using the registered
+    /// factory. Throws with a clear message when the mode has not been
+    /// registered — this happens when a cloud mode is selected without the
+    /// corresponding opt-in module wired up.
+    /// </summary>
+    public IKnowledgeBase Create(KnowledgeProviderMode mode, IServiceProvider services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        if (!_factories.TryGetValue(mode, out Func<IServiceProvider, IKnowledgeBase>? factory))
+        {
+            string registered = _factories.Count == 0
+                ? "(none)"
+                : string.Join(", ", _factories.Keys.Select(m => m.ToString()));
+            throw new InvalidOperationException(
+                $"Knowledge provider mode '{mode}' is not registered. " +
+                $"Registered modes: {registered}. " +
+                "Register the provider factory via KnowledgeProviderRegistry.Register(...) " +
+                "before starting the host, or change Knowledge:Provider:Mode to a registered value.");
+        }
+
+        return factory(services);
+    }
+}

--- a/src/RetailPulse.Api/Rag/KnowledgeProviderSelector.cs
+++ b/src/RetailPulse.Api/Rag/KnowledgeProviderSelector.cs
@@ -42,19 +42,13 @@ public sealed class KnowledgeProviderSelector
     /// Resolves the configured provider mode. See class-level docs for defaults
     /// and error behavior.
     /// </summary>
-    public KnowledgeProviderMode ResolveMode()
-    {
-        return ParseMode(_options.Value.Mode);
-    }
+    public KnowledgeProviderMode ResolveMode() => ParseMode(_options.Value.Mode);
 
     /// <summary>
     /// Resolves the configured degradation policy. See class-level docs for
     /// defaults and error behavior.
     /// </summary>
-    public KnowledgeDegradationMode ResolveDegradation()
-    {
-        return ParseDegradation(_options.Value.Degradation);
-    }
+    public KnowledgeDegradationMode ResolveDegradation() => ParseDegradation(_options.Value.Degradation);
 
     /// <summary>
     /// Materializes the primary provider from the registry using the resolved

--- a/src/RetailPulse.Api/Rag/KnowledgeProviderSelector.cs
+++ b/src/RetailPulse.Api/Rag/KnowledgeProviderSelector.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Options;
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Api.Rag;
+
+/// <summary>
+/// Deterministic, fail-fast resolution of the active knowledge provider from
+/// configuration. Selection is intentionally explicit — the selector never
+/// auto-detects a provider from ambient signals.
+///
+/// Resolution rules:
+/// <list type="bullet">
+///   <item>A missing or blank <see cref="KnowledgeProviderOptions.Mode"/> resolves
+///     to <see cref="KnowledgeProviderMode.InMemory"/>. This is the documented
+///     default and preserves the zero-cloud-dependency laptop demo.</item>
+///   <item>A recognized mode (case-insensitive) is honored as-is.</item>
+///   <item>An unknown / malformed value (including a bare number) throws with
+///     an actionable message. Startup fails.</item>
+///   <item>A missing or blank <see cref="KnowledgeProviderOptions.Degradation"/>
+///     resolves to <see cref="KnowledgeDegradationMode.FailLoud"/>. Cloud
+///     providers configured without a policy fail loudly rather than silently
+///     dropping back — the operator opts in to fallback explicitly.</item>
+/// </list>
+/// This class only <i>resolves</i> and <i>materializes</i> the provider. The
+/// startup health probe and query-time degradation live in
+/// <see cref="DegradingKnowledgeBase"/>.
+/// </summary>
+public sealed class KnowledgeProviderSelector
+{
+    private readonly IOptions<KnowledgeProviderOptions> _options;
+    private readonly KnowledgeProviderRegistry _registry;
+
+    public KnowledgeProviderSelector(
+        IOptions<KnowledgeProviderOptions> options,
+        KnowledgeProviderRegistry registry)
+    {
+        _options = options;
+        _registry = registry;
+    }
+
+    /// <summary>
+    /// Resolves the configured provider mode. See class-level docs for defaults
+    /// and error behavior.
+    /// </summary>
+    public KnowledgeProviderMode ResolveMode()
+    {
+        return ParseMode(_options.Value.Mode);
+    }
+
+    /// <summary>
+    /// Resolves the configured degradation policy. See class-level docs for
+    /// defaults and error behavior.
+    /// </summary>
+    public KnowledgeDegradationMode ResolveDegradation()
+    {
+        return ParseDegradation(_options.Value.Degradation);
+    }
+
+    /// <summary>
+    /// Materializes the primary provider from the registry using the resolved
+    /// mode. Delegates all failure modes (unknown mode, unregistered mode) to
+    /// deterministic exceptions the operator can act on.
+    /// </summary>
+    public IKnowledgeBase CreatePrimary(IServiceProvider services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        KnowledgeProviderMode mode = ResolveMode();
+        return _registry.Create(mode, services);
+    }
+
+    internal static KnowledgeProviderMode ParseMode(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return KnowledgeProviderMode.InMemory;
+
+        string trimmed = raw.Trim();
+
+        // Reject bare numeric input so the mode is always a documented,
+        // readable name and can never be selected by an accidental integer.
+        return int.TryParse(trimmed, out _) ||
+            !Enum.TryParse(trimmed, ignoreCase: true, out KnowledgeProviderMode mode) ||
+            !Enum.IsDefined(mode)
+            ? throw new InvalidOperationException(
+                $"{KnowledgeProviderOptions.ModeKey} '{raw}' is not a recognized knowledge provider mode. " +
+                $"Valid modes are: {string.Join(", ", Enum.GetNames<KnowledgeProviderMode>())}. " +
+                "Leave the value blank to use the default in-memory provider.")
+            : mode;
+    }
+
+    internal static KnowledgeDegradationMode ParseDegradation(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return KnowledgeDegradationMode.FailLoud;
+
+        string trimmed = raw.Trim();
+
+        return int.TryParse(trimmed, out _) ||
+            !Enum.TryParse(trimmed, ignoreCase: true, out KnowledgeDegradationMode mode) ||
+            !Enum.IsDefined(mode)
+            ? throw new InvalidOperationException(
+                $"{KnowledgeProviderOptions.DegradationKey} '{raw}' is not a recognized degradation policy. " +
+                $"Valid policies are: {string.Join(", ", Enum.GetNames<KnowledgeDegradationMode>())}. " +
+                "Leave the value blank to use the default (FailLoud) — the platform NEVER silently returns " +
+                "an empty result when the configured provider is unreachable.")
+            : mode;
+    }
+}

--- a/src/RetailPulse.Api/appsettings.json
+++ b/src/RetailPulse.Api/appsettings.json
@@ -155,7 +155,32 @@
   "Knowledge": {
     "MaxDocumentSizeBytes": 10485760,
     "MaxDocuments": 100,
-    "MaxChunks": 5000
+    "MaxChunks": 5000,
+
+    // ---- Knowledge provider selection (RAG) --------------------------
+    // Selects which IKnowledgeBase implementation serves search/ingest.
+    // The abstraction is intentionally explicit: absent or blank values
+    // fall back to safe, documented defaults; unknown values fail startup
+    // with an actionable message. See docs/adr/009-knowledge-provider-abstraction.md.
+    //
+    //   Mode        (default: InMemory)
+    //     - "InMemory"      Volatile BM25 keyword scoring. Zero cloud
+    //                       dependencies. Ships as the default and stays
+    //                       runnable on a laptop.
+    //     - "AzureAISearch" (opt-in, provisioned separately — issue #103)
+    //     - "FoundryIQ"     (opt-in, provisioned separately — issue #104)
+    //
+    //   Degradation (default: FailLoud) — behavior when the configured
+    //                cloud provider is unreachable at startup or query
+    //                time. NEVER silent empty results.
+    //     - "FailLoud"           Surface the failure. Startup aborts on
+    //                            a bad probe; query-time errors return 5xx.
+    //     - "FallbackToInMemory" Log a prominent warning and swap to the
+    //                            in-memory BM25 provider for this run.
+    "Provider": {
+      "Mode": "InMemory",
+      "Degradation": "FailLoud"
+    }
   },
 
   // ---- Observability store (in-memory cost/session caps) ----------------

--- a/src/RetailPulse.Contracts/Rag/IKnowledgeBase.cs
+++ b/src/RetailPulse.Contracts/Rag/IKnowledgeBase.cs
@@ -2,6 +2,18 @@ namespace RetailPulse.Contracts.Rag;
 
 /// <summary>
 /// Contract for the RAG knowledge base — document ingestion, search, and management.
+///
+/// Multiple providers implement this contract (in-memory BM25, optional cloud
+/// providers). Providers report their own capabilities via
+/// <see cref="GetCapabilities"/> so callers can present accurate relevance
+/// semantics (lexical vs semantic) without comparing scores across providers.
+/// Scores are provider-local and NOT comparable between implementations.
+///
+/// A provider that cannot reach its backend (startup or query time) must throw
+/// <see cref="KnowledgeProviderUnavailableException"/>. It MUST NOT return an
+/// empty result to signal outage — that path is reserved for a genuinely empty
+/// corpus. The degradation policy layer decides whether to fail loudly or fall
+/// back to the always-available in-memory provider based on configuration.
 /// </summary>
 public interface IKnowledgeBase
 {
@@ -9,10 +21,28 @@ public interface IKnowledgeBase
     Task<IReadOnlyList<SearchResult>> SearchAsync(string query, int topK = 5, CancellationToken ct = default);
     Task<IReadOnlyList<DocumentInfo>> ListDocumentsAsync(CancellationToken ct = default);
     Task DeleteDocumentAsync(string documentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Reports honest, static capabilities of this provider so callers can
+    /// present accurate relevance semantics and enforce provider-local quotas.
+    /// </summary>
+    KnowledgeBaseCapabilities GetCapabilities();
+
+    /// <summary>
+    /// Verifies the provider is reachable and configured correctly. Called at
+    /// startup by the degradation policy layer and may be called opportunistically
+    /// by health checks. Throws <see cref="KnowledgeProviderUnavailableException"/>
+    /// when the backend is unreachable; other exceptions indicate misconfiguration
+    /// or a bug and should propagate.
+    /// </summary>
+    Task ProbeAsync(CancellationToken ct = default);
 }
 
 /// <summary>
 /// A single search result with relevance scoring and citation metadata.
+/// <see cref="Score"/> is provider-local and MUST NOT be compared across
+/// providers — a lexical BM25 score has no relationship to an embedding cosine
+/// similarity. Consumers rank within a single provider's result set only.
 /// </summary>
 public record SearchResult(string DocumentId, string Title, string Chunk, double Score, string Source, int ChunkIndex);
 
@@ -20,3 +50,57 @@ public record SearchResult(string DocumentId, string Title, string Chunk, double
 /// Metadata about an indexed document.
 /// </summary>
 public record DocumentInfo(string Id, string Title, string Source, DateTime IngestedAt, int ChunkCount);
+
+/// <summary>
+/// Describes what kind of relevance a knowledge provider computes. Callers can
+/// use this to communicate expected behavior to users without inspecting the
+/// underlying implementation.
+/// </summary>
+public enum KnowledgeRelevanceKind
+{
+    /// <summary>Keyword / term-frequency matching (e.g. BM25).</summary>
+    Lexical = 0,
+
+    /// <summary>Vector / embedding similarity.</summary>
+    Semantic = 1,
+
+    /// <summary>Combined lexical + semantic (e.g. hybrid rank fusion).</summary>
+    Hybrid = 2,
+}
+
+/// <summary>
+/// Provider-reported capabilities. All fields are honest, static descriptions
+/// of the provider — the abstraction layer never fabricates or normalizes
+/// capabilities on the provider's behalf.
+/// </summary>
+/// <param name="ProviderName">Stable identifier for the provider (e.g. "InMemory").</param>
+/// <param name="Relevance">Kind of relevance scoring the provider produces.</param>
+/// <param name="Persistent">
+/// True when ingested documents survive process restart. False for the volatile
+/// in-memory provider.
+/// </param>
+/// <param name="RequiresCloud">
+/// True when the provider depends on a cloud resource (e.g. Azure AI Search)
+/// that must be provisioned separately.
+/// </param>
+/// <param name="Quotas">Provider-enforced quotas on documents / chunks / size.</param>
+/// <param name="ScoreSemantics">
+/// Human-readable description of the score range and its meaning. Always
+/// includes an explicit reminder that scores are not comparable across
+/// providers.
+/// </param>
+public record KnowledgeBaseCapabilities(
+    string ProviderName,
+    KnowledgeRelevanceKind Relevance,
+    bool Persistent,
+    bool RequiresCloud,
+    KnowledgeQuotas Quotas,
+    string ScoreSemantics);
+
+/// <summary>
+/// Provider-enforced quota limits reported for observability and API surface
+/// consistency. Providers that do not enforce a given quota should report the
+/// largest value they will accept (never <see cref="int.MaxValue"/> when the
+/// backend has a real ceiling).
+/// </summary>
+public record KnowledgeQuotas(int MaxDocuments, int MaxChunks, long MaxDocumentSizeBytes);

--- a/src/RetailPulse.Contracts/Rag/KnowledgeProviderUnavailableException.cs
+++ b/src/RetailPulse.Contracts/Rag/KnowledgeProviderUnavailableException.cs
@@ -1,0 +1,30 @@
+namespace RetailPulse.Contracts.Rag;
+
+/// <summary>
+/// Thrown by an <see cref="IKnowledgeBase"/> implementation to signal that its
+/// backend is unreachable or unauthenticated — a transient / configuration
+/// availability failure that the degradation policy layer knows how to react to.
+///
+/// A provider MUST use this exception rather than returning an empty result
+/// when it cannot serve a request. Empty results are reserved for a genuinely
+/// empty corpus. This distinction lets the degradation policy either fail
+/// loudly (surface the outage) or fall back to the in-memory provider — but
+/// never silently pretend the corpus is empty.
+/// </summary>
+public sealed class KnowledgeProviderUnavailableException : Exception
+{
+    /// <summary>Stable identifier of the provider that failed (e.g. "AzureAISearch").</summary>
+    public string ProviderName { get; }
+
+    public KnowledgeProviderUnavailableException(string providerName, string message)
+        : base(message)
+    {
+        ProviderName = providerName;
+    }
+
+    public KnowledgeProviderUnavailableException(string providerName, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        ProviderName = providerName;
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/DegradingKnowledgeBaseTests.cs
+++ b/tests/RetailPulse.Tests/Rag/DegradingKnowledgeBaseTests.cs
@@ -1,0 +1,211 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Rag;
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Tests.Rag;
+
+/// <summary>
+/// Both degradation policies exercised against a deliberately unreachable
+/// test provider. Verifies the two hard invariants from the ADR:
+///   1. FailLoud propagates the provider's unavailability exception at
+///      startup and at query time — the caller sees the failure.
+///   2. FallbackToInMemory swaps to the always-available in-memory instance
+///      and serves the caller's data plane from it — NEVER an empty result
+///      that could be mistaken for an empty corpus.
+/// </summary>
+public sealed class DegradingKnowledgeBaseTests
+{
+    private static InMemoryKnowledgeBase CreateInMemoryFallback() => new(
+        NullLoggerFactory.Instance.CreateLogger<InMemoryKnowledgeBase>(),
+        Options.Create(new KnowledgeOptions()));
+
+    private static DegradingKnowledgeBase Create(
+        IKnowledgeBase primary,
+        InMemoryKnowledgeBase fallback,
+        KnowledgeDegradationMode degradation) =>
+        new(primary, fallback, degradation, NullLoggerFactory.Instance.CreateLogger<DegradingKnowledgeBase>());
+
+    // ── FailLoud ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FailLoud_StartupProbe_Unreachable_Propagates()
+    {
+        var primary = new UnreachableTestKnowledgeBase();
+        InMemoryKnowledgeBase fallback = CreateInMemoryFallback();
+        DegradingKnowledgeBase kb = Create(primary, fallback, KnowledgeDegradationMode.FailLoud);
+
+        Func<Task> probe = () => kb.ProbeAsync();
+
+        await probe.Should().ThrowAsync<KnowledgeProviderUnavailableException>()
+            .Where(ex => ex.ProviderName == UnreachableTestKnowledgeBase.TestProviderName);
+        kb.PrimaryReplacedByFallback.Should().BeFalse(
+            "FailLoud never swaps the primary — startup should just abort");
+    }
+
+    [Fact]
+    public async Task FailLoud_Search_PropagatesProviderException()
+    {
+        var primary = new UnreachableTestKnowledgeBase();
+        InMemoryKnowledgeBase fallback = CreateInMemoryFallback();
+        await fallback.IngestDocumentAsync("Retail Playbook", "Retail category management guidance.", "src");
+        DegradingKnowledgeBase kb = Create(primary, fallback, KnowledgeDegradationMode.FailLoud);
+
+        Func<Task> search = () => kb.SearchAsync("retail");
+
+        await search.Should().ThrowAsync<KnowledgeProviderUnavailableException>();
+        primary.SearchCallCount.Should().Be(1);
+        // The endpoint layer converts this to a 5xx — NEVER an empty result.
+    }
+
+    [Fact]
+    public async Task FailLoud_Ingest_PropagatesProviderException()
+    {
+        var primary = new UnreachableTestKnowledgeBase();
+        DegradingKnowledgeBase kb = Create(primary, CreateInMemoryFallback(), KnowledgeDegradationMode.FailLoud);
+
+        Func<Task> ingest = () => kb.IngestDocumentAsync("Doc", "Content about retail.", "src");
+
+        await ingest.Should().ThrowAsync<KnowledgeProviderUnavailableException>();
+    }
+
+    // ── FallbackToInMemory ────────────────────────────────────────────
+
+    [Fact]
+    public async Task FallbackToInMemory_StartupProbe_Unreachable_SwapsToFallback()
+    {
+        var primary = new UnreachableTestKnowledgeBase();
+        InMemoryKnowledgeBase fallback = CreateInMemoryFallback();
+        DegradingKnowledgeBase kb = Create(primary, fallback, KnowledgeDegradationMode.FallbackToInMemory);
+
+        await kb.ProbeAsync();
+
+        kb.PrimaryReplacedByFallback.Should().BeTrue();
+        kb.ActiveProviderName.Should().Be(InMemoryKnowledgeBase.ProviderName);
+    }
+
+    [Fact]
+    public async Task FallbackToInMemory_SwappedAtStartup_SearchServedFromInMemory()
+    {
+        var primary = new UnreachableTestKnowledgeBase();
+        InMemoryKnowledgeBase fallback = CreateInMemoryFallback();
+        await fallback.IngestDocumentAsync("Fallback Doc",
+            "Holiday inventory management builds up starting eight weeks before peak season. " +
+            "Holiday planning drives holiday displays and holiday holiday holiday results.",
+            "fallback-src");
+        DegradingKnowledgeBase kb = Create(primary, fallback, KnowledgeDegradationMode.FallbackToInMemory);
+
+        await kb.ProbeAsync();
+        IReadOnlyList<SearchResult> results = await kb.SearchAsync("holiday");
+
+        // Search hit the fallback, not the unreachable primary — and returned
+        // a real result, not an empty list.
+        results.Should().NotBeEmpty(
+            "after fallback the caller sees the in-memory corpus — never an empty result masquerading as no matches");
+        primary.SearchCallCount.Should().Be(0,
+            "once swapped at startup, the primary is not touched by subsequent search calls");
+    }
+
+    [Fact]
+    public async Task FallbackToInMemory_ProbeSucceeded_SearchFailsAtQueryTime_UsesFallback()
+    {
+        // Simulates a provider that was healthy at startup but transient-fails
+        // at query time. The wrapper serves this one call from the fallback
+        // while leaving the primary as the configured provider going forward.
+        var primary = new FlakyTestKnowledgeBase();
+        InMemoryKnowledgeBase fallback = CreateInMemoryFallback();
+        await fallback.IngestDocumentAsync("Backup Doc",
+            "Category management playbook covers destination categories and routine categories. " +
+            "Category category category category category management in retail is a common playbook topic.",
+            "fallback");
+        DegradingKnowledgeBase kb = Create(primary, fallback, KnowledgeDegradationMode.FallbackToInMemory);
+
+        await kb.ProbeAsync();
+        kb.PrimaryReplacedByFallback.Should().BeFalse(
+            "the healthy probe means the primary is still active going forward");
+
+        primary.FailNextSearch();
+        IReadOnlyList<SearchResult> results = await kb.SearchAsync("category");
+
+        results.Should().NotBeEmpty(
+            "the query-time failure must be served from the fallback, not returned as empty");
+        primary.SearchCallCount.Should().Be(1,
+            "the wrapper tried the primary once and, on the outage exception, delegated to the fallback");
+    }
+
+    [Fact]
+    public async Task FallbackToInMemory_NonAvailabilityException_StillPropagates()
+    {
+        // A misconfiguration bug (e.g. bad argument) must NOT be silently
+        // swallowed by the fallback — only the outage exception is caught.
+        var primary = new ThrowingTestKnowledgeBase(new InvalidOperationException("bad config"));
+        DegradingKnowledgeBase kb = Create(primary, CreateInMemoryFallback(), KnowledgeDegradationMode.FallbackToInMemory);
+
+        Func<Task> search = () => kb.SearchAsync("anything");
+
+        await search.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // ── Support stubs ─────────────────────────────────────────────────
+
+    private sealed class FlakyTestKnowledgeBase : IKnowledgeBase
+    {
+        public int SearchCallCount { get; private set; }
+        private bool _failNext;
+
+        public void FailNextSearch() => _failNext = true;
+
+        public KnowledgeBaseCapabilities GetCapabilities() => new(
+            ProviderName: "FlakyTestProvider",
+            Relevance: KnowledgeRelevanceKind.Semantic,
+            Persistent: true,
+            RequiresCloud: true,
+            Quotas: new KnowledgeQuotas(1, 1, 1),
+            ScoreSemantics: "Test stub.");
+
+        public Task ProbeAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<string> IngestDocumentAsync(string title, string content, string source, CancellationToken ct = default) =>
+            Task.FromResult(Guid.NewGuid().ToString("N"));
+
+        public Task<IReadOnlyList<SearchResult>> SearchAsync(string query, int topK = 5, CancellationToken ct = default)
+        {
+            SearchCallCount++;
+            if (_failNext)
+            {
+                _failNext = false;
+                throw new KnowledgeProviderUnavailableException("FlakyTestProvider", "Simulated query-time outage.");
+            }
+            return Task.FromResult<IReadOnlyList<SearchResult>>([]);
+        }
+
+        public Task<IReadOnlyList<DocumentInfo>> ListDocumentsAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<DocumentInfo>>([]);
+
+        public Task DeleteDocumentAsync(string documentId, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class ThrowingTestKnowledgeBase : IKnowledgeBase
+    {
+        private readonly Exception _exception;
+
+        public ThrowingTestKnowledgeBase(Exception exception) { _exception = exception; }
+
+        public KnowledgeBaseCapabilities GetCapabilities() => new(
+            ProviderName: "ThrowingTestProvider",
+            Relevance: KnowledgeRelevanceKind.Semantic,
+            Persistent: true,
+            RequiresCloud: true,
+            Quotas: new KnowledgeQuotas(1, 1, 1),
+            ScoreSemantics: "Test stub.");
+
+        public Task ProbeAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<string> IngestDocumentAsync(string title, string content, string source, CancellationToken ct = default) => throw _exception;
+        public Task<IReadOnlyList<SearchResult>> SearchAsync(string query, int topK = 5, CancellationToken ct = default) => throw _exception;
+        public Task<IReadOnlyList<DocumentInfo>> ListDocumentsAsync(CancellationToken ct = default) => throw _exception;
+        public Task DeleteDocumentAsync(string documentId, CancellationToken ct = default) => throw _exception;
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/InMemoryKnowledgeBaseConformanceTests.cs
+++ b/tests/RetailPulse.Tests/Rag/InMemoryKnowledgeBaseConformanceTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Rag;
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Tests.Rag;
+
+/// <summary>
+/// Runs the shared <see cref="KnowledgeBaseConformanceTests"/> suite against
+/// the in-memory BM25 provider. Future provider issues (#103 Azure AI Search,
+/// #104 Foundry IQ) add their own subclass and get the same coverage floor.
+/// </summary>
+public sealed class InMemoryKnowledgeBaseConformanceTests : KnowledgeBaseConformanceTests
+{
+    protected override Task<IKnowledgeBase> CreateProviderAsync()
+    {
+        InMemoryKnowledgeBase kb = new(
+            NullLoggerFactory.Instance.CreateLogger<InMemoryKnowledgeBase>(),
+            Options.Create(new KnowledgeOptions()));
+        return Task.FromResult<IKnowledgeBase>(kb);
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/KnowledgeBaseConformanceTests.cs
+++ b/tests/RetailPulse.Tests/Rag/KnowledgeBaseConformanceTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Tests.Rag;
+
+/// <summary>
+/// Shared, provider-agnostic conformance suite for every
+/// <see cref="IKnowledgeBase"/> implementation. Encodes contract invariants
+/// that are TRULY COMMON across providers — lexical BM25 in-memory today,
+/// semantic Azure AI Search / Foundry IQ tomorrow (issues #103 / #104).
+///
+/// A new provider adds a concrete subclass that returns a fresh, isolated
+/// instance from <see cref="CreateProviderAsync"/>. The base class then runs
+/// the shared behavioral tests against it.
+///
+/// Assertions are deliberately loose about ranking specifics: exact score
+/// values, cutoffs, and ordering are provider-local and NOT comparable
+/// across providers. The suite verifies that ingest works, search finds
+/// what was ingested, list and delete round-trip, capabilities are honestly
+/// reported, and a healthy provider's <see cref="IKnowledgeBase.ProbeAsync"/>
+/// completes without throwing.
+/// </summary>
+public abstract class KnowledgeBaseConformanceTests
+{
+    /// <summary>
+    /// Creates a fresh, isolated provider instance. Called once per test.
+    /// Implementations must ensure state does not leak between tests
+    /// (a fresh in-memory instance or a per-test index prefix for cloud).
+    /// </summary>
+    protected abstract Task<IKnowledgeBase> CreateProviderAsync();
+
+    [Fact]
+    public async Task GetCapabilities_ReportsNonEmptyProviderName()
+    {
+        IKnowledgeBase kb = await CreateProviderAsync();
+
+        KnowledgeBaseCapabilities caps = kb.GetCapabilities();
+
+        caps.ProviderName.Should().NotBeNullOrWhiteSpace(
+            "every provider must self-identify so observability endpoints can report it");
+        caps.ScoreSemantics.Should().NotBeNullOrWhiteSpace(
+            "scores are provider-local and callers must be told so — this string is where we say so");
+        caps.Quotas.MaxDocuments.Should().BeGreaterThan(0);
+        caps.Quotas.MaxChunks.Should().BeGreaterThan(0);
+        caps.Quotas.MaxDocumentSizeBytes.Should().BeGreaterThan(0L);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_HealthyProvider_Completes()
+    {
+        IKnowledgeBase kb = await CreateProviderAsync();
+
+        // A healthy provider must not throw. Cloud implementations that
+        // cannot reach their backend at test time should throw
+        // KnowledgeProviderUnavailableException instead — this test asserts
+        // the happy path only.
+        Func<Task> probe = () => kb.ProbeAsync();
+        await probe.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Search_OnEmptyCorpus_ReturnsEmpty()
+    {
+        IKnowledgeBase kb = await CreateProviderAsync();
+
+        IReadOnlyList<SearchResult> results = await kb.SearchAsync("anything at all");
+
+        // Empty corpus MUST return an empty list, not throw. A cloud
+        // provider that cannot reach its backend must throw
+        // KnowledgeProviderUnavailableException — never fake an empty result.
+        results.Should().NotBeNull();
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Ingest_ReturnsNonEmptyDocumentId()
+    {
+        IKnowledgeBase kb = await CreateProviderAsync();
+
+        string id = await kb.IngestDocumentAsync(
+            title: "Conformance Doc",
+            content: "Retail category management defines the role and metrics for every category.",
+            source: "conformance-test");
+
+        id.Should().NotBeNullOrWhiteSpace(
+            "every ingested document must have a stable id the caller can use to delete it later");
+    }
+
+    [Fact]
+    public async Task Ingest_ThenSearch_FindsRelevantContent()
+    {
+        IKnowledgeBase kb = await CreateProviderAsync();
+        await kb.IngestDocumentAsync(
+            title: "Holiday Planning",
+            content:
+                "Holiday displays should go up in early October for maximum impact. " +
+                "Themed holiday displays outperform generic seasonal displays. " +
+                "Holiday holiday holiday planning is key for retail success.",
+            source: "conformance-test");
+
+        IReadOnlyList<SearchResult> results = await kb.SearchAsync("holiday");
+
+        results.Should().NotBeEmpty("ingested content must be discoverable via search");
+        results.Should().OnlyContain(r => r.Score >= 0,
+            "scores are provider-local but non-negative for every provider");
+        results.Should().OnlyContain(r => !string.IsNullOrEmpty(r.DocumentId));
+        results.Should().OnlyContain(r => !string.IsNullOrEmpty(r.Title));
+        results.Should().OnlyContain(r => r.Chunk != null);
+    }
+
+    [Fact]
+    public async Task ListDocuments_ReflectsIngestedDocuments()
+    {
+        IKnowledgeBase kb = await CreateProviderAsync();
+        await kb.IngestDocumentAsync("Alpha", "Content about alpha topic in retail.", "src");
+        await kb.IngestDocumentAsync("Beta", "Content about beta topic in retail.", "src");
+
+        IReadOnlyList<DocumentInfo> docs = await kb.ListDocumentsAsync();
+
+        docs.Should().HaveCount(2);
+        docs.Select(d => d.Title).Should().BeEquivalentTo(["Alpha", "Beta"]);
+        docs.Should().OnlyContain(d => !string.IsNullOrEmpty(d.Id));
+        docs.Should().OnlyContain(d => d.ChunkCount > 0,
+            "an ingested document must have at least one chunk to be searchable");
+    }
+
+    [Fact]
+    public async Task DeleteDocument_RemovesFromListAndSearch()
+    {
+        IKnowledgeBase kb = await CreateProviderAsync();
+        string aId = await kb.IngestDocumentAsync(
+            "Deletable",
+            "Uniqueterm-xyzzy content that is only in this document about retail merchandising.",
+            "src");
+        await kb.IngestDocumentAsync(
+            "Keeper",
+            "Different content about supply chain resilience with no overlap.",
+            "src");
+
+        await kb.DeleteDocumentAsync(aId);
+
+        IReadOnlyList<DocumentInfo> docs = await kb.ListDocumentsAsync();
+        docs.Should().HaveCount(1);
+        docs.Should().OnlyContain(d => d.Title == "Keeper");
+
+        IReadOnlyList<SearchResult> hits = await kb.SearchAsync("uniqueterm-xyzzy");
+        hits.Should().NotContain(r => r.DocumentId == aId,
+            "deleted documents must not appear in future searches");
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/KnowledgeProviderSelectorTests.cs
+++ b/tests/RetailPulse.Tests/Rag/KnowledgeProviderSelectorTests.cs
@@ -23,7 +23,7 @@ public sealed class KnowledgeProviderSelectorTests
         string? degradation,
         KnowledgeProviderRegistry? registry = null)
     {
-        var options = Options.Create(new KnowledgeProviderOptions
+        IOptions<KnowledgeProviderOptions> options = Options.Create(new KnowledgeProviderOptions
         {
             Mode = mode,
             Degradation = degradation,
@@ -151,7 +151,7 @@ public sealed class KnowledgeProviderSelectorTests
 
         KnowledgeProviderSelector selector = CreateSelector(mode: "InMemory", degradation: null, registry: registry);
 
-        var services = new ServiceCollection().BuildServiceProvider();
+        ServiceProvider services = new ServiceCollection().BuildServiceProvider();
         IKnowledgeBase primary = selector.CreatePrimary(services);
 
         primary.Should().BeSameAs(concrete);
@@ -168,7 +168,7 @@ public sealed class KnowledgeProviderSelectorTests
         registry.Register(KnowledgeProviderMode.InMemory, _ => CreateInMemory());
 
         KnowledgeProviderSelector selector = CreateSelector(mode: "AzureAISearch", degradation: null, registry: registry);
-        var services = new ServiceCollection().BuildServiceProvider();
+        ServiceProvider services = new ServiceCollection().BuildServiceProvider();
 
         Action act = () => selector.CreatePrimary(services);
 
@@ -189,7 +189,7 @@ public sealed class KnowledgeProviderSelectorTests
         registry.Register(KnowledgeProviderMode.InMemory, _ => CreateInMemory());
 
         KnowledgeProviderSelector selector = CreateSelector(mode: "TotallyMadeUp", degradation: null, registry: registry);
-        var services = new ServiceCollection().BuildServiceProvider();
+        ServiceProvider services = new ServiceCollection().BuildServiceProvider();
 
         Action act = () => selector.CreatePrimary(services);
 

--- a/tests/RetailPulse.Tests/Rag/KnowledgeProviderSelectorTests.cs
+++ b/tests/RetailPulse.Tests/Rag/KnowledgeProviderSelectorTests.cs
@@ -1,0 +1,200 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Rag;
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Tests.Rag;
+
+/// <summary>
+/// Deterministic resolution + fail-fast tests for
+/// <see cref="KnowledgeProviderSelector"/>. Covers the documented defaults,
+/// unknown-value rejection, and the "recognized-but-unregistered" case where
+/// a cloud mode is selected without the corresponding module wired up
+/// (issues #103 / #104).
+/// </summary>
+public sealed class KnowledgeProviderSelectorTests
+{
+    private static KnowledgeProviderSelector CreateSelector(
+        string? mode,
+        string? degradation,
+        KnowledgeProviderRegistry? registry = null)
+    {
+        var options = Options.Create(new KnowledgeProviderOptions
+        {
+            Mode = mode,
+            Degradation = degradation,
+        });
+        return new KnowledgeProviderSelector(options, registry ?? new KnowledgeProviderRegistry());
+    }
+
+    private static InMemoryKnowledgeBase CreateInMemory() => new(
+        NullLoggerFactory.Instance.CreateLogger<InMemoryKnowledgeBase>(),
+        Options.Create(new KnowledgeOptions()));
+
+    // ── Mode resolution ────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveMode_MissingOrBlank_DefaultsToInMemory(string? raw)
+    {
+        KnowledgeProviderSelector selector = CreateSelector(mode: raw, degradation: null);
+
+        selector.ResolveMode().Should().Be(KnowledgeProviderMode.InMemory);
+    }
+
+    [Theory]
+    [InlineData("InMemory", KnowledgeProviderMode.InMemory)]
+    [InlineData("inmemory", KnowledgeProviderMode.InMemory)]
+    [InlineData("  InMemory  ", KnowledgeProviderMode.InMemory)]
+    [InlineData("AzureAISearch", KnowledgeProviderMode.AzureAISearch)]
+    [InlineData("azureaisearch", KnowledgeProviderMode.AzureAISearch)]
+    [InlineData("FoundryIQ", KnowledgeProviderMode.FoundryIQ)]
+    public void ResolveMode_RecognizedName_ReturnsMatchingEnum(string raw, KnowledgeProviderMode expected)
+    {
+        KnowledgeProviderSelector selector = CreateSelector(mode: raw, degradation: null);
+
+        selector.ResolveMode().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Sqlite")]                // typo / not an enum
+    [InlineData("AzureAiSearch__typo")]   // close but wrong
+    [InlineData("!!invalid!!")]           // punctuation garbage
+    public void ResolveMode_UnknownName_ThrowsWithActionableMessage(string raw)
+    {
+        KnowledgeProviderSelector selector = CreateSelector(mode: raw, degradation: null);
+
+        Action act = () => selector.ResolveMode();
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should()
+                .Contain(raw, "the operator's exact input is echoed back so they can fix it")
+                .And.Contain("InMemory", "valid options must be listed in the error")
+                .And.Contain("AzureAISearch")
+                .And.Contain("FoundryIQ");
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("999")]
+    public void ResolveMode_BareNumber_Rejected(string raw)
+    {
+        // A mode is a documented, readable name — never an integer. This
+        // prevents an accidental integer overriding config from silently
+        // selecting a cloud provider.
+        KnowledgeProviderSelector selector = CreateSelector(mode: raw, degradation: null);
+
+        Action act = () => selector.ResolveMode();
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    // ── Degradation resolution ─────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveDegradation_MissingOrBlank_DefaultsToFailLoud(string? raw)
+    {
+        // FailLoud is the safer default: a configured cloud provider that
+        // silently dropped back would mask real outages. The operator opts
+        // into FallbackToInMemory deliberately.
+        KnowledgeProviderSelector selector = CreateSelector(mode: null, degradation: raw);
+
+        selector.ResolveDegradation().Should().Be(KnowledgeDegradationMode.FailLoud);
+    }
+
+    [Theory]
+    [InlineData("FailLoud", KnowledgeDegradationMode.FailLoud)]
+    [InlineData("failloud", KnowledgeDegradationMode.FailLoud)]
+    [InlineData("FallbackToInMemory", KnowledgeDegradationMode.FallbackToInMemory)]
+    [InlineData("fallbacktoinmemory", KnowledgeDegradationMode.FallbackToInMemory)]
+    public void ResolveDegradation_RecognizedName_ReturnsMatchingEnum(string raw, KnowledgeDegradationMode expected)
+    {
+        KnowledgeProviderSelector selector = CreateSelector(mode: null, degradation: raw);
+
+        selector.ResolveDegradation().Should().Be(expected);
+    }
+
+    [Fact]
+    public void ResolveDegradation_UnknownName_ThrowsWithActionableMessage()
+    {
+        KnowledgeProviderSelector selector = CreateSelector(mode: null, degradation: "SilentlyReturnEmpty");
+
+        Action act = () => selector.ResolveDegradation();
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should()
+                .Contain("SilentlyReturnEmpty")
+                .And.Contain("FailLoud")
+                .And.Contain("FallbackToInMemory")
+                .And.Contain("NEVER silently returns",
+                    "the error message documents the empty-result invariant");
+    }
+
+    // ── Provider materialization ──────────────────────────────────────
+
+    [Fact]
+    public void CreatePrimary_InMemoryRegistered_ResolvesInMemoryInstance()
+    {
+        var registry = new KnowledgeProviderRegistry();
+        InMemoryKnowledgeBase concrete = CreateInMemory();
+        registry.Register(KnowledgeProviderMode.InMemory, _ => concrete);
+
+        KnowledgeProviderSelector selector = CreateSelector(mode: "InMemory", degradation: null, registry: registry);
+
+        var services = new ServiceCollection().BuildServiceProvider();
+        IKnowledgeBase primary = selector.CreatePrimary(services);
+
+        primary.Should().BeSameAs(concrete);
+        primary.GetCapabilities().ProviderName.Should().Be(InMemoryKnowledgeBase.ProviderName);
+    }
+
+    [Fact]
+    public void CreatePrimary_RecognizedModeNotRegistered_ThrowsWithActionableMessage()
+    {
+        // AzureAISearch is a known enum value but its factory is only wired
+        // up by issue #103. Selecting it without registration must fail
+        // startup with an actionable message — never silently degrade.
+        var registry = new KnowledgeProviderRegistry();
+        registry.Register(KnowledgeProviderMode.InMemory, _ => CreateInMemory());
+
+        KnowledgeProviderSelector selector = CreateSelector(mode: "AzureAISearch", degradation: null, registry: registry);
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        Action act = () => selector.CreatePrimary(services);
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should()
+                .Contain("AzureAISearch")
+                .And.Contain("not registered")
+                .And.Contain("InMemory", "the message lists which modes ARE registered");
+    }
+
+    [Fact]
+    public void ResolveMode_BeforeCreatePrimary_UnknownMode_ThrowsBeforeRegistryLookup()
+    {
+        // The mode parser rejects unknown names before the registry is
+        // consulted, so the operator sees "not a recognized mode" rather
+        // than "not registered" for a typo.
+        var registry = new KnowledgeProviderRegistry();
+        registry.Register(KnowledgeProviderMode.InMemory, _ => CreateInMemory());
+
+        KnowledgeProviderSelector selector = CreateSelector(mode: "TotallyMadeUp", degradation: null, registry: registry);
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        Action act = () => selector.CreatePrimary(services);
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should()
+                .Contain("not a recognized knowledge provider mode");
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/UnreachableTestKnowledgeBase.cs
+++ b/tests/RetailPulse.Tests/Rag/UnreachableTestKnowledgeBase.cs
@@ -1,0 +1,74 @@
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Tests.Rag;
+
+/// <summary>
+/// Deliberately unreachable <see cref="IKnowledgeBase"/> stub used by the
+/// degradation-policy tests. Every data-plane operation throws
+/// <see cref="KnowledgeProviderUnavailableException"/> so we can exercise
+/// both <see cref="KnowledgeDegradationMode"/> policies without relying on
+/// a real cloud backend outage.
+///
+/// This class also demonstrates the reusable seam future cloud provider
+/// issues plug into: implement <see cref="IKnowledgeBase"/>, throw the
+/// contract exception when the backend is unreachable, and the degradation
+/// decorator handles the rest.
+/// </summary>
+internal sealed class UnreachableTestKnowledgeBase : IKnowledgeBase
+{
+    public const string TestProviderName = "UnreachableTestProvider";
+
+    public int ProbeCallCount { get; private set; }
+    public int SearchCallCount { get; private set; }
+    public int IngestCallCount { get; private set; }
+    public int ListCallCount { get; private set; }
+    public int DeleteCallCount { get; private set; }
+
+    public KnowledgeBaseCapabilities GetCapabilities() => new(
+        ProviderName: TestProviderName,
+        Relevance: KnowledgeRelevanceKind.Semantic,
+        Persistent: true,
+        RequiresCloud: true,
+        Quotas: new KnowledgeQuotas(MaxDocuments: 10_000, MaxChunks: 100_000, MaxDocumentSizeBytes: 25 * 1024 * 1024),
+        ScoreSemantics: "Test stub; provider is intentionally unreachable.");
+
+    public Task ProbeAsync(CancellationToken ct = default)
+    {
+        ProbeCallCount++;
+        throw new KnowledgeProviderUnavailableException(
+            TestProviderName,
+            "Unreachable test provider: probe intentionally fails.");
+    }
+
+    public Task<string> IngestDocumentAsync(string title, string content, string source, CancellationToken ct = default)
+    {
+        IngestCallCount++;
+        throw new KnowledgeProviderUnavailableException(
+            TestProviderName,
+            "Unreachable test provider: ingest intentionally fails.");
+    }
+
+    public Task<IReadOnlyList<SearchResult>> SearchAsync(string query, int topK = 5, CancellationToken ct = default)
+    {
+        SearchCallCount++;
+        throw new KnowledgeProviderUnavailableException(
+            TestProviderName,
+            "Unreachable test provider: search intentionally fails.");
+    }
+
+    public Task<IReadOnlyList<DocumentInfo>> ListDocumentsAsync(CancellationToken ct = default)
+    {
+        ListCallCount++;
+        throw new KnowledgeProviderUnavailableException(
+            TestProviderName,
+            "Unreachable test provider: list intentionally fails.");
+    }
+
+    public Task DeleteDocumentAsync(string documentId, CancellationToken ct = default)
+    {
+        DeleteCallCount++;
+        throw new KnowledgeProviderUnavailableException(
+            TestProviderName,
+            "Unreachable test provider: delete intentionally fails.");
+    }
+}


### PR DESCRIPTION
Closes #102

Working as Costco (Backend Dev)

## Summary

Introduces the provider seam for RAG knowledge behind `IKnowledgeBase` — abstraction, configuration surface, degradation policy, provider registry, ADR-009, and a shared conformance suite. **In-memory BM25 remains the DEFAULT** and continues to work on a laptop with zero cloud packages or resources.

## Default-InMemory guarantee

- `Knowledge:Provider:Mode` defaults to `InMemory` when absent or blank. No cloud packages added; `dotnet run --project src/RetailPulse.AppHost` boots and serves knowledge as before.
- `InMemoryKnowledgeBase` behavior — BM25 scoring, chunker, quotas — is unchanged. Existing InMemory tests pass unmodified.
- `KnowledgeBaseSeeder` still seeds the sample corpus when the in-memory instance is the active provider (either as configured primary or after fallback swapped it in).

## Provider seam

- `IKnowledgeBase` (in `Contracts.Rag`) gains `GetCapabilities()` and `ProbeAsync()`. Providers report honest, static capabilities (name, `Lexical`/`Semantic`/`Hybrid`, persistence, cloud dependency, quotas, and a `ScoreSemantics` string that explicitly states scores are provider-local and NOT comparable across providers).
- `KnowledgeProviderUnavailableException` is the provider-to-wrapper signal for outage. A provider must throw it rather than return an empty result — that is what makes the "never silent empty" invariant enforceable.
- `KnowledgeProviderRegistry` — the reusable seam future issues plug into. `Program.cs` registers the `InMemory` factory automatically; #103 / #104 add their own factories from their opt-in extension methods.
- `KnowledgeProviderSelector` reads `Knowledge:Provider:Mode` and `Knowledge:Provider:Degradation` with the same fail-fast style as `AuthenticationModeOptions`: missing/blank → documented default, unknown/malformed → startup fails with an actionable message that echoes the offending value and lists valid options. Bare numeric input is rejected.

## Explicit degradation behavior — NEVER silent empty

`DegradingKnowledgeBase` decorates the resolved primary and applies the configured policy.

| Policy | Startup probe fails | Query-time `KnowledgeProviderUnavailableException` | Other exception |
|---|---|---|---|
| `FailLoud` (default) | Aborts startup, logs error | Propagates to caller (endpoint returns 5xx) | Propagates |
| `FallbackToInMemory` | Logs prominent warning, swaps active provider to in-memory for process lifetime | Serves this one request from in-memory, primary stays configured going forward | Propagates |

The decorator never catches an exception and returns an empty list. Empty results are reserved for "no matching documents in the corpus".

`RagContextProvider` and every knowledge endpoint remain provider-agnostic — they consume `IKnowledgeBase` only. There is no direct reference to `InMemoryKnowledgeBase` from the request path.

## Shared conformance suite

`KnowledgeBaseConformanceTests` (abstract) codifies invariants every provider must satisfy: capabilities are honest, `ProbeAsync` on a healthy provider does not throw, search on an empty corpus returns empty, ingest returns a stable id, ingested content is discoverable, list surfaces ingested docs, delete removes docs and their chunks, and scores are non-negative. `InMemoryKnowledgeBaseConformanceTests` is the initial concrete instantiation. #103 / #104 subclass the same base and inherit the coverage floor.

## Tests

- `InMemoryKnowledgeBaseConformanceTests` — 7 tests, InMemory provider against the shared conformance suite.
- `KnowledgeProviderSelectorTests` — 17 tests: default resolution (blank mode → InMemory; blank degradation → FailLoud), recognized-name case-insensitivity, unknown-value fail-fast for both mode and degradation, bare-number rejection, factory materialization, "recognized-but-unregistered mode" (`AzureAISearch` selected without #103 wired) fail-fast with actionable message.
- `DegradingKnowledgeBaseTests` — 7 tests using a deliberately unreachable test provider (`UnreachableTestKnowledgeBase`, in the test project): FailLoud propagates at startup, at query time (search), and at ingest; FallbackToInMemory swaps on startup probe failure and serves subsequent search from in-memory; FallbackToInMemory handles query-time failures after a healthy probe by delegating one call to fallback while keeping the primary configured; non-availability exceptions (e.g. misconfiguration) always propagate — the wrapper only reacts to the outage contract, not to arbitrary failures.
- Existing `KnowledgeBaseTests` and `InMemoryKnowledgeBaseQuotaTests` pass **unmodified** — BM25 semantics were not touched.

**Test run**: `dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj` — **Passed: 2745 / Failed: 0 / Skipped: 0** (1m 34s). Solution builds with zero warnings.

## Explicitly NOT implemented in this PR

- **#103** Azure AI Search provider — the seam is in place; the implementation is out of scope for this issue.
- **#104** Foundry IQ provider — the seam is in place; the implementation is out of scope for this issue.
- **#105** Per-agent knowledge binding — out of scope for this issue.

## Limitation

Per the concurrent migration of `AgentExecutionPipeline.cs` in #89, no files under `src/RetailPulse.Api/Agents/` were modified in this PR. The knowledge-provider seam does not require Agent-tree changes because `RagContextProvider` already consumes `IKnowledgeBase` and is unchanged.

## Configuration

`appsettings.json` gains a `Knowledge:Provider` subsection documenting both keys and their defaults. See `docs/adr/009-knowledge-provider-abstraction.md` for the full seam design and rationale.
