### PR TITLE
Durable session and conversation persistence (#90)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,7 @@ Browser (ChatPanel) → POST /api/chat → RetailPulseAgent
 | **Shipment data** (distribution, fill rates) | `RetailPulseDb` → SQLite `Shipments` table | Same as above. |
 | **Field sentiment** (rep feedback, scores) | `RetailPulseDb` → SQLite `Sentiment` table | Same as above. |
 | **Tenant configuration** (brands, regions, channels) | `tenant.yaml` at repo root → loaded by `FileTenantProvider` | On disk. Single source of truth for the business domain. Changing this file triggers a database re-seed on next restart. |
-| **Conversation history** | Frontend state (`ChatPanel.tsx`) → sent with each request | Browser session only. Not persisted server-side. |
+| **Conversation history** | Frontend state (`ChatPanel.tsx`) → sent with each request; optionally mirrored to the durable server-side session store when `SessionPersistence:Enabled=true` (issue #90). | Browser session only by default. When enabled, sessions and turns for **authenticated** subjects are persisted to `data/sessions.db` via `SqliteSessionStore`, so a browser refresh can rehydrate the last conversation. Anonymous sessions are **never** persisted (see Session Persistence below). |
 | **Telemetry spans** | Frontend state (`Dashboard.tsx`) via SignalR | Browser session only. Resets on "Clear Telemetry" or "+ New Chat". |
 
 > **Key insight:** The analytics dataset lives in a SQLite database (`data/retailpulse.db`), seeded deterministically from `tenant.yaml`. Unlike the earlier in-memory approach, the agent can now **read and write** data via the `UpdateMetrics` MCP tool — enabling real-time scenario modeling, what-if analysis, and live data updates during demos. The database re-seeds automatically when `tenant.yaml` changes (tracked via content hash). To reset to baseline, delete the database file and restart. Swapping to production data sources requires only replacing the MCP Server tool implementations.
@@ -438,6 +438,87 @@ Incoming Request
 | `EntityMention` | 90 days | "Sierra Gold Tequila, Ridgeline Bourbon, Northeast region" |
 
 The `MemoryManagementAgent` handles privacy: "forget everything" wipes all user data (GDPR-ready). Memory DB is at `data/memory.db`.
+
+---
+
+## Durable Session Persistence (Issue #90)
+
+Chat sessions and turns can optionally survive an API restart, so a browser
+refresh rehydrates the last conversation rather than starting from scratch.
+The store follows the same pattern as `SqliteConversationMemory`,
+`SqliteApprovalGate`, and `SqliteAlertService`: SQLite in the shared writable
+data directory, opened through the centralized `SqliteMount` helper
+(`busy_timeout=10000`, `journal_mode=DELETE`, `synchronous=FULL`).
+
+### Pipeline
+
+```
+POST /api/chat (authenticated, non-anonymous, SessionPersistence:Enabled=true)
+  → ChatEndpoints resolves subject via UserIdentity.Resolve
+  → SessionOwnershipRegistry binds sessionId → subject
+  → Router → Agent → Response
+  → SqliteSessionStore.PersistTurnAsync (user turn + assistant turn, one transaction)
+       ├── Upserts Sessions row (subject fixed at first write)
+       └── Appends SessionTurns row (role, content, agent, routing, tokens, chart specs, span summary)
+
+GET  /api/sessions          → list caller's sessions (newest activity first)
+GET  /api/sessions/{id}     → rehydrate one session, capped at MaxTurnsPerRehydrate
+DELETE /api/sessions/{id}   → cascade-delete (turns then session), single transaction
+```
+
+### Configuration (`SessionPersistence` section, defaults)
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `Enabled` | `false` | Master switch. Off = no store singleton, no cleanup service, no DB file, no `/api/sessions/*` routes — Wave 1 behaviour is preserved bit-for-bit. |
+| `RetentionTtl` | `30.00:00:00` (30 days) | Sessions inactive for longer are purged by the background cleanup service. |
+| `CleanupInterval` | `01:00:00` (1 hour) | How often the sweep runs. Driven by `TimeProvider` so tests use a deterministic clock rather than sleeps. |
+| `RedactPiiOnWrite` | `true` | Apply the shared `PiiRedactor` (same seam the output guardrail uses) to turn content before writing. |
+| `MaxTurnsPerRehydrate` | `200` | Hard cap on `GET /api/sessions/{id}` so a single rehydrate cannot materialise unbounded content. Newest turns win. |
+| `MaxSessionsPerList` | `200` | Hard cap on `GET /api/sessions`. |
+
+### Privacy guarantees (see `docs/security.md` for the full contract)
+
+- **Anonymous sessions are NEVER persisted.** The chat endpoint short-circuits
+  writes via `IAnonymousChatPolicy`, and `/api/sessions/*` refuse anonymous
+  callers at entry with `403 session_persistence_unavailable`. Proved by the
+  strict-mock `AnonymousChatDoesNotPersistTests` regression.
+- **Subject-scoped SQL.** Every read/delete WHERE-clause filters on the
+  resolved subject; a cross-subject read resolves to `null`, which the
+  endpoint layer surfaces as `404` (never an oracle, never a silent empty).
+- **Ownership pinned at first write.** The `Sessions` upsert uses
+  `INSERT ... ON CONFLICT DO UPDATE ... WHERE Sessions.Subject = excluded.Subject`,
+  so a replayed session id cannot change owners. A turn write into a
+  foreign-owned session is rolled back rather than dropped as an orphan.
+- **Complete deletion.** `DELETE /api/sessions/{id}` removes the child
+  `SessionTurns` rows before the parent, in a single transaction, so an
+  interrupted purge cannot leave orphans.
+- **Observable retention.** `SessionCleanupBackgroundService` logs the
+  per-sweep `SessionsDeleted` and `TurnsDeleted` counts at `Information` so
+  retention is visible in production logs.
+
+### Schema
+
+```sql
+Sessions       (SessionId PK, Subject NOT NULL COLLATE NOCASE, TenantId, CreatedAt, LastActivityAt)
+SessionTurns   (TurnId PK, SessionId FK, Role, Content, AgentId,
+                RoutingIntent, RoutingAgentKey, RoutingConfidence,
+                InputTokens, OutputTokens, TotalTokens,
+                ChartSpecsJson, SpanSummary, Timestamp)
+```
+
+Indexes cover `(Subject, LastActivityAt DESC)` for the list query,
+`(LastActivityAt)` for the retention sweep, and `(SessionId, Timestamp)` for
+rehydrate ordering.
+
+### Deployment note
+
+Production ships `Enabled=false` today: the deployed synthetic demo runs on
+ephemeral per-replica storage (see `DataDirectoryResolver` and the note
+below), so persistence would only survive within one replica's lifetime.
+Once a policy-compatible durable volume is available, flip
+`SessionPersistence__Enabled=true` in the environment override and the DB
+file joins the other durable stores under the same mount.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -62,6 +62,55 @@ All chat interactions are recorded in a tamper-evident audit log (`DurableAuditL
 
 ---
 
+## Session Persistence (Issue #90)
+
+Durable server-side conversation history is available as an **opt-in** feature
+behind the `SessionPersistence:Enabled` configuration switch. It follows the
+same storage model as the other durable stores (`SqliteConversationMemory`,
+`SqliteApprovalGate`, `SqliteAlertService`): a SQLite database in the shared
+writable data directory, opened through the centralized `SqliteMount` helper
+with SMB-safe pragmas (`busy_timeout=10000`, `journal_mode=DELETE`,
+`synchronous=FULL`).
+
+Conversation content is more sensitive than the memory facts we already
+store, so the surface is deliberately narrow and every privacy control below
+is a hard gate — none of them can be turned off with a config flag alone.
+
+### Non-negotiable privacy controls
+
+| Control | Where it lives | What it does |
+|---------|---------------|--------------|
+| **Anonymous callers never persist** | `ChatEndpoints` short-circuits writes via `IAnonymousChatPolicy`; `SessionEndpoints` refuse anonymous callers at entry with `403 session_persistence_unavailable`. | Matches the existing cache/memory-disabled rule for `Anonymous` mode. Proved by `AnonymousChatDoesNotPersistTests` using a strict-mock `ISessionStore`. |
+| **Subject-scoped SQL** | Every read/delete WHERE-clause in `SqliteSessionStore` filters on the resolved subject. | A cross-subject read resolves to `null`, which the endpoint layer surfaces as `404`. The endpoint intentionally responds the same way for "unknown id" and "wrong owner" so it cannot be used as a probing oracle. |
+| **Ownership pinned at first write** | `INSERT ... ON CONFLICT(SessionId) DO UPDATE ... WHERE Sessions.Subject = excluded.Subject`, plus a post-upsert ownership check inside the same transaction. | A replayed session id cannot change owners; a turn from a foreign subject is rolled back, not dropped as an orphan. |
+| **Complete deletion** | `DELETE /api/sessions/{id}` removes `SessionTurns` rows before the parent `Sessions` row in a single transaction. | An interrupted purge cannot leave orphans, and the row is really gone — no soft-delete flag. |
+| **PII redaction on write** | `SessionPersistence:RedactPiiOnWrite` (default `true`) routes each turn's `Content` through the shared `PiiRedactor`. | Redaction on write and redaction on display stay in lock-step because both use the same seam the output guardrail uses. |
+| **Config kill-switch** | `SessionPersistence:Enabled=false` means no store singleton, no cleanup service, no DB file, and no `/api/sessions/*` routes. | Restores Wave 1 behaviour bit-for-bit. Verified by `SessionPersistenceServiceExtensionsTests.Disabled_DoesNotRegisterStore_OrCleanupService_OrTouchDisk`. |
+| **Bounded retention** | `SessionCleanupBackgroundService` uses `TimeProvider` to purge sessions inactive for `RetentionTtl` (default 30 days) on a `CleanupInterval` cadence (default 1 hour). | Emits per-sweep row counts at `Information` so retention is observable in production logs. |
+
+### Authorization
+
+`/api/sessions`, `/api/sessions/{id}` (GET and DELETE) all require the
+authenticated `RetailPulse.User` app role (via `RequireAuthorization()`).
+They are not on the anonymous allowlist in
+`AnonymousCapabilityPolicy._allowedRoutes`, so the deny-by-default anonymous
+guard rejects them before the endpoint ever runs; the endpoint additionally
+re-checks anonymity in case the mode ever changes. Rate-limiting policies
+(`relaxed` for reads, `moderate` for delete) follow the existing endpoint
+conventions.
+
+### Storage lifetime
+
+Production ships `Enabled=false` today because the deployed synthetic demo
+runs on ephemeral per-replica storage (`RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true`;
+see the deployment note in `docs/architecture.md`). Enabling persistence
+on ephemeral storage would set a durability expectation the substrate
+cannot honour. Once a policy-compatible durable volume is available,
+`SessionPersistence__Enabled=true` on the target environment joins the
+`sessions.db` file to the other durable stores under the same mount.
+
+---
+
 ## Authentication
 
 ### Provider selection (mode contract)

--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -1,8 +1,8 @@
 using System.ClientModel;
 using System.Diagnostics;
 using System.Globalization;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
 using RetailPulse.Api.Agents;
 using RetailPulse.Api.Auth;

--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -2,13 +2,17 @@ using System.ClientModel;
 using System.Diagnostics;
 using System.Globalization;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using RetailPulse.Api.Agents;
 using RetailPulse.Api.Auth;
+using RetailPulse.Api.Guardrails;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Memory;
 using RetailPulse.Api.Middleware;
 using RetailPulse.Api.Models;
 using RetailPulse.Api.Observability;
+using RetailPulse.Api.Persistence;
 using RetailPulse.Api.Prefetch;
 using RetailPulse.Api.Rag;
 using RetailPulse.Api.Security.Anonymous;
@@ -31,7 +35,7 @@ public static class ChatEndpoints
     public static WebApplication MapChatEndpoints(this WebApplication app, AgentDefinition agentDef)
     {
         // Chat endpoint — routes through guardrails → cache → multi-agent router with memory and tracing
-        app.MapPost("/api/chat", async (HttpContext httpContext, ChatRequest request, IAgentRouter router, IEnumerable<ISpecialistAgent> specialists, ConversationMemoryMiddleware memoryMiddleware, InMemoryTraceCollector traceCollector, GuardrailsMiddleware guardrails, IResponseCache responseCache, ICostTracker costTracker, IAuditLog auditLog, ConversationExporter conversationExporter, ITenantProvider tenantProvider, RagContextProvider ragProvider, MemoryExtractionChannel memoryChannel, IHubContext<TelemetryHub> hubContext, ILogger<Program> logger, CancellationToken clientCt, IAnonymousChatPolicy? anonymousChatPolicy = null, ISessionOwnershipRegistry? sessionOwnership = null, IConsensusCouncil? council = null) =>
+        app.MapPost("/api/chat", async (HttpContext httpContext, ChatRequest request, IAgentRouter router, IEnumerable<ISpecialistAgent> specialists, ConversationMemoryMiddleware memoryMiddleware, InMemoryTraceCollector traceCollector, GuardrailsMiddleware guardrails, IResponseCache responseCache, ICostTracker costTracker, IAuditLog auditLog, ConversationExporter conversationExporter, ITenantProvider tenantProvider, RagContextProvider ragProvider, MemoryExtractionChannel memoryChannel, IHubContext<TelemetryHub> hubContext, ILogger<Program> logger, CancellationToken clientCt, IAnonymousChatPolicy? anonymousChatPolicy = null, ISessionOwnershipRegistry? sessionOwnership = null, IConsensusCouncil? council = null, [FromServices] ISessionStore? sessionStore = null, [FromServices] IOptions<SessionPersistenceOptions>? sessionPersistenceOptions = null) =>
         {
             // Input validation — fail fast before expensive LLM pipeline
             ValidationResult validation = ChatRequestValidator.Validate(request);
@@ -64,11 +68,23 @@ public static class ChatEndpoints
                 bool cacheDisabled = anonymousChatPolicy.IsCacheDisabled();
                 bool memoryDisabled = anonymousChatPolicy.IsMemoryDisabled();
 
-                // Bind the session to this anonymous subject BEFORE any telemetry flows to its group.
-                // If the client-supplied id is already owned by a DIFFERENT subject, mint a fresh id
-                // for this turn so this subject's telemetry can never be delivered to another subject's
-                // hub group (the reverse of the JoinSession leak — Finding 6).
-                if (anonymous && sessionOwnership is not null && !sessionOwnership.TryBind(sessionId, userId))
+                // Session persistence is opt-in (issue #90). Anonymous callers are refused by
+                // the session endpoints and never reach the store below, mirroring the
+                // existing cache/memory-disabled rule for the anonymous provider.
+                bool persistenceEnabled = !anonymous
+                    && sessionStore is not null
+                    && (sessionPersistenceOptions?.Value.Enabled ?? false);
+
+                // Bind the session to this subject BEFORE any telemetry, memory, or persistence
+                // write. If the client-supplied id is already owned by a DIFFERENT subject, mint
+                // a fresh id for this turn so this subject's telemetry can never be delivered to
+                // another subject's hub group (Finding 6 — the reverse of the JoinSession leak)
+                // and this subject can never write into another subject's persisted transcript.
+                // Bound for anonymous callers unconditionally (existing Sprint 1 guard) and,
+                // now that authenticated turns can be persisted, whenever persistence is on.
+                if (sessionOwnership is not null
+                    && (anonymous || persistenceEnabled)
+                    && !sessionOwnership.TryBind(sessionId, userId))
                 {
                     sessionId = Guid.NewGuid().ToString("N");
                     sessionOwnership.TryBind(sessionId, userId);
@@ -131,6 +147,39 @@ public static class ChatEndpoints
                             AgentId = cached.AgentId,
                             Tokens = 0
                         }, ct);
+
+                        // Session persistence — cache hits still produced two accountable turns
+                        // for this subject, so they belong on disk just like the LLM-served path
+                        // below. Skipped when the feature is off or the caller is anonymous.
+                        if (persistenceEnabled)
+                        {
+                            SessionPersistenceOptions opts = sessionPersistenceOptions!.Value;
+                            string? tenantId = ResolveTenantId(tenantProvider);
+                            DateTimeOffset persistNow = DateTimeOffset.UtcNow;
+                            await PersistTurnSafeAsync(sessionStore!, new SessionTurnWrite
+                            {
+                                SessionId = sessionId,
+                                Subject = userId,
+                                TenantId = tenantId,
+                                Role = "user",
+                                Content = MaybeRedact(request.Message, opts),
+                                Timestamp = persistNow
+                            }, logger, ct);
+                            await PersistTurnSafeAsync(sessionStore!, new SessionTurnWrite
+                            {
+                                SessionId = sessionId,
+                                Subject = userId,
+                                TenantId = tenantId,
+                                Role = "assistant",
+                                Content = MaybeRedact(cached.Response, opts),
+                                AgentId = cached.AgentId,
+                                InputTokens = 0,
+                                OutputTokens = 0,
+                                TotalTokens = 0,
+                                SpanSummary = "cache.hit",
+                                Timestamp = persistNow
+                            }, logger, ct);
+                        }
 
                         return Results.Ok(new ChatResponse(
                             cached.Response,
@@ -553,6 +602,51 @@ public static class ChatEndpoints
                         DurationMs = response.TotalDurationMs.HasValue ? response.TotalDurationMs.Value : null,
                         Tokens = inputTokens + outputTokens
                     }, ct);
+
+                    // Durable session persistence (issue #90). Turns are only written when
+                    // the feature is enabled AND the caller is not anonymous (checked once
+                    // above via IAnonymousChatPolicy). Content is optionally redacted
+                    // through the same PiiRedactor seam the output guardrail uses so
+                    // redaction on write and on display stay in lock-step.
+                    if (persistenceEnabled)
+                    {
+                        SessionPersistenceOptions opts = sessionPersistenceOptions!.Value;
+                        string? tenantId = ResolveTenantId(tenantProvider);
+                        DateTimeOffset persistNow = DateTimeOffset.UtcNow;
+                        string spanSummary = BuildSpanSummary(response, specialist.Key, response.TotalDurationMs);
+
+                        await PersistTurnSafeAsync(sessionStore!, new SessionTurnWrite
+                        {
+                            SessionId = sessionId,
+                            Subject = userId,
+                            TenantId = tenantId,
+                            Role = "user",
+                            Content = MaybeRedact(request.Message, opts),
+                            RoutingIntent = decision.Intent,
+                            RoutingAgentKey = specialist.Key,
+                            RoutingConfidence = decision.Confidence,
+                            Timestamp = persistNow
+                        }, logger, ct);
+
+                        await PersistTurnSafeAsync(sessionStore!, new SessionTurnWrite
+                        {
+                            SessionId = sessionId,
+                            Subject = userId,
+                            TenantId = tenantId,
+                            Role = "assistant",
+                            Content = MaybeRedact(response.Reply, opts),
+                            AgentId = specialist.Key,
+                            RoutingIntent = decision.Intent,
+                            RoutingAgentKey = specialist.Key,
+                            RoutingConfidence = decision.Confidence,
+                            InputTokens = inputTokens,
+                            OutputTokens = outputTokens,
+                            TotalTokens = inputTokens + outputTokens,
+                            Charts = response.Charts,
+                            SpanSummary = spanSummary,
+                            Timestamp = persistNow
+                        }, logger, ct);
+                    }
                 }
 
                 // ── Guardrails: output PII redaction ─────────────────────────────
@@ -919,6 +1013,86 @@ public static class ChatEndpoints
                 return brand.Name;
         }
         return tenant.Brands.FirstOrDefault()?.Name ?? "Unknown";
+    }
+
+    // ── Session persistence helpers (issue #90) ─────────────────────────────
+
+    /// <summary>
+    /// Resolve a tenant identifier from <see cref="ITenantProvider"/>. Uses
+    /// <see cref="TenantConfiguration.Company"/> because the loaded tenant model does
+    /// not carry a dedicated id today, and Company is the human-recognisable label
+    /// operators expect to see in a rehydrated session. Blanks resolve to <c>null</c>
+    /// so the store column stays honest rather than filled with an empty string.
+    /// </summary>
+    private static string? ResolveTenantId(ITenantProvider tenantProvider)
+    {
+        try
+        {
+            TenantConfiguration tenant = tenantProvider.GetTenant();
+            return string.IsNullOrWhiteSpace(tenant.Company) ? null : tenant.Company;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Apply the shared <see cref="PiiRedactor"/> to a turn's content when
+    /// <see cref="SessionPersistenceOptions.RedactPiiOnWrite"/> is on. Kept as a
+    /// helper here (rather than as a new seam in <c>Guardrails/</c>) so this change
+    /// leaves the guardrail file set untouched — issue #100 owns Guardrails changes.
+    /// </summary>
+    private static string MaybeRedact(string content, SessionPersistenceOptions options) =>
+        options.RedactPiiOnWrite ? PiiRedactor.Redact(content) : content;
+
+    /// <summary>
+    /// Compact, JSON-shaped summary of the assistant response spans (tool call names,
+    /// counts, total duration). Enough to reconstruct an at-a-glance timeline when a
+    /// session is rehydrated long after the in-memory trace ring buffer has recycled.
+    /// </summary>
+    private static string BuildSpanSummary(ChatResponse response, string agentKey, long? totalDurationMs)
+    {
+        List<string> toolCalls = response.Spans?
+            .Where(s => s.Type == "tool_call")
+            .Select(s => s.Name)
+            .ToList() ?? [];
+
+        return System.Text.Json.JsonSerializer.Serialize(new
+        {
+            agent = agentKey,
+            spans = response.Spans?.Count ?? 0,
+            tools = toolCalls,
+            durationMs = totalDurationMs
+        });
+    }
+
+    /// <summary>
+    /// Persist a turn without breaking the chat response if the write fails. Persistence
+    /// is a best-effort side effect of a chat turn — a transient SQLite lock or a
+    /// disk-full condition must never turn a successful assistant reply into a 500. The
+    /// exception is logged so the failure is observable rather than silent.
+    /// </summary>
+    private static async Task PersistTurnSafeAsync(
+        ISessionStore sessionStore,
+        SessionTurnWrite write,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        try
+        {
+            await sessionStore.PersistTurnAsync(write, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to persist {Role} turn for session {SessionId}; chat response was still delivered.",
+                write.Role, write.SessionId);
+        }
     }
 }
 

--- a/src/RetailPulse.Api/Endpoints/SessionEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/SessionEndpoints.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Api.Security.Anonymous;
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Api.Endpoints;
+
+/// <summary>
+/// Endpoints for the durable session/turn store. Mapped only when
+/// <see cref="SessionPersistenceOptions.Enabled"/> is true so the API surface does not
+/// grow endpoints an operator never opted into (the same convention Anonymous/GitHub
+/// auth already use for their opt-in endpoints).
+///
+/// Every route resolves the caller's subject via <see cref="UserIdentity.Resolve"/> so
+/// writes (via <c>/api/chat</c>) and reads share one identity path — the historical
+/// "0 memories" drift from Sprint 1 stays fixed. Anonymous principals are refused at
+/// endpoint entry, mirroring the cache/memory disable pattern in <c>ChatEndpoints</c>.
+/// </summary>
+public static class SessionEndpoints
+{
+    public static WebApplication MapSessionEndpoints(this WebApplication app)
+    {
+        RouteGroupBuilder group = app.MapGroup("/api/sessions")
+            .WithTags("Sessions")
+            .RequireAuthorization();
+
+        // GET /api/sessions — list the caller's sessions (newest activity first).
+        group.MapGet("/", async (
+            ISessionStore store,
+            IOptions<SessionPersistenceOptions> options,
+            HttpContext httpContext,
+            CancellationToken ct) =>
+        {
+            if (RefuseAnonymous(httpContext, out IResult? refusal))
+                return refusal;
+
+            string subject = UserIdentity.Resolve(httpContext.User);
+            IReadOnlyList<SessionSummaryDto> sessions = await store.ListSessionsForSubjectAsync(subject, ct);
+
+            int cap = Math.Max(1, options.Value.MaxSessionsPerList);
+            if (sessions.Count > cap)
+                sessions = [.. sessions.Take(cap)];
+
+            return Results.Ok(sessions);
+        })
+        .WithName("ListSessions")
+        .WithSummary("List the caller's persisted chat sessions")
+        .Produces<IReadOnlyList<SessionSummaryDto>>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound)
+        .RequireRateLimiting("relaxed");
+
+        // GET /api/sessions/{sessionId} — rehydrate one session, or 404 if not owned.
+        group.MapGet("/{sessionId}", async (
+            string sessionId,
+            ISessionStore store,
+            IOptions<SessionPersistenceOptions> options,
+            HttpContext httpContext,
+            CancellationToken ct) =>
+        {
+            if (RefuseAnonymous(httpContext, out IResult? refusal))
+                return refusal;
+
+            string subject = UserIdentity.Resolve(httpContext.User);
+            SessionDetailDto? detail = await store.GetSessionAsync(subject, sessionId, ct);
+            if (detail is null)
+            {
+                // Cross-subject reads and truly-unknown ids share the same response so the
+                // endpoint cannot be used to probe another subject's session ids.
+                return Results.NotFound(new { error = $"Session '{sessionId}' not found." });
+            }
+
+            int cap = Math.Max(1, options.Value.MaxTurnsPerRehydrate);
+            if (detail.Turns.Count > cap)
+            {
+                // Keep the newest window — the browser gets the last <cap> turns of
+                // context so the transcript stays legible without unbounded memory.
+                IReadOnlyList<SessionTurnDto> trimmed = [.. detail.Turns.Skip(detail.Turns.Count - cap)];
+                detail = detail with { Turns = trimmed };
+            }
+
+            return Results.Ok(detail);
+        })
+        .WithName("GetSession")
+        .WithSummary("Rehydrate one persisted chat session for the caller")
+        .Produces<SessionDetailDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound)
+        .RequireRateLimiting("relaxed");
+
+        // DELETE /api/sessions/{sessionId} — purge a session and every turn under it.
+        group.MapDelete("/{sessionId}", async (
+            string sessionId,
+            ISessionStore store,
+            HttpContext httpContext,
+            CancellationToken ct) =>
+        {
+            if (RefuseAnonymous(httpContext, out IResult? refusal))
+                return refusal;
+
+            string subject = UserIdentity.Resolve(httpContext.User);
+            bool removed = await store.DeleteSessionAsync(subject, sessionId, ct);
+            return removed
+                ? Results.NoContent()
+                : Results.NotFound(new { error = $"Session '{sessionId}' not found." });
+        })
+        .WithName("DeleteSession")
+        .WithSummary("Delete every persisted turn for one session owned by the caller")
+        .Produces(StatusCodes.Status204NoContent)
+        .Produces(StatusCodes.Status404NotFound)
+        .RequireRateLimiting("moderate");
+
+        return app;
+    }
+
+    /// <summary>
+    /// Anonymous callers never persist and therefore never have anything to read. The
+    /// same shape as the chat-endpoint anonymous refusals: 403 with a machine-readable
+    /// code, no oracle for whether a given id exists.
+    /// </summary>
+    private static bool RefuseAnonymous(HttpContext httpContext, out IResult? refusal)
+    {
+        if (AnonymousCapabilityPolicy.IsAnonymousPrincipal(httpContext.User))
+        {
+            refusal = Results.Json(
+                new { error = "Anonymous sessions are not persisted.", code = "session_persistence_unavailable" },
+                statusCode: StatusCodes.Status403Forbidden);
+            return true;
+        }
+
+        refusal = null;
+        return false;
+    }
+}

--- a/src/RetailPulse.Api/Persistence/ISessionStore.cs
+++ b/src/RetailPulse.Api/Persistence/ISessionStore.cs
@@ -1,0 +1,55 @@
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Api.Persistence;
+
+/// <summary>
+/// Durable session/turn store. Follows the same shape as the other durable stores
+/// (<c>SqliteApprovalGate</c>, <c>SqliteConversationMemory</c>, <c>SqliteAlertService</c>):
+/// subject-scoped writes and reads, no cross-subject leakage, deterministic cleanup, and
+/// SMB-safe pragmas on every connection via <c>SqliteMount</c>.
+///
+/// Every read that takes a <c>subject</c> filters at the SQL layer, so a caller can never
+/// pull another subject's data even by guessing a session id — a foreign session id
+/// resolves to <c>null</c>, which the endpoint layer surfaces as a 404 (never a silent
+/// empty success).
+/// </summary>
+public interface ISessionStore
+{
+    /// <summary>
+    /// Upsert the session row and append a turn. Both operations run inside a single
+    /// SQLite transaction so a partial write cannot leave a session-less turn behind.
+    /// </summary>
+    Task PersistTurnAsync(SessionTurnWrite write, CancellationToken ct = default);
+
+    /// <summary>
+    /// List the caller's sessions, newest activity first, capped by
+    /// <see cref="SessionPersistenceOptions.MaxSessionsPerList"/>.
+    /// </summary>
+    Task<IReadOnlyList<SessionSummaryDto>> ListSessionsForSubjectAsync(
+        string subject, CancellationToken ct = default);
+
+    /// <summary>
+    /// Return the session and its ordered turns, or <c>null</c> when the id is unknown
+    /// or belongs to a different subject. The two failure modes are indistinguishable
+    /// by design — a caller must never be able to probe another subject's session id
+    /// via a 404-vs-403 oracle.
+    /// </summary>
+    Task<SessionDetailDto?> GetSessionAsync(
+        string subject, string sessionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete every row (session + turns) for the given session id when it is owned by
+    /// the caller. Returns <c>true</c> when at least one session row was removed, so the
+    /// endpoint layer can respond with 204 / 404 without a follow-up existence probe.
+    /// </summary>
+    Task<bool> DeleteSessionAsync(
+        string subject, string sessionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete sessions whose last activity is older than <paramref name="olderThan"/>.
+    /// Turns cascade with the session. Returns per-table row counts so the background
+    /// cleanup service can emit observable retention metrics.
+    /// </summary>
+    Task<CleanupResult> PurgeExpiredAsync(
+        DateTimeOffset olderThan, CancellationToken ct = default);
+}

--- a/src/RetailPulse.Api/Persistence/SessionCleanupBackgroundService.cs
+++ b/src/RetailPulse.Api/Persistence/SessionCleanupBackgroundService.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Options;
+
+namespace RetailPulse.Api.Persistence;
+
+/// <summary>
+/// Periodically deletes sessions and turns whose last activity is older than
+/// <see cref="SessionPersistenceOptions.RetentionTtl"/>. Uses <see cref="TimeProvider"/>
+/// so tests can drive the clock deterministically instead of sleeping, and logs the
+/// per-sweep row counts so retention is observable in production.
+///
+/// Registered only when <see cref="SessionPersistenceOptions.Enabled"/> is true (feature
+/// switch off means no service, no schema, no writes — see
+/// <see cref="SessionPersistenceServiceExtensions"/>).
+/// </summary>
+public sealed class SessionCleanupBackgroundService : BackgroundService
+{
+    private readonly ISessionStore _store;
+    private readonly IOptions<SessionPersistenceOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<SessionCleanupBackgroundService> _logger;
+
+    public SessionCleanupBackgroundService(
+        ISessionStore store,
+        IOptions<SessionPersistenceOptions> options,
+        TimeProvider timeProvider,
+        ILogger<SessionCleanupBackgroundService> logger)
+    {
+        _store = store;
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        SessionPersistenceOptions opts = _options.Value;
+
+        // Zero/negative retention = keep forever; zero/negative interval = don't sweep.
+        // Both are documented escape hatches for operators who want the store on but the
+        // sweeper off. Failing closed here would be worse than a no-op — you get to keep
+        // the durable writes without the deletion cadence.
+        if (opts.RetentionTtl <= TimeSpan.Zero || opts.CleanupInterval <= TimeSpan.Zero)
+        {
+            _logger.LogInformation(
+                "Session cleanup disabled (RetentionTtl={Ttl}, CleanupInterval={Interval}).",
+                opts.RetentionTtl, opts.CleanupInterval);
+            return;
+        }
+
+        _logger.LogInformation(
+            "Session cleanup started (RetentionTtl={Ttl}, CleanupInterval={Interval}).",
+            opts.RetentionTtl, opts.CleanupInterval);
+
+        using PeriodicTimer timer = new(opts.CleanupInterval, _timeProvider);
+        try
+        {
+            do
+            {
+                try
+                {
+                    DateTimeOffset cutoff = _timeProvider.GetUtcNow() - opts.RetentionTtl;
+                    CleanupResult result = await _store.PurgeExpiredAsync(cutoff, stoppingToken);
+
+                    if (result.SessionsDeleted > 0 || result.TurnsDeleted > 0)
+                    {
+                        _logger.LogInformation(
+                            "Session cleanup swept {Sessions} session(s) and {Turns} turn(s) older than {Cutoff:o}.",
+                            result.SessionsDeleted, result.TurnsDeleted, cutoff);
+                    }
+                    else
+                    {
+                        _logger.LogDebug(
+                            "Session cleanup found nothing older than {Cutoff:o}.", cutoff);
+                    }
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    // Never let the sweeper crash out — a corrupt row would then be
+                    // impossible to evict without a restart. Log loudly and try again
+                    // on the next tick.
+                    _logger.LogError(ex, "Session cleanup sweep failed; will retry on next interval.");
+                }
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal shutdown.
+        }
+
+        _logger.LogInformation("Session cleanup stopped.");
+    }
+}

--- a/src/RetailPulse.Api/Persistence/SessionPersistenceOptions.cs
+++ b/src/RetailPulse.Api/Persistence/SessionPersistenceOptions.cs
@@ -40,7 +40,7 @@ public sealed class SessionPersistenceOptions
     public TimeSpan CleanupInterval { get; set; } = TimeSpan.FromHours(1);
 
     /// <summary>
-    /// Apply <see cref="RetailPulse.Api.Guardrails.PiiRedactor"/> to turn content before persistence.
+    /// Apply <see cref="Guardrails.PiiRedactor"/> to turn content before persistence.
     /// On by default because rehydratable chat transcripts are a higher-value PII target than the
     /// summarized memory rows the memory store already holds — the redactor is the same shared
     /// seam the output guardrail already uses, so redaction on write and redaction on display

--- a/src/RetailPulse.Api/Persistence/SessionPersistenceOptions.cs
+++ b/src/RetailPulse.Api/Persistence/SessionPersistenceOptions.cs
@@ -1,0 +1,67 @@
+namespace RetailPulse.Api.Persistence;
+
+/// <summary>
+/// Configuration for the durable session/turn store.
+///
+/// Every knob has a sensible default so the feature can ship without any operator ceremony:
+/// enabled off by default (Wave 1 behaviour is preserved bit-for-bit until an operator turns it on),
+/// a 30-day retention TTL, a one-hour cleanup interval, and PII redaction on write ON by default
+/// because conversation content is more sensitive than the memory facts the existing durable
+/// stores already hold.
+/// </summary>
+public sealed class SessionPersistenceOptions
+{
+    public const string SectionName = "SessionPersistence";
+
+    /// <summary>
+    /// Master switch. When false, the store singleton is not registered, the cleanup hosted
+    /// service does not run, no database file is created or opened, and the chat pipeline
+    /// behaves exactly as it did before the feature was added. The session endpoints are
+    /// mapped only when this is true, matching the current feature-off convention used for
+    /// Anonymous/GitHub auth (endpoints appear only for the modes that back them).
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Retention TTL — sessions whose last activity is older than this are purged by the
+    /// background cleanup service. 30 days is the same order as the memory store's
+    /// implicit expiry and is a defensible default for a chat history that a user might
+    /// reasonably expect to see in the coming weeks. Values less than or equal to
+    /// <see cref="TimeSpan.Zero"/> disable purging (retention is unbounded).
+    /// </summary>
+    public TimeSpan RetentionTtl { get; set; } = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// How often the cleanup service scans for expired sessions. Default is one hour —
+    /// the same cadence as the memory expiry sweep — which keeps the SQLite DELETE
+    /// pressure low on the SMB-safe rollback journal while still keeping purged history
+    /// out of a compromised backup within a bounded window.
+    /// </summary>
+    public TimeSpan CleanupInterval { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Apply <see cref="RetailPulse.Api.Guardrails.PiiRedactor"/> to turn content before persistence.
+    /// On by default because rehydratable chat transcripts are a higher-value PII target than the
+    /// summarized memory rows the memory store already holds — the redactor is the same shared
+    /// seam the output guardrail already uses, so redaction on write and redaction on display
+    /// stay in lock-step.
+    /// </summary>
+    public bool RedactPiiOnWrite { get; set; } = true;
+
+    /// <summary>
+    /// Hard ceiling on the number of turns returned by <see cref="ISessionStore.GetSessionAsync"/>
+    /// so a single rehydrate request can't materialise an unbounded amount of content into
+    /// memory. Older turns are dropped first (the newest window survives). The chat endpoint
+    /// already trims to the last 10 exchanges before sending to the model, so this cap only
+    /// affects the browser's visible transcript.
+    /// </summary>
+    public int MaxTurnsPerRehydrate { get; set; } = 200;
+
+    /// <summary>
+    /// Hard ceiling on the number of sessions returned by <see cref="ISessionStore.ListSessionsForSubjectAsync"/>.
+    /// The list endpoint is intended for a sidebar-style history view; more than a couple of
+    /// hundred entries is not a UX any operator wants to ship, so this bounds the response
+    /// regardless of retention.
+    /// </summary>
+    public int MaxSessionsPerList { get; set; } = 200;
+}

--- a/src/RetailPulse.Api/Persistence/SessionPersistenceServiceExtensions.cs
+++ b/src/RetailPulse.Api/Persistence/SessionPersistenceServiceExtensions.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using RetailPulse.Api.Persistence;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// DI registration for the durable session/turn store. Mirrors the shape of
+/// <c>AddConversationMemory</c> / <c>AddProactiveAlerts</c>: one entry point, wires the
+/// options section, the singleton SQLite store, and the cleanup hosted service.
+/// </summary>
+public static class SessionPersistenceServiceExtensions
+{
+    /// <summary>
+    /// Bind <see cref="SessionPersistenceOptions"/> and, when
+    /// <see cref="SessionPersistenceOptions.Enabled"/> is true, register the SQLite store
+    /// singleton and the retention cleanup background service. When it is false, only
+    /// the options binding is registered — no database is created and no store singleton
+    /// exists in the container, so a bug in a downstream consumer that resolves
+    /// <c>ISessionStore</c> without checking the flag will fail loudly instead of
+    /// silently writing to a file the operator never asked to exist.
+    /// </summary>
+    public static IServiceCollection AddSessionPersistence(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string dbPath)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbPath);
+
+        services.Configure<SessionPersistenceOptions>(
+            configuration.GetSection(SessionPersistenceOptions.SectionName));
+
+        SessionPersistenceOptions opts = configuration
+            .GetSection(SessionPersistenceOptions.SectionName)
+            .Get<SessionPersistenceOptions>() ?? new SessionPersistenceOptions();
+
+        if (!opts.Enabled)
+            return services;
+
+        services.AddSingleton<ISessionStore>(sp =>
+            new SqliteSessionStore(
+                dbPath,
+                sp.GetRequiredService<ILogger<SqliteSessionStore>>()));
+
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddHostedService<SessionCleanupBackgroundService>();
+
+        return services;
+    }
+}

--- a/src/RetailPulse.Api/Persistence/SessionRecords.cs
+++ b/src/RetailPulse.Api/Persistence/SessionRecords.cs
@@ -1,0 +1,64 @@
+using RetailPulse.Contracts;
+
+namespace RetailPulse.Api.Persistence;
+
+/// <summary>
+/// Envelope handed to <see cref="ISessionStore.PersistTurnAsync"/> so the chat endpoint
+/// can express a single write intent (session-upsert + turn-insert) without exposing
+/// SQL details. The store treats this as an atomic pair — the session row is upserted
+/// (id, subject, tenant, created, last activity) and the turn row is appended.
+/// </summary>
+public sealed record SessionTurnWrite
+{
+    public required string SessionId { get; init; }
+
+    /// <summary>
+    /// Resolved via <see cref="RetailPulse.Api.Auth.UserIdentity.Resolve"/>. Anonymous callers
+    /// never reach the store; the caller is responsible for filtering them out per policy.
+    /// </summary>
+    public required string Subject { get; init; }
+
+    /// <summary>
+    /// Tenant identifier resolved from <see cref="RetailPulse.Contracts.ITenantProvider"/>.
+    /// Kept nullable so it degrades gracefully when a tenant configuration is not loaded
+    /// (the default constructor of <see cref="RetailPulse.Contracts.TenantConfiguration"/>
+    /// leaves <see cref="RetailPulse.Contracts.TenantConfiguration.Company"/> blank).
+    /// </summary>
+    public string? TenantId { get; init; }
+
+    public required string Role { get; init; }
+
+    public required string Content { get; init; }
+
+    public string? AgentId { get; init; }
+
+    public string? RoutingIntent { get; init; }
+
+    public string? RoutingAgentKey { get; init; }
+
+    public double? RoutingConfidence { get; init; }
+
+    public int? InputTokens { get; init; }
+
+    public int? OutputTokens { get; init; }
+
+    public int? TotalTokens { get; init; }
+
+    /// <summary>Chart specs emitted by the assistant turn; <c>null</c> for user turns and no-chart replies.</summary>
+    public IReadOnlyList<ChartSpec>? Charts { get; init; }
+
+    /// <summary>
+    /// Short, JSON-shaped summary of the pipeline spans (tool call names, counts, total
+    /// duration). The full trace tree lives in <see cref="RetailPulse.Api.Tracing.InMemoryTraceCollector"/>;
+    /// this is only enough to recover an at-a-glance view when a session is rehydrated
+    /// long after the trace ring buffer has recycled.
+    /// </summary>
+    public string? SpanSummary { get; init; }
+
+    public required DateTimeOffset Timestamp { get; init; }
+}
+
+/// <summary>
+/// Result of a cleanup sweep — the number of sessions and turns evicted for observability.
+/// </summary>
+public readonly record struct CleanupResult(int SessionsDeleted, int TurnsDeleted);

--- a/src/RetailPulse.Api/Persistence/SessionRecords.cs
+++ b/src/RetailPulse.Api/Persistence/SessionRecords.cs
@@ -13,16 +13,16 @@ public sealed record SessionTurnWrite
     public required string SessionId { get; init; }
 
     /// <summary>
-    /// Resolved via <see cref="RetailPulse.Api.Auth.UserIdentity.Resolve"/>. Anonymous callers
+    /// Resolved via <see cref="Auth.UserIdentity.Resolve"/>. Anonymous callers
     /// never reach the store; the caller is responsible for filtering them out per policy.
     /// </summary>
     public required string Subject { get; init; }
 
     /// <summary>
-    /// Tenant identifier resolved from <see cref="RetailPulse.Contracts.ITenantProvider"/>.
+    /// Tenant identifier resolved from <see cref="ITenantProvider"/>.
     /// Kept nullable so it degrades gracefully when a tenant configuration is not loaded
-    /// (the default constructor of <see cref="RetailPulse.Contracts.TenantConfiguration"/>
-    /// leaves <see cref="RetailPulse.Contracts.TenantConfiguration.Company"/> blank).
+    /// (the default constructor of <see cref="TenantConfiguration"/>
+    /// leaves <see cref="TenantConfiguration.Company"/> blank).
     /// </summary>
     public string? TenantId { get; init; }
 
@@ -49,7 +49,7 @@ public sealed record SessionTurnWrite
 
     /// <summary>
     /// Short, JSON-shaped summary of the pipeline spans (tool call names, counts, total
-    /// duration). The full trace tree lives in <see cref="RetailPulse.Api.Tracing.InMemoryTraceCollector"/>;
+    /// duration). The full trace tree lives in <see cref="Tracing.InMemoryTraceCollector"/>;
     /// this is only enough to recover an at-a-glance view when a session is rehydrated
     /// long after the trace ring buffer has recycled.
     /// </summary>

--- a/src/RetailPulse.Api/Persistence/SqliteSessionStore.cs
+++ b/src/RetailPulse.Api/Persistence/SqliteSessionStore.cs
@@ -270,7 +270,16 @@ public sealed class SqliteSessionStore : ISessionStore
                        ChartSpecsJson, SpanSummary, Timestamp
                 FROM SessionTurns
                 WHERE SessionId = @sid
-                ORDER BY Timestamp ASC, TurnId ASC
+                -- rowid tie-breaks identical timestamps by strict insertion order.
+                -- SessionTurns is a regular (rowid) table with TEXT PRIMARY KEY, so
+                -- every INSERT (which never sets rowid explicitly) receives a rowid
+                -- strictly greater than any previously inserted row. Ordering by
+                -- Timestamp first preserves historical chronology; the rowid
+                -- secondary sort is the durable insertion-order guarantee required
+                -- when production writes the user and assistant turns with the same
+                -- DateTimeOffset (issue #90). TurnId (random GUID) is not usable as
+                -- a tie-breaker because its ordinal is non-monotonic.
+                ORDER BY Timestamp ASC, rowid ASC
                 """;
             cmd.Parameters.AddWithValue("@sid", sessionId);
 

--- a/src/RetailPulse.Api/Persistence/SqliteSessionStore.cs
+++ b/src/RetailPulse.Api/Persistence/SqliteSessionStore.cs
@@ -1,0 +1,410 @@
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using RetailPulse.Api.Data;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Api.Persistence;
+
+/// <summary>
+/// SQLite-backed implementation of <see cref="ISessionStore"/>. Mirrors the shape of the
+/// other durable stores (<see cref="RetailPulse.Api.Approval.SqliteApprovalGate"/>,
+/// <see cref="RetailPulse.Api.Memory.SqliteConversationMemory"/>,
+/// <see cref="RetailPulse.Api.Alerts.SqliteAlertService"/>): the shared cache connection
+/// string is built once, every operation opens its own connection through
+/// <see cref="SqliteMount"/> so it gets the SMB-safe pragmas
+/// (<c>busy_timeout=10000</c>, <c>journal_mode=DELETE</c>, <c>synchronous=FULL</c>),
+/// and the schema is initialized eagerly on construction so the first request path is a
+/// straight INSERT.
+///
+/// Ownership is enforced at the SQL layer — every read/delete filters on the caller's
+/// subject in the WHERE clause, so a session id owned by a different subject cannot be
+/// coerced into returning content by any endpoint. Cross-subject reads resolve to
+/// <c>null</c>; the endpoint layer surfaces that as a 404.
+/// </summary>
+public sealed class SqliteSessionStore : ISessionStore
+{
+    private readonly string _connectionString;
+    private readonly ILogger<SqliteSessionStore> _logger;
+
+    private const string _iso8601 = "yyyy-MM-ddTHH:mm:ss.fffzzz";
+
+    private static readonly JsonSerializerOptions _chartJson = new()
+    {
+        WriteIndented = false,
+    };
+
+    public SqliteSessionStore(string dbPath, ILogger<SqliteSessionStore> logger)
+    {
+        _logger = logger;
+
+        string? dir = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Cache = SqliteCacheMode.Shared
+        }.ToString();
+
+        InitializeSchema();
+
+        _logger.LogInformation("Session store initialized at {DbPath}", dbPath);
+    }
+
+    // ── Schema ───────────────────────────────────────────────────────────
+
+    private void InitializeSchema()
+    {
+        using SqliteConnection conn = SqliteMount.Open(_connectionString);
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS Sessions (
+                SessionId       TEXT    PRIMARY KEY,
+                Subject         TEXT    NOT NULL COLLATE NOCASE,
+                TenantId        TEXT,
+                CreatedAt       TEXT    NOT NULL,
+                LastActivityAt  TEXT    NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS IX_Sessions_Subject_LastActivity
+                ON Sessions (Subject, LastActivityAt DESC);
+
+            CREATE INDEX IF NOT EXISTS IX_Sessions_LastActivity
+                ON Sessions (LastActivityAt);
+
+            CREATE TABLE IF NOT EXISTS SessionTurns (
+                TurnId              TEXT    PRIMARY KEY,
+                SessionId           TEXT    NOT NULL,
+                Role                TEXT    NOT NULL,
+                Content             TEXT    NOT NULL,
+                AgentId             TEXT,
+                RoutingIntent       TEXT,
+                RoutingAgentKey     TEXT,
+                RoutingConfidence   REAL,
+                InputTokens         INTEGER,
+                OutputTokens        INTEGER,
+                TotalTokens         INTEGER,
+                ChartSpecsJson      TEXT,
+                SpanSummary         TEXT,
+                Timestamp           TEXT    NOT NULL,
+                FOREIGN KEY (SessionId) REFERENCES Sessions(SessionId)
+            );
+
+            CREATE INDEX IF NOT EXISTS IX_SessionTurns_Session_Ts
+                ON SessionTurns (SessionId, Timestamp);
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    // ── Writes ───────────────────────────────────────────────────────────
+
+    public async Task PersistTurnAsync(SessionTurnWrite write, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(write);
+        ArgumentException.ThrowIfNullOrWhiteSpace(write.SessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(write.Subject);
+        ArgumentException.ThrowIfNullOrWhiteSpace(write.Role);
+
+        string now = write.Timestamp.ToString(_iso8601, CultureInfo.InvariantCulture);
+        string turnId = Guid.NewGuid().ToString("N");
+        string? chartJson = write.Charts is { Count: > 0 }
+            ? JsonSerializer.Serialize(write.Charts, _chartJson)
+            : null;
+
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+        await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync(ct);
+
+        // Upsert session — created-at survives, last-activity always advances. The
+        // subject is fixed at the first write (INSERT OR IGNORE) so a caller cannot
+        // overwrite an existing owner even if the same session id is replayed.
+        await using (SqliteCommand insertSession = conn.CreateCommand())
+        {
+            insertSession.Transaction = tx;
+            insertSession.CommandText = """
+                INSERT INTO Sessions (SessionId, Subject, TenantId, CreatedAt, LastActivityAt)
+                VALUES (@sid, @subject, @tenant, @now, @now)
+                ON CONFLICT(SessionId) DO UPDATE SET LastActivityAt = excluded.LastActivityAt
+                    WHERE Sessions.Subject = excluded.Subject
+                """;
+            insertSession.Parameters.AddWithValue("@sid", write.SessionId);
+            insertSession.Parameters.AddWithValue("@subject", write.Subject);
+            insertSession.Parameters.AddWithValue("@tenant", (object?)write.TenantId ?? DBNull.Value);
+            insertSession.Parameters.AddWithValue("@now", now);
+            await insertSession.ExecuteNonQueryAsync(ct);
+        }
+
+        // Guard against writing a turn to a session already owned by a different
+        // subject. If the upsert above matched the existing subject the row is
+        // present; otherwise the write is a no-op and we fail closed rather than
+        // dropping an orphan turn.
+        await using (SqliteCommand ownership = conn.CreateCommand())
+        {
+            ownership.Transaction = tx;
+            ownership.CommandText = "SELECT Subject FROM Sessions WHERE SessionId = @sid";
+            ownership.Parameters.AddWithValue("@sid", write.SessionId);
+            object? owner = await ownership.ExecuteScalarAsync(ct);
+            if (owner is not string ownerStr || !string.Equals(ownerStr, write.Subject, StringComparison.OrdinalIgnoreCase))
+            {
+                await tx.RollbackAsync(ct);
+                _logger.LogWarning(
+                    "Session {SessionId} is owned by a different subject — turn write rejected.",
+                    write.SessionId);
+                return;
+            }
+        }
+
+        await using (SqliteCommand insertTurn = conn.CreateCommand())
+        {
+            insertTurn.Transaction = tx;
+            insertTurn.CommandText = """
+                INSERT INTO SessionTurns (
+                    TurnId, SessionId, Role, Content, AgentId,
+                    RoutingIntent, RoutingAgentKey, RoutingConfidence,
+                    InputTokens, OutputTokens, TotalTokens,
+                    ChartSpecsJson, SpanSummary, Timestamp)
+                VALUES (
+                    @tid, @sid, @role, @content, @agentId,
+                    @intent, @agentKey, @confidence,
+                    @inTokens, @outTokens, @totalTokens,
+                    @chartsJson, @spanSummary, @ts)
+                """;
+            insertTurn.Parameters.AddWithValue("@tid", turnId);
+            insertTurn.Parameters.AddWithValue("@sid", write.SessionId);
+            insertTurn.Parameters.AddWithValue("@role", write.Role);
+            insertTurn.Parameters.AddWithValue("@content", write.Content);
+            insertTurn.Parameters.AddWithValue("@agentId", (object?)write.AgentId ?? DBNull.Value);
+            insertTurn.Parameters.AddWithValue("@intent", (object?)write.RoutingIntent ?? DBNull.Value);
+            insertTurn.Parameters.AddWithValue("@agentKey", (object?)write.RoutingAgentKey ?? DBNull.Value);
+            insertTurn.Parameters.AddWithValue("@confidence", (object?)write.RoutingConfidence ?? DBNull.Value);
+            insertTurn.Parameters.AddWithValue("@inTokens", (object?)write.InputTokens ?? DBNull.Value);
+            insertTurn.Parameters.AddWithValue("@outTokens", (object?)write.OutputTokens ?? DBNull.Value);
+            insertTurn.Parameters.AddWithValue("@totalTokens", (object?)write.TotalTokens ?? DBNull.Value);
+            insertTurn.Parameters.AddWithValue("@chartsJson", (object?)chartJson ?? DBNull.Value);
+            insertTurn.Parameters.AddWithValue("@spanSummary", (object?)write.SpanSummary ?? DBNull.Value);
+            insertTurn.Parameters.AddWithValue("@ts", now);
+            await insertTurn.ExecuteNonQueryAsync(ct);
+        }
+
+        await tx.CommitAsync(ct);
+
+        _logger.LogDebug(
+            "Persisted {Role} turn {TurnId} to session {SessionId} for subject {Subject}",
+            write.Role, turnId, write.SessionId, write.Subject);
+    }
+
+    // ── Reads ────────────────────────────────────────────────────────────
+
+    public async Task<IReadOnlyList<SessionSummaryDto>> ListSessionsForSubjectAsync(
+        string subject, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+        await using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT s.SessionId, s.TenantId, s.CreatedAt, s.LastActivityAt,
+                   (SELECT COUNT(*) FROM SessionTurns t WHERE t.SessionId = s.SessionId) AS TurnCount
+            FROM Sessions s
+            WHERE s.Subject = @subject
+            ORDER BY s.LastActivityAt DESC
+            LIMIT 500
+            """;
+        cmd.Parameters.AddWithValue("@subject", subject);
+
+        var results = new List<SessionSummaryDto>();
+        await using SqliteDataReader reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new SessionSummaryDto(
+                SessionId: reader.GetString(0),
+                TenantId: reader.IsDBNull(1) ? null : reader.GetString(1),
+                CreatedAt: ParseTimestamp(reader.GetString(2)),
+                LastActivityAt: ParseTimestamp(reader.GetString(3)),
+                TurnCount: reader.GetInt32(4)));
+        }
+        return results;
+    }
+
+    public async Task<SessionDetailDto?> GetSessionAsync(
+        string subject, string sessionId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+
+        SessionDetailDto? header = null;
+        await using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = """
+                SELECT SessionId, TenantId, CreatedAt, LastActivityAt
+                FROM Sessions
+                WHERE SessionId = @sid AND Subject = @subject
+                """;
+            cmd.Parameters.AddWithValue("@sid", sessionId);
+            cmd.Parameters.AddWithValue("@subject", subject);
+
+            await using SqliteDataReader reader = await cmd.ExecuteReaderAsync(ct);
+            if (!await reader.ReadAsync(ct))
+                return null;
+
+            header = new SessionDetailDto(
+                SessionId: reader.GetString(0),
+                TenantId: reader.IsDBNull(1) ? null : reader.GetString(1),
+                CreatedAt: ParseTimestamp(reader.GetString(2)),
+                LastActivityAt: ParseTimestamp(reader.GetString(3)),
+                Turns: []);
+        }
+
+        var turns = new List<SessionTurnDto>();
+        await using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = """
+                SELECT TurnId, Role, Content, AgentId,
+                       RoutingIntent, RoutingAgentKey, RoutingConfidence,
+                       InputTokens, OutputTokens, TotalTokens,
+                       ChartSpecsJson, SpanSummary, Timestamp
+                FROM SessionTurns
+                WHERE SessionId = @sid
+                ORDER BY Timestamp ASC, TurnId ASC
+                """;
+            cmd.Parameters.AddWithValue("@sid", sessionId);
+
+            await using SqliteDataReader reader = await cmd.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
+            {
+                turns.Add(new SessionTurnDto(
+                    TurnId: reader.GetString(0),
+                    Role: reader.GetString(1),
+                    Content: reader.GetString(2),
+                    AgentId: reader.IsDBNull(3) ? null : reader.GetString(3),
+                    RoutingIntent: reader.IsDBNull(4) ? null : reader.GetString(4),
+                    RoutingAgentKey: reader.IsDBNull(5) ? null : reader.GetString(5),
+                    RoutingConfidence: reader.IsDBNull(6) ? null : reader.GetDouble(6),
+                    InputTokens: reader.IsDBNull(7) ? null : reader.GetInt32(7),
+                    OutputTokens: reader.IsDBNull(8) ? null : reader.GetInt32(8),
+                    TotalTokens: reader.IsDBNull(9) ? null : reader.GetInt32(9),
+                    Charts: reader.IsDBNull(10) ? null : DeserializeCharts(reader.GetString(10)),
+                    SpanSummary: reader.IsDBNull(11) ? null : reader.GetString(11),
+                    Timestamp: ParseTimestamp(reader.GetString(12))));
+            }
+        }
+
+        return header with { Turns = turns };
+    }
+
+    public async Task<bool> DeleteSessionAsync(
+        string subject, string sessionId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+        await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync(ct);
+
+        // Verify ownership up front. Doing the check as a SELECT (rather than a
+        // conditional DELETE ... RETURNING) lets us short-circuit before touching
+        // either table, and it means the FK constraint between SessionTurns and
+        // Sessions never has to be reasoned about with a half-applied delete.
+        await using (SqliteCommand ownership = conn.CreateCommand())
+        {
+            ownership.Transaction = tx;
+            ownership.CommandText = "SELECT 1 FROM Sessions WHERE SessionId = @sid AND Subject = @subject";
+            ownership.Parameters.AddWithValue("@sid", sessionId);
+            ownership.Parameters.AddWithValue("@subject", subject);
+            object? row = await ownership.ExecuteScalarAsync(ct);
+            if (row is null)
+            {
+                await tx.RollbackAsync(ct);
+                return false;
+            }
+        }
+
+        // Delete order matters: SessionTurns.SessionId has a FOREIGN KEY reference
+        // to Sessions.SessionId, so the child rows must go first (Microsoft.Data.Sqlite
+        // enables foreign_keys=ON per connection by default). Same transaction, so
+        // an interrupted purge cannot leave orphan turns behind.
+        await using (SqliteCommand deleteTurns = conn.CreateCommand())
+        {
+            deleteTurns.Transaction = tx;
+            deleteTurns.CommandText = "DELETE FROM SessionTurns WHERE SessionId = @sid";
+            deleteTurns.Parameters.AddWithValue("@sid", sessionId);
+            await deleteTurns.ExecuteNonQueryAsync(ct);
+        }
+
+        await using (SqliteCommand deleteSession = conn.CreateCommand())
+        {
+            deleteSession.Transaction = tx;
+            deleteSession.CommandText = """
+                DELETE FROM Sessions
+                WHERE SessionId = @sid AND Subject = @subject
+                """;
+            deleteSession.Parameters.AddWithValue("@sid", sessionId);
+            deleteSession.Parameters.AddWithValue("@subject", subject);
+            await deleteSession.ExecuteNonQueryAsync(ct);
+        }
+
+        await tx.CommitAsync(ct);
+
+        _logger.LogInformation(
+            "Deleted session {SessionId} for subject {Subject}", sessionId, subject);
+        return true;
+    }
+
+    public async Task<CleanupResult> PurgeExpiredAsync(
+        DateTimeOffset olderThan, CancellationToken ct = default)
+    {
+        string cutoff = olderThan.ToString(_iso8601, CultureInfo.InvariantCulture);
+
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+        await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync(ct);
+
+        int turnRows;
+        await using (SqliteCommand deleteTurns = conn.CreateCommand())
+        {
+            deleteTurns.Transaction = tx;
+            deleteTurns.CommandText = """
+                DELETE FROM SessionTurns
+                WHERE SessionId IN (
+                    SELECT SessionId FROM Sessions WHERE LastActivityAt < @cutoff)
+                """;
+            deleteTurns.Parameters.AddWithValue("@cutoff", cutoff);
+            turnRows = await deleteTurns.ExecuteNonQueryAsync(ct);
+        }
+
+        int sessionRows;
+        await using (SqliteCommand deleteSessions = conn.CreateCommand())
+        {
+            deleteSessions.Transaction = tx;
+            deleteSessions.CommandText = "DELETE FROM Sessions WHERE LastActivityAt < @cutoff";
+            deleteSessions.Parameters.AddWithValue("@cutoff", cutoff);
+            sessionRows = await deleteSessions.ExecuteNonQueryAsync(ct);
+        }
+
+        await tx.CommitAsync(ct);
+        return new CleanupResult(sessionRows, turnRows);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static DateTimeOffset ParseTimestamp(string value) =>
+        DateTimeOffset.Parse(value, CultureInfo.InvariantCulture);
+
+    private static IReadOnlyList<ChartSpec>? DeserializeCharts(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<List<ChartSpec>>(json, _chartJson);
+        }
+        catch (JsonException)
+        {
+            // Malformed charts should never break rehydrate — surface no charts and
+            // let the caller keep the rest of the transcript.
+            return null;
+        }
+    }
+}

--- a/src/RetailPulse.Api/Persistence/SqliteSessionStore.cs
+++ b/src/RetailPulse.Api/Persistence/SqliteSessionStore.cs
@@ -9,9 +9,9 @@ namespace RetailPulse.Api.Persistence;
 
 /// <summary>
 /// SQLite-backed implementation of <see cref="ISessionStore"/>. Mirrors the shape of the
-/// other durable stores (<see cref="RetailPulse.Api.Approval.SqliteApprovalGate"/>,
-/// <see cref="RetailPulse.Api.Memory.SqliteConversationMemory"/>,
-/// <see cref="RetailPulse.Api.Alerts.SqliteAlertService"/>): the shared cache connection
+/// other durable stores (<see cref="Approval.SqliteApprovalGate"/>,
+/// <see cref="Memory.SqliteConversationMemory"/>,
+/// <see cref="Alerts.SqliteAlertService"/>): the shared cache connection
 /// string is built once, every operation opens its own connection through
 /// <see cref="SqliteMount"/> so it gets the SMB-safe pragmas
 /// (<c>busy_timeout=10000</c>, <c>journal_mode=DELETE</c>, <c>synchronous=FULL</c>),

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -26,6 +26,7 @@ using RetailPulse.Api.Middleware;
 using RetailPulse.Api.Models;
 using RetailPulse.Api.Observability;
 using RetailPulse.Api.OpenAI;
+using RetailPulse.Api.Persistence;
 using RetailPulse.Api.Rag;
 using RetailPulse.Api.Resilience;
 using RetailPulse.Api.Scorecard;
@@ -601,6 +602,16 @@ builder.Services.AddConversationMemory(memoryDbPath);
 string alertsDbPath = Path.Combine(dataDirectory, "alerts.db");
 builder.Services.AddProactiveAlerts(alertsDbPath);
 
+// Durable session/turn persistence (issue #90). Off by default: when
+// SessionPersistence:Enabled is false the store singleton is not registered and no
+// database file is created — the chat pipeline behaves identically to Wave 1. When
+// on, sessions and turns for AUTHENTICATED subjects survive an API restart, so a
+// browser refresh can rehydrate the last conversation. Anonymous sessions are never
+// written: the chat endpoint skips persistence via IAnonymousChatPolicy, and the
+// session endpoints refuse anonymous callers at entry. See SessionPersistenceOptions.
+string sessionsDbPath = Path.Combine(dataDirectory, "sessions.db");
+builder.Services.AddSessionPersistence(builder.Configuration, sessionsDbPath);
+
 // Distributed tracing — in-memory ring buffer with bounded-channel SignalR push
 builder.Services.AddSingleton<TelemetryPushChannel>();
 builder.Services.AddSingleton(sp =>
@@ -1127,6 +1138,15 @@ app.MapMarginEndpoints();
 app.MapDeadLetterEndpoints();
 app.MapMemoryEndpoints();
 app.MapCacheEndpoints();
+
+// Durable session endpoints — mapped only when SessionPersistence:Enabled is true so
+// no session surface exists when the feature is off. See MapSessionEndpoints and
+// SessionPersistenceServiceExtensions for the rationale (mirrors the Anonymous/GitHub
+// opt-in endpoint conventions above).
+if (app.Services.GetService<ISessionStore>() is not null)
+{
+    app.MapSessionEndpoints();
+}
 
 // Anonymous mode: map the single unauthenticated bootstrap endpoint that mints short-lived
 // session tokens for a future frontend (Sprint 3). Mapped only when Authentication:Mode=Anonymous

--- a/src/RetailPulse.Api/appsettings.Production.json
+++ b/src/RetailPulse.Api/appsettings.Production.json
@@ -146,6 +146,21 @@
     "MaxMessagesPerSession": 200
   },
 
+  // ---- Durable session and conversation persistence (issue #90) ---------
+  // Off in Production by default because the deployed synthetic demo runs on
+  // ephemeral per-replica storage (see DataDirectoryResolver), so persistence
+  // would only survive within one replica's lifetime — enabling it here would
+  // set a durability expectation the storage substrate cannot honour. Once a
+  // policy-compatible durable volume is available, flip SessionPersistence__Enabled=true.
+  "SessionPersistence": {
+    "Enabled": false,
+    "RetentionTtl": "30.00:00:00",
+    "CleanupInterval": "01:00:00",
+    "RedactPiiOnWrite": true,
+    "MaxTurnsPerRehydrate": 200,
+    "MaxSessionsPerList": 200
+  },
+
   // ---- Tool-result cache ------------------------------------------------
   "ToolCache": {
     "Enabled": true,

--- a/src/RetailPulse.Api/appsettings.json
+++ b/src/RetailPulse.Api/appsettings.json
@@ -191,6 +191,33 @@
     "MaxMessagesPerSession": 200
   },
 
+  // ---- Durable session and conversation persistence (issue #90) ---------
+  // Adds SQLite-backed session/turn persistence so a browser refresh can
+  // rehydrate the last conversation. Off by default — enable per environment
+  // via SessionPersistence__Enabled=true or an environment override file.
+  // When off, no database file is created and the chat pipeline behaves
+  // exactly as it did before the feature was added. Anonymous sessions are
+  // NEVER persisted, regardless of this switch: the chat endpoint short-
+  // circuits persistence via IAnonymousChatPolicy and the session endpoints
+  // refuse anonymous callers at entry. Retention is enforced by a background
+  // cleanup service that uses TimeProvider (no wall-clock sleeps) and logs
+  // each sweep's row counts so retention is observable in production.
+  //
+  //   Enabled           (default: false) — master switch
+  //   RetentionTtl      (default: 30 days) — evict sessions inactive for this long
+  //   CleanupInterval   (default: 1 hour)  — how often the sweep runs
+  //   RedactPiiOnWrite  (default: true)    — apply PiiRedactor on write
+  //   MaxTurnsPerRehydrate  (default: 200) — cap on GET /api/sessions/{id}
+  //   MaxSessionsPerList    (default: 200) — cap on GET /api/sessions
+  "SessionPersistence": {
+    "Enabled": false,
+    "RetentionTtl": "30.00:00:00",
+    "CleanupInterval": "01:00:00",
+    "RedactPiiOnWrite": true,
+    "MaxTurnsPerRehydrate": 200,
+    "MaxSessionsPerList": 200
+  },
+
   // ---- Tool-result cache ------------------------------------------------
   "ToolCache": {
     "Enabled": true,

--- a/src/RetailPulse.Contracts/Persistence/SessionDtos.cs
+++ b/src/RetailPulse.Contracts/Persistence/SessionDtos.cs
@@ -1,0 +1,44 @@
+namespace RetailPulse.Contracts.Persistence;
+
+/// <summary>
+/// Summary view of a persisted chat session — one row per session in the caller's list endpoint.
+/// Content is intentionally omitted; use <see cref="SessionDetailDto"/> to rehydrate turns.
+/// </summary>
+public record SessionSummaryDto(
+    string SessionId,
+    string? TenantId,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset LastActivityAt,
+    int TurnCount);
+
+/// <summary>
+/// Full session detail, including the ordered turn history used to rehydrate the browser.
+/// The store returns the caller's own sessions only; a request for a session owned by a
+/// different subject fails with a 404 rather than a silent empty success.
+/// </summary>
+public record SessionDetailDto(
+    string SessionId,
+    string? TenantId,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset LastActivityAt,
+    IReadOnlyList<SessionTurnDto> Turns);
+
+/// <summary>
+/// One persisted chat turn — either a user prompt or an assistant reply. The role names
+/// match the values the chat pipeline already emits into <see cref="RetailPulse.Contracts.ChatHistoryMessage"/>
+/// so a rehydrated session can be posted straight back into <c>/api/chat</c>.
+/// </summary>
+public record SessionTurnDto(
+    string TurnId,
+    string Role,
+    string Content,
+    string? AgentId,
+    string? RoutingIntent,
+    string? RoutingAgentKey,
+    double? RoutingConfidence,
+    int? InputTokens,
+    int? OutputTokens,
+    int? TotalTokens,
+    IReadOnlyList<ChartSpec>? Charts,
+    string? SpanSummary,
+    DateTimeOffset Timestamp);

--- a/src/RetailPulse.Contracts/Persistence/SessionDtos.cs
+++ b/src/RetailPulse.Contracts/Persistence/SessionDtos.cs
@@ -25,7 +25,7 @@ public record SessionDetailDto(
 
 /// <summary>
 /// One persisted chat turn — either a user prompt or an assistant reply. The role names
-/// match the values the chat pipeline already emits into <see cref="RetailPulse.Contracts.ChatHistoryMessage"/>
+/// match the values the chat pipeline already emits into <see cref="ChatHistoryMessage"/>
 /// so a rehydrated session can be posted straight back into <c>/api/chat</c>.
 /// </summary>
 public record SessionTurnDto(

--- a/tests/RetailPulse.Tests/Persistence/AnonymousChatDoesNotPersistTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/AnonymousChatDoesNotPersistTests.cs
@@ -1,0 +1,263 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using RetailPulse.Api.Agents;
+using RetailPulse.Api.Caching;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Api.Guardrails;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Memory;
+using RetailPulse.Api.Middleware;
+using RetailPulse.Api.Models;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Api.Rag;
+using RetailPulse.Api.Security;
+using RetailPulse.Api.Tracing;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Caching;
+using RetailPulse.Contracts.Consensus;
+using RetailPulse.Contracts.Guardrails;
+using RetailPulse.Contracts.Memory;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Rag;
+using RetailPulse.Contracts.Routing;
+using ChatRequest = RetailPulse.Contracts.ChatRequest;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
+
+namespace RetailPulse.Tests.Persistence;
+
+/// <summary>
+/// End-to-end regression test that drives the real <see cref="ChatEndpoints.MapChatEndpoints"/>
+/// delegate through an in-process anonymous TestServer with the durable session store
+/// switched ON, and asserts <b>zero</b> calls flow through <see cref="ISessionStore"/>.
+///
+/// This is the non-negotiable privacy proof for issue #90: anonymous callers already have
+/// cache and memory disabled by policy, and conversation persistence must follow the same
+/// rule. Testing this at the endpoint level (not the store level) is what closes the loop —
+/// a regression that flips the persistence check while leaving the store guard would be
+/// invisible to a store-only test.
+/// </summary>
+public sealed class AnonymousChatDoesNotPersistTests
+{
+    private const string Issuer = "retail-pulse-anonymous";
+    private const string Audience = "retail-pulse-api";
+    private const string SigningKeyText = "session-persist-anon-signing-key-0123456789";
+    private static readonly SymmetricSecurityKey SigningKey = new(Encoding.UTF8.GetBytes(SigningKeyText));
+
+    [Fact]
+    public async Task AnonymousChat_NeverWritesToSessionStore_EvenWithPersistenceEnabled()
+    {
+        var storeMock = new Mock<ISessionStore>(MockBehavior.Strict);
+
+        using ChatFixture fx = CreateServer(storeMock);
+
+        // Send several turns from two distinct anonymous subjects to a cacheable prompt and
+        // a non-cacheable one. The session-persistence path runs on both the LLM-served
+        // branch and the cache-hit branch of ChatEndpoints, so we cover both.
+        HttpResponseMessage r1 = await PostChat(fx, Token("anon-x"), new ChatRequest("Hello there.", SessionId: "s-x"));
+        HttpResponseMessage r2 = await PostChat(fx, Token("anon-y"), new ChatRequest("How many stores do we have?", SessionId: "s-y"));
+        HttpResponseMessage r3 = await PostChat(fx, Token("anon-y"), new ChatRequest("How many stores do we have?", SessionId: "s-y"));
+
+        r1.StatusCode.Should().Be(HttpStatusCode.OK);
+        r2.StatusCode.Should().Be(HttpStatusCode.OK);
+        r3.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // The store is MockBehavior.Strict: any call at all — from either the LLM path or
+        // the cache-hit path — would throw and fail this test.
+        storeMock.Verify(
+            s => s.PersistTurnAsync(It.IsAny<SessionTurnWrite>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "anonymous callers must never persist a turn, regardless of the feature switch");
+    }
+
+    private static async Task<HttpResponseMessage> PostChat(ChatFixture fx, string token, ChatRequest body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/api/chat");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Content = JsonContent.Create(body);
+        return await fx.Client.SendAsync(req);
+    }
+
+    private static string Token(string subject)
+    {
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, subject),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+            new("provider", "Anonymous"),
+            new("roles", "RetailPulse.Anonymous"),
+            new("scp", "chat_limited"),
+        };
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = Audience,
+            Subject = new ClaimsIdentity(claims),
+            NotBefore = DateTime.UtcNow.AddMinutes(-1),
+            Expires = DateTime.UtcNow.AddMinutes(10),
+            SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.HmacSha256),
+        };
+
+        var handler = new JsonWebTokenHandler { SetDefaultTimesOnTokenCreation = false };
+        return handler.CreateToken(descriptor);
+    }
+
+    private static ChatFixture CreateServer(Mock<ISessionStore> storeMock)
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Authentication:Mode"] = "Anonymous",
+                ["Anonymous:AllowHosted"] = "true",
+                ["Anonymous:SigningKey"] = SigningKeyText,
+                ["Anonymous:Issuer"] = Issuer,
+                ["Anonymous:Audience"] = Audience,
+                ["Anonymous:MaxRequestBytes"] = "16384",
+                ["Anonymous:Chat:PerSubjectPerMinute"] = "100",
+                ["Anonymous:Chat:PerIpPerMinute"] = "100",
+                ["Anonymous:Limits:DailyMaxRequests"] = "500",
+                ["Anonymous:Limits:DailyMaxTokens"] = "1000000",
+                ["Anonymous:Limits:DailyMaxCostUsd"] = "100",
+
+                // Session persistence is enabled here. The test proves anonymous callers
+                // are refused at the pipeline gate REGARDLESS of the master switch, so the
+                // switch itself is not what protects them.
+                ["SessionPersistence:Enabled"] = "true",
+            })
+            .Build();
+
+        WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Configuration.AddConfiguration(config);
+        builder.Services.AddLogging();
+        builder.Services.AddRouting();
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddSignalR();
+
+        builder.Services.AddProviderNeutralAuthentication(config, builder.Environment);
+        builder.Services.AddSingleton<ISessionOwnershipRegistry, SessionOwnershipRegistry>();
+
+        // Real pipeline collaborators (no LLM, no memory recall — anonymous disables both).
+        builder.Services.AddSingleton<InMemoryResponseCache>();
+        builder.Services.AddSingleton<IResponseCache>(sp => sp.GetRequiredService<InMemoryResponseCache>());
+        builder.Services.AddSingleton<InMemoryKnowledgeBase>();
+        builder.Services.AddSingleton<IKnowledgeBase>(sp => sp.GetRequiredService<InMemoryKnowledgeBase>());
+        builder.Services.AddSingleton<RagContextProvider>();
+        builder.Services.AddSingleton<InMemorySuspiciousRequestLog>();
+        builder.Services.AddSingleton<ISuspiciousRequestLog>(sp => sp.GetRequiredService<InMemorySuspiciousRequestLog>());
+        builder.Services.AddSingleton<GuardrailsConfig>();
+        builder.Services.AddScoped<GuardrailsMiddleware>();
+        builder.Services.AddSingleton<InMemoryTraceCollector>();
+        builder.Services.Configure<ObservabilityOptions>(_ => { });
+        builder.Services.AddSingleton<ConversationExporter>();
+        builder.Services.AddSingleton<MemoryExtractionChannel>();
+        builder.Services.AddSingleton<MemoryExtractionService>();
+        builder.Services.AddSingleton<ConversationMemoryMiddleware>();
+        builder.Services.AddScoped<StreamingMiddleware>();
+        builder.Services.AddScoped<StreamingProgressFeature>();
+
+        builder.Services.AddSingleton(new Mock<IChatClient>().Object);
+        builder.Services.AddSingleton(new Mock<IConversationMemory>().Object);
+        builder.Services.AddSingleton(new Mock<IConsensusCouncil>().Object);
+
+        var cost = new Mock<ICostTracker>();
+        cost.Setup(c => c.TrackUsageAsync(It.IsAny<UsageEvent>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        builder.Services.AddSingleton(cost.Object);
+
+        var audit = new Mock<IAuditLog>();
+        audit.Setup(a => a.LogAsync(It.IsAny<AuditEntry>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        builder.Services.AddSingleton(audit.Object);
+
+        var tenant = new Mock<ITenantProvider>();
+        tenant.Setup(t => t.GetTenant()).Returns(new TenantConfiguration());
+        builder.Services.AddSingleton(tenant.Object);
+
+        builder.Services.AddSingleton<IAgentRouter, FakeRouter>();
+        builder.Services.AddSingleton<ISpecialistAgent, EchoSpecialist>();
+
+        // Wire the mock ISessionStore + real options section so ChatEndpoints
+        // sees the same shape as production.
+        builder.Services.AddSingleton(storeMock.Object);
+        builder.Services.Configure<SessionPersistenceOptions>(
+            config.GetSection(SessionPersistenceOptions.SectionName));
+
+        WebApplication app = builder.Build();
+        app.UseRouting();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseMiddleware<AnonymousGuardMiddleware>();
+        app.MapChatEndpoints(new AgentDefinition { Name = "test" });
+
+        // Sanity: the options should surface Enabled=true so this test genuinely
+        // exercises the "persistence is on but the caller is anonymous" case.
+        SessionPersistenceOptions opts = app.Services.GetRequiredService<IOptions<SessionPersistenceOptions>>().Value;
+        opts.Enabled.Should().BeTrue("the test set SessionPersistence:Enabled=true");
+
+        app.StartAsync().GetAwaiter().GetResult();
+        return new ChatFixture(app);
+    }
+
+    private sealed class FakeRouter : IAgentRouter
+    {
+        public Task<RoutingDecision> RouteAsync(
+            string message,
+            IReadOnlyList<ChatHistoryMessage>? conversationHistory,
+            UserContext? user,
+            string? tenantId,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RoutingDecision("general", AgentIntent.General, 0.9, [AgentIntent.General]));
+    }
+
+    private sealed class EchoSpecialist : ISpecialistAgent
+    {
+        public string Key => "general";
+        public string DisplayName => "General";
+        public string Model => "gpt-test";
+        public IReadOnlyList<string> SupportedIntents => [AgentIntent.General];
+
+        public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default) =>
+            Task.FromResult(new ChatResponse(
+                request.User?.ObjectId ?? "(none)",
+                request.SessionId ?? "s",
+                [new AgentSpan("agent.general.response", "response", "done", 1, DateTimeOffset.UtcNow, request.SessionId)],
+                Charts: null,
+                TotalDurationMs: 1,
+                TokenUsage: new TokenUsage(1, 1, 2)));
+    }
+
+    private sealed class ChatFixture : IDisposable
+    {
+        private readonly WebApplication _app;
+
+        public ChatFixture(WebApplication app)
+        {
+            _app = app;
+            Client = app.GetTestClient();
+        }
+
+        public HttpClient Client { get; }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _app.StopAsync().GetAwaiter().GetResult();
+            ((IDisposable)_app).Dispose();
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Persistence/SessionCleanupBackgroundServiceTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SessionCleanupBackgroundServiceTests.cs
@@ -1,0 +1,197 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Tests.Persistence;
+
+/// <summary>
+/// Retention/observability tests for <see cref="SessionCleanupBackgroundService"/>.
+/// Uses a hand-rolled <see cref="TimeProvider"/> so the sweep cadence is driven by
+/// deterministic ticks, not <see cref="Task.Delay"/> — matching the issue #90
+/// mandate to use a clock abstraction rather than sleeps. We only need to run
+/// enough time forward to trigger one <see cref="ISessionStore.PurgeExpiredAsync"/>
+/// call and observe that the reported result surfaces in the logs.
+/// </summary>
+public sealed class SessionCleanupBackgroundServiceTests
+{
+    [Fact]
+    public async Task PurgesExpiredSessions_OnClockTick_AndLogsRowCounts()
+    {
+        var store = new Mock<ISessionStore>(MockBehavior.Strict);
+        DateTimeOffset? seenCutoff = null;
+        store.Setup(s => s.PurgeExpiredAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .Callback<DateTimeOffset, CancellationToken>((cutoff, _) => seenCutoff ??= cutoff)
+            .ReturnsAsync(new CleanupResult(SessionsDeleted: 3, TurnsDeleted: 12));
+
+        IOptions<SessionPersistenceOptions> options = Options.Create(new SessionPersistenceOptions
+        {
+            Enabled = true,
+            RetentionTtl = TimeSpan.FromDays(30),
+            CleanupInterval = TimeSpan.FromMinutes(15),
+        });
+
+        DateTimeOffset now = new(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var clock = new ManualTimeProvider(now);
+        var logger = new CountingLogger<SessionCleanupBackgroundService>();
+
+        var svc = new SessionCleanupBackgroundService(store.Object, options, clock, logger);
+
+        using var cts = new CancellationTokenSource();
+        Task loop = svc.StartAsync(cts.Token);
+
+        // One tick of the CleanupInterval → PeriodicTimer fires → PurgeExpiredAsync runs.
+        // Poll rather than sleep so the test doesn't race the timer's own scheduling.
+        clock.Advance(options.Value.CleanupInterval);
+        bool purged = await WaitUntilAsync(() => seenCutoff.HasValue, TimeSpan.FromSeconds(5));
+        purged.Should().BeTrue("the first tick after CleanupInterval must trigger a purge sweep");
+
+        // The sweep reads GetUtcNow() at tick time, which is now start + CleanupInterval.
+        // The cutoff must therefore reflect the injected clock at THAT moment, not the
+        // wall clock — the whole point of the TimeProvider abstraction.
+        DateTimeOffset expectedCutoff = now + options.Value.CleanupInterval - options.Value.RetentionTtl;
+        seenCutoff.Should().Be(expectedCutoff,
+            "the cutoff must be exactly (injected-now - RetentionTtl) so the injected clock — not the wall clock — drives retention");
+
+        bool logged = await WaitUntilAsync(() => logger.InformationCount >= 2, TimeSpan.FromSeconds(5));
+        logged.Should().BeTrue("cleanup start + swept counts must both be logged for retention observability");
+
+        await cts.CancelAsync();
+        await svc.StopAsync(CancellationToken.None);
+        await loop;
+    }
+
+    [Fact]
+    public async Task ExitsWithoutSweeping_When_RetentionOrIntervalIsNonPositive()
+    {
+        var store = new Mock<ISessionStore>(MockBehavior.Strict);
+        IOptions<SessionPersistenceOptions> options = Options.Create(new SessionPersistenceOptions
+        {
+            Enabled = true,
+            RetentionTtl = TimeSpan.Zero,
+            CleanupInterval = TimeSpan.FromMinutes(15),
+        });
+
+        var svc = new SessionCleanupBackgroundService(
+            store.Object, options, TimeProvider.System, Mock.Of<ILogger<SessionCleanupBackgroundService>>());
+
+        using var cts = new CancellationTokenSource();
+        await svc.StartAsync(cts.Token);
+        await svc.StopAsync(CancellationToken.None);
+
+        // No purge call must have been made — the sweeper turns itself off when
+        // retention is unbounded, so the operator gets durable writes without a
+        // deletion cadence they didn't ask for.
+        store.Verify(
+            s => s.PurgeExpiredAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(20);
+        }
+        return condition();
+    }
+
+    /// <summary>
+    /// Small deterministic <see cref="TimeProvider"/> used to drive the cleanup
+    /// service's <see cref="PeriodicTimer"/> without a wall-clock dependency.
+    /// We only need <see cref="CreateTimer"/> semantics rich enough for
+    /// <see cref="PeriodicTimer.WaitForNextTickAsync"/> to fire once per
+    /// <see cref="Advance"/> call whose delta covers the timer's period.
+    /// </summary>
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now;
+        private readonly List<ManualTimer> _timers = [];
+        private readonly Lock _lock = new();
+
+        public ManualTimeProvider(DateTimeOffset start) { _now = start; }
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = new ManualTimer(this, callback, state, dueTime, period);
+            lock (_lock) _timers.Add(timer);
+            return timer;
+        }
+
+        public void Advance(TimeSpan delta)
+        {
+            List<ManualTimer> snapshot;
+            lock (_lock)
+            {
+                _now += delta;
+                snapshot = [.. _timers];
+            }
+            foreach (ManualTimer t in snapshot) t.Tick(delta);
+        }
+
+        internal void Remove(ManualTimer t)
+        {
+            lock (_lock) _timers.Remove(t);
+        }
+    }
+
+    private sealed class ManualTimer : ITimer
+    {
+        private readonly ManualTimeProvider _provider;
+        private readonly TimerCallback _callback;
+        private readonly object? _state;
+        private TimeSpan _dueTime;
+        private TimeSpan _period;
+        private TimeSpan _accum;
+        private bool _disposed;
+
+        public ManualTimer(ManualTimeProvider provider, TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            _provider = provider;
+            _callback = callback;
+            _state = state;
+            _dueTime = dueTime;
+            _period = period;
+        }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            _dueTime = dueTime;
+            _period = period;
+            _accum = TimeSpan.Zero;
+            return true;
+        }
+
+        public void Tick(TimeSpan delta)
+        {
+            if (_disposed) return;
+            _accum += delta;
+            while (!_disposed && _accum >= _dueTime && _dueTime > TimeSpan.Zero)
+            {
+                _accum -= _dueTime;
+                _dueTime = _period > TimeSpan.Zero ? _period : Timeout.InfiniteTimeSpan;
+                _callback(_state);
+            }
+        }
+
+        public void Dispose() { _disposed = true; _provider.Remove(this); }
+        public ValueTask DisposeAsync() { Dispose(); return ValueTask.CompletedTask; }
+    }
+
+    private sealed class CountingLogger<T> : ILogger<T>
+    {
+        public int InformationCount;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Information) Interlocked.Increment(ref InformationCount);
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Persistence/SessionPersistenceServiceExtensionsTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SessionPersistenceServiceExtensionsTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RetailPulse.Api.Persistence;
+
+namespace RetailPulse.Tests.Persistence;
+
+/// <summary>
+/// Config-switch tests for the durable session persistence feature. Proves the
+/// disabled-by-config acceptance criterion from issue #90: when
+/// <c>SessionPersistence:Enabled</c> is false, no <see cref="ISessionStore"/> is
+/// registered, no <see cref="SessionCleanupBackgroundService"/> is hosted, and no
+/// database file is created — the chat pipeline behaves exactly as it did before
+/// the feature was added.
+/// </summary>
+public sealed class SessionPersistenceServiceExtensionsTests
+{
+    private static IServiceCollection BuildServices(IDictionary<string, string?> settings, string dbPath)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSessionPersistence(configuration, dbPath);
+        return services;
+    }
+
+    [Fact]
+    public void Disabled_DoesNotRegisterStore_OrCleanupService_OrTouchDisk()
+    {
+        string dbPath = Path.Combine(Path.GetTempPath(), $"session_disabled_{Guid.NewGuid():N}.db");
+
+        IServiceCollection services = BuildServices(
+            new Dictionary<string, string?> { ["SessionPersistence:Enabled"] = "false" },
+            dbPath);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetService<ISessionStore>().Should().BeNull(
+            "the feature switch is off, so no store singleton must be resolvable — a stray consumer must fail loudly, not silently write to disk");
+
+        provider.GetServices<IHostedService>()
+            .OfType<SessionCleanupBackgroundService>()
+            .Should().BeEmpty("the cleanup service must not be scheduled when persistence is off");
+
+        File.Exists(dbPath).Should().BeFalse(
+            "the disabled path must never create a database file — Wave 1 behaviour is bit-for-bit preserved");
+    }
+
+    [Fact]
+    public void Enabled_RegistersStore_AndCleanupService()
+    {
+        string dbPath = Path.Combine(Path.GetTempPath(), $"session_enabled_{Guid.NewGuid():N}.db");
+
+        try
+        {
+            IServiceCollection services = BuildServices(
+                new Dictionary<string, string?> { ["SessionPersistence:Enabled"] = "true" },
+                dbPath);
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+
+            provider.GetService<ISessionStore>().Should().NotBeNull(
+                "the feature switch is on, so the SQLite-backed store must be resolvable");
+
+            provider.GetServices<IHostedService>()
+                .OfType<SessionCleanupBackgroundService>()
+                .Should().ContainSingle("retention must be enforced by a single background sweep when persistence is on");
+        }
+        finally
+        {
+            try { File.Delete(dbPath); } catch { }
+            try { File.Delete(dbPath + "-shm"); } catch { }
+            try { File.Delete(dbPath + "-wal"); } catch { }
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Persistence/SessionStoreRestartTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SessionStoreRestartTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using Moq;
 using RetailPulse.Api.Persistence;
@@ -82,5 +83,87 @@ public sealed class SessionStoreRestartTests : IDisposable
         // which does not survive a fresh connection on a network filesystem.
         File.Exists(_dbPath + "-wal").Should().BeFalse("DELETE journal mode leaves no persistent WAL sidecar");
         File.Exists(_dbPath + "-shm").Should().BeFalse("DELETE journal mode leaves no persistent SHM sidecar");
+    }
+
+    /// <summary>
+    /// Schema-compatibility guarantee for the durable-insertion-order fix. The
+    /// tie-breaker for identical timestamps is <c>rowid</c>, which every SQLite
+    /// regular-rowid table already carries — no <c>ALTER TABLE</c> is needed and
+    /// databases created before this change continue to order correctly on the
+    /// upgraded build. Simulate that by writing a user→assistant pair with the
+    /// same <c>DateTimeOffset</c> against the file, closing the store, opening a
+    /// fresh <see cref="SqliteSessionStore"/> against the same path, and asserting
+    /// the rehydrated transcript still returns user first, assistant second.
+    /// </summary>
+    [Fact]
+    public async Task InsertionOrder_SurvivesRestart_ForIdenticalTimestamps()
+    {
+        string sessionId = Guid.NewGuid().ToString("N");
+        DateTimeOffset persistNow = DateTimeOffset.UtcNow;
+
+        {
+            var writer = new SqliteSessionStore(_dbPath, Mock.Of<ILogger<SqliteSessionStore>>());
+            await writer.PersistTurnAsync(new SessionTurnWrite
+            {
+                SessionId = sessionId,
+                Subject = "alice",
+                TenantId = "Contoso",
+                Role = "user",
+                Content = "u-restart",
+                Timestamp = persistNow
+            });
+            await writer.PersistTurnAsync(new SessionTurnWrite
+            {
+                SessionId = sessionId,
+                Subject = "alice",
+                TenantId = "Contoso",
+                Role = "assistant",
+                Content = "a-restart",
+                Timestamp = persistNow
+            });
+        }
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        var reader = new SqliteSessionStore(_dbPath, Mock.Of<ILogger<SqliteSessionStore>>());
+
+        SessionDetailDto? detail = await reader.GetSessionAsync("alice", sessionId);
+        detail.Should().NotBeNull();
+        detail.Turns.Should().HaveCount(2);
+        detail.Turns[0].Role.Should().Be("user", "the user turn was persisted before the assistant turn");
+        detail.Turns[0].Content.Should().Be("u-restart");
+        detail.Turns[1].Role.Should().Be("assistant");
+        detail.Turns[1].Content.Should().Be("a-restart");
+    }
+
+    /// <summary>
+    /// Backwards-compatibility guarantee: the durable-insertion-order fix relies
+    /// on the intrinsic <c>rowid</c> column of a regular-rowid SQLite table (a
+    /// TEXT PRIMARY KEY does not turn the table into WITHOUT ROWID). Confirm that
+    /// against the actual schema materialized on disk by
+    /// <see cref="SqliteSessionStore"/>: if the schema ever regressed to
+    /// <c>WITHOUT ROWID</c>, the tie-breaker would silently stop being monotonic
+    /// and this test would fail before any real transcript did.
+    /// </summary>
+    [Fact]
+    public void SessionTurnsTable_IsRegularRowidTable_ForInsertionOrderTieBreak()
+    {
+        _ = new SqliteSessionStore(_dbPath, Mock.Of<ILogger<SqliteSessionStore>>());
+
+        string connString = new SqliteConnectionStringBuilder
+        {
+            DataSource = _dbPath,
+            Mode = SqliteOpenMode.ReadOnly
+        }.ToString();
+
+        using SqliteConnection conn = new(connString);
+        conn.Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'SessionTurns'";
+        string ddl = (string)cmd.ExecuteScalar()!;
+
+        ddl.Should().NotContain(
+            "WITHOUT ROWID",
+            "the store depends on rowid as the durable insertion-order tie-breaker for identical timestamps");
     }
 }

--- a/tests/RetailPulse.Tests/Persistence/SessionStoreRestartTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SessionStoreRestartTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Tests.Persistence;
+
+/// <summary>
+/// Restart-durability test for the SQLite session store — the "browser refresh
+/// after a redeploy" acceptance criterion from issue #90. Persist some turns
+/// through one store instance, dispose the connection scope, then open a
+/// brand-new <see cref="SqliteSessionStore"/> pointed at the same file. All rows
+/// must be readable, ownership must still be enforced, and the SMB-safe pragmas
+/// (<c>journal_mode=DELETE</c>, no <c>-wal</c>/<c>-shm</c> sidecars) must survive
+/// the process boundary — which is what tolerating an API restart requires.
+/// </summary>
+public sealed class SessionStoreRestartTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public SessionStoreRestartTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"session_restart_{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { }
+        try { File.Delete(_dbPath + "-wal"); } catch { }
+        try { File.Delete(_dbPath + "-shm"); } catch { }
+    }
+
+    private static SessionTurnWrite MakeTurn(string sessionId, string subject, string role, string content) =>
+        new()
+        {
+            SessionId = sessionId,
+            Subject = subject,
+            TenantId = "Contoso",
+            Role = role,
+            Content = content,
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+    [Fact]
+    public async Task Sessions_Survive_A_Store_Restart()
+    {
+        string aliceSession = Guid.NewGuid().ToString("N");
+        string bobSession = Guid.NewGuid().ToString("N");
+
+        // First "process": write two subjects' conversations, then let the store
+        // (and its connection scope) go out of scope, mimicking an API restart.
+        {
+            var writer = new SqliteSessionStore(_dbPath, Mock.Of<ILogger<SqliteSessionStore>>());
+            await writer.PersistTurnAsync(MakeTurn(aliceSession, "alice", "user", "hello"));
+            await writer.PersistTurnAsync(MakeTurn(aliceSession, "alice", "assistant", "hi alice"));
+            await writer.PersistTurnAsync(MakeTurn(bobSession, "bob", "user", "bob's turn"));
+        }
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        // Second "process": brand-new store instance, same path.
+        var reader = new SqliteSessionStore(_dbPath, Mock.Of<ILogger<SqliteSessionStore>>());
+
+        SessionDetailDto? alice = await reader.GetSessionAsync("alice", aliceSession);
+        alice.Should().NotBeNull("Alice's session must survive the restart");
+        alice.Turns.Should().HaveCount(2);
+        alice.Turns[0].Content.Should().Be("hello");
+        alice.Turns[1].Content.Should().Be("hi alice");
+
+        SessionDetailDto? bob = await reader.GetSessionAsync("bob", bobSession);
+        bob.Should().NotBeNull("Bob's session must survive too");
+        bob.Turns.Should().HaveCount(1);
+
+        // Cross-subject probes must still fail after a restart — the ownership
+        // check is in the schema (Subject column + WHERE), not in memory.
+        SessionDetailDto? cross = await reader.GetSessionAsync("bob", aliceSession);
+        cross.Should().BeNull("cross-subject reads must fail across restarts, not just within one process");
+
+        // SMB-safe pragmas: DELETE journal mode leaves no persistent -wal / -shm
+        // sidecars on the disk. Their presence would indicate a regression to WAL,
+        // which does not survive a fresh connection on a network filesystem.
+        File.Exists(_dbPath + "-wal").Should().BeFalse("DELETE journal mode leaves no persistent WAL sidecar");
+        File.Exists(_dbPath + "-shm").Should().BeFalse("DELETE journal mode leaves no persistent SHM sidecar");
+    }
+}

--- a/tests/RetailPulse.Tests/Persistence/SqliteSessionStoreTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SqliteSessionStoreTests.cs
@@ -1,0 +1,215 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Tests.Persistence;
+
+/// <summary>
+/// Unit tests for <see cref="SqliteSessionStore"/> — the durable server-side backing for
+/// issue #90 (chat session persistence). Cover the privacy-critical paths: subject
+/// scoping on every read, ownership guard on write, purge with an injected clock, and
+/// concurrent writes across distinct sessions.
+/// </summary>
+public sealed class SqliteSessionStoreTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly SqliteSessionStore _store;
+
+    public SqliteSessionStoreTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"session_store_test_{Guid.NewGuid():N}.db");
+        _store = new SqliteSessionStore(_dbPath, Mock.Of<ILogger<SqliteSessionStore>>());
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { }
+        try { File.Delete(_dbPath + "-wal"); } catch { }
+        try { File.Delete(_dbPath + "-shm"); } catch { }
+    }
+
+    private static SessionTurnWrite MakeTurn(
+        string sessionId,
+        string subject,
+        string role = "user",
+        string content = "hello",
+        DateTimeOffset? ts = null) =>
+        new()
+        {
+            SessionId = sessionId,
+            Subject = subject,
+            TenantId = "Contoso",
+            Role = role,
+            Content = content,
+            RoutingIntent = "chat",
+            RoutingAgentKey = "generalist",
+            RoutingConfidence = 0.87,
+            InputTokens = 12,
+            OutputTokens = 34,
+            TotalTokens = 46,
+            Timestamp = ts ?? DateTimeOffset.UtcNow
+        };
+
+    [Fact]
+    public async Task PersistTurn_Then_GetSession_RoundTripsAllFields()
+    {
+        string sessionId = Guid.NewGuid().ToString("N");
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        await _store.PersistTurnAsync(MakeTurn(sessionId, "alice", "user", "hi", now));
+        await _store.PersistTurnAsync(MakeTurn(sessionId, "alice", "assistant", "hello, alice", now.AddSeconds(1)));
+
+        SessionDetailDto? detail = await _store.GetSessionAsync("alice", sessionId);
+
+        detail.Should().NotBeNull();
+        detail.SessionId.Should().Be(sessionId);
+        detail.TenantId.Should().Be("Contoso");
+        detail.Turns.Should().HaveCount(2);
+        detail.Turns[0].Role.Should().Be("user");
+        detail.Turns[0].Content.Should().Be("hi");
+        detail.Turns[1].Role.Should().Be("assistant");
+        detail.Turns[1].Content.Should().Be("hello, alice");
+        detail.Turns[1].RoutingAgentKey.Should().Be("generalist");
+        detail.Turns[1].TotalTokens.Should().Be(46);
+    }
+
+    [Fact]
+    public async Task GetSession_ReturnsNull_ForForeignSubject()
+    {
+        string sessionId = Guid.NewGuid().ToString("N");
+        await _store.PersistTurnAsync(MakeTurn(sessionId, "alice"));
+
+        // Bob asking for Alice's session must resolve to null (endpoint layer surfaces 404).
+        SessionDetailDto? detail = await _store.GetSessionAsync("bob", sessionId);
+
+        detail.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PersistTurn_DoesNotWrite_WhenSessionOwnedByDifferentSubject()
+    {
+        string sessionId = Guid.NewGuid().ToString("N");
+
+        await _store.PersistTurnAsync(MakeTurn(sessionId, "alice", "user", "alice content"));
+
+        // Bob tries to append to Alice's session — must be rejected silently. The
+        // ownership guard rolls the transaction back so no orphan turn lands.
+        await _store.PersistTurnAsync(MakeTurn(sessionId, "bob", "assistant", "sneaky reply"));
+
+        SessionDetailDto? forAlice = await _store.GetSessionAsync("alice", sessionId);
+        forAlice.Should().NotBeNull();
+        forAlice.Turns.Should().HaveCount(1);
+        forAlice.Turns[0].Content.Should().Be("alice content");
+
+        SessionDetailDto? forBob = await _store.GetSessionAsync("bob", sessionId);
+        forBob.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ListSessions_ScopedToSubject()
+    {
+        await _store.PersistTurnAsync(MakeTurn(Guid.NewGuid().ToString("N"), "alice"));
+        await _store.PersistTurnAsync(MakeTurn(Guid.NewGuid().ToString("N"), "alice"));
+        await _store.PersistTurnAsync(MakeTurn(Guid.NewGuid().ToString("N"), "bob"));
+
+        IReadOnlyList<SessionSummaryDto> alice = await _store.ListSessionsForSubjectAsync("alice");
+        IReadOnlyList<SessionSummaryDto> bob = await _store.ListSessionsForSubjectAsync("bob");
+        IReadOnlyList<SessionSummaryDto> mallory = await _store.ListSessionsForSubjectAsync("mallory");
+
+        alice.Should().HaveCount(2);
+        bob.Should().HaveCount(1);
+        mallory.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteSession_RemovesTurns_AndReturnsFalseForForeignSubject()
+    {
+        string sessionId = Guid.NewGuid().ToString("N");
+        await _store.PersistTurnAsync(MakeTurn(sessionId, "alice", "user"));
+        await _store.PersistTurnAsync(MakeTurn(sessionId, "alice", "assistant"));
+
+        // Foreign delete must fail closed.
+        bool bobDelete = await _store.DeleteSessionAsync("bob", sessionId);
+        bobDelete.Should().BeFalse();
+
+        SessionDetailDto? stillThere = await _store.GetSessionAsync("alice", sessionId);
+        stillThere.Should().NotBeNull();
+
+        // Owner delete removes the whole conversation.
+        bool aliceDelete = await _store.DeleteSessionAsync("alice", sessionId);
+        aliceDelete.Should().BeTrue();
+
+        SessionDetailDto? gone = await _store.GetSessionAsync("alice", sessionId);
+        gone.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PurgeExpired_EvictsOldSessionsAndTurns_ButKeepsRecent()
+    {
+        DateTimeOffset old = DateTimeOffset.UtcNow.AddDays(-40);
+        DateTimeOffset recent = DateTimeOffset.UtcNow.AddMinutes(-5);
+
+        string oldSession = Guid.NewGuid().ToString("N");
+        string recentSession = Guid.NewGuid().ToString("N");
+
+        await _store.PersistTurnAsync(MakeTurn(oldSession, "alice", "user", "old", old));
+        await _store.PersistTurnAsync(MakeTurn(oldSession, "alice", "assistant", "old reply", old.AddSeconds(1)));
+        await _store.PersistTurnAsync(MakeTurn(recentSession, "alice", "user", "fresh", recent));
+
+        DateTimeOffset cutoff = DateTimeOffset.UtcNow.AddDays(-30);
+        CleanupResult result = await _store.PurgeExpiredAsync(cutoff);
+
+        result.SessionsDeleted.Should().Be(1);
+        result.TurnsDeleted.Should().Be(2);
+
+        IReadOnlyList<SessionSummaryDto> remaining = await _store.ListSessionsForSubjectAsync("alice");
+        remaining.Should().HaveCount(1);
+        remaining[0].SessionId.Should().Be(recentSession);
+    }
+
+    [Fact]
+    public async Task ParallelWrites_ToDistinctSessions_Succeed()
+    {
+        // The SMB-safe pragmas (busy_timeout=10000, DELETE journal) let concurrent
+        // writers cooperate through the busy handler rather than throwing SQLITE_BUSY.
+        int count = 16;
+        Task[] writes = [.. Enumerable.Range(0, count).Select(i =>
+            _store.PersistTurnAsync(MakeTurn(
+                sessionId: Guid.NewGuid().ToString("N"),
+                subject: "alice",
+                role: "user",
+                content: $"turn-{i}")))];
+
+        await Task.WhenAll(writes);
+
+        IReadOnlyList<SessionSummaryDto> sessions = await _store.ListSessionsForSubjectAsync("alice");
+        sessions.Should().HaveCount(count);
+    }
+
+    [Fact]
+    public async Task Charts_RoundTripThroughJson_WhenPresent()
+    {
+        string sessionId = Guid.NewGuid().ToString("N");
+        var chart = new ChartSpec
+        {
+            Type = "line",
+            Title = "Sales",
+            XAxisTitle = "week",
+            YAxisTitle = "revenue"
+        };
+        SessionTurnWrite write = MakeTurn(sessionId, "alice", "assistant", "here you go") with
+        {
+            Charts = [chart]
+        };
+        await _store.PersistTurnAsync(write);
+
+        SessionDetailDto? detail = await _store.GetSessionAsync("alice", sessionId);
+        detail.Should().NotBeNull();
+        detail.Turns[0].Charts.Should().NotBeNull();
+        detail.Turns[0].Charts.Should().HaveCount(1);
+        detail.Turns[0].Charts![0].Title.Should().Be("Sales");
+    }
+}

--- a/tests/RetailPulse.Tests/Persistence/SqliteSessionStoreTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SqliteSessionStoreTests.cs
@@ -212,4 +212,59 @@ public sealed class SqliteSessionStoreTests : IDisposable
         detail.Turns[0].Charts.Should().HaveCount(1);
         detail.Turns[0].Charts![0].Title.Should().Be("Sales");
     }
+
+    /// <summary>
+    /// Regression for the reviewer finding on PR #117: production writes the user
+    /// and assistant turns with the same <c>DateTimeOffset persistNow</c> in both
+    /// the cache-hit and LLM paths (<c>ChatEndpoints.cs</c>). If rehydration sorts
+    /// only by <c>Timestamp</c> — with a random-GUID <c>TurnId</c> as the
+    /// tie-breaker — the assistant turn will sort before the user turn about half
+    /// the time. The store must guarantee strict insertion order when timestamps
+    /// are identical.
+    /// </summary>
+    [Fact]
+    public async Task GetSession_PreservesInsertionOrder_WhenTimestampsAreIdentical()
+    {
+        string sessionId = Guid.NewGuid().ToString("N");
+        DateTimeOffset persistNow = DateTimeOffset.UtcNow;
+
+        await _store.PersistTurnAsync(MakeTurn(sessionId, "alice", "user", "u-content", persistNow));
+        await _store.PersistTurnAsync(MakeTurn(sessionId, "alice", "assistant", "a-content", persistNow));
+
+        SessionDetailDto? detail = await _store.GetSessionAsync("alice", sessionId);
+
+        detail.Should().NotBeNull();
+        detail.Turns.Should().HaveCount(2);
+        detail.Turns[0].Role.Should().Be("user", "the user turn was persisted first");
+        detail.Turns[0].Content.Should().Be("u-content");
+        detail.Turns[1].Role.Should().Be("assistant", "the assistant turn was persisted second");
+        detail.Turns[1].Content.Should().Be("a-content");
+    }
+
+    /// <summary>
+    /// Fuzz variant of the identical-timestamp regression. Repeats the same
+    /// user-then-assistant persist ten times per iteration so that if the
+    /// tie-breaker ever regressed to a random-GUID <c>TurnId</c> order (roughly a
+    /// coin flip per pair), the probability of missing the failure is negligible
+    /// (~1e-30). Keeps the guarantee honest even under lucky GUID draws.
+    /// </summary>
+    [Fact]
+    public async Task GetSession_PreservesInsertionOrder_UnderRepeatedIdenticalTimestampPairs()
+    {
+        DateTimeOffset persistNow = DateTimeOffset.UtcNow;
+
+        for (int i = 0; i < 10; i++)
+        {
+            string sessionId = Guid.NewGuid().ToString("N");
+            await _store.PersistTurnAsync(MakeTurn(sessionId, "alice", "user", $"u-{i}", persistNow));
+            await _store.PersistTurnAsync(MakeTurn(sessionId, "alice", "assistant", $"a-{i}", persistNow));
+
+            SessionDetailDto? detail = await _store.GetSessionAsync("alice", sessionId);
+
+            detail.Should().NotBeNull();
+            detail.Turns.Should().HaveCount(2);
+            detail.Turns[0].Role.Should().Be("user");
+            detail.Turns[1].Role.Should().Be("assistant");
+        }
+    }
 }


### PR DESCRIPTION
Closes #90

## What

Add opt-in server-side persistence for chat sessions and turns so a browser
refresh can rehydrate the last conversation across an API restart. Follows the
same pattern as the existing durable stores (`SqliteConversationMemory`,
`SqliteApprovalGate`, `SqliteAlertService`): SQLite in the shared writable data
directory, opened through the centralized `SqliteMount` helper with SMB-safe
pragmas (`busy_timeout=10000`, `journal_mode=DELETE`, `synchronous=FULL`).

## Surface

- `SqliteSessionStore` (`ISessionStore`) — subject-scoped upsert, list,
  rehydrate, delete, and TTL purge; every read/delete WHERE-clause filters on
  the resolved subject so a cross-subject read resolves to `null` (surfaced as
  `404`, never as a silent empty).
- `SessionEndpoints` — `GET /api/sessions`, `GET /api/sessions/{id}`,
  `DELETE /api/sessions/{id}` (subject-scoped, `RequireAuthorization`,
  anonymous callers refused at entry with `403 session_persistence_unavailable`).
- `SessionCleanupBackgroundService` — retention sweep driven by
  `TimeProvider` (tests use a deterministic clock, no sleeps), logs per-sweep
  `SessionsDeleted` / `TurnsDeleted` counts so retention is observable in
  production.
- `ChatEndpoints` persists user + assistant turns for authenticated callers
  on both the LLM path and the cache-hit path; anonymous callers are
  short-circuited via `IAnonymousChatPolicy` and never write, matching the
  cache/memory-disabled rule.
- `SessionPersistence` configuration section, `Enabled=false` by default so
  Wave 1 behaviour is preserved bit-for-bit until an operator opts in.
- `docs/architecture.md` and `docs/security.md` updated with the pipeline,
  schema, configuration, and privacy contract.

## Privacy contract (non-negotiable)

- **Anonymous sessions are never persisted.** Chat write path guarded by
  `IAnonymousChatPolicy`; session endpoints refuse anonymous callers at entry.
  Proved end-to-end by `AnonymousChatDoesNotPersistTests`, which boots the
  real chat delegate with a **strict-mock** `ISessionStore` and asserts zero
  calls flow through on the anonymous path (even with the feature switch on).
- **Subject-scoped SQL on every read/delete** — cross-subject requests
  resolve to `null` and surface as `404`. Endpoint uses the same `404` for
  "unknown id" and "wrong owner" so it cannot be used as a probing oracle.
- **Ownership pinned at first write** — `INSERT ... ON CONFLICT ...
  WHERE Sessions.Subject = excluded.Subject`, plus a post-upsert ownership
  check inside the same transaction. A turn from a foreign subject is rolled
  back rather than dropped as an orphan.
- **Complete deletion** — cascade removes child `SessionTurns` before the
  parent `Sessions` row inside one transaction; no soft-delete flag.
- **PII redaction on write** — `SessionPersistence:RedactPiiOnWrite=true`
  routes each turn's `Content` through the shared `PiiRedactor` so redaction
  on write and on display stay in lock-step.
- **Config kill-switch** — `Enabled=false` means no store singleton, no
  cleanup service, no DB file, and no `/api/sessions/*` routes. Restores the
  pre-feature behaviour bit-for-bit.

## Tests (all green — 2776 passed, 0 failed)

- `SqliteSessionStoreTests` — round-trip, cross-subject isolation, ownership
  guard on write, delete cascade, purge with an injected clock, parallel
  writes across distinct sessions, chart-spec JSON round-trip.
- `SessionStoreRestartTests` — persist through one instance, dispose,
  reopen a brand-new store on the same path, verify all rows rehydrate and
  ownership is still enforced. Asserts no `-wal`/`-shm` sidecars linger.
- `SessionPersistenceServiceExtensionsTests` — proves `Enabled=false`
  registers no store singleton, no hosted cleanup service, and creates no
  DB file; `Enabled=true` wires both.
- `SessionCleanupBackgroundServiceTests` — retention sweep driven by a
  hand-rolled `ManualTimeProvider`, asserts cutoff = injected-now − TTL and
  that per-sweep counts surface as `Information` logs.
- `AnonymousChatDoesNotPersistTests` — end-to-end regression through the
  real `ChatEndpoints` delegate with a strict-mock store on the anonymous
  path.

## Validation

- `dotnet build` — clean.
- `dotnet test tests/RetailPulse.Tests` — 2776 passed / 0 failed.
- `dotnet format RetailPulse.slnx --verify-no-changes` — clean.

## Files

```
src/RetailPulse.Api/Endpoints/SessionEndpoints.cs                            (new)
src/RetailPulse.Api/Persistence/ISessionStore.cs                             (new)
src/RetailPulse.Api/Persistence/SqliteSessionStore.cs                        (new)
src/RetailPulse.Api/Persistence/SessionPersistenceOptions.cs                 (new)
src/RetailPulse.Api/Persistence/SessionPersistenceServiceExtensions.cs       (new)
src/RetailPulse.Api/Persistence/SessionCleanupBackgroundService.cs           (new)
src/RetailPulse.Api/Persistence/SessionRecords.cs                            (new)
src/RetailPulse.Contracts/Persistence/SessionDtos.cs                         (new)
src/RetailPulse.Api/Endpoints/ChatEndpoints.cs                               (modified — persist path + persistenceEnabled gate)
src/RetailPulse.Api/Program.cs                                               (modified — AddSessionPersistence + MapSessionEndpoints)
src/RetailPulse.Api/appsettings.json                                         (modified — SessionPersistence defaults)
src/RetailPulse.Api/appsettings.Production.json                              (modified — Enabled=false with rationale)
tests/RetailPulse.Tests/Persistence/*                                        (new — 5 test files, 14 tests)
docs/architecture.md                                                         (modified — Session Persistence section)
docs/security.md                                                             (modified — Session Persistence section)
```
