### PR TITLE
Pre-commit dotnet format hook + line-ending guardrails (Closes #116)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,32 @@
 # Normalize line endings to LF on checkout
 * text=auto eol=lf
 
+# Explicit LF for shell/text files that must run on Linux/macOS regardless of
+# host OS. `text=auto` already handles this via content detection, but being
+# explicit prevents a broken pre-commit hook (or CI script) if a contributor's
+# editor ever saves one of these with CRLF.
+*.sh          text eol=lf
+*.bash        text eol=lf
+.githooks/*   text eol=lf
+
+# Explicit binary markers so `text=auto` cannot mis-classify these formats and
+# corrupt them on Windows checkout. Covers every binary asset actually
+# committed to the repo today (see docs/, infra/, src/**/wwwroot/).
+*.png         binary
+*.jpg         binary
+*.jpeg        binary
+*.gif         binary
+*.ico         binary
+*.webp        binary
+*.pdf         binary
+*.zip         binary
+*.gz          binary
+*.tgz         binary
+*.woff        binary
+*.woff2       binary
+*.ttf         binary
+*.otf         binary
+
 # Squad: union merge for append-only team state files
 .squad/decisions.md merge=union
 .squad/agents/*/history.md merge=union

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -68,7 +68,11 @@ for path in "${staged_cs[@]}"; do
     worktree_eol=$(printf '%s' "$eol_line" | awk '{print $2}')
     if [ "$index_eol" = "i/lf" ] && [ "$worktree_eol" = "w/crlf" ]; then
         if git diff --ignore-cr-at-eol --quiet -- "$path"; then
-            git checkout -- "$path"
+            # `git checkout -- <path>` will silently no-op on Git for Windows
+            # when core.autocrlf=true because the checked-out (CRLF) content
+            # matches the working tree, so strip \r bytes directly instead.
+            tmp="$path.pre-commit-tmp.$$"
+            tr -d '\r' < "$path" > "$tmp" && mv "$tmp" "$path"
             normalized=$((normalized + 1))
         fi
     fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# .githooks/pre-commit - Retail Pulse formatting gate
+#
+# Purpose:
+#   Catches `dotnet format` violations locally, before commit, so the CI `lint`
+#   job (.github/workflows/ci.yml) does not become the first place we discover a
+#   mechanical formatting problem. CI remains the authority; this hook is an
+#   early warning, not a replacement.
+#
+# What it runs:
+#   dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic \
+#       --include <staged .cs files>
+#
+#   The verification flags and target solution match the CI command exactly.
+#   Scoping via `--include` keeps routine commits fast; CI still runs the full
+#   solution check on every push.
+#
+# CRLF handling:
+#   .gitattributes declares `* text=auto eol=lf`, so `git add` always stores LF
+#   in the index. A file authored on Windows with CRLF in the working tree
+#   would otherwise still trip `dotnet format`'s ENDOFLINE check even though the
+#   committed content is LF and CI-clean. When the working-tree copy differs
+#   from the index only by CRLF, the hook re-checks out from the index so what
+#   we verify on disk matches what will be committed. Files with real unstaged
+#   edits are left alone.
+#
+# Bypass:
+#   git commit --no-verify
+#
+#   Legitimate reasons: emergency hotfixes, WIP commits on a private branch,
+#   commits that touch no C# (docs, infra text), or when the local SDK version
+#   diverges from CI. See docs/contributing.md#pre-commit-formatting-hook.
+#
+# Shell:
+#   Bash. Git for Windows ships bash and uses it to run hooks even when the
+#   user invokes `git commit` from PowerShell or cmd, so a single bash hook
+#   covers Windows, Linux, and macOS.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+# Collect staged .cs files (added / copied / modified / renamed). NUL-delimited
+# so paths with spaces are handled correctly.
+staged_cs=()
+while IFS= read -r -d '' path; do
+    case "$path" in
+        *.cs) staged_cs+=("$path") ;;
+    esac
+done < <(git diff --cached --name-only --diff-filter=ACMR -z)
+
+if [ ${#staged_cs[@]} -eq 0 ]; then
+    echo "pre-commit: no staged C# files; skipping dotnet format check." >&2
+    exit 0
+fi
+
+# Normalize CRLF -> LF in the working tree for files whose index copy is already
+# LF (per .gitattributes) and whose only working-tree difference is line
+# endings. `git diff --ignore-cr-at-eol --quiet` succeeds iff the working-tree
+# file matches the index modulo CR, so we won't clobber genuine unstaged edits.
+normalized=0
+for path in "${staged_cs[@]}"; do
+    eol_line=$(git ls-files --eol -- "$path" 2>/dev/null | head -n 1 || true)
+    [ -n "$eol_line" ] || continue
+    # Fields (whitespace-padded): i/<eol>  w/<eol>  attr/...  <path>
+    index_eol=$(printf '%s' "$eol_line" | awk '{print $1}')
+    worktree_eol=$(printf '%s' "$eol_line" | awk '{print $2}')
+    if [ "$index_eol" = "i/lf" ] && [ "$worktree_eol" = "w/crlf" ]; then
+        if git diff --ignore-cr-at-eol --quiet -- "$path"; then
+            git checkout -- "$path"
+            normalized=$((normalized + 1))
+        fi
+    fi
+done
+
+if [ "$normalized" -gt 0 ]; then
+    echo "pre-commit: normalized CRLF -> LF in $normalized working-tree file(s) to match the staged index." >&2
+fi
+
+if ! command -v dotnet >/dev/null 2>&1; then
+    echo "pre-commit: 'dotnet' not on PATH; skipping format check (CI will still enforce)." >&2
+    exit 0
+fi
+
+echo "pre-commit: running dotnet format on ${#staged_cs[@]} staged C# file(s)..." >&2
+
+# `--include` accepts a comma-separated list.
+include_arg=$(printf '%s,' "${staged_cs[@]}")
+include_arg=${include_arg%,}
+
+if dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic --include "$include_arg"; then
+    echo "pre-commit: dotnet format passed." >&2
+    exit 0
+fi
+
+cat >&2 <<'MSG'
+
+pre-commit: dotnet format --verify-no-changes reported violations above.
+
+  Fix locally, then re-stage and commit:
+      dotnet format RetailPulse.slnx --include <files>
+      git add <files>
+      git commit
+
+  Bypass (only when you know why - see docs/contributing.md):
+      git commit --no-verify
+
+CI runs the full-solution formatter on every push and remains the authority.
+MSG
+exit 1

--- a/README.md
+++ b/README.md
@@ -105,7 +105,34 @@ cd src/RetailPulse.Web && npm ci && cd ../..
 dotnet run --project src/RetailPulse.AppHost
 ```
 
-### 5. Open the React dashboard
+### 5. Enable the pre-commit formatting hook
+
+The repo ships a versioned pre-commit hook under [`.githooks/`](.githooks) that
+runs `dotnet format --verify-no-changes` on staged C# files before every
+commit, so the CI `lint` job is never the first place a formatting failure
+shows up. It is not enabled by `git clone` — run it once per clone:
+
+```powershell
+# Windows
+pwsh scripts/setup-hooks.ps1
+```
+
+```bash
+# Linux / macOS / Git Bash
+./scripts/setup-hooks.sh
+```
+
+Equivalent one-liner:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Bypass a single commit with `git commit --no-verify`. See
+[docs/contributing.md](docs/contributing.md#pre-commit-formatting-hook) for
+the full behaviour, bypass guidance, and line-ending troubleshooting.
+
+### 6. Open the React dashboard
 
 Navigate to [http://localhost:5173](http://localhost:5173) and start asking questions!
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,113 @@
+# Contributing
+
+This page covers the local setup steps that are not implied by simply cloning
+the repo. The [README](../README.md#quick-start) covers the runtime
+prerequisites (.NET 10 SDK, Node.js 20+, OpenAI credentials); this doc covers
+the developer ergonomics that keep pull requests healthy.
+
+## Pre-commit formatting hook
+
+Retail Pulse ships a versioned pre-commit hook under [`.githooks/`](../.githooks)
+that runs the same `dotnet format --verify-no-changes` check the CI `lint` job
+enforces (see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)). The
+CI job remains the authority; the hook is an early warning that catches
+mechanical problems locally so a review round-trip is not spent on them.
+
+### One-time setup after cloning
+
+Hooks are not enabled by `git clone`. Run **one** of the following once per
+clone:
+
+```powershell
+# Windows / PowerShell
+pwsh scripts/setup-hooks.ps1
+```
+
+```bash
+# Linux / macOS / Git Bash
+./scripts/setup-hooks.sh
+```
+
+Or, equivalently, the one-liner both scripts run:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+To confirm it worked:
+
+```bash
+git config --get core.hooksPath
+# expected output: .githooks
+```
+
+### What the hook does
+
+On every `git commit` it:
+
+1. Collects the `.cs` files staged for the commit.
+2. Normalizes any working-tree file whose only difference from the index is
+   CRLF (Windows editors sometimes save new files with CRLF; `.gitattributes`
+   forces LF in the index anyway, so this just lines the working tree up with
+   what will be committed). Files with real unstaged edits are left alone.
+3. Runs `dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic --include <staged files>`.
+
+If the formatter finds violations, the commit is blocked and the offending
+diagnostics are printed. If no `.cs` files are staged (docs, infra text,
+config), the hook exits cleanly without invoking the formatter. If `dotnet` is
+not on PATH the hook skips with a warning; CI still enforces.
+
+### Bypass
+
+```bash
+git commit --no-verify
+```
+
+Legitimate reasons to bypass:
+
+- Emergency hotfix where the CI signal is enough and the pre-commit round-trip
+  cost is not.
+- A local `dotnet` SDK that lags CI (e.g. mid-upgrade); a `--no-verify` commit
+  lets CI be the arbiter.
+- WIP commits on a private branch you plan to squash before opening a PR.
+- Commits that touch no C# — the hook already no-ops, but `--no-verify` also
+  skips any future hooks we add.
+
+Bypassing does **not** skip CI. The `lint` job still runs on every push and
+PR and will fail the build if the formatter finds anything.
+
+### Line endings
+
+CI runs on `ubuntu-latest`; contributors work on Windows, macOS, and Linux.
+`.gitattributes` (`* text=auto eol=lf` plus explicit `text eol=lf` for shell
+scripts and `.githooks/*`) forces LF in the repo, but a Windows editor can
+still create a new file with CRLF in the working tree, which trips
+`dotnet format`'s `ENDOFLINE` check even though the *committed* content is LF.
+
+The pre-commit hook handles the common case (staged file matches index modulo
+CR) by re-checking the file out from the index before verifying. If your file
+has real content differences plus CRLF, fix the line endings explicitly:
+
+```powershell
+# Convert one file in-place to LF (PowerShell)
+$content = Get-Content path/to/File.cs -Raw
+[System.IO.File]::WriteAllText((Resolve-Path 'path/to/File.cs'), ($content -replace "`r`n", "`n"))
+```
+
+```bash
+# Convert one file in-place to LF (bash / dos2unix)
+dos2unix path/to/File.cs
+# or
+sed -i 's/\r$//' path/to/File.cs
+```
+
+Then `git add` and commit again.
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Hook did not run | `git config --get core.hooksPath` — must print `.githooks`. Re-run the setup script. |
+| Hook runs but is slow on huge commits | Scoping is already applied; the first invocation warms the analyzer cache. Subsequent commits reuse it. Bypass with `--no-verify` for genuinely oversized commits. |
+| `dotnet` not on PATH | Install the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or bypass with `--no-verify`; CI enforces on push. |
+| Formatter flags `ENDOFLINE` after a normalization pass | The working tree has real unstaged edits with CRLF. Convert to LF (see above) and re-stage. |

--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -1,0 +1,27 @@
+# Enables the versioned pre-commit hook in .githooks/ for this clone.
+#
+# Run once after cloning:
+#     pwsh scripts/setup-hooks.ps1
+#
+# Same effect as: git config core.hooksPath .githooks
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = git rev-parse --show-toplevel
+if ($LASTEXITCODE -ne 0) {
+    throw "Not inside a git repository."
+}
+
+Push-Location $repoRoot
+try {
+    git config core.hooksPath .githooks
+    if ($LASTEXITCODE -ne 0) {
+        throw "git config core.hooksPath .githooks failed."
+    }
+    Write-Host "pre-commit hook enabled (core.hooksPath = .githooks)."
+    Write-Host "Bypass a single commit with:  git commit --no-verify"
+    Write-Host "Details: docs/contributing.md#pre-commit-formatting-hook"
+}
+finally {
+    Pop-Location
+}

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Enables the versioned pre-commit hook in .githooks/ for this clone.
+#
+# Run once after cloning:
+#     ./scripts/setup-hooks.sh
+#
+# Same effect as: git config core.hooksPath .githooks
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+git config core.hooksPath .githooks
+
+echo "pre-commit hook enabled (core.hooksPath = .githooks)."
+echo "Bypass a single commit with:  git commit --no-verify"
+echo "Details: docs/contributing.md#pre-commit-formatting-hook"


### PR DESCRIPTION
Closes #116

## What

Adds a versioned pre-commit formatting hook under `.githooks/` wired via `core.hooksPath`, plus the line-ending guardrails and contributor docs the issue calls for. The CI `lint` job (`.github/workflows/ci.yml`, unchanged) remains the authority — the hook is an early warning that catches `dotnet format` failures locally before they cost a reviewer round-trip.

## Why

The `Lint (dotnet format)` job has caused four review rejections across PRs #88, #89 (twice), and #100. In every case the build was green and tests passed — only formatting failed, in CI, after a push. Root causes per issue #116: (1) no pre-commit hook exists in the repo, and (2) Windows contributors can create files with CRLF in the working tree that pass locally but fail Linux CI's `ENDOFLINE` check.

## Files

| Path | Purpose |
|------|---------|
| `.githooks/pre-commit` | Bash pre-commit hook. Runs the exact CI verification (`dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic`) scoped via `--include` to the staged `.cs` files. Normalizes working-tree CRLF back to LF when it differs from the LF-normalized index only by line endings. Documented `--no-verify` bypass. |
| `.gitattributes` | Adds explicit `text eol=lf` for `*.sh`, `*.bash`, and `.githooks/*`; explicit `binary` markers for image / font / archive formats so `text=auto` cannot mis-classify them. |
| `scripts/setup-hooks.ps1` and `scripts/setup-hooks.sh` | One-command activation for the hook (`git config core.hooksPath .githooks`). |
| `docs/contributing.md` | New file. Documents the hook, the setup command, bypass with legitimate uses, CRLF handling, and a troubleshooting table. |
| `README.md` | New Quick Start step 5 pointing at the setup scripts and contributing doc. |

## Reproduction (before the fix)

Reproduced the CRLF failure first on `main` in a disposable worktree (`C:\src\rp-crlf-repro`) with a Windows-authored CRLF `.cs` file:

```powershell
# Windows: create a new C# file with CRLF line endings
$csharp = "using System;`r`n`r`nnamespace RetailPulse.Api.Repro;`r`n`r`npublic static class CrlfRepro`n{`n    public static string Hello() => `"hello`";`n}`r`n"
[System.IO.File]::WriteAllText('src\RetailPulse.Api\CrlfRepro.cs', $csharp)
# byte scan: LF=8 CR=8 (mixed CRLF)

dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic --include src/RetailPulse.Api/CrlfRepro.cs
```

Observed on `main`:

```
Running formatters.
CrlfRepro.cs(1,14): error ENDOFLINE: Fix end of line marker. Replace 2 characters with '\n'.
CrlfRepro.cs(2,1):  error ENDOFLINE: Fix end of line marker. Replace 2 characters with '\n'.
...
CrlfRepro.cs(8,2):  error ENDOFLINE: Fix end of line marker. Replace 2 characters with '\n'.
Formatted 1 of 553 files.
Format complete in 18181ms.
EXITCODE=2
```

Exactly the `ENDOFLINE` failure mode observed on PRs #88, #89, and #100.

## Proof of fix (Windows)

Fresh detached worktree at `C:\src\rp-hook-test` from the feature-branch tip, ran the setup script, and executed the four acceptance scenarios:

| Scenario | Command | Expected | Observed |
|----------|---------|----------|----------|
| **Fresh-clone activation** | `pwsh scripts/setup-hooks.ps1` | `core.hooksPath = .githooks` | ✅ set |
| **Clean commit** | Commit an LF-only, well-formatted `.cs` file | Hook runs, `dotnet format passed.`, commit lands | ✅ EXIT=0, commit `6a99abc` |
| **Formatting violation blocked** | Commit a file with bad whitespace + no final newline | Hook prints `WHITESPACE` / `FINALNEWLINE` errors, blocks with EXIT=1, prints bypass guidance | ✅ EXIT=1, commit not created, guidance printed |
| **`--no-verify` bypass** | `git commit --no-verify -m ...` on the same violating file | Commit lands without running the hook | ✅ EXIT=0, commit `96970a3` |
| **CRLF committed through hook** | Author `.cs` file with CRLF via `WriteAllText`, `git add`, `git commit` | Hook prints `normalized CRLF -> LF in 1 working-tree file(s)`, dotnet format passes, commit lands, blob is pure LF | ✅ EXIT=0, working tree becomes LF, `git ls-tree` blob is 133 bytes / **LF=6 CR=0** |

## Proof of fix (Linux CI)

The committed blob for the Windows-authored CRLF file is byte-for-byte LF (`git cat-file -p <sha>` returns 133 bytes, 6 LF, 0 CR). Linux CI checks out the blob as-is under `.gitattributes eol=lf`, so `dotnet format --verify-no-changes` will read an LF-only file and pass. I did not have a local Linux environment to execute this end-to-end; the final Linux formatter proof is left to PR CI, which runs the identical command this hook mirrors (`.github/workflows/ci.yml` job `lint`).

## Setup

After cloning, run either:

```powershell
pwsh scripts/setup-hooks.ps1
```

```bash
./scripts/setup-hooks.sh
```

Equivalent one-liner: `git config core.hooksPath .githooks`. Referenced from the README Quick Start (step 5) and `docs/contributing.md`.

## Bypass

`git commit --no-verify` — documented in `docs/contributing.md#bypass`, with legitimate use cases: emergency hotfixes, WIP commits on a private branch you plan to squash, commits that touch no C#, or a local `dotnet` SDK that lags CI. CI still enforces on push regardless.

## CI remains authoritative

The `lint` job (`.github/workflows/ci.yml`) runs `dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic` on `ubuntu-latest` and is unchanged in this PR. The hook mirrors that exact command; CI runs on the full solution and the hook scopes via `--include` to the staged `.cs` files for routine-commit speed. There is no divergence in what is enforced, only in scope.

## Local validation

- `dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic` on the feature-branch tip: **exit 0**, `Formatted 0 of 552 files.`
- Frontend / npm validation deferred to CI per programme guidance.

## Notes

- `.gitattributes eol=lf` was already in place; this PR adds explicit `text eol=lf` for shell scripts and hook files, and explicit `binary` markers for image, font, PDF, and archive formats to make intent unambiguous.
- The hook is bash-only; Git for Windows uses its bundled bash to run hooks even when the user invokes `git commit` from PowerShell or cmd, so a single `pre-commit` file covers Windows, Linux, and macOS.
- Not modified: `.squad/*` (mutable state from another session), `src/RetailPulse.Api/Agents/*` (concurrent #98 work), CI workflows.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
