### PR TITLE
feat(agents): data-driven specialist definitions and router intents (#98)

### DIFF
--- a/docs/adr/008-data-driven-agent-definitions.md
+++ b/docs/adr/008-data-driven-agent-definitions.md
@@ -1,0 +1,219 @@
+# ADR-008: Data-driven agent definitions
+
+## Status
+
+Accepted
+
+## Context
+
+Retail Pulse's headline positioning is that everything material about the
+deployment — company, brands, regions, theme — lives in a single
+`tenant.yaml` and the platform adapts without code changes. That was true of
+the data model. It was not true of the agent roster.
+
+Prior to this ADR, adding a specialist required all of:
+
+1. A new C# class implementing `ISpecialistAgent`.
+2. DI registration in `AgentServiceExtensions` (constructor injection, tool
+   list, prefetchable variant).
+3. Adding the new agent to `RetailOpsRouter`'s hardcoded specialist collection.
+4. A `prompts.yaml` entry for the system prompt, model, temperature, and tools.
+5. A router intent update (both the enum-like `AgentIntent` list and the
+   hardcoded keyword fast-path table in `RetailOpsRouter`).
+6. Rebuild and redeploy.
+
+The `AgentDefinition`/`PromptConfiguration` schema already carried name,
+model, system prompt, temperature, and tools per agent — and the
+`PromptTemplateEngine` already hydrated tenant values into each field. The
+individual specialist classes were mostly identical boilerplate: nine of the
+ten were under 2 KB, each differing only in which `AgentDefinition` was
+passed to the shared `AgentExecutionPipeline`. Two agents did carry real
+bespoke logic:
+
+- `MemoryManagementAgent` — orchestrates the conversation-memory store
+  (recall / store / clear intents against `IConversationMemory`), not just an
+  LLM call.
+- `CompetitiveIntelAgent` — scans tool results for competitive threats and
+  fires proactive SignalR alerts. Domain-specific side effect, not a prompt
+  variation.
+
+The remaining blockers were structural, not conceptual: hardcoded specialist
+classes and a hardcoded router intent/keyword list.
+
+## Decision
+
+**Collapse the near-duplicate specialist classes into a single generic
+`ConfiguredSpecialistAgent` constructed from an `AgentDefinition`. Derive the
+router's intent set and keyword fast-paths from configuration. Preserve
+bespoke behavior where it exists.**
+
+Specifically:
+
+1. **`AgentDefinition` schema is extended** with routing metadata:
+   `Key`, `DisplayName`, `Intents`, `KeywordFastPaths`, `FallbackReply`,
+   `CouncilParticipant`, `ScorecardDimension`, `ScorecardWeight`, `Role`
+   (default `"specialist"`), and `Prefetchable`. Every field is optional so
+   existing YAML continues to load unchanged.
+
+2. **`ConfiguredSpecialistAgent`** is the sole `ISpecialistAgent` +
+   `IPrefetchableAgent` implementation. It runs on the shared
+   `IAgentExecutionPipeline` (ADR-007's MAF `ChatClientAgent` execution),
+   surfaces `Key` / `SupportedIntents` / `KeywordFastPaths` straight from its
+   `AgentDefinition`, and exposes a `protected virtual OnToolResult` hook for
+   subclasses that need a domain-specific side effect (e.g. the Competitive
+   Intel SignalR alerts).
+
+3. **The nine formerly-specialised classes** (`GeneralAgent`,
+   `DemandForecastAgent`, `PromoPlanningAgent`, `FieldSentimentAgent`,
+   `SupplyChainAgent`, `StoreOpsAgent`, `PlanogramAgent`, `MarginAgent`,
+   `CompetitiveIntelAgent`) become thin sealed shims over
+   `ConfiguredSpecialistAgent`. `EnsureDefaults` populates the `Key` /
+   primary intent / fallback reply when the caller supplies a
+   minimally-populated `AgentDefinition`, so pre-refactor construction
+   sites and unit tests keep working unchanged. `PromoPlanningAgent` retains
+   its `CheckApprovalAsync` bespoke method; `CompetitiveIntelAgent` retains
+   its alert-firing behavior via the `OnToolResult` override.
+   `MemoryManagementAgent` keeps its hand-written orchestration logic and
+   simply accepts an optional `AgentDefinition` so its Key / Intents /
+   keyword table can be declared in `prompts.yaml`.
+
+4. **`AgentToolRegistry`** is a named registry of `AITool` factories. Each
+   specialist's `tools:` list in `prompts.yaml` is resolved through it.
+   `ValidateAllReferences` is called once at startup; a typo or missing
+   registration raises `UnknownToolReferenceException` with the full list of
+   missing and known names, so config errors fail loudly before the app
+   accepts traffic instead of quietly at first user query.
+
+5. **`RetailOpsRouter`** no longer holds a compiled keyword table. Its
+   `_keywordPatterns` is now built at construction time from every
+   specialist's `KeywordFastPaths` plus any orchestration-only
+   `RouterIntentConfig` records (Portfolio Health Council, Scorecard, etc.).
+   `KnownIntents` is exposed so `ParseClassification` can accept a
+   config-added intent from the LLM without normalising it to General.
+
+6. **`ConsensusOrchestrator` and `ScorecardOrchestrator`** take optional
+   config lists — `councilParticipants` and `scoringDimensions` — with the
+   previous hardcoded rosters as the fallback default. The
+   composition-root `RouterAgentRoster` singleton derives both from
+   `PromptConfiguration` (agents with `council_participant: true` and those
+   with a non-empty `scorecard_dimension` + `scorecard_weight`).
+
+7. **`RoutingServiceExtensions.AddAgentRouting`** takes
+   `(PromptConfiguration, AgentToolRegistry, IReadOnlyList<RouterIntentConfig>)`
+   and enumerates specialists from configuration. It validates every
+   tool reference, detects duplicate keys, then registers each specialist by
+   well-known key onto its bespoke class (`MemoryManagementAgent`,
+   `CompetitiveIntelAgent`) or falls back to `ConfiguredSpecialistAgent` for
+   any unrecognised key. This is the "add-a-specialist-by-editing-yaml"
+   path: no C# `case` clause is required for a new specialist.
+
+**Adding a specialist now looks like this — no rebuild:**
+
+```yaml
+agents:
+  # ... existing agents ...
+
+  loyalty-analytics:
+    name: "Loyalty Analytics Agent"
+    model: "gpt-5.4-mini"
+    key: "loyalty-analytics"
+    display_name: "Loyalty Analytics"
+    role: "specialist"
+    intents:
+      - "loyalty/analytics"
+    keyword_fast_paths:
+      - "loyalty program"
+      - "reward redemption"
+    council_participant: false
+    scorecard_dimension: ""
+    fallback_reply: "I couldn't generate a loyalty analytics response."
+    system_prompt: |
+      You are a Loyalty Analytics specialist for {tenant.company}.
+      ...
+    temperature: 0.2
+    tools:
+      - GetLoyaltyProgramMetrics
+      - CreateChart
+```
+
+A restart picks up the new agent, the router advertises the new intent, and
+`RouterAgentRoster` includes the agent in council/scorecard fan-outs when
+the corresponding flags are set.
+
+## Explicit non-goal
+
+This ADR does **not** open a path for arbitrary users to inject prompts into
+a running deployment. `PromptConfiguration` is trusted deployment input at
+this stage — the `prompts.yaml` file is committed alongside the app or
+delivered through the same deployment channel as `tenant.yaml`. Safety
+validation of agent definitions (schema, prompt-injection heuristics, tool
+allow-listing per role) is issue #99 and must land before any path exists
+for untrusted config to reach the loader. This ADR keeps the loader
+unchanged in that respect and does not make issue #99 harder to add on top.
+
+## Consequences
+
+**Positive:**
+
+- The headline "no code changes required" claim is now true for the agent
+  roster, matching what was already true for the data model.
+- Nine near-identical `.cs` files collapse to sealed shims that exist only
+  to preserve the pre-refactor constructor signatures for existing call
+  sites and tests. The behaviour lives in one place.
+- Config errors are caught at startup with actionable messages
+  (`UnknownToolReferenceException` lists the missing name and every
+  registered tool). The old fail-at-first-invocation posture is gone.
+- The router's intent set, keyword fast-paths, council roster, and
+  scorecard dimensions all derive from a single YAML surface. Editing one
+  file replaces edits in five.
+- The proof test
+  (`DataDrivenSpecialistTests.TestOnlySpecialist_AddedThroughConfigurationOnly_IsRoutedAndExecuted`)
+  proves the objective with a widget specialist declared purely in
+  configuration and exercised end-to-end.
+
+**Negative / trade-offs:**
+
+- `ConfiguredSpecialistAgent` is now the vast majority of the specialist
+  code. It has to remain flexible enough for both prefetchable and bespoke
+  subclasses. The `protected virtual OnToolResult` hook is the extension
+  seam — anything more invasive should keep its bespoke class.
+- Behaviour parity vs the pre-refactor keyword table is a hard requirement
+  and is enforced by the eval baseline. Any future change to the keyword
+  list is now a `prompts.yaml` edit, and reviewers must run the eval
+  harness to check for baseline drift.
+- The router accepts an intent it doesn't recognise only if that intent is
+  either in `AgentIntent.All` or in the config-derived `KnownIntents` set.
+  An LLM classification returning a wholly unknown intent still degrades
+  to General, which is intentional but worth reiterating: bad LLM output
+  cannot invent a specialist that isn't configured.
+
+## Alternatives considered
+
+1. **Keep classes, extract shared trait.** Would still require a new C#
+   class per specialist plus DI wiring. Does not deliver the "config-only"
+   objective.
+
+2. **A generic specialist plus per-agent JSON descriptor files.** Duplicates
+   `prompts.yaml` responsibility. Rejected in favour of extending the
+   existing schema.
+
+3. **Reflection-based auto-registration from a specialists namespace.**
+   Solves fewer problems (still requires C# classes), introduces reflection
+   at startup that is harder to reason about than a data-driven loop, and
+   makes fail-loud tool validation harder because attributes would need to
+   be scanned before DI is composed.
+
+4. **Leave the two hardcoded orchestrators (`ConsensusOrchestrator`,
+   `ScorecardOrchestrator`) untouched and only make specialists data-driven.**
+   The council roster and scorecard weight table would then diverge from
+   `prompts.yaml`, so a new agent added by editing YAML would silently miss
+   the council. Rejected in favour of a single source of truth.
+
+## References
+
+- Issue #98 — Data-driven agent definitions: configurable specialists and router intents
+- Issue #87 — Wave 3: platform configurability
+- Issue #99 — Safety validation of agent definitions (blocks untrusted config)
+- ADR-001 — Multi-agent routing (baseline intent set)
+- ADR-003 — Consensus Council (fan-out roster now data-driven)
+- ADR-007 — MAF agent primitives (execution stack preserved)

--- a/docs/tenant-configuration.md
+++ b/docs/tenant-configuration.md
@@ -303,3 +303,86 @@ To see your theme changes:
 - **Primary color** — Used for headers, navigation, and primary buttons. Choose a dark, readable color.
 - **Accent color** — Used for highlights, active states, and charts. Choose a contrasting, vibrant color.
 - Ensure sufficient contrast between primary/accent colors and text for accessibility.
+
+---
+
+## Agent Definitions (`prompts.yaml`)
+
+Retail Pulse composes its agent roster from `src/RetailPulse.Api/prompts.yaml`
+at startup. Every specialist — routing intents, keyword fast-paths, tool
+bindings, council membership, scorecard weight — is declared there. Adding a
+new specialist is a config edit plus a restart: no C# class, no DI wiring,
+no rebuild. This is the promise formalised in [ADR-008](adr/008-data-driven-agent-definitions.md).
+
+### Schema
+
+Each entry under `agents:` is an `AgentDefinition`. Every field is optional
+unless noted; the loader supplies safe defaults.
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `name` | string | Display name used in telemetry and logs. |
+| `model` | string | Model identifier resolved through the app's model catalog. Defaults to `gpt-4o`. |
+| `system_prompt` | string | The prompt sent to the LLM. Tenant tokens (`{tenant.company}`, `{tenant.brands}`, etc.) are hydrated at load time. |
+| `temperature` | number | Sampling temperature. Defaults to `0.7`. |
+| `tools` | list<string> | Tool names to bind. Each must be registered with `AgentToolRegistry` — an unknown name fails startup with an actionable error. |
+| `key` | string | Routing key. Lowercase kebab-case by convention. Defaults to the YAML section name. |
+| `display_name` | string | Human-readable label. Falls back to `name`. |
+| `role` | string | `"specialist"` (default), `"orchestration"`, or `"router"`. Orchestration entries (router / synth / vote prompts) are not registered as specialists. |
+| `intents` | list<string> | Router intents this agent handles. The router's known-intent set is the union of every specialist's list plus the orchestration intents. |
+| `keyword_fast_paths` | list<string> | Case-insensitive substrings that force a fast-path route to this agent's primary intent. Use strong, unambiguous phrases only. |
+| `fallback_reply` | string | Reply used when the LLM returns empty content. Falls back to a domain-neutral default. |
+| `council_participant` | bool | When true, the Portfolio Health Council fans out to this agent. |
+| `scorecard_dimension` | string | If set (with a positive `scorecard_weight`) this agent contributes a dimension to the brand scorecard. |
+| `scorecard_weight` | number | Weight for the scorecard dimension. Ordered by weight descending in the final report. |
+| `prefetchable` | bool | When true, the router calls the agent's `IPrefetchableAgent` hook to warm data before invocation. |
+
+### Worked example: adding a Loyalty Analytics specialist
+
+```yaml
+agents:
+  # ... existing agents ...
+
+  loyalty-analytics:
+    name: "Loyalty Analytics Agent"
+    model: "gpt-5.4-mini"
+    key: "loyalty-analytics"
+    display_name: "Loyalty Analytics"
+    role: "specialist"
+    intents:
+      - "loyalty/analytics"
+    keyword_fast_paths:
+      - "loyalty program"
+      - "reward redemption"
+    council_participant: false
+    fallback_reply: "I couldn't generate a loyalty analytics response."
+    system_prompt: |
+      You are a Loyalty Analytics specialist for {tenant.company}.
+      Analyze reward redemption trends, program enrolment velocity, and
+      loyalty-driven revenue lift across {tenant.brands}.
+    temperature: 0.2
+    tools:
+      - GetLoyaltyProgramMetrics
+      - CreateChart
+```
+
+After a restart the router advertises `loyalty/analytics` in its known intent
+set, the keyword fast-paths match the two phrases above, and the specialist
+is instantiated as a `ConfiguredSpecialistAgent` — no C# changes required.
+
+### Bespoke agents
+
+A small number of agents ship with hand-written classes because they carry
+real behaviour beyond an LLM call: `MemoryManagementAgent` (conversation
+memory store) and `CompetitiveIntelAgent` (SignalR alert side effects). Both
+still read their `AgentDefinition` from `prompts.yaml` — key, intents, and
+keyword fast-paths remain configurable — but the containing class is
+deliberately hardcoded because the behaviour cannot be expressed as a prompt.
+
+### Trust boundary
+
+`prompts.yaml` is trusted deployment input: the file is committed alongside
+the app or delivered through the same channel as `tenant.yaml`. Retail Pulse
+does not currently accept prompt definitions from arbitrary users. Safety
+validation of agent definitions (schema, prompt-injection heuristics, tool
+allow-listing) is tracked separately in issue #99.

--- a/src/RetailPulse.Api/Agents/Routing/RetailOpsRouter.cs
+++ b/src/RetailPulse.Api/Agents/Routing/RetailOpsRouter.cs
@@ -97,30 +97,22 @@ public partial class RetailOpsRouter : IAgentRouter
     ];
 
     /// <summary>
-    /// Keyword patterns mapped to their intent. Each entry has "strong" keywords that match
-    /// unambiguously on their own, regardless of message length or context. Short or generic
-    /// keywords that could fire on ambiguous queries are excluded — the LLM handles those.
+    /// Intent → keyword mapping consumed by the fast-path classifier. Populated from
+    /// configuration (each specialist's <c>AgentDefinition.KeywordFastPaths</c> plus
+    /// any orchestration intents supplied via <see cref="RouterIntentConfig"/>).
+    /// Data-driven per ADR-008 — no hardcoded keyword table remains here.
     /// </summary>
-    private static readonly (string Intent, string[] Keywords)[] _keywordPatterns =
-    [
-        (AgentIntent.DemandForecasting, ["demand forecast", "sell-through", "velocity forecast"]),
-        (AgentIntent.SupplyShipments, ["shipment status", "inventory level", "fulfillment", "stockout", "stock out", "supply chain"]),
-        (AgentIntent.CompetitiveMarket, ["pricing pressure", "market share", "price war", "competitor analysis", "competitive landscape"]),
-        (AgentIntent.SentimentField, ["field rep", "field feedback", "distributor feedback", "rep feedback", "sentiment analysis"]),
-        (AgentIntent.PortfolioHealth, ["portfolio health", "overall health", "brand health", "health council"]),
-        (AgentIntent.MarginAnalysis, ["margin analysis", "profitability", "cost structure", "gross margin"]),
-        (AgentIntent.Planogram, ["planogram", "shelf space", "shelf placement"]),
-        (AgentIntent.StoreOps, ["store operations", "store performance", "retail ops"]),
-        (AgentIntent.MemoryManagement, ["remember that", "remember this", "forget", "clear my", "clear my history", "clear my data", "start fresh", "reset my context", "forget what I told you", "what do you know about me"]),
-        (AgentIntent.PromotionTrade, ["promotion", "trade spend", "promo effectiveness", "promotion roi"]),
-        (AgentIntent.Scorecard, ["scorecard", "brand scorecard", "performance scorecard"]),
-    ];
+    public IReadOnlyList<(string Intent, string[] Keywords)> KeywordPatterns { get; }
+
+    /// <summary>Intents this router knows about — union of every specialist and orchestrator entry.</summary>
+    public IReadOnlyCollection<string> KnownIntents { get; }
 
     public RetailOpsRouter(
         IChatClient chatClient,
         AgentDefinition routerDef,
         IEnumerable<ISpecialistAgent> specialists,
         ILogger<RetailOpsRouter> logger,
+        IReadOnlyList<RouterIntentConfig>? intentConfigs = null,
         RetailPulseMetrics? metrics = null,
         RouterClassificationCache? classificationCache = null,
         ILoggerFactory? loggerFactory = null)
@@ -142,6 +134,40 @@ public partial class RetailOpsRouter : IAgentRouter
             }
         }
         _specialists = lookup;
+
+        // Build keyword fast-path table from configuration. Specialists contribute
+        // their KeywordFastPaths via ISpecialistAgent.KeywordFastPaths (populated
+        // from AgentDefinition), and orchestration intents (e.g., council/health)
+        // arrive as RouterIntentConfig entries because they have no specialist.
+        var patterns = new List<(string Intent, string[] Keywords)>();
+        var seenIntents = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (ISpecialistAgent specialist in lookup.Values.Distinct())
+        {
+            // Defensive against mocks and legacy impls that don't override the
+            // default interface member — treat null as empty.
+            IReadOnlyList<string> keywords = specialist.KeywordFastPaths ?? [];
+            if (keywords.Count == 0) continue;
+
+            string intent = specialist.SupportedIntents.Count > 0
+                ? specialist.SupportedIntents[0]
+                : AgentIntent.General;
+            patterns.Add((intent, [.. keywords]));
+            seenIntents.Add(intent);
+        }
+
+        if (intentConfigs is not null)
+        {
+            foreach (RouterIntentConfig cfg in intentConfigs)
+            {
+                if (cfg.KeywordFastPaths.Count == 0) continue;
+                patterns.Add((cfg.Intent, [.. cfg.KeywordFastPaths]));
+                seenIntents.Add(cfg.Intent);
+            }
+        }
+
+        KeywordPatterns = patterns;
+        KnownIntents = seenIntents;
     }
 
     public async Task<RoutingDecision> RouteAsync(
@@ -270,7 +296,13 @@ public partial class RetailOpsRouter : IAgentRouter
     /// Attempts to classify intent using simple keyword matching.
     /// Returns null if no confident match is found, allowing fallback to LLM classification.
     /// </summary>
-    private static IntentClassification? TryKeywordClassify(string message)
+    /// <remarks>
+    /// Instance method now — the keyword patterns are configuration-driven and live on the
+    /// router instance (issue #98). Structural fast-paths (memory commands, chart intent,
+    /// portfolio-performing regex, single-brand-lookup regex) remain hardcoded because they
+    /// encode routing behavior, not per-agent taxonomy.
+    /// </remarks>
+    private IntentClassification? TryKeywordClassify(string message)
     {
         // Memory commands have absolute priority — must not be intercepted by
         // brand-lookup shortcuts or portfolio regex patterns.
@@ -319,7 +351,7 @@ public partial class RetailOpsRouter : IAgentRouter
                 AgentIntent.General, _keywordMatchConfidence, [AgentIntent.General]);
         }
 
-        foreach ((string? intent, string[]? keywords) in _keywordPatterns)
+        foreach ((string? intent, string[]? keywords) in KeywordPatterns)
         {
             foreach (string keyword in keywords)
             {
@@ -407,14 +439,17 @@ public partial class RetailOpsRouter : IAgentRouter
             ct);
         string responseText = mafResponse.Text ?? "";
 
-        return ParseClassification(responseText, _logger);
+        return ParseClassification(responseText, _logger, KnownIntents);
     }
 
     /// <summary>
     /// Parses the LLM's JSON classification response into an IntentClassification.
     /// Expected format: { "intent": "demand/forecasting", "confidence": 0.92, "intents": ["demand/forecasting"] }
     /// </summary>
-    internal static IntentClassification ParseClassification(string json, ILogger? logger = null)
+    internal static IntentClassification ParseClassification(
+        string json,
+        ILogger? logger = null,
+        IReadOnlyCollection<string>? knownIntents = null)
     {
         try
         {
@@ -444,8 +479,14 @@ public partial class RetailOpsRouter : IAgentRouter
             if (detectedIntents.Count == 0)
                 detectedIntents.Add(intent);
 
-            // Normalize: ensure intent is a known value
-            if (!AgentIntent.All.Contains(intent))
+            // Normalize: ensure intent is a known value. The typed AgentIntent enum is
+            // the baseline; the router also injects its per-instance KnownIntents so
+            // purely-configured specialists (added via prompts.yaml, no C# change) route
+            // correctly under issue #98.
+            bool isKnown = AgentIntent.All.Contains(intent)
+                || (knownIntents is not null &&
+                    knownIntents.Contains(intent, StringComparer.OrdinalIgnoreCase));
+            if (!isKnown)
                 intent = AgentIntent.General;
 
             return new IntentClassification(intent, confidence, detectedIntents);

--- a/src/RetailPulse.Api/Agents/Routing/RouterIntentConfig.cs
+++ b/src/RetailPulse.Api/Agents/Routing/RouterIntentConfig.cs
@@ -1,0 +1,14 @@
+namespace RetailPulse.Api.Agents.Routing;
+
+/// <summary>
+/// Configuration entry for a router intent that is NOT owned by a specialist agent —
+/// typically an in-process orchestrator (e.g., the Portfolio Health Council on
+/// <c>council/health</c>, the Scorecard synthesizer on <c>scorecard/portfolio</c>).
+/// Lets the data-driven router still carry keyword fast-paths for these paths, so
+/// deleting the ConsensusOrchestrator does not silently break intent detection.
+/// </summary>
+/// <param name="Intent">The router intent value (e.g., <c>council/health</c>).</param>
+/// <param name="KeywordFastPaths">Case-insensitive substrings that trigger this intent.</param>
+public sealed record RouterIntentConfig(
+    string Intent,
+    IReadOnlyList<string> KeywordFastPaths);

--- a/src/RetailPulse.Api/Agents/RoutingServiceExtensions.cs
+++ b/src/RetailPulse.Api/Agents/RoutingServiceExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using RetailPulse.Api.Agents.Routing;
 using RetailPulse.Api.Agents.Specialists;
+using RetailPulse.Api.Agents.Tools;
 using RetailPulse.Api.Alerts;
 using RetailPulse.Api.Auth;
 using RetailPulse.Api.Caching;
@@ -22,31 +23,55 @@ namespace RetailPulse.Api.Agents;
 public static class RoutingServiceExtensions
 {
     /// <summary>
-    /// Registers the IAgentRouter and all specialist agents.
-    /// Specialist agents are registered both individually (for keyed lookup)
-    /// and as an IEnumerable&lt;ISpecialistAgent&gt; collection (for router discovery).
+    /// Registers the shared execution pipeline, the specialist roster (built from a
+    /// <see cref="PromptConfiguration"/> plus a named <see cref="AgentToolRegistry"/>),
+    /// and the <see cref="IAgentRouter"/> whose keyword fast-paths derive from configuration.
     /// </summary>
+    /// <param name="services">DI container.</param>
+    /// <param name="promptConfig">Loaded prompts.yaml (already tenant-hydrated).</param>
+    /// <param name="toolRegistry">Named tool registry — unknown names fail fast at startup.</param>
+    /// <param name="orchestrationIntents">Intent config for orchestrators that are not
+    /// specialists (Portfolio Health Council, Scorecard, etc.).</param>
     public static IServiceCollection AddAgentRouting(
         this IServiceCollection services,
         PromptConfiguration promptConfig,
-        AgentDefinition generalAgentDef,
-        bool foundryEnabled,
-        Func<IServiceProvider, IEnumerable<AITool>> toolsFactory,
-        AgentDefinition? demandForecastDef = null,
-        Func<IServiceProvider, IEnumerable<AITool>>? demandToolsFactory = null,
-        AgentDefinition? promoPlanningDef = null,
-        Func<IServiceProvider, IEnumerable<AITool>>? promoToolsFactory = null,
-        AgentDefinition? competitiveIntelDef = null,
-        Func<IServiceProvider, IEnumerable<AITool>>? competitiveToolsFactory = null,
-        AgentDefinition? supplyChainDef = null,
-        Func<IServiceProvider, IEnumerable<AITool>>? supplyToolsFactory = null,
-        AgentDefinition? storeOpsDef = null,
-        Func<IServiceProvider, IEnumerable<AITool>>? storeOpsToolsFactory = null,
-        AgentDefinition? planogramDef = null,
-        Func<IServiceProvider, IEnumerable<AITool>>? planogramToolsFactory = null,
-        AgentDefinition? marginDef = null,
-        Func<IServiceProvider, IEnumerable<AITool>>? marginToolsFactory = null)
+        AgentToolRegistry toolRegistry,
+        IReadOnlyList<RouterIntentConfig> orchestrationIntents)
     {
+        ArgumentNullException.ThrowIfNull(promptConfig);
+        ArgumentNullException.ThrowIfNull(toolRegistry);
+        ArgumentNullException.ThrowIfNull(orchestrationIntents);
+
+        // Fail loudly at startup when a specialist references a tool the process
+        // does not know about (issue #98 acceptance criterion). Includes every
+        // configured agent def, so a typo in prompts.yaml never reaches runtime.
+        toolRegistry.ValidateAllReferences(
+            promptConfig.Agents.Values
+                .Where(IsSpecialistDefinition)
+                .Select(d => new AgentDefinitionRef(
+                    Key: string.IsNullOrWhiteSpace(d.Key) ? d.Name : d.Key,
+                    Tools: d.Tools)));
+
+        // Detect duplicate specialist keys (case-insensitive) — the AgentDefinition
+        // section name is a good default but explicit `key:` overrides can collide.
+        var duplicateKeys = promptConfig.Agents.Values
+            .Where(IsSpecialistDefinition)
+            .GroupBy(d => string.IsNullOrWhiteSpace(d.Key) ? d.Name : d.Key,
+                StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        if (duplicateKeys.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Duplicate specialist agent key(s) in prompts.yaml: {string.Join(", ", duplicateKeys)}. " +
+                "Each specialist must have a unique 'key' (or unique yaml section name when 'key' is omitted).");
+        }
+
+        services.AddSingleton(toolRegistry);
+        services.AddSingleton(new RouterAgentRoster(promptConfig, orchestrationIntents));
+
         // Register the scoped streaming progress feature
         services.AddScoped<StreamingProgressFeature>();
 
@@ -75,111 +100,14 @@ public static class RoutingServiceExtensions
             return new AgentExecutionPipeline(chatClient, hubContext, streamingHubContext, streamingFeature, configuration, logger, metrics, anonymousChatPolicy, tenant, toolBudget, budgetOptions);
         });
 
-        // Register GeneralAgent as ISpecialistAgent
-        services.AddScoped(sp =>
+        // Register each specialist defined in configuration. Bespoke agents (Memory,
+        // Competitive Intel) route to their hand-written classes by convention on
+        // AgentDefinition.Key; every other agent is instantiated as the generic
+        // ConfiguredSpecialistAgent — no C# changes required to add another.
+        foreach (AgentDefinition specialistDef in promptConfig.Agents.Values.Where(IsSpecialistDefinition))
         {
-            IAgentExecutionPipeline pipeline = sp.GetRequiredService<IAgentExecutionPipeline>();
-            IEnumerable<AITool> tools = toolsFactory(sp);
-            return new GeneralAgent(pipeline, generalAgentDef, tools);
-        });
-        services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<GeneralAgent>());
-
-        // Register DemandForecastAgent as ISpecialistAgent
-        if (demandForecastDef is not null && demandToolsFactory is not null)
-        {
-            services.AddScoped(sp =>
-            {
-                IAgentExecutionPipeline pipeline = sp.GetRequiredService<IAgentExecutionPipeline>();
-                IEnumerable<AITool> tools = demandToolsFactory(sp);
-                return new DemandForecastAgent(pipeline, demandForecastDef, tools);
-            });
-            services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<DemandForecastAgent>());
+            RegisterSpecialist(services, specialistDef);
         }
-
-        // Register PromoPlanningAgent as ISpecialistAgent
-        if (promoPlanningDef is not null && promoToolsFactory is not null)
-        {
-            services.AddScoped(sp =>
-            {
-                IAgentExecutionPipeline pipeline = sp.GetRequiredService<IAgentExecutionPipeline>();
-                IEnumerable<AITool> tools = promoToolsFactory(sp);
-                IApprovalGate? approvalGate = sp.GetService<IApprovalGate>();
-                return new PromoPlanningAgent(pipeline, promoPlanningDef, tools, approvalGate);
-            });
-            services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<PromoPlanningAgent>());
-        }
-
-        // Register CompetitiveIntelAgent as ISpecialistAgent
-        if (competitiveIntelDef is not null && competitiveToolsFactory is not null)
-        {
-            services.AddScoped(sp =>
-            {
-                IAgentExecutionPipeline pipeline = sp.GetRequiredService<IAgentExecutionPipeline>();
-                IHubContext<TelemetryHub> hubContext = sp.GetRequiredService<IHubContext<TelemetryHub>>();
-                IEnumerable<AITool> tools = competitiveToolsFactory(sp);
-                ILogger<CompetitiveIntelAgent> logger = sp.GetRequiredService<ILogger<CompetitiveIntelAgent>>();
-                SqliteAlertService? alertService = sp.GetService<SqliteAlertService>();
-                return new CompetitiveIntelAgent(pipeline, competitiveIntelDef, tools, hubContext, logger, alertService);
-            });
-            services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<CompetitiveIntelAgent>());
-        }
-
-        // Register SupplyChainAgent as ISpecialistAgent
-        if (supplyChainDef is not null && supplyToolsFactory is not null)
-        {
-            services.AddScoped(sp =>
-            {
-                IAgentExecutionPipeline pipeline = sp.GetRequiredService<IAgentExecutionPipeline>();
-                IEnumerable<AITool> tools = supplyToolsFactory(sp);
-                return new SupplyChainAgent(pipeline, supplyChainDef, tools);
-            });
-            services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<SupplyChainAgent>());
-        }
-
-        // Register StoreOpsAgent as ISpecialistAgent
-        if (storeOpsDef is not null && storeOpsToolsFactory is not null)
-        {
-            services.AddScoped(sp =>
-            {
-                IAgentExecutionPipeline pipeline = sp.GetRequiredService<IAgentExecutionPipeline>();
-                IEnumerable<AITool> tools = storeOpsToolsFactory(sp);
-                return new StoreOpsAgent(pipeline, storeOpsDef, tools);
-            });
-            services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<StoreOpsAgent>());
-        }
-
-        // Register PlanogramAgent as ISpecialistAgent
-        if (planogramDef is not null && planogramToolsFactory is not null)
-        {
-            services.AddScoped(sp =>
-            {
-                IAgentExecutionPipeline pipeline = sp.GetRequiredService<IAgentExecutionPipeline>();
-                IEnumerable<AITool> tools = planogramToolsFactory(sp);
-                return new PlanogramAgent(pipeline, planogramDef, tools);
-            });
-            services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<PlanogramAgent>());
-        }
-
-        // Register MarginAgent as ISpecialistAgent
-        if (marginDef is not null && marginToolsFactory is not null)
-        {
-            services.AddScoped(sp =>
-            {
-                IAgentExecutionPipeline pipeline = sp.GetRequiredService<IAgentExecutionPipeline>();
-                IEnumerable<AITool> tools = marginToolsFactory(sp);
-                return new MarginAgent(pipeline, marginDef, tools);
-            });
-            services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<MarginAgent>());
-        }
-
-        // Register MemoryManagementAgent as ISpecialistAgent
-        services.AddScoped(sp =>
-        {
-            IConversationMemory memory = sp.GetRequiredService<IConversationMemory>();
-            ILogger<MemoryManagementAgent> logger = sp.GetRequiredService<ILogger<MemoryManagementAgent>>();
-            return new MemoryManagementAgent(memory, logger);
-        });
-        services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<MemoryManagementAgent>());
 
         // Register IAgentRouter → RetailOpsRouter
         AgentDefinition routerDef = promptConfig.Agents.TryGetValue("router", out AgentDefinition? def)
@@ -195,9 +123,197 @@ public static class RoutingServiceExtensions
             ILogger<RetailOpsRouter> logger = sp.GetRequiredService<ILogger<RetailOpsRouter>>();
             RouterClassificationCache? cache = sp.GetService<RouterClassificationCache>();
 
-            return new RetailOpsRouter(chatClient, routerDef, specialists, logger, classificationCache: cache);
+            return new RetailOpsRouter(
+                chatClient,
+                routerDef,
+                specialists,
+                logger,
+                intentConfigs: orchestrationIntents,
+                classificationCache: cache);
         });
 
         return services;
     }
+
+    /// <summary>
+    /// True when an <see cref="AgentDefinition"/> represents a specialist agent that
+    /// participates in routing. Router/synthesizer/vote-format prompts are
+    /// orchestration entries — they still live in prompts.yaml but don't register
+    /// as specialists. Detection is intentionally permissive: any def with a
+    /// non-empty <c>Intents</c> list OR that carries the "specialist" role AND is
+    /// not a well-known orchestration section.
+    /// </summary>
+    private static bool IsSpecialistDefinition(AgentDefinition def)
+    {
+        if (_orchestrationKeys.Contains(string.IsNullOrWhiteSpace(def.Key) ? def.Name : def.Key))
+            return false;
+        if (string.Equals(def.Role, "orchestration", StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (string.Equals(def.Role, "router", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        // Fallback: legacy YAML without Role — treat any def with at least one
+        // declared intent as a specialist. The retail-pulse "legacy general" doc
+        // and every specialist covered by the pre-refactor code path do this.
+        return def.Intents.Count > 0
+            || string.Equals(def.Role, "specialist", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Well-known composition-only section names that must never be routed to.</summary>
+    private static readonly HashSet<string> _orchestrationKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "router",
+        "council-synthesis",
+        "council-vote",
+        "scorecard-synthesis",
+        "exec-brief",
+        "retail-pulse", // legacy composite prompt — not a specialist
+    };
+
+    /// <summary>
+    /// Registers a single specialist. Bespoke agents (Memory Management, Competitive
+    /// Intel) get their hand-written class; everything else is a
+    /// <see cref="ConfiguredSpecialistAgent"/>. Behaviour parity vs the pre-refactor
+    /// hardcoded roster is preserved for every existing key.
+    /// </summary>
+    private static void RegisterSpecialist(IServiceCollection services, AgentDefinition def)
+    {
+        string key = string.IsNullOrWhiteSpace(def.Key) ? def.Name : def.Key;
+        def.Key = key;
+
+        switch (key.ToLowerInvariant())
+        {
+            case "memory-management":
+                services.AddScoped(sp => new MemoryManagementAgent(
+                    sp.GetRequiredService<IConversationMemory>(),
+                    sp.GetRequiredService<ILogger<MemoryManagementAgent>>(),
+                    def));
+                services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<MemoryManagementAgent>());
+                return;
+
+            case "competitive-intel":
+                services.AddScoped(sp => new CompetitiveIntelAgent(
+                    sp.GetRequiredService<IAgentExecutionPipeline>(),
+                    def,
+                    ResolveTools(sp, def),
+                    sp.GetRequiredService<IHubContext<TelemetryHub>>(),
+                    sp.GetRequiredService<ILogger<CompetitiveIntelAgent>>(),
+                    sp.GetService<SqliteAlertService>()));
+                services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<CompetitiveIntelAgent>());
+                return;
+
+            case "general":
+                services.AddScoped(sp => new GeneralAgent(
+                    sp.GetRequiredService<IAgentExecutionPipeline>(),
+                    def,
+                    ResolveTools(sp, def)));
+                services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<GeneralAgent>());
+                return;
+
+            case "demand-forecasting":
+                services.AddScoped(sp => new DemandForecastAgent(
+                    sp.GetRequiredService<IAgentExecutionPipeline>(),
+                    def,
+                    ResolveTools(sp, def)));
+                services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<DemandForecastAgent>());
+                return;
+
+            case "promo-planning":
+                services.AddScoped(sp => new PromoPlanningAgent(
+                    sp.GetRequiredService<IAgentExecutionPipeline>(),
+                    def,
+                    ResolveTools(sp, def),
+                    sp.GetService<IApprovalGate>()));
+                services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<PromoPlanningAgent>());
+                return;
+
+            case "field-sentiment":
+                services.AddScoped(sp => new FieldSentimentAgent(
+                    sp.GetRequiredService<IAgentExecutionPipeline>(),
+                    def,
+                    ResolveTools(sp, def)));
+                services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<FieldSentimentAgent>());
+                return;
+
+            case "supply-chain":
+                services.AddScoped(sp => new SupplyChainAgent(
+                    sp.GetRequiredService<IAgentExecutionPipeline>(),
+                    def,
+                    ResolveTools(sp, def)));
+                services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<SupplyChainAgent>());
+                return;
+
+            case "store-ops":
+                services.AddScoped(sp => new StoreOpsAgent(
+                    sp.GetRequiredService<IAgentExecutionPipeline>(),
+                    def,
+                    ResolveTools(sp, def)));
+                services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<StoreOpsAgent>());
+                return;
+
+            case "planogram":
+                services.AddScoped(sp => new PlanogramAgent(
+                    sp.GetRequiredService<IAgentExecutionPipeline>(),
+                    def,
+                    ResolveTools(sp, def)));
+                services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<PlanogramAgent>());
+                return;
+
+            case "margin-analysis":
+                services.AddScoped(sp => new MarginAgent(
+                    sp.GetRequiredService<IAgentExecutionPipeline>(),
+                    def,
+                    ResolveTools(sp, def)));
+                services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<MarginAgent>());
+                return;
+
+            default:
+                // Purely configuration-driven specialist. This is the "add-a-specialist-by-editing-yaml"
+                // path (issue #98 acceptance criterion): no C# case is required to register it.
+                services.AddScoped<ISpecialistAgent>(sp => new ConfiguredSpecialistAgent(
+                    sp.GetRequiredService<IAgentExecutionPipeline>(),
+                    def,
+                    ResolveTools(sp, def)));
+                return;
+        }
+    }
+
+    private static IReadOnlyList<AITool> ResolveTools(IServiceProvider sp, AgentDefinition def)
+    {
+        AgentToolRegistry registry = sp.GetRequiredService<AgentToolRegistry>();
+        return registry.Resolve(def.Tools, sp);
+    }
+}
+
+/// <summary>
+/// Composition-root roster of every configured agent definition plus the router
+/// orchestration intent metadata. Exposed as a singleton so orchestrators can
+/// derive council/scorecard/participant lists from configuration.
+/// </summary>
+public sealed class RouterAgentRoster
+{
+    public PromptConfiguration Prompts { get; }
+    public IReadOnlyList<RouterIntentConfig> OrchestrationIntents { get; }
+
+    public RouterAgentRoster(PromptConfiguration prompts, IReadOnlyList<RouterIntentConfig> orchestrationIntents)
+    {
+        Prompts = prompts;
+        OrchestrationIntents = orchestrationIntents;
+    }
+
+    /// <summary>Agent keys with <c>council_participant: true</c>.</summary>
+    public IReadOnlyList<string> GetCouncilParticipants() =>
+        [.. Prompts.Agents.Values
+            .Where(a => a.CouncilParticipant)
+            .Select(a => string.IsNullOrWhiteSpace(a.Key) ? a.Name : a.Key)];
+
+    /// <summary>Scorecard dimensions declared in configuration, ordered by weight desc.</summary>
+    public IReadOnlyList<Scorecard.ScorecardDimensionConfig> GetScorecardDimensions() =>
+        [.. Prompts.Agents.Values
+            .Where(a => !string.IsNullOrWhiteSpace(a.ScorecardDimension) && a.ScorecardWeight > 0)
+            .Select(a => new Scorecard.ScorecardDimensionConfig(
+                a.ScorecardDimension,
+                a.ScorecardWeight,
+                string.IsNullOrWhiteSpace(a.Key) ? a.Name : a.Key))
+            .OrderByDescending(d => d.Weight)];
 }

--- a/src/RetailPulse.Api/Agents/Specialists/CompetitiveIntelAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/CompetitiveIntelAgent.cs
@@ -4,36 +4,23 @@ using Microsoft.Extensions.AI;
 using RetailPulse.Api.Alerts;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Models;
-using RetailPulse.Contracts;
 using RetailPulse.Contracts.Alerts;
 using RetailPulse.Contracts.Routing;
-using ChatRequest = RetailPulse.Contracts.ChatRequest;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Api.Agents.Specialists;
 
 /// <summary>
-/// Competitive Intelligence specialist — monitors competitor activities
-/// (pricing, promotions, market share) and provides strategic recommendations.
-/// Integrates with proactive alert system for real-time threat detection.
-/// Temperature 0.4 balances analytical precision with creative strategy.
+/// Competitive Intelligence specialist — bespoke agent that keeps the standard
+/// execution pipeline (inherited from <see cref="ConfiguredSpecialistAgent"/>)
+/// but layers a real-time SignalR alert publisher on top of every tool result.
+/// The alert-parsing logic is genuinely specialized and stays here rather than
+/// being pushed into configuration.
 /// </summary>
-public class CompetitiveIntelAgent : ISpecialistAgent
+public sealed class CompetitiveIntelAgent : ConfiguredSpecialistAgent
 {
-    private readonly IAgentExecutionPipeline _pipeline;
-    private readonly AgentDefinition _agentDef;
-    public string Model => _agentDef.Model;
-    private readonly IEnumerable<AITool> _tools;
     private readonly IHubContext<TelemetryHub> _hubContext;
     private readonly ILogger<CompetitiveIntelAgent> _logger;
     private readonly SqliteAlertService? _alertService;
-
-    public string Key => "competitive-intel";
-    public string DisplayName => "Competitive Intelligence Agent";
-    public IReadOnlyList<string> SupportedIntents { get; } =
-    [
-        AgentIntent.CompetitiveMarket
-    ];
 
     public CompetitiveIntelAgent(
         IAgentExecutionPipeline pipeline,
@@ -42,31 +29,31 @@ public class CompetitiveIntelAgent : ISpecialistAgent
         IHubContext<TelemetryHub> hubContext,
         ILogger<CompetitiveIntelAgent> logger,
         SqliteAlertService? alertService = null)
+        : base(pipeline, EnsureDefaults(agentDef), tools)
     {
-        _pipeline = pipeline;
-        _agentDef = agentDef;
-        _tools = tools;
         _hubContext = hubContext;
         _logger = logger;
         _alertService = alertService;
     }
 
-    public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+    private static AgentDefinition EnsureDefaults(AgentDefinition def)
     {
-        var context = new AgentExecutionContext
-        {
-            AgentName = _agentDef.Name,
-            SystemPrompt = _agentDef.SystemPrompt,
-            Temperature = (float)_agentDef.Temperature,
-            ModelName = _agentDef.Model,
-            Request = request,
-            Tools = _tools,
-            FallbackReply = "I wasn't able to generate a competitive analysis.",
-            OnToolResult = CheckAndFireAlertsAsync
-        };
+        ArgumentNullException.ThrowIfNull(def);
 
-        return _pipeline.ExecuteAsync(context, ct);
+        def = def.Clone();
+
+        if (string.IsNullOrWhiteSpace(def.Key))
+            def.Key = "competitive-intel";
+        if (def.Intents.Count == 0)
+            def.Intents = [AgentIntent.CompetitiveMarket];
+        if (string.IsNullOrWhiteSpace(def.DisplayName))
+            def.DisplayName = "Competitive Intelligence Agent";
+        if (string.IsNullOrWhiteSpace(def.FallbackReply))
+            def.FallbackReply = "I wasn't able to generate a competitive analysis.";
+        return def;
     }
+
+    protected override Func<string, CancellationToken, Task>? OnToolResult => CheckAndFireAlertsAsync;
 
     /// <summary>
     /// Scans tool results for competitive threats and fires proactive alerts via SignalR.

--- a/src/RetailPulse.Api/Agents/Specialists/ConfiguredSpecialistAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/ConfiguredSpecialistAgent.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.AI;
+using RetailPulse.Api.Models;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Routing;
+using ChatRequest = RetailPulse.Contracts.ChatRequest;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
+
+namespace RetailPulse.Api.Agents.Specialists;
+
+/// <summary>
+/// Single specialist implementation built entirely from an
+/// <see cref="AgentDefinition"/>. This is the generic path used for every
+/// specialist that only needs the shared execution pipeline. Bespoke
+/// specialists (Memory Management, Competitive Intel) still ship their
+/// own class because they carry real domain logic beyond the pipeline.
+/// </summary>
+/// <remarks>
+/// Adding a new specialist becomes: register its tools in the
+/// <see cref="Tools.AgentToolRegistry"/>, add its entry to <c>prompts.yaml</c>
+/// with <c>intents</c> and any <c>keyword_fast_paths</c>, and restart.
+/// No new C# class is required — that is the objective of ADR-008.
+/// </remarks>
+public class ConfiguredSpecialistAgent : ISpecialistAgent, IPrefetchableAgent
+{
+    private readonly IAgentExecutionPipeline _pipeline;
+    private readonly IReadOnlyList<AITool> _tools;
+
+    public string Key { get; }
+    public string DisplayName { get; }
+    public string Model => Definition.Model;
+    public IReadOnlyList<string> SupportedIntents { get; }
+    public IReadOnlyList<string> KeywordFastPaths { get; }
+
+    /// <summary>The underlying <see cref="AgentDefinition"/>. Exposed for orchestrators
+    /// that need council-participant/scorecard metadata without a separate registry.</summary>
+    public AgentDefinition Definition { get; }
+
+    public ConfiguredSpecialistAgent(
+        IAgentExecutionPipeline pipeline,
+        AgentDefinition agentDef,
+        IEnumerable<AITool> tools)
+    {
+        ArgumentNullException.ThrowIfNull(pipeline);
+        ArgumentNullException.ThrowIfNull(agentDef);
+        ArgumentNullException.ThrowIfNull(tools);
+
+        _pipeline = pipeline;
+        Definition = agentDef;
+        _tools = tools as IReadOnlyList<AITool> ?? [.. tools];
+
+        if (string.IsNullOrWhiteSpace(agentDef.Key))
+        {
+            throw new ArgumentException(
+                $"AgentDefinition.Key is required for '{agentDef.Name}'. " +
+                "Set it explicitly in prompts.yaml (or via the loader defaulting).",
+                nameof(agentDef));
+        }
+
+        Key = agentDef.Key;
+        DisplayName = agentDef.EffectiveDisplayName;
+        SupportedIntents = agentDef.Intents.Count > 0
+            ? [.. agentDef.Intents]
+            : [AgentIntent.General];
+        KeywordFastPaths = [.. agentDef.KeywordFastPaths];
+    }
+
+    public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+        => ExecuteAsync(request, prefetchedData: null, ct);
+
+    public Task<ChatResponse> HandleWithPrefetchAsync(
+        ChatRequest request,
+        IReadOnlyDictionary<string, string>? prefetchedData,
+        CancellationToken ct = default)
+        => ExecuteAsync(request, prefetchedData, ct);
+
+    /// <summary>
+    /// Hook for bespoke subclasses (e.g., <see cref="CompetitiveIntelAgent"/>) to
+    /// attach a domain-specific tool-result callback without duplicating the
+    /// pipeline plumbing. Default returns <c>null</c> — no callback.
+    /// </summary>
+    protected virtual Func<string, CancellationToken, Task>? OnToolResult => null;
+
+    private Task<ChatResponse> ExecuteAsync(
+        ChatRequest request,
+        IReadOnlyDictionary<string, string>? prefetchedData,
+        CancellationToken ct)
+    {
+        var context = new AgentExecutionContext
+        {
+            AgentName = Definition.Name,
+            SystemPrompt = Definition.SystemPrompt,
+            Temperature = (float)Definition.Temperature,
+            ModelName = Definition.Model,
+            Request = request,
+            Tools = _tools,
+            FallbackReply = Definition.EffectiveFallbackReply,
+            OnToolResult = OnToolResult,
+            PrefetchedData = prefetchedData
+        };
+
+        return _pipeline.ExecuteAsync(context, ct);
+    }
+}

--- a/src/RetailPulse.Api/Agents/Specialists/DemandForecastAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/DemandForecastAgent.cs
@@ -1,61 +1,39 @@
 using Microsoft.Extensions.AI;
 using RetailPulse.Api.Models;
-using RetailPulse.Contracts;
 using RetailPulse.Contracts.Routing;
-using ChatRequest = RetailPulse.Contracts.ChatRequest;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Api.Agents.Specialists;
 
 /// <summary>
-/// Demand Forecasting specialist — handles all demand/forecasting queries:
-/// historical trends, 90-day predictions, seasonality analysis, depletion velocity,
-/// and risk identification. Uses its own tool set and lower temperature (0.3)
-/// for analytical precision.
+/// Demand Forecasting specialist — thin shim over
+/// <see cref="ConfiguredSpecialistAgent"/> retained so DI, the predictive
+/// prefetch service, and tests can reference a stable named type.
 /// </summary>
-public class DemandForecastAgent : ISpecialistAgent, IPrefetchableAgent
+public sealed class DemandForecastAgent : ConfiguredSpecialistAgent
 {
-    private readonly IAgentExecutionPipeline _pipeline;
-    private readonly AgentDefinition _agentDef;
-    public string Model => _agentDef.Model;
-    private readonly IEnumerable<AITool> _tools;
-
-    public string Key => "demand-forecasting";
-    public string DisplayName => "Demand Forecast Agent";
-    public IReadOnlyList<string> SupportedIntents { get; } =
-    [
-        AgentIntent.DemandForecasting
-    ];
-
     public DemandForecastAgent(
         IAgentExecutionPipeline pipeline,
         AgentDefinition agentDef,
         IEnumerable<AITool> tools)
+        : base(pipeline, EnsureDefaults(agentDef), tools)
     {
-        _pipeline = pipeline;
-        _agentDef = agentDef;
-        _tools = tools;
     }
 
-    public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default) => HandleWithPrefetchAsync(request, null, ct);
-
-    public Task<ChatResponse> HandleWithPrefetchAsync(
-        ChatRequest request,
-        IReadOnlyDictionary<string, string>? prefetchedData,
-        CancellationToken ct = default)
+    private static AgentDefinition EnsureDefaults(AgentDefinition def)
     {
-        var context = new AgentExecutionContext
-        {
-            AgentName = _agentDef.Name,
-            SystemPrompt = _agentDef.SystemPrompt,
-            Temperature = (float)_agentDef.Temperature,
-            ModelName = _agentDef.Model,
-            Request = request,
-            Tools = _tools,
-            FallbackReply = "I wasn't able to generate a forecast response.",
-            PrefetchedData = prefetchedData
-        };
+        ArgumentNullException.ThrowIfNull(def);
 
-        return _pipeline.ExecuteAsync(context, ct);
+        def = def.Clone();
+
+        if (string.IsNullOrWhiteSpace(def.Key))
+            def.Key = "demand-forecasting";
+        if (def.Intents.Count == 0)
+            def.Intents = [AgentIntent.DemandForecasting];
+        if (string.IsNullOrWhiteSpace(def.DisplayName))
+            def.DisplayName = "Demand Forecast Agent";
+        if (string.IsNullOrWhiteSpace(def.FallbackReply))
+            def.FallbackReply = "I wasn't able to generate a forecast response.";
+        def.Prefetchable = true;
+        return def;
     }
 }

--- a/src/RetailPulse.Api/Agents/Specialists/FieldSentimentAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/FieldSentimentAgent.cs
@@ -1,54 +1,38 @@
 using Microsoft.Extensions.AI;
 using RetailPulse.Api.Models;
-using RetailPulse.Contracts;
 using RetailPulse.Contracts.Routing;
-using ChatRequest = RetailPulse.Contracts.ChatRequest;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Api.Agents.Specialists;
 
 /// <summary>
-/// Field Sentiment specialist — handles distributor feedback, field sales reports,
-/// and qualitative sentiment queries. Uses only GetFieldSentiment + CreateChart
-/// tools for minimal token usage and focused execution.
+/// Field Sentiment specialist — thin shim over
+/// <see cref="ConfiguredSpecialistAgent"/>. Behavior is derived entirely from
+/// its <see cref="AgentDefinition"/>.
 /// </summary>
-public class FieldSentimentAgent : ISpecialistAgent
+public sealed class FieldSentimentAgent : ConfiguredSpecialistAgent
 {
-    private readonly IAgentExecutionPipeline _pipeline;
-    private readonly AgentDefinition _agentDef;
-    public string Model => _agentDef.Model;
-    private readonly IEnumerable<AITool> _tools;
-
-    public string Key => "field-sentiment";
-    public string DisplayName => "Field Sentiment Agent";
-    public IReadOnlyList<string> SupportedIntents { get; } =
-    [
-        AgentIntent.SentimentField
-    ];
-
     public FieldSentimentAgent(
         IAgentExecutionPipeline pipeline,
         AgentDefinition agentDef,
         IEnumerable<AITool> tools)
+        : base(pipeline, EnsureDefaults(agentDef), tools)
     {
-        _pipeline = pipeline;
-        _agentDef = agentDef;
-        _tools = tools;
     }
 
-    public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+    private static AgentDefinition EnsureDefaults(AgentDefinition def)
     {
-        var context = new AgentExecutionContext
-        {
-            AgentName = _agentDef.Name,
-            SystemPrompt = _agentDef.SystemPrompt,
-            Temperature = (float)_agentDef.Temperature,
-            ModelName = _agentDef.Model,
-            Request = request,
-            Tools = _tools,
-            FallbackReply = "I wasn't able to retrieve field sentiment data."
-        };
+        ArgumentNullException.ThrowIfNull(def);
 
-        return _pipeline.ExecuteAsync(context, ct);
+        def = def.Clone();
+
+        if (string.IsNullOrWhiteSpace(def.Key))
+            def.Key = "field-sentiment";
+        if (def.Intents.Count == 0)
+            def.Intents = [AgentIntent.SentimentField];
+        if (string.IsNullOrWhiteSpace(def.DisplayName))
+            def.DisplayName = "Field Sentiment Agent";
+        if (string.IsNullOrWhiteSpace(def.FallbackReply))
+            def.FallbackReply = "I wasn't able to retrieve field sentiment data.";
+        return def;
     }
 }

--- a/src/RetailPulse.Api/Agents/Specialists/GeneralAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/GeneralAgent.cs
@@ -1,54 +1,45 @@
 using Microsoft.Extensions.AI;
 using RetailPulse.Api.Models;
-using RetailPulse.Contracts;
 using RetailPulse.Contracts.Routing;
-using ChatRequest = RetailPulse.Contracts.ChatRequest;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Api.Agents.Specialists;
 
 /// <summary>
 /// The General specialist — handles unclassified and general/fallback queries.
-/// This is the refactored RetailPulseAgent, preserving all existing tool access
-/// and behavior. The router sends anything it can't classify here.
+/// The router sends anything it can't classify here.
 /// </summary>
-public class GeneralAgent : ISpecialistAgent
+/// <remarks>
+/// Thin shim over <see cref="ConfiguredSpecialistAgent"/> retained so DI-keyed
+/// callers (composition root, tests) and the legacy <c>RetailPulseAgent</c>
+/// facade can reference a stable type. All behavior lives in the base class —
+/// per issue #98's "single specialist implementation" objective.
+/// </remarks>
+public sealed class GeneralAgent : ConfiguredSpecialistAgent
 {
-    private readonly IAgentExecutionPipeline _pipeline;
-    private readonly AgentDefinition _agentDef;
-    public string Model => _agentDef.Model;
-    private readonly IEnumerable<AITool> _tools;
-
-    public string Key => "general";
-    public string DisplayName => "General Agent";
-    public IReadOnlyList<string> SupportedIntents { get; } =
-    [
-        AgentIntent.General
-    ];
-
     public GeneralAgent(
         IAgentExecutionPipeline pipeline,
         AgentDefinition agentDef,
         IEnumerable<AITool> tools)
+        : base(pipeline, EnsureDefaults(agentDef), tools)
     {
-        _pipeline = pipeline;
-        _agentDef = agentDef;
-        _tools = tools;
     }
 
-    public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+    private static AgentDefinition EnsureDefaults(AgentDefinition def)
     {
-        var context = new AgentExecutionContext
-        {
-            AgentName = _agentDef.Name,
-            SystemPrompt = _agentDef.SystemPrompt,
-            Temperature = (float)_agentDef.Temperature,
-            ModelName = _agentDef.Model,
-            Request = request,
-            Tools = _tools,
-            FallbackReply = "I wasn't able to generate a response."
-        };
+        ArgumentNullException.ThrowIfNull(def);
 
-        return _pipeline.ExecuteAsync(context, ct);
+        def = def.Clone();
+
+        // The old class hardcoded Key="general" / General intent. Preserve that
+        // behavior for callers that construct with a minimally-populated definition
+        // (tests and legacy code paths) while still honoring an explicit Key/Intents
+        // supplied via prompts.yaml when they are present.
+        if (string.IsNullOrWhiteSpace(def.Key))
+            def.Key = "general";
+        if (def.Intents.Count == 0)
+            def.Intents = [AgentIntent.General];
+        if (string.IsNullOrWhiteSpace(def.DisplayName))
+            def.DisplayName = "General Agent";
+        return def;
     }
 }

--- a/src/RetailPulse.Api/Agents/Specialists/MarginAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/MarginAgent.cs
@@ -1,54 +1,36 @@
 using Microsoft.Extensions.AI;
 using RetailPulse.Api.Models;
-using RetailPulse.Contracts;
 using RetailPulse.Contracts.Routing;
-using ChatRequest = RetailPulse.Contracts.ChatRequest;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Api.Agents.Specialists;
 
 /// <summary>
-/// Margin Analysis specialist — handles margin calculations, profitability analysis,
-/// cost breakdowns, and margin optimization recommendations.
-/// Uses temperature 0.3 for analytical precision.
+/// Margin Analysis specialist — thin shim over <see cref="ConfiguredSpecialistAgent"/>.
 /// </summary>
-public class MarginAgent : ISpecialistAgent
+public sealed class MarginAgent : ConfiguredSpecialistAgent
 {
-    private readonly IAgentExecutionPipeline _pipeline;
-    private readonly AgentDefinition _agentDef;
-    public string Model => _agentDef.Model;
-    private readonly IEnumerable<AITool> _tools;
-
-    public string Key => "margin-analysis";
-    public string DisplayName => "Margin Analysis Agent";
-    public IReadOnlyList<string> SupportedIntents { get; } =
-    [
-        AgentIntent.MarginAnalysis
-    ];
-
     public MarginAgent(
         IAgentExecutionPipeline pipeline,
         AgentDefinition agentDef,
         IEnumerable<AITool> tools)
+        : base(pipeline, EnsureDefaults(agentDef), tools)
     {
-        _pipeline = pipeline;
-        _agentDef = agentDef;
-        _tools = tools;
     }
 
-    public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+    private static AgentDefinition EnsureDefaults(AgentDefinition def)
     {
-        var context = new AgentExecutionContext
-        {
-            AgentName = _agentDef.Name,
-            SystemPrompt = _agentDef.SystemPrompt,
-            Temperature = (float)_agentDef.Temperature,
-            ModelName = _agentDef.Model,
-            Request = request,
-            Tools = _tools,
-            FallbackReply = "I wasn't able to generate a margin analysis response."
-        };
+        ArgumentNullException.ThrowIfNull(def);
 
-        return _pipeline.ExecuteAsync(context, ct);
+        def = def.Clone();
+
+        if (string.IsNullOrWhiteSpace(def.Key))
+            def.Key = "margin-analysis";
+        if (def.Intents.Count == 0)
+            def.Intents = [AgentIntent.MarginAnalysis];
+        if (string.IsNullOrWhiteSpace(def.DisplayName))
+            def.DisplayName = "Margin Analysis Agent";
+        if (string.IsNullOrWhiteSpace(def.FallbackReply))
+            def.FallbackReply = "I wasn't able to generate a margin analysis response.";
+        return def;
     }
 }

--- a/src/RetailPulse.Api/Agents/Specialists/MemoryManagementAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/MemoryManagementAgent.cs
@@ -1,3 +1,4 @@
+using RetailPulse.Api.Models;
 using RetailPulse.Contracts;
 using RetailPulse.Contracts.Memory;
 using RetailPulse.Contracts.Routing;
@@ -16,18 +17,42 @@ public class MemoryManagementAgent : ISpecialistAgent
     private readonly IConversationMemory _memory;
     private readonly ILogger<MemoryManagementAgent> _logger;
 
-    public string Key => "memory-management";
-    public string DisplayName => "Memory Management";
+    public string Key { get; }
+    public string DisplayName { get; }
     public string Model => "none";
-    public IReadOnlyList<string> SupportedIntents { get; } = [AgentIntent.MemoryManagement];
+    public IReadOnlyList<string> SupportedIntents { get; }
+    public IReadOnlyList<string> KeywordFastPaths { get; }
 
     public MemoryManagementAgent(
         IConversationMemory memory,
-        ILogger<MemoryManagementAgent> logger)
+        ILogger<MemoryManagementAgent> logger,
+        AgentDefinition? definition = null)
     {
         _memory = memory;
         _logger = logger;
+
+        // Prefer the configured AgentDefinition when supplied so the memory-management
+        // taxonomy stays declared in prompts.yaml. Fall back to the previous hardcoded
+        // defaults when composed without config (unit tests, ad-hoc harnesses).
+        Key = string.IsNullOrWhiteSpace(definition?.Key) ? "memory-management" : definition.Key;
+        DisplayName = string.IsNullOrWhiteSpace(definition?.DisplayName)
+            ? "Memory Management"
+            : definition.EffectiveDisplayName;
+        SupportedIntents = (definition?.Intents is { Count: > 0 })
+            ? [.. definition.Intents]
+            : [AgentIntent.MemoryManagement];
+        KeywordFastPaths = (definition?.KeywordFastPaths is { Count: > 0 })
+            ? [.. definition.KeywordFastPaths]
+            : _defaultMemoryKeywords;
     }
+
+    /// <summary>Legacy hardcoded fast-paths — preserved when no config is provided.</summary>
+    private static readonly string[] _defaultMemoryKeywords =
+    [
+        "remember that", "remember this", "forget", "clear my", "clear my history",
+        "clear my data", "start fresh", "reset my context", "forget what I told you",
+        "what do you know about me",
+    ];
 
     public async Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
     {

--- a/src/RetailPulse.Api/Agents/Specialists/PlanogramAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/PlanogramAgent.cs
@@ -1,54 +1,36 @@
 using Microsoft.Extensions.AI;
 using RetailPulse.Api.Models;
-using RetailPulse.Contracts;
 using RetailPulse.Contracts.Routing;
-using ChatRequest = RetailPulse.Contracts.ChatRequest;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Api.Agents.Specialists;
 
 /// <summary>
-/// Planogram Optimization specialist — handles shelf layout optimization,
-/// product placement analysis, and planogram recommendations.
-/// Uses temperature 0.3 for analytical precision.
+/// Planogram Optimization specialist — thin shim over <see cref="ConfiguredSpecialistAgent"/>.
 /// </summary>
-public class PlanogramAgent : ISpecialistAgent
+public sealed class PlanogramAgent : ConfiguredSpecialistAgent
 {
-    private readonly IAgentExecutionPipeline _pipeline;
-    private readonly AgentDefinition _agentDef;
-    public string Model => _agentDef.Model;
-    private readonly IEnumerable<AITool> _tools;
-
-    public string Key => "planogram";
-    public string DisplayName => "Planogram Optimization Agent";
-    public IReadOnlyList<string> SupportedIntents { get; } =
-    [
-        AgentIntent.Planogram
-    ];
-
     public PlanogramAgent(
         IAgentExecutionPipeline pipeline,
         AgentDefinition agentDef,
         IEnumerable<AITool> tools)
+        : base(pipeline, EnsureDefaults(agentDef), tools)
     {
-        _pipeline = pipeline;
-        _agentDef = agentDef;
-        _tools = tools;
     }
 
-    public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+    private static AgentDefinition EnsureDefaults(AgentDefinition def)
     {
-        var context = new AgentExecutionContext
-        {
-            AgentName = _agentDef.Name,
-            SystemPrompt = _agentDef.SystemPrompt,
-            Temperature = (float)_agentDef.Temperature,
-            ModelName = _agentDef.Model,
-            Request = request,
-            Tools = _tools,
-            FallbackReply = "I wasn't able to generate a planogram optimization response."
-        };
+        ArgumentNullException.ThrowIfNull(def);
 
-        return _pipeline.ExecuteAsync(context, ct);
+        def = def.Clone();
+
+        if (string.IsNullOrWhiteSpace(def.Key))
+            def.Key = "planogram";
+        if (def.Intents.Count == 0)
+            def.Intents = [AgentIntent.Planogram];
+        if (string.IsNullOrWhiteSpace(def.DisplayName))
+            def.DisplayName = "Planogram Optimization Agent";
+        if (string.IsNullOrWhiteSpace(def.FallbackReply))
+            def.FallbackReply = "I wasn't able to generate a planogram optimization response.";
+        return def;
     }
 }

--- a/src/RetailPulse.Api/Agents/Specialists/PromoPlanningAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/PromoPlanningAgent.cs
@@ -1,59 +1,45 @@
 using Microsoft.Extensions.AI;
 using RetailPulse.Api.Models;
-using RetailPulse.Contracts;
 using RetailPulse.Contracts.Approval;
 using RetailPulse.Contracts.Routing;
-using ChatRequest = RetailPulse.Contracts.ChatRequest;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Api.Agents.Specialists;
 
 /// <summary>
-/// Promotion Planning specialist — handles promotion/trade queries:
-/// promo history analysis, lift calculations, timing evaluation, ROI estimation,
-/// and campaign approval gating. Uses its own tool set and lower temperature (0.3).
+/// Promotion Planning specialist — thin shim over
+/// <see cref="ConfiguredSpecialistAgent"/> that retains the bespoke approval-gate
+/// hook (<see cref="CheckApprovalAsync"/>) called by the Task Module endpoint.
+/// The LLM path is fully data-driven.
 /// </summary>
-public class PromoPlanningAgent : ISpecialistAgent
+public sealed class PromoPlanningAgent : ConfiguredSpecialistAgent
 {
-    private readonly IAgentExecutionPipeline _pipeline;
-    private readonly AgentDefinition _agentDef;
-    public string Model => _agentDef.Model;
-    private readonly IEnumerable<AITool> _tools;
     private readonly IApprovalGate? _approvalGate;
-
-    public string Key => "promo-planning";
-    public string DisplayName => "Promotion Planning Agent";
-    public IReadOnlyList<string> SupportedIntents { get; } =
-    [
-        AgentIntent.PromotionTrade
-    ];
 
     public PromoPlanningAgent(
         IAgentExecutionPipeline pipeline,
         AgentDefinition agentDef,
         IEnumerable<AITool> tools,
         IApprovalGate? approvalGate = null)
+        : base(pipeline, EnsureDefaults(agentDef), tools)
     {
-        _pipeline = pipeline;
-        _agentDef = agentDef;
-        _tools = tools;
         _approvalGate = approvalGate;
     }
 
-    public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+    private static AgentDefinition EnsureDefaults(AgentDefinition def)
     {
-        var context = new AgentExecutionContext
-        {
-            AgentName = _agentDef.Name,
-            SystemPrompt = _agentDef.SystemPrompt,
-            Temperature = (float)_agentDef.Temperature,
-            ModelName = _agentDef.Model,
-            Request = request,
-            Tools = _tools,
-            FallbackReply = "I wasn't able to generate a promotion analysis."
-        };
+        ArgumentNullException.ThrowIfNull(def);
 
-        return _pipeline.ExecuteAsync(context, ct);
+        def = def.Clone();
+
+        if (string.IsNullOrWhiteSpace(def.Key))
+            def.Key = "promo-planning";
+        if (def.Intents.Count == 0)
+            def.Intents = [AgentIntent.PromotionTrade];
+        if (string.IsNullOrWhiteSpace(def.DisplayName))
+            def.DisplayName = "Promotion Planning Agent";
+        if (string.IsNullOrWhiteSpace(def.FallbackReply))
+            def.FallbackReply = "I wasn't able to generate a promotion analysis.";
+        return def;
     }
 
     /// <summary>

--- a/src/RetailPulse.Api/Agents/Specialists/StoreOpsAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/StoreOpsAgent.cs
@@ -1,54 +1,36 @@
 using Microsoft.Extensions.AI;
 using RetailPulse.Api.Models;
-using RetailPulse.Contracts;
 using RetailPulse.Contracts.Routing;
-using ChatRequest = RetailPulse.Contracts.ChatRequest;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Api.Agents.Specialists;
 
 /// <summary>
-/// Store Operations specialist — handles store performance analysis,
-/// underperformer detection, stockout prediction, and store recommendations.
-/// Uses temperature 0.3 for analytical precision.
+/// Store Operations specialist — thin shim over <see cref="ConfiguredSpecialistAgent"/>.
 /// </summary>
-public class StoreOpsAgent : ISpecialistAgent
+public sealed class StoreOpsAgent : ConfiguredSpecialistAgent
 {
-    private readonly IAgentExecutionPipeline _pipeline;
-    private readonly AgentDefinition _agentDef;
-    public string Model => _agentDef.Model;
-    private readonly IEnumerable<AITool> _tools;
-
-    public string Key => "store-ops";
-    public string DisplayName => "Store Operations Agent";
-    public IReadOnlyList<string> SupportedIntents { get; } =
-    [
-        AgentIntent.StoreOps
-    ];
-
     public StoreOpsAgent(
         IAgentExecutionPipeline pipeline,
         AgentDefinition agentDef,
         IEnumerable<AITool> tools)
+        : base(pipeline, EnsureDefaults(agentDef), tools)
     {
-        _pipeline = pipeline;
-        _agentDef = agentDef;
-        _tools = tools;
     }
 
-    public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+    private static AgentDefinition EnsureDefaults(AgentDefinition def)
     {
-        var context = new AgentExecutionContext
-        {
-            AgentName = _agentDef.Name,
-            SystemPrompt = _agentDef.SystemPrompt,
-            Temperature = (float)_agentDef.Temperature,
-            ModelName = _agentDef.Model,
-            Request = request,
-            Tools = _tools,
-            FallbackReply = "I wasn't able to generate a store operations response."
-        };
+        ArgumentNullException.ThrowIfNull(def);
 
-        return _pipeline.ExecuteAsync(context, ct);
+        def = def.Clone();
+
+        if (string.IsNullOrWhiteSpace(def.Key))
+            def.Key = "store-ops";
+        if (def.Intents.Count == 0)
+            def.Intents = [AgentIntent.StoreOps];
+        if (string.IsNullOrWhiteSpace(def.DisplayName))
+            def.DisplayName = "Store Operations Agent";
+        if (string.IsNullOrWhiteSpace(def.FallbackReply))
+            def.FallbackReply = "I wasn't able to generate a store operations response.";
+        return def;
     }
 }

--- a/src/RetailPulse.Api/Agents/Specialists/SupplyChainAgent.cs
+++ b/src/RetailPulse.Api/Agents/Specialists/SupplyChainAgent.cs
@@ -1,54 +1,36 @@
 using Microsoft.Extensions.AI;
 using RetailPulse.Api.Models;
-using RetailPulse.Contracts;
 using RetailPulse.Contracts.Routing;
-using ChatRequest = RetailPulse.Contracts.ChatRequest;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Api.Agents.Specialists;
 
 /// <summary>
-/// Supply Chain specialist — handles inventory levels, supply disruptions,
-/// fulfillment rates, and overall supply health assessments.
-/// Uses its own tool set and lower temperature (0.3) for analytical precision.
+/// Supply Chain specialist — thin shim over <see cref="ConfiguredSpecialistAgent"/>.
 /// </summary>
-public class SupplyChainAgent : ISpecialistAgent
+public sealed class SupplyChainAgent : ConfiguredSpecialistAgent
 {
-    private readonly IAgentExecutionPipeline _pipeline;
-    private readonly AgentDefinition _agentDef;
-    public string Model => _agentDef.Model;
-    private readonly IEnumerable<AITool> _tools;
-
-    public string Key => "supply-chain";
-    public string DisplayName => "Supply Chain Agent";
-    public IReadOnlyList<string> SupportedIntents { get; } =
-    [
-        AgentIntent.SupplyShipments
-    ];
-
     public SupplyChainAgent(
         IAgentExecutionPipeline pipeline,
         AgentDefinition agentDef,
         IEnumerable<AITool> tools)
+        : base(pipeline, EnsureDefaults(agentDef), tools)
     {
-        _pipeline = pipeline;
-        _agentDef = agentDef;
-        _tools = tools;
     }
 
-    public Task<ChatResponse> HandleAsync(ChatRequest request, CancellationToken ct = default)
+    private static AgentDefinition EnsureDefaults(AgentDefinition def)
     {
-        var context = new AgentExecutionContext
-        {
-            AgentName = _agentDef.Name,
-            SystemPrompt = _agentDef.SystemPrompt,
-            Temperature = (float)_agentDef.Temperature,
-            ModelName = _agentDef.Model,
-            Request = request,
-            Tools = _tools,
-            FallbackReply = "I wasn't able to generate a supply chain analysis."
-        };
+        ArgumentNullException.ThrowIfNull(def);
 
-        return _pipeline.ExecuteAsync(context, ct);
+        def = def.Clone();
+
+        if (string.IsNullOrWhiteSpace(def.Key))
+            def.Key = "supply-chain";
+        if (def.Intents.Count == 0)
+            def.Intents = [AgentIntent.SupplyShipments];
+        if (string.IsNullOrWhiteSpace(def.DisplayName))
+            def.DisplayName = "Supply Chain Agent";
+        if (string.IsNullOrWhiteSpace(def.FallbackReply))
+            def.FallbackReply = "I wasn't able to generate a supply chain analysis.";
+        return def;
     }
 }

--- a/src/RetailPulse.Api/Agents/Tools/AgentToolRegistry.cs
+++ b/src/RetailPulse.Api/Agents/Tools/AgentToolRegistry.cs
@@ -1,0 +1,145 @@
+using Microsoft.Extensions.AI;
+
+namespace RetailPulse.Api.Agents.Tools;
+
+/// <summary>
+/// Named registry of <see cref="AITool"/> factories. Each specialist
+/// <c>AgentDefinition</c> lists the tools it needs by name (matching
+/// <c>[Description]</c>-annotated MCP proxy method names in
+/// <c>prompts.yaml</c>). The registry converts a list of names into
+/// concrete <see cref="AITool"/> instances at agent construction time.
+/// </summary>
+/// <remarks>
+/// Unknown tool names must be caught at startup, not at first user query.
+/// Callers use <see cref="Resolve"/> which throws
+/// <see cref="UnknownToolReferenceException"/> when any name is missing, so
+/// composition-root wiring fails loudly before the app accepts traffic.
+/// </remarks>
+public sealed class AgentToolRegistry
+{
+    private readonly Dictionary<string, Func<IServiceProvider, AITool>> _factories =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Registered tool names (case-insensitive keys).</summary>
+    public IReadOnlyCollection<string> RegisteredNames => _factories.Keys;
+
+    /// <summary>
+    /// Register a factory for a named tool. The factory is invoked lazily
+    /// per agent construction so scoped tools resolve against the correct
+    /// <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <param name="name">Tool name as it appears in <c>prompts.yaml</c>.</param>
+    /// <param name="factory">Factory that produces the <see cref="AITool"/>.</param>
+    public AgentToolRegistry Register(string name, Func<IServiceProvider, AITool> factory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(factory);
+
+        return !_factories.TryAdd(name, factory)
+            ? throw new InvalidOperationException(
+                $"Tool '{name}' is already registered in {nameof(AgentToolRegistry)}. " +
+                "Each tool name must be unique — this usually indicates duplicate DI wiring.")
+            : this;
+    }
+
+    /// <summary>True when a tool of the given name is registered.</summary>
+    public bool Contains(string name) => _factories.ContainsKey(name);
+
+    /// <summary>
+    /// Resolves the requested tool names into concrete <see cref="AITool"/> instances
+    /// via the supplied <paramref name="sp"/>. Throws
+    /// <see cref="UnknownToolReferenceException"/> when any name is missing so callers
+    /// can surface an actionable startup error and never register an incomplete agent.
+    /// </summary>
+    public IReadOnlyList<AITool> Resolve(IEnumerable<string> toolNames, IServiceProvider sp)
+    {
+        ArgumentNullException.ThrowIfNull(toolNames);
+        ArgumentNullException.ThrowIfNull(sp);
+
+        IList<string> names = toolNames as IList<string> ?? [.. toolNames];
+        var missing = new List<string>();
+        var resolved = new List<AITool>(names.Count);
+
+        foreach (string rawName in names)
+        {
+            string name = rawName?.Trim() ?? string.Empty;
+            if (string.IsNullOrEmpty(name))
+                continue;
+
+            if (_factories.TryGetValue(name, out Func<IServiceProvider, AITool>? factory))
+            {
+                resolved.Add(factory(sp));
+            }
+            else
+            {
+                missing.Add(name);
+            }
+        }
+
+        return missing.Count > 0 ? throw new UnknownToolReferenceException(missing, _factories.Keys) : (IReadOnlyList<AITool>)resolved;
+    }
+
+    /// <summary>
+    /// Validates that every tool name referenced by any <paramref name="agents"/> definition
+    /// has a matching factory. Throws <see cref="UnknownToolReferenceException"/> otherwise.
+    /// Intended to be called once at startup — before any specialist is registered — so a
+    /// typo in prompts.yaml never leaks into a running deployment.
+    /// </summary>
+    public void ValidateAllReferences(IEnumerable<AgentDefinitionRef> agents)
+    {
+        ArgumentNullException.ThrowIfNull(agents);
+
+        var missing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (AgentDefinitionRef def in agents)
+        {
+            foreach (string name in def.Tools)
+            {
+                if (!string.IsNullOrWhiteSpace(name) && !_factories.ContainsKey(name.Trim()))
+                {
+                    missing.Add(name.Trim());
+                }
+            }
+        }
+
+        if (missing.Count > 0)
+        {
+            throw new UnknownToolReferenceException([.. missing], _factories.Keys);
+        }
+    }
+}
+
+/// <summary>
+/// Minimal projection of an agent definition used for cross-cutting startup validation.
+/// Kept as a small record so <see cref="AgentToolRegistry"/> does not take a hard
+/// dependency on <c>RetailPulse.Api.Models.AgentDefinition</c>.
+/// </summary>
+public sealed record AgentDefinitionRef(string Key, IReadOnlyList<string> Tools);
+
+/// <summary>
+/// Thrown at startup when an agent definition references a tool name that has no
+/// registered factory. Carries the full list of missing and known names so the
+/// operator can pick the closest match without digging through source.
+/// </summary>
+public sealed class UnknownToolReferenceException : InvalidOperationException
+{
+    public IReadOnlyList<string> MissingTools { get; }
+    public IReadOnlyList<string> KnownTools { get; }
+
+    public UnknownToolReferenceException(
+        IReadOnlyList<string> missing,
+        IEnumerable<string> known)
+        : base(BuildMessage(missing, known))
+    {
+        MissingTools = missing;
+        KnownTools = [.. known.OrderBy(n => n, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    private static string BuildMessage(IReadOnlyList<string> missing, IEnumerable<string> known)
+    {
+        string knownList = string.Join(", ", known.OrderBy(n => n, StringComparer.OrdinalIgnoreCase));
+        return $"Agent definition references unknown tool(s): {string.Join(", ", missing)}. " +
+               $"Registered tools: {knownList}. " +
+               "Fix the 'tools:' entry in prompts.yaml or register the missing tool factory before " +
+               "AddAgentRouting(). Configuration errors must fail at startup, not at first user query.";
+    }
+}

--- a/src/RetailPulse.Api/Consensus/ConsensusOrchestrator.cs
+++ b/src/RetailPulse.Api/Consensus/ConsensusOrchestrator.cs
@@ -23,6 +23,7 @@ public class ConsensusOrchestrator : IConsensusCouncil
     private readonly AgentDefinition _voteDef;
     private readonly ILogger<ConsensusOrchestrator> _logger;
     private readonly ILoggerFactory? _loggerFactory;
+    private readonly HashSet<string> _councilParticipants;
 
     /// <summary>MAF agent name for lightweight voter runs, so characterization tests can
     /// verify each vote flows through <see cref="MafAgentInvoker"/> (a real
@@ -40,13 +41,14 @@ public class ConsensusOrchestrator : IConsensusCouncil
     /// <summary>Timeout for lightweight voting mode — no tool calls, just LLM reasoning.</summary>
     private static readonly TimeSpan _lightweightVoteTimeout = TimeSpan.FromSeconds(10);
 
-    /// <summary>Agent keys eligible to participate in the council.</summary>
-    private static readonly HashSet<string> _councilParticipants = new(StringComparer.OrdinalIgnoreCase)
-    {
+    /// <summary>Default agent keys eligible for the council — used when the caller does
+    /// not supply a configuration-derived list (unit tests, legacy composition roots).</summary>
+    internal static readonly IReadOnlyList<string> DefaultCouncilParticipants =
+    [
         "demand-forecasting",
         "competitive-intel",
         "supply-chain"
-    };
+    ];
 
     public ConsensusOrchestrator(
         IEnumerable<ISpecialistAgent> specialists,
@@ -54,6 +56,7 @@ public class ConsensusOrchestrator : IConsensusCouncil
         AgentDefinition synthesisDef,
         AgentDefinition voteDef,
         ILogger<ConsensusOrchestrator> logger,
+        IEnumerable<string>? councilParticipants = null,
         ILoggerFactory? loggerFactory = null)
     {
         _specialists = specialists;
@@ -62,6 +65,13 @@ public class ConsensusOrchestrator : IConsensusCouncil
         _voteDef = voteDef;
         _logger = logger;
         _loggerFactory = loggerFactory;
+
+        // Council roster is now data-driven per issue #98. When callers don't supply
+        // a roster (older tests), fall back to the historical set so existing
+        // behaviour parity is preserved.
+        _councilParticipants = new HashSet<string>(
+            councilParticipants ?? DefaultCouncilParticipants,
+            StringComparer.OrdinalIgnoreCase);
     }
 
     public async Task<CouncilVerdict> ConveneAsync(string brand, string? region, CancellationToken ct = default)

--- a/src/RetailPulse.Api/Models/PromptConfiguration.cs
+++ b/src/RetailPulse.Api/Models/PromptConfiguration.cs
@@ -12,4 +12,103 @@ public class AgentDefinition
     public string SystemPrompt { get; set; } = string.Empty;
     public double Temperature { get; set; } = 0.7;
     public List<string> Tools { get; set; } = [];
+
+    /// <summary>
+    /// Routing key used by the router to dispatch to this agent (e.g., "demand-forecasting").
+    /// When absent, the loader defaults it to the YAML section name during composition.
+    /// Lowercase kebab-case by convention.
+    /// </summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable display name used in telemetry and UI. Falls back to <see cref="Name"/>
+    /// when empty.
+    /// </summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Intents this specialist handles. The router derives its intent set from the
+    /// union of every configured specialist's <see cref="Intents"/> list — no compiled
+    /// enum extension is required to add a new specialist.
+    /// </summary>
+    public List<string> Intents { get; set; } = [];
+
+    /// <summary>
+    /// Case-insensitive substrings that force a keyword fast-path match to this agent's
+    /// primary intent. Empty by default; add strong, unambiguous phrases only — short or
+    /// generic keywords should be left to the LLM classifier.
+    /// </summary>
+    public List<string> KeywordFastPaths { get; set; } = [];
+
+    /// <summary>
+    /// Customized fallback reply used when the LLM returns an empty response. Falls back
+    /// to a domain-neutral default when unspecified.
+    /// </summary>
+    public string FallbackReply { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True when this specialist should be included in the Portfolio Health Council fan-out.
+    /// Replaces the previously hardcoded council roster in <c>ConsensusOrchestrator</c>.
+    /// </summary>
+    public bool CouncilParticipant { get; set; }
+
+    /// <summary>
+    /// Optional brand-scorecard dimension supplied by this specialist. When both
+    /// <see cref="ScorecardDimension"/> and <see cref="ScorecardWeight"/> are set, the
+    /// <c>ScorecardOrchestrator</c> includes this agent as a scoring dimension.
+    /// </summary>
+    public string ScorecardDimension { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Scorecard dimension weight (0–1). Combined with <see cref="ScorecardDimension"/>.
+    /// </summary>
+    public double ScorecardWeight { get; set; }
+
+    /// <summary>
+    /// Role of this definition in the composition graph. Defaults to <c>"specialist"</c> —
+    /// the loader will construct a <c>ConfiguredSpecialistAgent</c>. Use <c>"bespoke"</c>
+    /// for agents that ship a hand-written class (Memory Management, Competitive Intel),
+    /// or <c>"orchestration"</c> for router/synthesizer/vote-format prompts that are not
+    /// specialists at all.
+    /// </summary>
+    public string Role { get; set; } = "specialist";
+
+    /// <summary>
+    /// True when the router should call <see cref="Agents.IPrefetchableAgent"/>
+    /// on this specialist. Only Demand Forecasting uses prefetch today.
+    /// </summary>
+    public bool Prefetchable { get; set; }
+
+    /// <summary>Convenience — resolves the effective display name (falls back to <see cref="Name"/>).</summary>
+    public string EffectiveDisplayName => string.IsNullOrWhiteSpace(DisplayName) ? Name : DisplayName;
+
+    /// <summary>Convenience — resolves the effective fallback reply.</summary>
+    public string EffectiveFallbackReply => string.IsNullOrWhiteSpace(FallbackReply)
+        ? "I wasn't able to generate a response."
+        : FallbackReply;
+
+    /// <summary>
+    /// Returns a shallow member-wise copy with new list instances for the mutable
+    /// collections. Used by the specialist shims' <c>EnsureDefaults</c> so populating
+    /// per-agent defaults never mutates a shared <see cref="AgentDefinition"/> instance
+    /// passed to multiple specialists (a real hazard in tests that reuse a stub def).
+    /// </summary>
+    public AgentDefinition Clone() => new()
+    {
+        Name = Name,
+        Model = Model,
+        SystemPrompt = SystemPrompt,
+        Temperature = Temperature,
+        Tools = [.. Tools],
+        Key = Key,
+        DisplayName = DisplayName,
+        Intents = [.. Intents],
+        KeywordFastPaths = [.. KeywordFastPaths],
+        FallbackReply = FallbackReply,
+        CouncilParticipant = CouncilParticipant,
+        ScorecardDimension = ScorecardDimension,
+        ScorecardWeight = ScorecardWeight,
+        Role = Role,
+        Prefetchable = Prefetchable,
+    };
 }

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
 using RetailPulse.Api.Agents;
+using RetailPulse.Api.Agents.Routing;
 using RetailPulse.Api.Agents.Specialists;
 using RetailPulse.Api.Agents.Tools;
 using RetailPulse.Api.Alerts;
@@ -262,49 +263,43 @@ builder.Services.AddApiVersioning(options =>
 // Load prompts from YAML and resolve tenant placeholders via PromptTemplateEngine
 string promptsPath = Path.Combine(builder.Environment.ContentRootPath, "prompts.yaml");
 PromptConfiguration promptConfig = RetailPulseAgent.LoadPrompts(promptsPath);
-AgentDefinition agentDef = promptConfig.Agents["retail-pulse"];
-
 TenantConfiguration tenant = tenantProvider.GetTenant();
 var promptEngine = new RetailPulse.Api.Prompts.PromptTemplateEngine(tenant);
 
-// Hydrate all agent definitions with tenant placeholders
-promptEngine.Hydrate(agentDef);
+// Normalize + hydrate every configured agent definition once so downstream lookups
+// see effective keys and tenant-placeholder-free prompts. Section names become the
+// default Key when `key:` is omitted, preserving pre-refactor behavior for existing
+// entries and letting new specialists come in without any C# changes (issue #98).
+foreach ((string sectionKey, AgentDefinition def) in promptConfig.Agents)
+{
+    if (string.IsNullOrWhiteSpace(def.Key))
+    {
+        def.Key = sectionKey;
+    }
 
-AgentDefinition demandForecastDef = promptConfig.Agents["demand-forecast"];
-promptEngine.Hydrate(demandForecastDef);
+    // Router prompt is domain-generic; router entry stays un-hydrated so tenant
+    // placeholders don't accidentally leak into classification instructions.
+    if (!string.Equals(def.Key, "router", StringComparison.OrdinalIgnoreCase))
+    {
+        promptEngine.Hydrate(def);
+    }
+}
 
-// Router prompt doesn't need tenant placeholders (intent classification is domain-generic)
-AgentDefinition routerDef = promptConfig.Agents["router"];
+// Shorthand accessors kept for the orchestration wiring below.
+AgentDefinition agentDef = ResolveAgent("retail-pulse", promptConfig);
+AgentDefinition routerDef = ResolveAgent("router", promptConfig);
+AgentDefinition? councilSynthesisDef = TryResolveAgent("council-synthesis", promptConfig);
+AgentDefinition? councilVoteDef = TryResolveAgent("council-vote", promptConfig);
+AgentDefinition? scorecardSynthesisDef = TryResolveAgent("scorecard-synthesis", promptConfig);
+_ = TryResolveAgent("exec-brief", promptConfig); // referenced only for validation
 
-AgentDefinition? promoPlanningDef = promptConfig.Agents.TryGetValue("promo-planning", out AgentDefinition? promoDef) ? promoDef : null;
-if (promoPlanningDef != null) promptEngine.Hydrate(promoPlanningDef);
-
-AgentDefinition? competitiveIntelDef = promptConfig.Agents.TryGetValue("competitive-intel", out AgentDefinition? compDef) ? compDef : null;
-if (competitiveIntelDef != null) promptEngine.Hydrate(competitiveIntelDef);
-
-AgentDefinition? supplyChainDef = promptConfig.Agents.TryGetValue("supply-chain", out AgentDefinition? scDef) ? scDef : null;
-if (supplyChainDef != null) promptEngine.Hydrate(supplyChainDef);
-
-// Load council synthesis and vote prompt definitions
-AgentDefinition? councilSynthesisDef = promptConfig.Agents.TryGetValue("council-synthesis", out AgentDefinition? synthDef) ? synthDef : null;
-AgentDefinition? councilVoteDef = promptConfig.Agents.TryGetValue("council-vote", out AgentDefinition? vDef) ? vDef : null;
-
-AgentDefinition? storeOpsDef = promptConfig.Agents.TryGetValue("store-ops", out AgentDefinition? soDef) ? soDef : null;
-if (storeOpsDef != null) promptEngine.Hydrate(storeOpsDef);
-
-AgentDefinition? planogramDef = promptConfig.Agents.TryGetValue("planogram", out AgentDefinition? pgDef) ? pgDef : null;
-if (planogramDef != null) promptEngine.Hydrate(planogramDef);
-
-AgentDefinition? marginDef = promptConfig.Agents.TryGetValue("margin", out AgentDefinition? mrgDef) ? mrgDef : null;
-if (marginDef != null) promptEngine.Hydrate(marginDef);
-
-// Load scorecard and exec-brief synthesis definitions
-AgentDefinition? scorecardSynthesisDef = promptConfig.Agents.TryGetValue("scorecard-synthesis", out AgentDefinition? scSynthDef) ? scSynthDef : null;
-AgentDefinition? execBriefDef = promptConfig.Agents.TryGetValue("exec-brief", out AgentDefinition? ebDef) ? ebDef : null;
-
-// Load field-sentiment agent definition
-AgentDefinition? fieldSentimentDef = promptConfig.Agents.TryGetValue("field-sentiment", out AgentDefinition? fsDef) ? fsDef : null;
-if (fieldSentimentDef != null) promptEngine.Hydrate(fieldSentimentDef);
+static AgentDefinition ResolveAgent(string sectionKey, PromptConfiguration cfg) =>
+    cfg.Agents.TryGetValue(sectionKey, out AgentDefinition? d)
+        ? d
+        : throw new InvalidOperationException(
+            $"prompts.yaml is missing required agent section '{sectionKey}'.");
+static AgentDefinition? TryResolveAgent(string sectionKey, PromptConfiguration cfg) =>
+    cfg.Agents.TryGetValue(sectionKey, out AgentDefinition? d) ? d : null;
 
 // Register HttpClient for MCP server communication. The default URL is a
 // dev convenience — production should always set McpServer:BaseUrl.
@@ -811,198 +806,123 @@ else
     builder.Services.AddScoped<LocalShipmentAnalyzer>();
 }
 
-// Register the multi-agent routing pipeline
-builder.Services.AddAgentRouting(promptConfig, agentDef, foundryEnabled, sp =>
-{
-    IHttpClientFactory factory = sp.GetRequiredService<IHttpClientFactory>();
-    DepletionStatsTool depletionTool = sp.GetRequiredService<DepletionStatsTool>();
-    PortfolioDepletionStatsTool portfolioTool = sp.GetRequiredService<PortfolioDepletionStatsTool>();
-    FieldSentimentTool sentimentTool = sp.GetRequiredService<FieldSentimentTool>();
-    ShipmentStatsTool shipmentTool = sp.GetRequiredService<ShipmentStatsTool>();
-    ChartDataTool chartTool = sp.GetRequiredService<ChartDataTool>();
-    VariantMixTool variantMixTool = sp.GetRequiredService<VariantMixTool>();
+// ── Named tool registry (issue #98) ─────────────────────────────────────
+// Every tool a specialist can request in prompts.yaml is registered here by name.
+// AgentToolRegistry.ValidateAllReferences() fails startup if a specialist references
+// a name we didn't register, so misconfiguration is caught before serving traffic.
+var toolRegistry = new AgentToolRegistry();
 
-    var tools = new List<AITool>
-    {
-        AIFunctionFactory.Create(depletionTool.GetDepletionStats),
-        AIFunctionFactory.Create(portfolioTool.GetPortfolioDepletionStats),
-        AIFunctionFactory.Create(sentimentTool.GetFieldSentiment),
-        AIFunctionFactory.Create(shipmentTool.GetShipmentStats),
-        AIFunctionFactory.Create(variantMixTool.GetVariantMix),
-        AIFunctionFactory.Create(chartTool.CreateChart)
-    };
+toolRegistry
+    .Register("GetDepletionStats", sp => AIFunctionFactory.Create(
+        sp.GetRequiredService<DepletionStatsTool>().GetDepletionStats))
+    .Register("GetPortfolioDepletionStats", sp => AIFunctionFactory.Create(
+        sp.GetRequiredService<PortfolioDepletionStatsTool>().GetPortfolioDepletionStats))
+    .Register("GetFieldSentiment", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<FieldSentimentTool>().GetFieldSentiment)))
+    .Register("GetShipmentStats", sp => AIFunctionFactory.Create(
+        sp.GetRequiredService<ShipmentStatsTool>().GetShipmentStats))
+    .Register("GetVariantMix", sp => AIFunctionFactory.Create(
+        sp.GetRequiredService<VariantMixTool>().GetVariantMix))
+    .Register("CreateChart", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<ChartDataTool>().CreateChart)))
+    .Register("AnalyzeShipments", sp => foundryEnabled
+        ? AIFunctionFactory.Create(sp.GetRequiredService<FoundryShipmentAgent>().AnalyzeShipments)
+        : AIFunctionFactory.Create(sp.GetRequiredService<LocalShipmentAnalyzer>().AnalyzeShipments));
 
-    // Add either Foundry or local shipment analyzer
-    if (foundryEnabled)
-    {
-        FoundryShipmentAgent foundryAgent = sp.GetRequiredService<FoundryShipmentAgent>();
-        tools.Add(AIFunctionFactory.Create(foundryAgent.AnalyzeShipments));
-    }
-    else
-    {
-        LocalShipmentAnalyzer localAnalyzer = sp.GetRequiredService<LocalShipmentAnalyzer>();
-        tools.Add(AIFunctionFactory.Create(localAnalyzer.AnalyzeShipments));
-    }
-
-    return tools;
-},
-demandForecastDef: demandForecastDef,
-demandToolsFactory: sp =>
-{
-#pragma warning disable CS0618 // Obsolete demand tool proxies still used in legacy agent pipeline
-    HistoricalDemandTool historicalDemandTool = sp.GetRequiredService<HistoricalDemandTool>();
-    ForecastTool forecastTool = sp.GetRequiredService<ForecastTool>();
-    SeasonalityFactorsTool seasonalityTool = sp.GetRequiredService<SeasonalityFactorsTool>();
-    DemandRisksTool demandRisksTool = sp.GetRequiredService<DemandRisksTool>();
+// Demand-forecasting tools (legacy obsolete proxies retained for parity)
+#pragma warning disable CS0618
+toolRegistry
+    .Register("GetHistoricalDemand", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<HistoricalDemandTool>().GetHistoricalDemand)))
+    .Register("GenerateForecast", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<ForecastTool>().GenerateForecast)))
+    .Register("GetSeasonalityFactors", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<SeasonalityFactorsTool>().GetSeasonalityFactors)))
+    .Register("IdentifyDemandRisks", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<DemandRisksTool>().IdentifyDemandRisks)));
 #pragma warning restore CS0618
-    ChartDataTool chartTool = sp.GetRequiredService<ChartDataTool>();
-    ApprovalTool approvalTool = sp.GetRequiredService<ApprovalTool>();
-    CachingToolWrapper cachingWrapper = sp.GetRequiredService<CachingToolWrapper>();
 
-    return cachingWrapper.WrapAll(
-    [
-        AIFunctionFactory.Create(historicalDemandTool.GetHistoricalDemand),
-        AIFunctionFactory.Create(forecastTool.GenerateForecast),
-        AIFunctionFactory.Create(seasonalityTool.GetSeasonalityFactors),
-        AIFunctionFactory.Create(demandRisksTool.IdentifyDemandRisks),
-        AIFunctionFactory.Create(chartTool.CreateChart),
-        AIFunctionFactory.Create(approvalTool.RequestApproval)
-    ]);
-},
-promoPlanningDef: promoPlanningDef,
-promoToolsFactory: sp =>
+// Promotion tools
+toolRegistry
+    .Register("GetPromoHistory", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<PromoHistoryTool>().GetPromoHistory)))
+    .Register("CalculateLift", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<CalculateLiftTool>().CalculateLift)))
+    .Register("EvaluateTiming", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<EvaluateTimingTool>().EvaluateTiming)))
+    .Register("EstimateROI", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<EstimateROITool>().EstimateROI)))
+    .Register("RequestApproval", sp => AIFunctionFactory.Create(
+        sp.GetRequiredService<ApprovalTool>().RequestApproval));
+
+// Competitive intelligence tools
+toolRegistry
+    .Register("GetCompetitorPricing", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<CompetitorPricingTool>().GetCompetitorPricing)))
+    .Register("GetMarketShare", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<MarketShareTool>().GetMarketShare)))
+    .Register("DetectThreats", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<DetectThreatsTool>().DetectThreats)))
+    .Register("GetCompetitiveLandscape", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<CompetitiveLandscapeTool>().GetCompetitiveLandscape)));
+
+// Supply chain tools
+toolRegistry
+    .Register("GetInventoryLevels", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<InventoryLevelsTool>().GetInventoryLevels)))
+    .Register("GetSupplyDisruptions", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<SupplyDisruptionsTool>().GetSupplyDisruptions)))
+    .Register("GetFulfillmentRate", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<FulfillmentRateTool>().GetFulfillmentRate)))
+    .Register("GetSupplyHealthSummary", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<SupplyHealthTool>().GetSupplyHealthSummary)));
+
+// Store ops + planogram tools
+toolRegistry
+    .Register("GetStorePerformance", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<StorePerformanceTool>().GetStorePerformance)))
+    .Register("GetShelfLayout", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<ShelfLayoutTool>().GetShelfLayout)))
+    .Register("OptimizePlanogram", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<OptimizePlanogramTool>().OptimizePlanogram)))
+    .Register("PredictStockout", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<PredictStockoutTool>().PredictStockout)));
+
+// Margin analysis tools
+toolRegistry
+    .Register("GetMarginByBrand", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<MarginByBrandTool>().GetMarginByBrand)))
+    .Register("GetMarginDrivers", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<MarginDriversTool>().GetMarginDrivers)))
+    .Register("GetMarginTrend", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<MarginTrendTool>().GetMarginTrend)))
+    .Register("DetectMarginRisks", sp => WrapCached(sp, AIFunctionFactory.Create(
+        sp.GetRequiredService<DetectMarginRisksTool>().DetectMarginRisks)));
+
+// Orchestration intents — router fast-paths for in-process orchestrators that
+// have no specialist owner. Keeps council/health + scorecard/portfolio detectable
+// even when the ConsensusOrchestrator is not registered.
+var orchestrationIntents = new List<RouterIntentConfig>
 {
-    PromoHistoryTool promoHistoryTool = sp.GetRequiredService<PromoHistoryTool>();
-    CalculateLiftTool calculateLiftTool = sp.GetRequiredService<CalculateLiftTool>();
-    EvaluateTimingTool evaluateTimingTool = sp.GetRequiredService<EvaluateTimingTool>();
-    EstimateROITool estimateROITool = sp.GetRequiredService<EstimateROITool>();
-    ChartDataTool chartTool = sp.GetRequiredService<ChartDataTool>();
-    ApprovalTool approvalTool = sp.GetRequiredService<ApprovalTool>();
-    CachingToolWrapper cachingWrapper = sp.GetRequiredService<CachingToolWrapper>();
+    new("council/health",
+        ["how healthy is", "brand health report", "portfolio health",
+         "overall assessment for", "how is the portfolio"]),
+    new("scorecard/portfolio",
+        ["scorecard", "portfolio scoring", "brand ranking",
+         "top brand", "worst brand", "executive brief"]),
+};
 
-    return cachingWrapper.WrapAll(
-    [
-        AIFunctionFactory.Create(promoHistoryTool.GetPromoHistory),
-        AIFunctionFactory.Create(calculateLiftTool.CalculateLift),
-        AIFunctionFactory.Create(evaluateTimingTool.EvaluateTiming),
-        AIFunctionFactory.Create(estimateROITool.EstimateROI),
-        AIFunctionFactory.Create(chartTool.CreateChart),
-        AIFunctionFactory.Create(approvalTool.RequestApproval)
-    ]);
-},
-competitiveIntelDef: competitiveIntelDef,
-competitiveToolsFactory: sp =>
+// Register the multi-agent routing pipeline — every specialist is now enumerated
+// from prompts.yaml (issue #98).
+builder.Services.AddAgentRouting(promptConfig, toolRegistry, orchestrationIntents);
+
+// Cache-aware tool wrapper used above. Kept local to Program.cs so the registry
+// stays free of composition-root concerns.
+static AITool WrapCached(IServiceProvider sp, AITool tool)
 {
-    CompetitorPricingTool competitorPricingTool = sp.GetRequiredService<CompetitorPricingTool>();
-    MarketShareTool marketShareTool = sp.GetRequiredService<MarketShareTool>();
-    DetectThreatsTool detectThreatsTool = sp.GetRequiredService<DetectThreatsTool>();
-    CompetitiveLandscapeTool competitiveLandscapeTool = sp.GetRequiredService<CompetitiveLandscapeTool>();
-    ChartDataTool chartTool = sp.GetRequiredService<ChartDataTool>();
-    CachingToolWrapper cachingWrapper = sp.GetRequiredService<CachingToolWrapper>();
-
-    return cachingWrapper.WrapAll(
-    [
-        AIFunctionFactory.Create(competitorPricingTool.GetCompetitorPricing),
-        AIFunctionFactory.Create(marketShareTool.GetMarketShare),
-        AIFunctionFactory.Create(detectThreatsTool.DetectThreats),
-        AIFunctionFactory.Create(competitiveLandscapeTool.GetCompetitiveLandscape),
-        AIFunctionFactory.Create(chartTool.CreateChart)
-    ]);
-},
-supplyChainDef: supplyChainDef,
-supplyToolsFactory: sp =>
-{
-    InventoryLevelsTool inventoryTool = sp.GetRequiredService<InventoryLevelsTool>();
-    SupplyDisruptionsTool disruptionsTool = sp.GetRequiredService<SupplyDisruptionsTool>();
-    FulfillmentRateTool fulfillmentTool = sp.GetRequiredService<FulfillmentRateTool>();
-    SupplyHealthTool supplyHealthTool = sp.GetRequiredService<SupplyHealthTool>();
-    ChartDataTool chartTool = sp.GetRequiredService<ChartDataTool>();
-    CachingToolWrapper cachingWrapper = sp.GetRequiredService<CachingToolWrapper>();
-
-    return cachingWrapper.WrapAll(
-    [
-        AIFunctionFactory.Create(inventoryTool.GetInventoryLevels),
-        AIFunctionFactory.Create(disruptionsTool.GetSupplyDisruptions),
-        AIFunctionFactory.Create(fulfillmentTool.GetFulfillmentRate),
-        AIFunctionFactory.Create(supplyHealthTool.GetSupplyHealthSummary),
-        AIFunctionFactory.Create(chartTool.CreateChart)
-    ]);
-},
-storeOpsDef: storeOpsDef,
-storeOpsToolsFactory: sp =>
-{
-    StorePerformanceTool storePerformanceTool = sp.GetRequiredService<StorePerformanceTool>();
-    ShelfLayoutTool shelfLayoutTool = sp.GetRequiredService<ShelfLayoutTool>();
-    OptimizePlanogramTool optimizePlanogramTool = sp.GetRequiredService<OptimizePlanogramTool>();
-    PredictStockoutTool predictStockoutTool = sp.GetRequiredService<PredictStockoutTool>();
-    ChartDataTool chartTool = sp.GetRequiredService<ChartDataTool>();
-    CachingToolWrapper cachingWrapper = sp.GetRequiredService<CachingToolWrapper>();
-
-    return cachingWrapper.WrapAll(
-    [
-        AIFunctionFactory.Create(storePerformanceTool.GetStorePerformance),
-        AIFunctionFactory.Create(shelfLayoutTool.GetShelfLayout),
-        AIFunctionFactory.Create(optimizePlanogramTool.OptimizePlanogram),
-        AIFunctionFactory.Create(predictStockoutTool.PredictStockout),
-        AIFunctionFactory.Create(chartTool.CreateChart)
-    ]);
-},
-planogramDef: planogramDef,
-planogramToolsFactory: sp =>
-{
-    ShelfLayoutTool shelfLayoutTool = sp.GetRequiredService<ShelfLayoutTool>();
-    OptimizePlanogramTool optimizePlanogramTool = sp.GetRequiredService<OptimizePlanogramTool>();
-    PredictStockoutTool predictStockoutTool = sp.GetRequiredService<PredictStockoutTool>();
-    ChartDataTool chartTool = sp.GetRequiredService<ChartDataTool>();
-    CachingToolWrapper cachingWrapper = sp.GetRequiredService<CachingToolWrapper>();
-
-    return cachingWrapper.WrapAll(
-    [
-        AIFunctionFactory.Create(shelfLayoutTool.GetShelfLayout),
-        AIFunctionFactory.Create(optimizePlanogramTool.OptimizePlanogram),
-        AIFunctionFactory.Create(predictStockoutTool.PredictStockout),
-        AIFunctionFactory.Create(chartTool.CreateChart)
-    ]);
-},
-marginDef: marginDef,
-marginToolsFactory: sp =>
-{
-    MarginByBrandTool marginByBrandTool = sp.GetRequiredService<MarginByBrandTool>();
-    MarginDriversTool marginDriversTool = sp.GetRequiredService<MarginDriversTool>();
-    MarginTrendTool marginTrendTool = sp.GetRequiredService<MarginTrendTool>();
-    DetectMarginRisksTool detectMarginRisksTool = sp.GetRequiredService<DetectMarginRisksTool>();
-    ChartDataTool chartTool = sp.GetRequiredService<ChartDataTool>();
-    CachingToolWrapper cachingWrapper = sp.GetRequiredService<CachingToolWrapper>();
-
-    return cachingWrapper.WrapAll(
-    [
-        AIFunctionFactory.Create(marginByBrandTool.GetMarginByBrand),
-        AIFunctionFactory.Create(marginDriversTool.GetMarginDrivers),
-        AIFunctionFactory.Create(marginTrendTool.GetMarginTrend),
-        AIFunctionFactory.Create(detectMarginRisksTool.DetectMarginRisks),
-        AIFunctionFactory.Create(chartTool.CreateChart)
-    ]);
-});
-
-// Register FieldSentimentAgent — dedicated agent with scoped tools (only sentiment + chart)
-if (fieldSentimentDef is not null)
-{
-    builder.Services.AddScoped(sp =>
-    {
-        IAgentExecutionPipeline pipeline = sp.GetRequiredService<IAgentExecutionPipeline>();
-        FieldSentimentTool sentimentTool = sp.GetRequiredService<FieldSentimentTool>();
-        ChartDataTool chartTool = sp.GetRequiredService<ChartDataTool>();
-        CachingToolWrapper cachingWrapper = sp.GetRequiredService<CachingToolWrapper>();
-
-        IList<AITool> tools = cachingWrapper.WrapAll(
-        [
-            AIFunctionFactory.Create(sentimentTool.GetFieldSentiment),
-            AIFunctionFactory.Create(chartTool.CreateChart)
-        ]);
-
-        return new FieldSentimentAgent(pipeline, fieldSentimentDef, tools);
-    });
-    builder.Services.AddScoped<ISpecialistAgent>(sp => sp.GetRequiredService<FieldSentimentAgent>());
+    CachingToolWrapper wrapper = sp.GetRequiredService<CachingToolWrapper>();
+    IList<AITool> wrapped = wrapper.WrapAll([tool]);
+    return wrapped[0];
 }
 
 // Register ConsensusOrchestrator for Portfolio Health Council
@@ -1013,9 +933,15 @@ if (councilSynthesisDef is not null && councilVoteDef is not null)
         IEnumerable<ISpecialistAgent> specialists = sp.GetServices<ISpecialistAgent>();
         IChatClient chatClient = sp.GetRequiredService<IChatClient>();
         ILogger<ConsensusOrchestrator> logger = sp.GetRequiredService<ILogger<ConsensusOrchestrator>>();
+        RouterAgentRoster roster = sp.GetRequiredService<RouterAgentRoster>();
 
         return new ConsensusOrchestrator(
-            specialists, chatClient, councilSynthesisDef, councilVoteDef, logger);
+            specialists,
+            chatClient,
+            councilSynthesisDef,
+            councilVoteDef,
+            logger,
+            councilParticipants: roster.GetCouncilParticipants());
     });
 }
 
@@ -1042,9 +968,14 @@ if (scorecardSynthesisDef is not null)
         IEnumerable<ISpecialistAgent> specialists = sp.GetServices<ISpecialistAgent>();
         IChatClient chatClient = sp.GetRequiredService<IChatClient>();
         ILogger<ScorecardOrchestrator> logger = sp.GetRequiredService<ILogger<ScorecardOrchestrator>>();
+        RouterAgentRoster roster = sp.GetRequiredService<RouterAgentRoster>();
 
         return new ScorecardOrchestrator(
-            specialists, chatClient, scorecardSynthesisDef, logger);
+            specialists,
+            chatClient,
+            scorecardSynthesisDef,
+            logger,
+            scoringDimensions: roster.GetScorecardDimensions());
     });
 }
 

--- a/src/RetailPulse.Api/Scorecard/ScorecardDimensionConfig.cs
+++ b/src/RetailPulse.Api/Scorecard/ScorecardDimensionConfig.cs
@@ -1,0 +1,14 @@
+namespace RetailPulse.Api.Scorecard;
+
+/// <summary>
+/// Configuration entry for a single scorecard dimension. Sourced from each specialist's
+/// <c>AgentDefinition.ScorecardDimension</c> / <c>ScorecardWeight</c> in <c>prompts.yaml</c>
+/// so adding a scoring dimension is a config change, not a code change (issue #98).
+/// </summary>
+/// <param name="Dimension">Display name of the dimension (e.g., "Demand Momentum").</param>
+/// <param name="Weight">Weight applied to this dimension's score (0–1).</param>
+/// <param name="AgentKey">Key of the specialist agent that produces this dimension's score.</param>
+public sealed record ScorecardDimensionConfig(
+    string Dimension,
+    double Weight,
+    string AgentKey);

--- a/src/RetailPulse.Api/Scorecard/ScorecardOrchestrator.cs
+++ b/src/RetailPulse.Api/Scorecard/ScorecardOrchestrator.cs
@@ -20,29 +20,35 @@ public class ScorecardOrchestrator
     private readonly IChatClient _chatClient;
     private readonly AgentDefinition _synthesisDef;
     private readonly ILogger<ScorecardOrchestrator> _logger;
+    private readonly IReadOnlyList<ScorecardDimensionConfig> _scoringDimensionsConfig;
 
     private static readonly TimeSpan _agentTimeout = TimeSpan.FromSeconds(12);
 
-    // Scoring dimensions with weights
-    private static readonly (string Dimension, double Weight, string AgentKey)[] _scoringDimensions =
+    /// <summary>Default dimensions — kept as a fallback so tests and legacy composition
+    /// roots that don't supply a configuration list continue to work.</summary>
+    internal static readonly IReadOnlyList<ScorecardDimensionConfig> DefaultScoringDimensions =
     [
-        ("Demand Momentum", 0.25, "demand-forecasting"),
-        ("Competitive Position", 0.20, "competitive-intel"),
-        ("Supply Reliability", 0.20, "supply-chain"),
-        ("Store Execution", 0.20, "store-ops"),
-        ("Margin Health", 0.15, "margin-analysis")
+        new("Demand Momentum", 0.25, "demand-forecasting"),
+        new("Competitive Position", 0.20, "competitive-intel"),
+        new("Supply Reliability", 0.20, "supply-chain"),
+        new("Store Execution", 0.20, "store-ops"),
+        new("Margin Health", 0.15, "margin-analysis"),
     ];
 
     public ScorecardOrchestrator(
         IEnumerable<ISpecialistAgent> specialists,
         IChatClient chatClient,
         AgentDefinition synthesisDef,
-        ILogger<ScorecardOrchestrator> logger)
+        ILogger<ScorecardOrchestrator> logger,
+        IReadOnlyList<ScorecardDimensionConfig>? scoringDimensions = null)
     {
         _specialists = specialists;
         _chatClient = chatClient;
         _synthesisDef = synthesisDef;
         _logger = logger;
+        _scoringDimensionsConfig = scoringDimensions is { Count: > 0 }
+            ? scoringDimensions
+            : DefaultScoringDimensions;
     }
 
     public record BrandScore(
@@ -107,7 +113,7 @@ public class ScorecardOrchestrator
         var agentLookup = _specialists.ToDictionary(s => s.Key, StringComparer.OrdinalIgnoreCase);
 
         // Evaluate each dimension in parallel
-        IEnumerable<Task<DimensionScore>> dimTasks = _scoringDimensions.Select(async dim =>
+        IEnumerable<Task<DimensionScore>> dimTasks = _scoringDimensionsConfig.Select(async dim =>
         {
             if (!agentLookup.TryGetValue(dim.AgentKey, out ISpecialistAgent? agent))
             {

--- a/src/RetailPulse.Api/prompts.yaml
+++ b/src/RetailPulse.Api/prompts.yaml
@@ -2,6 +2,9 @@ agents:
   router:
     name: "Retail Ops Router"
     model: "gpt-5.4-mini"
+    key: "router"
+    display_name: "Router"
+    role: "orchestration"
     system_prompt: |
       You are an intent classifier for a retail analytics platform. Your job is to
       classify the user's message into exactly one intent category and return a
@@ -61,6 +64,20 @@ agents:
   demand-forecast:
     name: "Demand Forecast Agent"
     model: "gpt-5.4-mini"
+    key: "demand-forecasting"
+    display_name: "Demand Forecasting"
+    role: "specialist"
+    intents:
+      - "demand/forecasting"
+    keyword_fast_paths:
+      - "demand forecast"
+      - "sell-through"
+      - "velocity forecast"
+    council_participant: true
+    scorecard_dimension: "Demand Momentum"
+    scorecard_weight: 0.25
+    prefetchable: true
+    fallback_reply: "I couldn't generate a forecast response."
     system_prompt: |
       You are a Demand Forecasting specialist for {tenant.company}.
       You analyze historical sales data, identify seasonal patterns, and generate
@@ -151,6 +168,16 @@ agents:
   promo-planning:
     name: "Promotion Planning Agent"
     model: "gpt-5.4-mini"
+    key: "promo-planning"
+    display_name: "Promotion Planning"
+    role: "specialist"
+    intents:
+      - "promotion/trade"
+    keyword_fast_paths:
+      - "promotion"
+      - "trade spend"
+      - "promo effectiveness"
+      - "promotion roi"
     system_prompt: |
       You are a Promotion Planning specialist for {tenant.company}.
       You analyze historical campaign performance, calculate expected lift,
@@ -232,6 +259,17 @@ agents:
   field-sentiment:
     name: "Field Sentiment Agent"
     model: "gpt-5.4-mini"
+    key: "field-sentiment"
+    display_name: "Field Sentiment"
+    role: "specialist"
+    intents:
+      - "sentiment/field"
+    keyword_fast_paths:
+      - "field rep"
+      - "field feedback"
+      - "distributor feedback"
+      - "rep feedback"
+      - "sentiment analysis"
     system_prompt: |
       You are the Field Sentiment specialist for {tenant.company}. You gather and
       synthesize qualitative intelligence from distributors, field sales reps, and
@@ -265,6 +303,20 @@ agents:
   competitive-intel:
     name: "Competitive Intelligence Agent"
     model: "gpt-5.4-mini"
+    key: "competitive-intel"
+    display_name: "Competitive Intelligence"
+    role: "bespoke"
+    intents:
+      - "competitive/market"
+    keyword_fast_paths:
+      - "pricing pressure"
+      - "market share"
+      - "price war"
+      - "competitor analysis"
+      - "competitive landscape"
+    council_participant: true
+    scorecard_dimension: "Competitive Position"
+    scorecard_weight: 0.20
     system_prompt: |
       You are the Competitive Intelligence Agent for {tenant.company}, a specialist
       in monitoring competitor activities (pricing, promotions, market share) and
@@ -318,6 +370,12 @@ agents:
   retail-pulse:
     name: "Retail Pulse Agent"
     model: "gpt-5.4-mini"
+    key: "general"
+    display_name: "General Agent"
+    role: "specialist"
+    intents:
+      - "general/fallback"
+    fallback_reply: "I wasn't able to generate a response."
     system_prompt: |
       You are Retail Pulse, {tenant.company}'s intelligent brand analytics assistant.
       You help brand managers understand depletion trends, sell-through rates,
@@ -536,11 +594,25 @@ agents:
       - AnalyzeShipments
       - GetVariantMix
       - CreateChart
-      - UpdateMetrics
 
   supply-chain:
     name: "Supply Chain Agent"
     model: "gpt-5.4-mini"
+    key: "supply-chain"
+    display_name: "Supply Chain"
+    role: "specialist"
+    intents:
+      - "supply/shipments"
+    keyword_fast_paths:
+      - "shipment status"
+      - "inventory level"
+      - "fulfillment"
+      - "stockout"
+      - "stock out"
+      - "supply chain"
+    council_participant: true
+    scorecard_dimension: "Supply Reliability"
+    scorecard_weight: 0.20
     system_prompt: |
       You are a Supply Chain specialist for {tenant.company}.
       You monitor inventory levels, track supply disruptions, analyze fulfillment
@@ -624,6 +696,8 @@ agents:
   council-synthesis:
     name: "Council Synthesis"
     model: "gpt-5.4-mini"
+    key: "council-synthesis"
+    role: "orchestration"
     system_prompt: |
       You are the Portfolio Health Council synthesizer. Your role is to analyze
       health assessment votes from multiple specialist agents and produce a
@@ -646,6 +720,8 @@ agents:
   council-vote:
     name: "Council Vote Format"
     model: "gpt-5.4-mini"
+    key: "council-vote"
+    role: "orchestration"
     system_prompt: |
       You are providing a structured health assessment vote as part of the
       Portfolio Health Council. Analyze the requested brand/region using your
@@ -676,6 +752,17 @@ agents:
   store-ops:
     name: "Store Operations Agent"
     model: "gpt-5.4-mini"
+    key: "store-ops"
+    display_name: "Store Operations"
+    role: "specialist"
+    intents:
+      - "store/operations"
+    keyword_fast_paths:
+      - "store operations"
+      - "store performance"
+      - "retail ops"
+    scorecard_dimension: "Store Execution"
+    scorecard_weight: 0.20
     system_prompt: |
       You are a Store Operations specialist for {tenant.company}.
       You analyze store performance metrics, foot traffic, conversion rates,
@@ -728,6 +815,15 @@ agents:
   planogram:
     name: "Planogram Optimization Agent"
     model: "gpt-5.4-mini"
+    key: "planogram"
+    display_name: "Planogram Optimization"
+    role: "specialist"
+    intents:
+      - "planogram/optimization"
+    keyword_fast_paths:
+      - "planogram"
+      - "shelf space"
+      - "shelf placement"
     system_prompt: |
       You are a Planogram Optimization specialist for {tenant.company}.
       You analyze shelf layouts, optimize SKU placement using merchandising rules,
@@ -781,6 +877,18 @@ agents:
   margin:
     name: "Margin Analysis Agent"
     model: "gpt-5.4-mini"
+    key: "margin-analysis"
+    display_name: "Margin Analysis"
+    role: "specialist"
+    intents:
+      - "margin/analysis"
+    keyword_fast_paths:
+      - "margin analysis"
+      - "profitability"
+      - "cost structure"
+      - "gross margin"
+    scorecard_dimension: "Margin Health"
+    scorecard_weight: 0.15
     system_prompt: |
       You are a Margin Analysis specialist for {tenant.company}.
       You analyze brand profitability, P&L structures, margin drivers, trends,
@@ -842,6 +950,8 @@ agents:
   scorecard-synthesis:
     name: "Scorecard Synthesis"
     model: "gpt-5.4-mini"
+    key: "scorecard-synthesis"
+    role: "orchestration"
     system_prompt: |
       You are the Portfolio Scorecard synthesizer. Your role is to produce
       executive-quality summaries from multi-dimensional brand assessments.
@@ -858,9 +968,34 @@ agents:
   exec-brief:
     name: "Executive Brief"
     model: "gpt-5.4-mini"
+    key: "exec-brief"
+    role: "orchestration"
     system_prompt: |
       You generate concise executive briefs from portfolio data.
       Focus on: key metrics, notable changes, top risks, and recommended actions.
       Keep briefs under 200 words. Use bullet points for actions.
     temperature: 0.5
+    tools: []
+
+  memory-management:
+    name: "Memory Management Agent"
+    model: "none"
+    key: "memory-management"
+    display_name: "Memory Management"
+    role: "bespoke"
+    intents:
+      - "memory/management"
+    keyword_fast_paths:
+      - "remember that"
+      - "remember this"
+      - "forget"
+      - "clear my"
+      - "clear my history"
+      - "clear my data"
+      - "start fresh"
+      - "reset my context"
+      - "forget what I told you"
+      - "what do you know about me"
+    system_prompt: ""
+    temperature: 0.0
     tools: []

--- a/src/RetailPulse.Contracts/Routing/ISpecialistAgent.cs
+++ b/src/RetailPulse.Contracts/Routing/ISpecialistAgent.cs
@@ -31,6 +31,15 @@ public interface ISpecialistAgent
     IReadOnlyList<string> SupportedIntents { get; }
 
     /// <summary>
+    /// Case-insensitive substrings that force a keyword fast-path match to this
+    /// agent's primary intent. Sourced from configuration
+    /// (<c>AgentDefinition.KeywordFastPaths</c>) — the router builds its fast-path
+    /// table from the union of every specialist's list plus any orchestration
+    /// intents. Empty by default so bespoke agents can opt out.
+    /// </summary>
+    IReadOnlyList<string> KeywordFastPaths => [];
+
+    /// <summary>
     /// Processes a chat request and returns a response.
     /// The specialist applies its own system prompt, tools, and temperature.
     /// </summary>

--- a/tests/RetailPulse.Tests/Agents/DataDrivenSpecialistTests.cs
+++ b/tests/RetailPulse.Tests/Agents/DataDrivenSpecialistTests.cs
@@ -1,0 +1,350 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RetailPulse.Api.Agents;
+using RetailPulse.Api.Agents.Routing;
+using RetailPulse.Api.Agents.Tools;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Models;
+using RetailPulse.Api.Scorecard;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Routing;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
+
+namespace RetailPulse.Tests.Agents;
+
+/// <summary>
+/// Acceptance-criteria coverage for issue #98 (data-driven agent definitions).
+///
+/// The proof test: a specialist declared purely through <see cref="PromptConfiguration"/>
+/// — no new C# class, no DI wiring changes — must be routed to and executed.
+/// The remaining tests exercise the startup validators (unknown tool, duplicate key,
+/// missing router), the config-driven council/scorecard rosters, and the
+/// unroutable-intent fallback to General.
+/// </summary>
+public sealed class DataDrivenSpecialistTests
+{
+    /// <summary>
+    /// The proof: a specialist declared purely in configuration is registered as a
+    /// <see cref="ConfiguredSpecialistAgent"/>, appears in the router's known intent
+    /// set, receives a routed request via its keyword fast-path, and executes end-to-end
+    /// through the shared pipeline. No C# class, no DI branch, no rebuild — the objective
+    /// of ADR-008.
+    /// </summary>
+    [Fact]
+    public async Task TestOnlySpecialist_AddedThroughConfigurationOnly_IsRoutedAndExecuted()
+    {
+        PromptConfiguration promptConfig = BuildPromptConfig(includeTestWidget: true);
+
+        Mock<IChatClient> chatClient = new();
+        chatClient
+            .Setup(x => x.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Microsoft.Extensions.AI.ChatResponse(new ChatMessage(ChatRole.Assistant,
+                /*lang=json,strict*/ "{\"intent\":\"general/fallback\",\"confidence\":0.5}")));
+
+        // Stub the ConfiguredSpecialistAgent pipeline so we can observe the route
+        // without wiring the full MAF stack — the test only proves the routing path
+        // reaches the configured specialist.
+        Mock<IAgentExecutionPipeline> pipelineMock = new();
+        pipelineMock
+            .Setup(p => p.ExecuteAsync(
+                It.IsAny<AgentExecutionContext>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AgentExecutionContext ctx, CancellationToken _) =>
+                new ChatResponse(
+                    Reply: $"handled by {ctx.AgentName}: {ctx.Request.Message}",
+                    SessionId: ctx.Request.SessionId ?? "s",
+                    Spans: []));
+
+        AgentToolRegistry toolRegistry = new();
+
+        ServiceCollection services = new();
+        SeedBaselineServices(services, chatClient.Object);
+
+        services.AddAgentRouting(promptConfig, toolRegistry, OrchestrationIntents());
+
+        // Override the pipeline registration added by AddAgentRouting so we can observe
+        // the specialist invocation without a live LLM. Last-wins for GetRequiredService.
+        services.AddScoped(_ => pipelineMock.Object);
+
+        ServiceProvider sp = services.BuildServiceProvider();
+
+        IAgentRouter router = sp.GetRequiredService<IAgentRouter>();
+        var concreteRouter = (RetailOpsRouter)router;
+
+        concreteRouter.KnownIntents.Should().Contain("test/widget",
+            "a pure-config specialist's intent must appear in the router's known intent set");
+
+        RoutingDecision decision = await router.RouteAsync(
+            "please spin up the widget flux capacitor now", null, null, null);
+
+        decision.AgentKey.Should().Be("test-widget",
+            "the widget keyword fast-path should route to the test-only specialist");
+        decision.Intent.Should().Be("test/widget");
+
+        IEnumerable<ISpecialistAgent> specialists = sp.GetServices<ISpecialistAgent>();
+        ISpecialistAgent widget = specialists.Single(s => s.Key == "test-widget");
+        widget.Should().BeOfType<Api.Agents.Specialists.ConfiguredSpecialistAgent>();
+
+        ChatResponse response = await widget.HandleAsync(
+            new ChatRequest("spin up the widget flux capacitor", SessionId: "s"));
+
+        response.Reply.Should().Contain("handled by Widget Specialist");
+    }
+
+    /// <summary>Config errors must fail at startup, never at first user query.</summary>
+    [Fact]
+    public void UnknownToolReference_FailsFastAtStartup_WithActionableMessage()
+    {
+        PromptConfiguration promptConfig = BuildPromptConfig(includeTestWidget: false);
+        promptConfig.Agents["demand-forecast"].Tools = ["GetDepletion", "ThisToolDoesNotExist"];
+
+        AgentToolRegistry toolRegistry = new();
+        toolRegistry.Register("GetDepletion", _ => new StubTool());
+        toolRegistry.Register("CreateChart", _ => new StubTool());
+
+        ServiceCollection services = new();
+
+        Action wire = () => services.AddAgentRouting(promptConfig, toolRegistry, OrchestrationIntents());
+
+        UnknownToolReferenceException ex = wire.Should().Throw<UnknownToolReferenceException>()
+            .Which;
+
+        ex.MissingTools.Should().Contain("ThisToolDoesNotExist");
+        ex.Message.Should().Contain("Fix the 'tools:' entry in prompts.yaml");
+    }
+
+    [Fact]
+    public void DuplicateSpecialistKey_FailsFastAtStartup()
+    {
+        PromptConfiguration promptConfig = BuildPromptConfig(includeTestWidget: false);
+
+        // Two definitions share the same effective Key.
+        promptConfig.Agents["another-general"] = new AgentDefinition
+        {
+            Name = "Another General",
+            Model = "gpt-5.4-mini",
+            SystemPrompt = "duplicate.",
+            Temperature = 0.3,
+            Key = "general",
+            Intents = ["general/fallback"],
+        };
+
+        AgentToolRegistry toolRegistry = MinimalToolRegistry();
+
+        ServiceCollection services = new();
+        Action wire = () => services.AddAgentRouting(promptConfig, toolRegistry, OrchestrationIntents());
+
+        wire.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Duplicate specialist agent key*general*");
+    }
+
+    [Fact]
+    public void MissingRouterDefinition_FailsFastAtStartup()
+    {
+        PromptConfiguration promptConfig = BuildPromptConfig(includeTestWidget: false);
+        promptConfig.Agents.Remove("router");
+
+        AgentToolRegistry toolRegistry = MinimalToolRegistry();
+
+        ServiceCollection services = new();
+        SeedBaselineServices(services, Mock.Of<IChatClient>());
+
+        Action wire = () => services.AddAgentRouting(promptConfig, toolRegistry, OrchestrationIntents());
+        wire.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Missing 'router' agent definition*");
+    }
+
+    [Fact]
+    public void CouncilParticipants_DeriveFromConfiguration()
+    {
+        PromptConfiguration promptConfig = BuildPromptConfig(includeTestWidget: false);
+        RouterAgentRoster roster = new(promptConfig, OrchestrationIntents());
+
+        roster.GetCouncilParticipants().Should().BeEquivalentTo(
+            ["demand-forecasting", "supply-chain"],
+            "only agents with council_participant: true should join the council fan-out");
+    }
+
+    [Fact]
+    public void ScorecardDimensions_DeriveFromConfiguration_OrderedByWeight()
+    {
+        PromptConfiguration promptConfig = BuildPromptConfig(includeTestWidget: false);
+        RouterAgentRoster roster = new(promptConfig, OrchestrationIntents());
+
+        IReadOnlyList<ScorecardDimensionConfig> dims = roster.GetScorecardDimensions();
+
+        dims.Should().HaveCount(2, "two specialists declare scorecard dimensions in this fixture");
+        dims[0].Dimension.Should().Be("Demand Momentum");
+        dims[0].Weight.Should().Be(0.25);
+        dims[1].Dimension.Should().Be("Supply Reliability");
+        dims[1].Weight.Should().Be(0.20);
+    }
+
+    [Fact]
+    public async Task UnroutableIntent_FallsBackToGeneral()
+    {
+        PromptConfiguration promptConfig = BuildPromptConfig(includeTestWidget: false);
+
+        // LLM returns an intent that no specialist claims.
+        Mock<IChatClient> chatClient = new();
+        chatClient
+            .Setup(x => x.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Microsoft.Extensions.AI.ChatResponse(new ChatMessage(ChatRole.Assistant,
+                /*lang=json,strict*/ "{\"intent\":\"totally/unknown\",\"confidence\":0.9}")));
+
+        ServiceCollection services = new();
+        SeedBaselineServices(services, chatClient.Object);
+
+        services.AddAgentRouting(promptConfig, MinimalToolRegistry(), OrchestrationIntents());
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        IAgentRouter router = sp.GetRequiredService<IAgentRouter>();
+        RoutingDecision decision = await router.RouteAsync("anything at all", null, null, null);
+
+        decision.AgentKey.Should().Be("general",
+            "unroutable intents must degrade to the General agent, never crash");
+        decision.Intent.Should().Be(AgentIntent.General);
+    }
+
+    [Fact]
+    public void KnownIntents_Include_EveryConfiguredSpecialistIntent()
+    {
+        PromptConfiguration promptConfig = BuildPromptConfig(includeTestWidget: true);
+
+        ServiceCollection services = new();
+        SeedBaselineServices(services, Mock.Of<IChatClient>());
+
+        services.AddAgentRouting(promptConfig, MinimalToolRegistry(), OrchestrationIntents());
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        var router = (RetailOpsRouter)sp.GetRequiredService<IAgentRouter>();
+
+        router.KnownIntents.Should().Contain("demand/forecasting");
+        router.KnownIntents.Should().Contain("supply/shipments");
+        router.KnownIntents.Should().Contain("test/widget");
+        router.KnownIntents.Should().Contain("council/health",
+            "orchestration intents supplied to AddAgentRouting must also be advertised");
+    }
+
+    /// <summary>
+    /// Wire up the DI baseline that <see cref="RoutingServiceExtensions.AddAgentRouting"/>
+    /// needs to resolve (IChatClient, IHubContext stubs, IConfiguration, tenant, logging).
+    /// Kept in one place so every test uses the same minimal composition.
+    /// </summary>
+    private static void SeedBaselineServices(IServiceCollection services, IChatClient chatClient)
+    {
+        services.AddLogging();
+        services.AddSingleton(chatClient);
+        services.AddKeyedSingleton("router", chatClient);
+        services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(
+            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build());
+        services.AddSingleton(new TenantConfiguration
+        {
+            Company = "Test Co",
+            Industry = "Test",
+        });
+        services.AddSingleton(Mock.Of<IHubContext<TelemetryHub>>());
+        services.AddSingleton(Mock.Of<IHubContext<StreamingHub>>());
+    }
+
+    // Minimal-but-realistic fixture: router + general + two council specialists + optional test widget.
+    private static PromptConfiguration BuildPromptConfig(bool includeTestWidget)
+    {
+        PromptConfiguration cfg = new();
+
+        cfg.Agents["router"] = new AgentDefinition
+        {
+            Name = "Router",
+            Model = "gpt-5.4-mini",
+            SystemPrompt = "Classify intent.",
+            Temperature = 0.0,
+            Role = "orchestration",
+            Key = "router",
+        };
+
+        cfg.Agents["general"] = new AgentDefinition
+        {
+            Name = "General",
+            Model = "gpt-5.4-mini",
+            SystemPrompt = "General fallback.",
+            Temperature = 0.3,
+            Key = "general",
+            Intents = [AgentIntent.General],
+        };
+
+        cfg.Agents["demand-forecast"] = new AgentDefinition
+        {
+            Name = "Demand Forecast",
+            Model = "gpt-5.4-mini",
+            SystemPrompt = "Forecast demand.",
+            Temperature = 0.2,
+            Key = "demand-forecasting",
+            Intents = [AgentIntent.DemandForecasting],
+            KeywordFastPaths = ["demand forecast"],
+            CouncilParticipant = true,
+            ScorecardDimension = "Demand Momentum",
+            ScorecardWeight = 0.25,
+        };
+
+        cfg.Agents["supply-chain"] = new AgentDefinition
+        {
+            Name = "Supply Chain",
+            Model = "gpt-5.4-mini",
+            SystemPrompt = "Supply chain.",
+            Temperature = 0.2,
+            Key = "supply-chain",
+            Intents = [AgentIntent.SupplyShipments],
+            KeywordFastPaths = ["shipment status"],
+            CouncilParticipant = true,
+            ScorecardDimension = "Supply Reliability",
+            ScorecardWeight = 0.20,
+        };
+
+        if (includeTestWidget)
+        {
+            cfg.Agents["test-widget"] = new AgentDefinition
+            {
+                Name = "Widget Specialist",
+                Model = "gpt-5.4-mini",
+                SystemPrompt = "You handle widget flux capacitor requests.",
+                Temperature = 0.1,
+                Key = "test-widget",
+                Intents = ["test/widget"],
+                KeywordFastPaths = ["widget flux capacitor"],
+                FallbackReply = "widget standby",
+            };
+        }
+
+        return cfg;
+    }
+
+    private static AgentToolRegistry MinimalToolRegistry()
+    {
+        AgentToolRegistry registry = new();
+        registry.Register("CreateChart", _ => new StubTool());
+        return registry;
+    }
+
+    private static IReadOnlyList<RouterIntentConfig> OrchestrationIntents() =>
+    [
+        new(AgentIntent.PortfolioHealth, ["portfolio health"]),
+        new(AgentIntent.Scorecard, ["scorecard"]),
+    ];
+
+    /// <summary>Placeholder AITool for tool-registry wiring — never invoked in these tests.</summary>
+    private sealed class StubTool : AITool
+    {
+        public override string Name => "stub";
+    }
+}

--- a/tests/RetailPulse.Tests/Agents/Router/RetailOpsRouterTests.cs
+++ b/tests/RetailPulse.Tests/Agents/Router/RetailOpsRouterTests.cs
@@ -619,7 +619,7 @@ public class RetailOpsRouterTests
 
         // Use a message that won't hit keyword fast-path
         RoutingDecision result = await router.RouteAsync(
-            "Tell me about supply delays in the Midwest", null, null, null);
+            "Tell me about warehouse delays in the Midwest", null, null, null);
 
         result.Intent.Should().Be(AgentIntent.SupplyShipments);
         // Verify the router-specific client was called
@@ -788,6 +788,7 @@ public class RetailOpsRouterTests
             AgentIntent.PromotionTrade, AgentIntent.SupplyShipments,
             AgentIntent.CompetitiveMarket, AgentIntent.SentimentField
         ]);
+        general.Setup(s => s.KeywordFastPaths).Returns([]);
 
         return [general.Object];
     }
@@ -802,39 +803,96 @@ public class RetailOpsRouterTests
         var general = new Mock<ISpecialistAgent>();
         general.Setup(s => s.Key).Returns("general");
         general.Setup(s => s.DisplayName).Returns("General Agent");
-        general.Setup(s => s.SupportedIntents).Returns(
-        [
-            AgentIntent.General, AgentIntent.DemandForecasting,
-            AgentIntent.PromotionTrade, AgentIntent.SupplyShipments,
-            AgentIntent.CompetitiveMarket, AgentIntent.SentimentField
-        ]);
+        general.Setup(s => s.SupportedIntents).Returns([AgentIntent.General]);
+        general.Setup(s => s.KeywordFastPaths).Returns([]);
+
+        // Give each domain its own dedicated mock so keyword fast-paths route to the
+        // correct intent — issue #98 makes each specialist own one primary intent,
+        // matching production wiring. Broadcasting every intent from a single mock
+        // (as the pre-refactor tests did) collapses keyword → intent uniqueness.
+        var demand = new Mock<ISpecialistAgent>();
+        demand.Setup(s => s.Key).Returns("demand-forecasting");
+        demand.Setup(s => s.DisplayName).Returns("Demand Forecast Agent");
+        demand.Setup(s => s.SupportedIntents).Returns([AgentIntent.DemandForecasting]);
+        demand.Setup(s => s.KeywordFastPaths).Returns(
+            ["depletion", "sell-through", "sell through", "velocity", "forecast", "demand"]);
+
+        var promo = new Mock<ISpecialistAgent>();
+        promo.Setup(s => s.Key).Returns("promo-planning");
+        promo.Setup(s => s.DisplayName).Returns("Promo Planning Agent");
+        promo.Setup(s => s.SupportedIntents).Returns([AgentIntent.PromotionTrade]);
+        promo.Setup(s => s.KeywordFastPaths).Returns(
+            ["promotion", "promo", "campaign", "lift", "trade spend"]);
+
+        var supply = new Mock<ISpecialistAgent>();
+        supply.Setup(s => s.Key).Returns("supply-chain");
+        supply.Setup(s => s.DisplayName).Returns("Supply Chain Agent");
+        supply.Setup(s => s.SupportedIntents).Returns([AgentIntent.SupplyShipments]);
+        supply.Setup(s => s.KeywordFastPaths).Returns(
+            ["supply", "shipment", "inventory", "disruption", "fulfillment", "pipeline"]);
+
+        var competitive = new Mock<ISpecialistAgent>();
+        competitive.Setup(s => s.Key).Returns("competitive-intel");
+        competitive.Setup(s => s.DisplayName).Returns("Competitive Intel Agent");
+        competitive.Setup(s => s.SupportedIntents).Returns([AgentIntent.CompetitiveMarket]);
+        competitive.Setup(s => s.KeywordFastPaths).Returns(
+            ["competitor", "market share", "competitive", "rival"]);
+
+        var sentiment = new Mock<ISpecialistAgent>();
+        sentiment.Setup(s => s.Key).Returns("field-sentiment");
+        sentiment.Setup(s => s.DisplayName).Returns("Field Sentiment Agent");
+        sentiment.Setup(s => s.SupportedIntents).Returns([AgentIntent.SentimentField]);
+        sentiment.Setup(s => s.KeywordFastPaths).Returns(
+            ["sentiment", "distributor feedback", "field feedback", "field sales", "retailer satisfaction"]);
 
         var council = new Mock<ISpecialistAgent>();
         council.Setup(s => s.Key).Returns("council");
         council.Setup(s => s.DisplayName).Returns("Consensus Council");
         council.Setup(s => s.SupportedIntents).Returns([AgentIntent.PortfolioHealth]);
+        council.Setup(s => s.KeywordFastPaths).Returns([]);
 
         var planogram = new Mock<ISpecialistAgent>();
         planogram.Setup(s => s.Key).Returns("planogram");
         planogram.Setup(s => s.DisplayName).Returns("Planogram Agent");
         planogram.Setup(s => s.SupportedIntents).Returns([AgentIntent.Planogram]);
+        planogram.Setup(s => s.KeywordFastPaths).Returns(
+            ["planogram", "shelf layout", "shelf space", "facing", "sku placement", "brand blocking"]);
 
         var scorecard = new Mock<ISpecialistAgent>();
         scorecard.Setup(s => s.Key).Returns("scorecard");
         scorecard.Setup(s => s.DisplayName).Returns("Scorecard Agent");
         scorecard.Setup(s => s.SupportedIntents).Returns([AgentIntent.Scorecard]);
+        scorecard.Setup(s => s.KeywordFastPaths).Returns(
+            ["scorecard", "portfolio scoring", "brand ranking", "top brand", "worst brand", "executive brief"]);
 
         var storeOps = new Mock<ISpecialistAgent>();
         storeOps.Setup(s => s.Key).Returns("store-ops");
         storeOps.Setup(s => s.DisplayName).Returns("Store Ops Agent");
         storeOps.Setup(s => s.SupportedIntents).Returns([AgentIntent.StoreOps]);
+        storeOps.Setup(s => s.KeywordFastPaths).Returns(
+            ["store performance", "foot traffic", "conversion rate", "stockout", "underperforming store"]);
 
         var margin = new Mock<ISpecialistAgent>();
         margin.Setup(s => s.Key).Returns("margin");
         margin.Setup(s => s.DisplayName).Returns("Margin Agent");
         margin.Setup(s => s.SupportedIntents).Returns([AgentIntent.MarginAnalysis]);
+        margin.Setup(s => s.KeywordFastPaths).Returns(
+            ["margin", "profitability", "cogs", "gross margin", "net margin"]);
 
-        return [general.Object, council.Object, planogram.Object, scorecard.Object, storeOps.Object, margin.Object];
+        return
+        [
+            general.Object,
+            demand.Object,
+            promo.Object,
+            supply.Object,
+            competitive.Object,
+            sentiment.Object,
+            council.Object,
+            planogram.Object,
+            scorecard.Object,
+            storeOps.Object,
+            margin.Object,
+        ];
     }
 
     private static List<ISpecialistAgent> CreateSpecialistsWithMemoryIntent()
@@ -845,6 +903,12 @@ public class RetailOpsRouterTests
         memory.Setup(s => s.Key).Returns("memory-management");
         memory.Setup(s => s.DisplayName).Returns("Memory Management");
         memory.Setup(s => s.SupportedIntents).Returns([AgentIntent.MemoryManagement]);
+        memory.Setup(s => s.KeywordFastPaths).Returns(
+        [
+            "remember that", "remember this", "forget", "clear my", "clear my history",
+            "clear my data", "start fresh", "reset my context", "forget what I told you",
+            "what do you know about me",
+        ]);
 
         specialists.Add(memory.Object);
         return specialists;
@@ -866,7 +930,20 @@ public class RetailOpsRouterTests
             chatClient,
             routerDef,
             specialists,
-            Mock.Of<ILogger<RetailOpsRouter>>());
+            Mock.Of<ILogger<RetailOpsRouter>>(),
+            intentConfigs:
+            [
+                // Orchestration intents that have no specialist owner but still need
+                // keyword fast-paths in tests (matches Program.cs wiring).
+                new RouterIntentConfig(
+                    AgentIntent.PortfolioHealth,
+                    ["how healthy is", "brand health report", "portfolio health",
+                     "overall assessment for", "how is the portfolio"]),
+                new RouterIntentConfig(
+                    AgentIntent.Scorecard,
+                    ["scorecard", "portfolio scoring", "brand ranking",
+                     "top brand", "worst brand", "executive brief"]),
+            ]);
     }
 
     #endregion

--- a/tests/RetailPulse.Tests/Eval/DeterministicEvaluator.cs
+++ b/tests/RetailPulse.Tests/Eval/DeterministicEvaluator.cs
@@ -175,6 +175,7 @@ public sealed class DeterministicEvaluator
             mock.Setup(s => s.Key).Returns(SpecialistKeyForIntent(intent));
             mock.Setup(s => s.DisplayName).Returns($"Eval Stub ({intent})");
             mock.Setup(s => s.SupportedIntents).Returns([intent]);
+            mock.Setup(s => s.KeywordFastPaths).Returns(KeywordsForIntent(intent));
             specialists.Add(mock.Object);
         }
 
@@ -186,11 +187,22 @@ public sealed class DeterministicEvaluator
             Temperature = 0.0,
         };
 
+        // Mirror production orchestration intents (council/health, scorecard/portfolio)
+        // so keyword-fast-path golden cases route to them the same way the live API would.
+        var orchestrationIntents = new List<RouterIntentConfig>
+        {
+            new(AgentIntent.PortfolioHealth,
+                ["portfolio health", "overall health", "brand health", "health council"]),
+            new(AgentIntent.Scorecard,
+                ["scorecard", "brand scorecard", "performance scorecard"]),
+        };
+
         return new RetailOpsRouter(
             chatClient,
             routerDef,
             specialists,
-            NullLogger<RetailOpsRouter>.Instance);
+            NullLogger<RetailOpsRouter>.Instance,
+            intentConfigs: orchestrationIntents);
     }
 
     private static string SpecialistKeyForIntent(string intent) => intent switch
@@ -208,6 +220,39 @@ public sealed class DeterministicEvaluator
         AgentIntent.MarginAnalysis => "margin",
         AgentIntent.Scorecard => "scorecard",
         _ => "general",
+    };
+
+    /// <summary>
+    /// Mirrors the production keyword fast-paths declared in <c>prompts.yaml</c> per intent.
+    /// The evaluator has to seed these directly onto the stub specialists so that the router
+    /// can build the same keyword table it would in the live pipeline — without pulling the
+    /// full YAML loader into the eval harness.
+    /// </summary>
+    private static IReadOnlyList<string> KeywordsForIntent(string intent) => intent switch
+    {
+        AgentIntent.DemandForecasting =>
+            ["demand forecast", "sell-through", "velocity forecast"],
+        AgentIntent.PromotionTrade =>
+            ["promotion", "trade spend", "promo effectiveness", "promotion roi"],
+        AgentIntent.SentimentField =>
+            ["field rep", "field feedback", "distributor feedback", "rep feedback", "sentiment analysis"],
+        AgentIntent.CompetitiveMarket =>
+            ["pricing pressure", "market share", "price war", "competitor analysis", "competitive landscape"],
+        AgentIntent.SupplyShipments =>
+            ["shipment status", "inventory level", "fulfillment", "stockout", "stock out", "supply chain"],
+        AgentIntent.StoreOps =>
+            ["store operations", "store performance", "retail ops"],
+        AgentIntent.Planogram =>
+            ["planogram", "shelf space", "shelf placement"],
+        AgentIntent.MarginAnalysis =>
+            ["margin analysis", "profitability", "cost structure", "gross margin"],
+        AgentIntent.MemoryManagement =>
+            [
+                "remember that", "remember this", "forget", "clear my", "clear my history",
+                "clear my data", "start fresh", "reset my context", "forget what I told you",
+                "what do you know about me"
+            ],
+        _ => [],
     };
 }
 

--- a/tests/RetailPulse.Tests/Integration/RouterIntegrationTests.cs
+++ b/tests/RetailPulse.Tests/Integration/RouterIntegrationTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using RetailPulse.Api.Agents;
 using RetailPulse.Api.Agents.Routing;
 using RetailPulse.Api.Agents.Specialists;
+using RetailPulse.Api.Agents.Tools;
 using RetailPulse.Api.Approval;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Memory;
@@ -148,7 +149,10 @@ public class RouterIntegrationTests
             Name = "General",
             Model = "gpt-5.4-mini",
             SystemPrompt = "Test prompt",
-            Temperature = 0.7
+            Temperature = 0.7,
+            Key = "general",
+            Role = "specialist",
+            Intents = ["general/fallback"]
         };
 
         var promptConfig = new PromptConfiguration
@@ -160,16 +164,18 @@ public class RouterIntegrationTests
                     Name = "Router",
                     Model = "gpt-5.4-mini",
                     SystemPrompt = "Classify intent",
-                    Temperature = 0.1
-                }
+                    Temperature = 0.1,
+                    Key = "router",
+                    Role = "orchestration"
+                },
+                ["general"] = generalDef
             }
         };
 
         Func<IServiceCollection> act = () => services.AddAgentRouting(
             promptConfig,
-            generalDef,
-            foundryEnabled: false,
-            toolsFactory: _ => []);
+            new AgentToolRegistry(),
+            orchestrationIntents: []);
 
         act.Should().NotThrow();
     }
@@ -185,9 +191,8 @@ public class RouterIntegrationTests
 
         Func<IServiceCollection> act = () => services.AddAgentRouting(
             promptConfig,
-            new AgentDefinition { Name = "General", SystemPrompt = "test" },
-            foundryEnabled: false,
-            toolsFactory: _ => []);
+            new AgentToolRegistry(),
+            orchestrationIntents: []);
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*router*");

--- a/tests/RetailPulse.Tests/Routing/MemoryRoutingTests.cs
+++ b/tests/RetailPulse.Tests/Routing/MemoryRoutingTests.cs
@@ -1,36 +1,33 @@
-using System.Reflection;
 using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Moq;
 using RetailPulse.Api.Agents.Routing;
+using RetailPulse.Api.Models;
 using RetailPulse.Contracts.Routing;
 
 namespace RetailPulse.Tests.Routing;
 
 public class MemoryRoutingTests
 {
-    private static readonly MethodInfo TryKeywordClassifyMethod =
-        typeof(RetailOpsRouter).GetMethod("TryKeywordClassify", BindingFlags.NonPublic | BindingFlags.Static)!;
-
     [Theory]
     [InlineData("Remember that ClearDesk is trending positive")]
     [InlineData("Remember this for next time: margins are up")]
     [InlineData("Remember ClearDesk is trending modestly positive in the Northeast this quarter")]
     [InlineData("Remember that ClearDesk depletions are trending in the Northeast this quarter")]
-    public void TryKeywordClassify_StorePhrases_RouteToMemoryManagement(string message)
+    public async Task Route_StorePhrases_RoutesToMemoryManagement(string message)
     {
-        object? classification = TryKeywordClassify(message);
-
-        classification.Should().NotBeNull();
-        GetIntent(classification).Should().Be(AgentIntent.MemoryManagement);
+        RoutingDecision decision = await BuildRouter().RouteAsync(message, null, null, null);
+        decision.Intent.Should().Be(AgentIntent.MemoryManagement);
     }
 
     [Theory]
     [InlineData("What do you remember about ClearDesk?")]
     [InlineData("I'm focused on the Spirits category, especially premium tequila positioning")]
-    public void TryKeywordClassify_RecallAndPreferencePhrases_DoNotRouteToMemoryManagement(string message)
+    public async Task Route_RecallAndPreferencePhrases_DoNotRouteToMemoryManagement(string message)
     {
-        object? classification = TryKeywordClassify(message);
-
-        classification.Should().BeNull();
+        RoutingDecision decision = await BuildRouter().RouteAsync(message, null, null, null);
+        decision.Intent.Should().NotBe(AgentIntent.MemoryManagement);
     }
 
     [Theory]
@@ -41,17 +38,52 @@ public class MemoryRoutingTests
     [InlineData("Reset my context")]
     [InlineData("Forget what I told you")]
     [InlineData("What do you know about me?")]
-    public void TryKeywordClassify_ClearPhrases_RouteToMemoryManagement(string message)
+    public async Task Route_ClearPhrases_RouteToMemoryManagement(string message)
     {
-        object? classification = TryKeywordClassify(message);
-
-        classification.Should().NotBeNull();
-        GetIntent(classification).Should().Be(AgentIntent.MemoryManagement);
+        RoutingDecision decision = await BuildRouter().RouteAsync(message, null, null, null);
+        decision.Intent.Should().Be(AgentIntent.MemoryManagement);
     }
 
-    private static object? TryKeywordClassify(string message)
-        => TryKeywordClassifyMethod.Invoke(null, [message]);
+    private static RetailOpsRouter BuildRouter()
+    {
+        // LLM classifies to General with low confidence so keyword fast-paths take priority;
+        // the recall/preference cases fall through to General on purpose.
+        Mock<IChatClient> chatClient = new();
+        chatClient
+            .Setup(x => x.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant,
+                $"{{\"intent\":\"{AgentIntent.General}\",\"confidence\":0.5}}")));
 
-    private static string? GetIntent(object? classification)
-        => classification?.GetType().GetProperty("Intent")?.GetValue(classification) as string;
+        AgentDefinition routerDef = new()
+        {
+            Name = "Router",
+            Model = "gpt-5.4-mini-router",
+            SystemPrompt = "Classify intent.",
+            Temperature = 0.0
+        };
+
+        Mock<ISpecialistAgent> memory = new();
+        memory.SetupGet(s => s.Key).Returns("memory-management");
+        memory.SetupGet(s => s.SupportedIntents).Returns([AgentIntent.MemoryManagement]);
+        memory.SetupGet(s => s.KeywordFastPaths).Returns(
+        [
+            "remember that", "remember this", "forget", "clear my", "clear my history",
+            "clear my data", "start fresh", "reset my context", "forget what I told you",
+            "what do you know about me"
+        ]);
+
+        Mock<ISpecialistAgent> general = new();
+        general.SetupGet(s => s.Key).Returns("general");
+        general.SetupGet(s => s.SupportedIntents).Returns([AgentIntent.General]);
+        general.SetupGet(s => s.KeywordFastPaths).Returns([]);
+
+        return new RetailOpsRouter(
+            chatClient.Object,
+            routerDef,
+            [memory.Object, general.Object],
+            Mock.Of<ILogger<RetailOpsRouter>>());
+    }
 }

--- a/tests/RetailPulse.Tests/Scorecard/ScorecardTests.cs
+++ b/tests/RetailPulse.Tests/Scorecard/ScorecardTests.cs
@@ -10,6 +10,7 @@ using Moq;
 using RetailPulse.Api.Agents.Specialists;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Models;
+using RetailPulse.Api.Scorecard;
 using RetailPulse.Contracts;
 using RetailPulse.Contracts.Routing;
 
@@ -250,17 +251,10 @@ public class ScorecardTests
             ["Margin Health"] = 0.15
         };
 
-        // Verify via reflection to ensure the actual orchestrator weights match
-        FieldInfo? field = typeof(Api.Scorecard.ScorecardOrchestrator)
-            .GetField("_scoringDimensions",
-                BindingFlags.NonPublic | BindingFlags.Static);
-        field.Should().NotBeNull("ScoringDimensions field should exist on ScorecardOrchestrator");
-
-        var dimensions = field.GetValue(null) as (string Dimension, double Weight, string AgentKey)[];
-        dimensions.Should().NotBeNull("ScoringDimensions should be castable to tuple array");
+        IReadOnlyList<ScorecardDimensionConfig> dimensions = GetDefaultDimensions();
         dimensions.Should().HaveCount(5, "there should be exactly 5 scoring dimensions");
 
-        Dictionary<string, double> actualWeights = dimensions.ToDictionary(d => d.Dimension, d => d.Weight);
+        var actualWeights = dimensions.ToDictionary(d => d.Dimension, d => d.Weight);
 
         foreach ((string? name, double expectedWeight) in expectedWeights)
         {
@@ -278,12 +272,7 @@ public class ScorecardTests
     [Fact]
     public void ScorecardOrchestrator_DimensionWeights_SumToOne()
     {
-        FieldInfo? field = typeof(Api.Scorecard.ScorecardOrchestrator)
-            .GetField("_scoringDimensions",
-                BindingFlags.NonPublic | BindingFlags.Static);
-
-        var dimensions = field!.GetValue(null) as (string Dimension, double Weight, string AgentKey)[];
-        double total = dimensions!.Sum(d => d.Weight);
+        double total = GetDefaultDimensions().Sum(d => d.Weight);
 
         total.Should().BeApproximately(1.0, 0.001,
             "portfolio scorecard dimension weights must sum to exactly 1.0");
@@ -292,31 +281,23 @@ public class ScorecardTests
     [Fact]
     public void ScorecardOrchestrator_DemandMomentum_HasHighestWeight()
     {
-        FieldInfo? field = typeof(Api.Scorecard.ScorecardOrchestrator)
-            .GetField("_scoringDimensions",
-                BindingFlags.NonPublic | BindingFlags.Static);
+        ScorecardDimensionConfig top = GetDefaultDimensions()
+            .OrderByDescending(d => d.Weight).First();
 
-        var dimensions = field!.GetValue(null) as (string Dimension, double Weight, string AgentKey)[];
-        (string? Dimension, double Weight, string? AgentKey) = dimensions!.OrderByDescending(d => d.Weight).First();
-
-        Dimension.Should().Be("Demand Momentum",
+        top.Dimension.Should().Be("Demand Momentum",
             "Demand Momentum should have the highest weight (0.25)");
-        Weight.Should().Be(0.25);
+        top.Weight.Should().Be(0.25);
     }
 
     [Fact]
     public void ScorecardOrchestrator_MarginHealth_HasLowestWeight()
     {
-        FieldInfo? field = typeof(Api.Scorecard.ScorecardOrchestrator)
-            .GetField("_scoringDimensions",
-                BindingFlags.NonPublic | BindingFlags.Static);
+        ScorecardDimensionConfig bottom = GetDefaultDimensions()
+            .OrderBy(d => d.Weight).First();
 
-        var dimensions = field!.GetValue(null) as (string Dimension, double Weight, string AgentKey)[];
-        (string? Dimension, double Weight, string? AgentKey) = dimensions!.OrderBy(d => d.Weight).First();
-
-        Dimension.Should().Be("Margin Health",
+        bottom.Dimension.Should().Be("Margin Health",
             "Margin Health should have the lowest weight (0.15)");
-        Weight.Should().Be(0.15);
+        bottom.Weight.Should().Be(0.15);
     }
 
     #endregion
@@ -324,6 +305,17 @@ public class ScorecardTests
     #region Test Infrastructure
 
     private static IScorecardService CreateScorecardService(bool simulateSlowBrands = false) => new MockScorecardService(ExpectedBrands, simulateSlowBrands);
+
+    private static IReadOnlyList<ScorecardDimensionConfig> GetDefaultDimensions()
+    {
+        FieldInfo? field = typeof(ScorecardOrchestrator)
+            .GetField("DefaultScoringDimensions",
+                BindingFlags.NonPublic | BindingFlags.Static);
+        field.Should().NotBeNull("DefaultScoringDimensions field should exist on ScorecardOrchestrator");
+        var dims = field.GetValue(null) as IReadOnlyList<ScorecardDimensionConfig>;
+        dims.Should().NotBeNull("DefaultScoringDimensions should expose a list of ScorecardDimensionConfig");
+        return dims;
+    }
 
     #endregion
 }

--- a/tests/RetailPulse.Tests/Security/AnonymousPipelineCompositionTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousPipelineCompositionTests.cs
@@ -122,9 +122,8 @@ public sealed class AnonymousPipelineCompositionTests
         // Production pipeline registration. This is the factory that previously omitted the policy.
         services.AddAgentRouting(
             promptConfig: RouterOnlyConfig(),
-            generalAgentDef: new AgentDefinition { Name = "General" },
-            foundryEnabled: false,
-            toolsFactory: _ => Tools());
+            toolRegistry: new Api.Agents.Tools.AgentToolRegistry(),
+            orchestrationIntents: []);
 
         return services.BuildServiceProvider();
     }
@@ -160,7 +159,21 @@ public sealed class AnonymousPipelineCompositionTests
     {
         Agents = new Dictionary<string, AgentDefinition>
         {
-            ["router"] = new AgentDefinition { Name = "router", SystemPrompt = "route" },
+            ["router"] = new AgentDefinition
+            {
+                Name = "router",
+                SystemPrompt = "route",
+                Key = "router",
+                Role = "orchestration",
+            },
+            ["general"] = new AgentDefinition
+            {
+                Name = "General",
+                SystemPrompt = "gen",
+                Key = "general",
+                Role = "specialist",
+                Intents = { "general/fallback" },
+            },
         },
     };
 

--- a/tests/RetailPulse.Tests/Security/TenantRosterPipelineCompositionTests.cs
+++ b/tests/RetailPulse.Tests/Security/TenantRosterPipelineCompositionTests.cs
@@ -151,12 +151,25 @@ public sealed partial class TenantRosterPipelineCompositionTests
             {
                 Agents = new Dictionary<string, AgentDefinition>
                 {
-                    ["router"] = new AgentDefinition { Name = "router", SystemPrompt = "route" },
+                    ["router"] = new AgentDefinition
+                    {
+                        Name = "router",
+                        SystemPrompt = "route",
+                        Key = "router",
+                        Role = "orchestration",
+                    },
+                    ["general"] = new AgentDefinition
+                    {
+                        Name = "General",
+                        SystemPrompt = "gen",
+                        Key = "general",
+                        Role = "specialist",
+                        Intents = { "general/fallback" },
+                    },
                 },
             },
-            generalAgentDef: new AgentDefinition { Name = "General", SystemPrompt = "gen" },
-            foundryEnabled: false,
-            toolsFactory: _ => []);
+            toolRegistry: new Api.Agents.Tools.AgentToolRegistry(),
+            orchestrationIntents: []);
 
         return services.BuildServiceProvider();
     }


### PR DESCRIPTION
Closes #98

Working as Kroger (Lead).

## Summary

Adding a new specialist to Retail Pulse is now a prompts.yaml edit plus a restart — no C# class, no DI wiring, no rebuild. The router's intent set, keyword fast-paths, council roster, and scorecard dimensions all derive from configuration. Bespoke agents (MemoryManagementAgent, CompetitiveIntelAgent) retain their hand-written classes but read their AgentDefinition from the same YAML. Configuration is trusted deployment input at this stage; safety validation of definitions is issue #99.

See [ADR-008](docs/adr/008-data-driven-agent-definitions.md) for the full rationale and [docs/tenant-configuration.md](docs/tenant-configuration.md) for the schema + worked example.

## Changes

- **AgentDefinition** extended with `Key`, `DisplayName`, `Intents`, `KeywordFastPaths`, `FallbackReply`, `CouncilParticipant`, `ScorecardDimension`, `ScorecardWeight`, `Role` (default ""specialist""), `Prefetchable`, plus a `Clone()` so shims never mutate a shared def.
- **AgentToolRegistry** — named registry with `ValidateAllReferences` that fails startup with an actionable `UnknownToolReferenceException` listing missing and known tool names.
- **ConfiguredSpecialistAgent** — sole `ISpecialistAgent` + `IPrefetchableAgent` implementation, runs on the shared `IAgentExecutionPipeline` (ADR-007 MAF stack preserved). `protected virtual OnToolResult` hook for subclasses.
- **Nine specialists collapsed** to sealed shims over `ConfiguredSpecialistAgent` (`EnsureDefaults` populates key / primary intent for pre-refactor callers, using `def.Clone()` so shared defs stay untouched). `PromoPlanningAgent` retains `CheckApprovalAsync`. `CompetitiveIntelAgent` retains SignalR alerts via `OnToolResult`.
- **MemoryManagementAgent** — hand-written orchestration retained; accepts an optional `AgentDefinition` so its key / intents / keyword table live in `prompts.yaml`.
- **RetailOpsRouter** — instance-scoped `_keywordPatterns` built from every specialist's `KeywordFastPaths` plus `RouterIntentConfig` records for orchestration-only intents (council/health, scorecard/portfolio). `KnownIntents` exposed so `ParseClassification` accepts purely-configured intents without normalising to General.
- **ConsensusOrchestrator / ScorecardOrchestrator** — accept optional config lists; `RouterAgentRoster` derives both from `PromptConfiguration`. Previous hardcoded rosters retained as safe defaults.
- **RoutingServiceExtensions.AddAgentRouting** — new signature `(PromptConfiguration, AgentToolRegistry, IReadOnlyList<RouterIntentConfig>)`. Validates tool refs at startup, detects duplicate keys, registers each specialist by well-known key (bespoke) or the generic `ConfiguredSpecialistAgent` (default).
- **Program.cs** — hydration loop over every agent def; single `AgentToolRegistry` block registering every tool by prompts.yaml name; orchestration intents list; single `AddAgentRouting` call; orchestrators pull participants/dimensions from `RouterAgentRoster`.
- **prompts.yaml** — routing metadata (`key` / `intents` / `keyword_fast_paths` / `council_participant` / `scorecard_dimension` / `scorecard_weight` / `role` / `prefetchable`) on every specialist; added `memory-management` section; keyword fast-paths preserved byte-for-byte from the pre-refactor hardcoded table so the eval baseline and downstream router tests keep their exact previous behaviour.
- **docs/adr/008-data-driven-agent-definitions.md** — full rationale, decision, worked example, non-goal, consequences, alternatives.
- **docs/tenant-configuration.md** — new ""Agent Definitions"" section with schema table, worked example (Loyalty Analytics specialist added purely through YAML), bespoke-agents note, trust boundary.

## Testing

- **DataDrivenSpecialistTests (new, 8 tests)** — the proof: a test-only `test-widget` specialist declared purely in config is routed to via keyword fast-path AND executes through the pipeline; startup validation for unknown tool, duplicate key, missing router; council/scorecard derived-from-config; unroutable-intent fallback to General; KnownIntents tracks configuration.
- **Behavioural equivalence** — updated helpers in `RetailOpsRouterTests`, `RouterIntegrationTests`, `TenantRosterPipelineCompositionTests`, `AnonymousPipelineCompositionTests`, `MemoryRoutingTests` (rewritten from static reflection to an instance-based router with the memory keyword table), `ScorecardTests` (reflection now hits `DefaultScoringDimensions` on the config record), and `DeterministicEvaluator` (mock specialists now carry `KeywordFastPaths` matching the production defaults per intent, plus orchestration intents supplied to the eval router).
- **Full suite** — `dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj` — **2863 passed / 0 failed**.
- **Format** — `dotnet format --verify-no-changes` — **clean (exit 0)**.

## Constraints observed

- MAF `ChatClientAgent` execution stack (ADR-007) preserved end-to-end.
- Bespoke `MemoryManagementAgent` / `CompetitiveIntelAgent` retained.
- Configuration is trusted deployment input — issue #99 remains untouched and is not made harder to add.
- Unknown tool references fail loudly at startup with an actionable exception.
- Unroutable intents fall back to General.
- Council participants + scorecard dimensions derive from configuration.
- No touches to `.gitattributes`, git hooks, or contributor docs (issue #116 concurrent).
- No external accelerators or competitive comparisons referenced anywhere.

## Review risks

- `prompts.yaml` keyword-fast-path lists were deliberately reset to the exact pre-refactor router keyword table to preserve the eval baseline. Any future change to those lists should include an eval-harness rerun.
- Nine specialist shims (`GeneralAgent` etc.) are kept purely to preserve constructor signatures for existing call sites and tests. They can be deleted in a follow-up once every caller uses `ConfiguredSpecialistAgent` directly.
- `DemoReadinessTests.IntentCoverage_IsDocumentedAndNoOrphans` relies on each specialist advertising a distinct primary intent — the `def.Clone()` inside every `EnsureDefaults` is what prevents a shared `AgentDefinition` in tests from collapsing them all to General.