### PR TITLE
Harden durable approval lifecycle across restarts

### DIFF
--- a/src/RetailPulse.Api/Approval/ApprovalOptions.cs
+++ b/src/RetailPulse.Api/Approval/ApprovalOptions.cs
@@ -1,0 +1,38 @@
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Configuration for <see cref="SqliteApprovalGate"/>. Every knob has a sensible
+/// default so the feature ships without operator ceremony; the only value an
+/// operator typically overrides is <see cref="DefaultTimeout"/> when a deployment's
+/// human-response SLA is longer or shorter than five minutes.
+/// </summary>
+public sealed class ApprovalOptions
+{
+    public const string SectionName = "Approval";
+
+    /// <summary>
+    /// Authoritative default timeout used when the caller passes no explicit timeout
+    /// to <see cref="SqliteApprovalGate.RequestApprovalAsync"/>. This value is
+    /// persisted alongside the row so a waiter created in a later process still
+    /// honours the timeout the row was created with — the runtime configuration
+    /// cannot silently shrink or extend a pending request that a human has already
+    /// been notified about. Default: 5 minutes.
+    /// </summary>
+    public TimeSpan DefaultTimeout { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// How often an in-process waiter refreshes its row's <c>HeartbeatAt</c> column so
+    /// operators can observe liveness. Reconciliation itself uses the durable
+    /// agent-instance id (not the heartbeat) to decide whether a Pending row belongs
+    /// to the current process — the heartbeat is purely observability. Default: 30s.
+    /// </summary>
+    public TimeSpan HeartbeatInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Whether the startup reconciliation service runs. Off would leak stuck-Pending
+    /// rows on restart and reintroduce the exact bug this feature exists to fix —
+    /// keep it on. Exposed only so tests can register the gate without the hosted
+    /// service. Default: true.
+    /// </summary>
+    public bool ReconcileOnStartup { get; set; } = true;
+}

--- a/src/RetailPulse.Api/Approval/ApprovalReconciliationBackgroundService.cs
+++ b/src/RetailPulse.Api/Approval/ApprovalReconciliationBackgroundService.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Options;
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Startup reconciliation for durable approval requests. Runs before Kestrel begins
+/// accepting traffic (hosted services complete <see cref="IHostedService.StartAsync"/>
+/// before the generic web host service ends its own StartAsync in ASP.NET Core), so
+/// any Pending row left behind by a previous process is closed — or resumed — before
+/// the first HTTP request or agent invocation can create a new one.
+///
+/// <para>
+/// The delegated <see cref="IApprovalResumeStrategy"/> is the single seam Wave 2
+/// (issues #93/#94) replaces to swap deterministic orphaning for a checkpoint-driven
+/// resume. Reconciliation is idempotent: a repeated call is a no-op because every
+/// previously eligible row has already been terminated (or adopted by this instance).
+/// </para>
+/// </summary>
+public sealed class ApprovalReconciliationBackgroundService : IHostedService
+{
+    private readonly SqliteApprovalGate _gate;
+    private readonly IApprovalResumeStrategy _strategy;
+    private readonly IOptions<ApprovalOptions> _options;
+    private readonly ILogger<ApprovalReconciliationBackgroundService> _logger;
+
+    public ApprovalReconciliationBackgroundService(
+        IApprovalGate gate,
+        IApprovalResumeStrategy strategy,
+        IOptions<ApprovalOptions> options,
+        ILogger<ApprovalReconciliationBackgroundService> logger)
+    {
+        // The reconciliation surface (ReconcilePendingAsync) lives on the concrete
+        // implementation, not IApprovalGate, so we intentionally require the SQLite
+        // gate concrete type here. This keeps IApprovalGate lean for callers that
+        // never need to reconcile.
+        if (gate is not SqliteApprovalGate sqlite)
+            throw new InvalidOperationException(
+                $"ApprovalReconciliationBackgroundService requires {nameof(SqliteApprovalGate)}; got {gate.GetType().Name}.");
+
+        _gate = sqlite;
+        _strategy = strategy;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.Value.ReconcileOnStartup)
+        {
+            _logger.LogInformation("Approval reconciliation disabled by configuration; skipping startup sweep.");
+            return;
+        }
+
+        try
+        {
+            int terminated = await _gate.ReconcilePendingAsync(_strategy, cancellationToken);
+            _logger.LogInformation(
+                "Approval reconciliation complete on instance {InstanceId}: {Terminated} orphaned request(s) closed.",
+                _gate.InstanceId, terminated);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Reconciliation failure must NOT wedge startup — an operator would rather
+            // serve traffic with a small pool of stuck-Pending rows (which the next
+            // successful startup can reconcile) than fail to boot at all. The error is
+            // logged so it surfaces in observability.
+            _logger.LogError(ex, "Approval reconciliation failed on instance {InstanceId}.", _gate.InstanceId);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/RetailPulse.Api/Approval/ApprovalReconciliationBackgroundService.cs
+++ b/src/RetailPulse.Api/Approval/ApprovalReconciliationBackgroundService.cs
@@ -4,11 +4,16 @@ using RetailPulse.Contracts.Approval;
 namespace RetailPulse.Api.Approval;
 
 /// <summary>
-/// Startup reconciliation for durable approval requests. Runs before Kestrel begins
-/// accepting traffic (hosted services complete <see cref="IHostedService.StartAsync"/>
-/// before the generic web host service ends its own StartAsync in ASP.NET Core), so
-/// any Pending row left behind by a previous process is closed — or resumed — before
-/// the first HTTP request or agent invocation can create a new one.
+/// Startup reconciliation for durable approval requests. Runs as an
+/// <see cref="IHostedService"/> during host startup and sweeps every Pending row
+/// left behind by a previous process, closing it — or handing it to a resume
+/// strategy — through the configured <see cref="IApprovalResumeStrategy"/>. Ordering
+/// with the web host is not strictly guaranteed, so the first HTTP request or agent
+/// invocation may briefly race the sweep. That is safe: race-safety is enforced at
+/// the row via a single conditional <c>Pending → terminal</c> UPDATE, and
+/// <see cref="IApprovalGate.RespondAsync"/> returns the actual persisted winner
+/// instead of the caller-requested decision, so a late human response can never
+/// silently overwrite a row that this sweep has already terminated.
 ///
 /// <para>
 /// The delegated <see cref="IApprovalResumeStrategy"/> is the single seam Wave 2

--- a/src/RetailPulse.Api/Approval/ApprovalReconciliationBackgroundService.cs
+++ b/src/RetailPulse.Api/Approval/ApprovalReconciliationBackgroundService.cs
@@ -35,8 +35,10 @@ public sealed class ApprovalReconciliationBackgroundService : IHostedService
         // gate concrete type here. This keeps IApprovalGate lean for callers that
         // never need to reconcile.
         if (gate is not SqliteApprovalGate sqlite)
+        {
             throw new InvalidOperationException(
                 $"ApprovalReconciliationBackgroundService requires {nameof(SqliteApprovalGate)}; got {gate.GetType().Name}.");
+        }
 
         _gate = sqlite;
         _strategy = strategy;

--- a/src/RetailPulse.Api/Approval/OrphanUnresumableStrategy.cs
+++ b/src/RetailPulse.Api/Approval/OrphanUnresumableStrategy.cs
@@ -1,0 +1,34 @@
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Wave 1 default <see cref="IApprovalResumeStrategy"/>: every Pending approval
+/// whose owning execution did not survive the restart is deterministically closed
+/// with <see cref="ApprovalDecision.Orphaned"/> (terminal reason
+/// <c>OrphanedOnRestart</c>).
+///
+/// <para>
+/// Rationale: Wave 1 has no execution checkpoint layer, so nothing exists to
+/// resume — leaving the row Pending would silently reproduce the original bug
+/// (approving later has no effect because no in-process waiter is listening).
+/// Closing terminally means the history surface, the endpoint, and any Wave 2
+/// consumer see exactly one outcome per request.
+/// </para>
+///
+/// <para>
+/// Wave 2 (issues #93/#94) replaces this registration with a strategy that
+/// consults the durable session store (issue #90) through the
+/// <see cref="ApprovalContext.SessionId"/> / <see cref="ApprovalContext.ConversationId"/>
+/// correlation columns already persisted on every row. When a checkpoint can be
+/// resumed the strategy returns <see cref="ApprovalResumeAction.Resume"/> and the
+/// gate refreshes the owning instance so the resumed execution owns the terminal
+/// transition. No schema migration is required for that swap — the seam is
+/// entirely in the DI registration.
+/// </para>
+/// </summary>
+public sealed class OrphanUnresumableStrategy : IApprovalResumeStrategy
+{
+    public Task<ApprovalResumeAction> DecideAsync(ApprovalRequest orphaned, CancellationToken ct = default)
+        => Task.FromResult(ApprovalResumeAction.OrphanTerminal);
+}

--- a/src/RetailPulse.Api/Approval/SqliteApprovalGate.cs
+++ b/src/RetailPulse.Api/Approval/SqliteApprovalGate.cs
@@ -13,25 +13,72 @@ namespace RetailPulse.Api.Approval;
 /// connection so it is durable on the Azure Files mount and does not fail fast on a
 /// transient lock; single-writer only (API runs maxReplicas: 1). All database I/O
 /// uses async APIs with CancellationToken support.
-/// WaitForApprovalAsync uses exponential backoff instead of fixed-interval polling.
+/// WaitForApprovalAsync uses exponential backoff (driven by an injected
+/// <see cref="TimeProvider"/>) instead of fixed-interval polling, and every
+/// Pending → terminal transition is a single conditional SQL update so a
+/// simultaneous human response and timeout race resolves to exactly one persisted
+/// winner. On losing the race the waiter re-reads the row and returns the actual
+/// winner, so the returned <see cref="ApprovalResult"/> and the stored row always
+/// agree — no double-resolution is possible.
+///
+/// <para>
+/// Restart safety: every row carries the id of the process that owns its waiter
+/// (<c>AgentInstanceId</c>) plus a heartbeat and the authoritative stored timeout.
+/// <see cref="ReconcilePendingAsync"/> is called by
+/// <see cref="ApprovalReconciliationBackgroundService"/> before traffic and closes
+/// any Pending row whose owning process is gone through the configured
+/// <see cref="IApprovalResumeStrategy"/>. Wave 1 orphans terminally; Wave 2 will
+/// use the persisted <see cref="ApprovalContext.SessionId"/> /
+/// <see cref="ApprovalContext.ConversationId"/> correlation to resume a
+/// checkpointed execution without any gate-side change (see #93/#94).
+/// </para>
 /// </summary>
 public sealed class SqliteApprovalGate : IApprovalGate
 {
     private readonly string _connectionString;
     private readonly ILogger<SqliteApprovalGate> _logger;
     private readonly TimeSpan _defaultTimeout;
+    private readonly TimeProvider _timeProvider;
+    // Per-process instance id — distinguishes waits owned by THIS process from
+    // waits still stored Pending after a restart. New GUID per gate instance so
+    // two gates (e.g., two independent tests) never collide, and a real restart
+    // gets a fresh id so reconciliation can see the previous owner is gone.
+    private readonly string _instanceId;
 
     private const string _iso8601 = "yyyy-MM-ddTHH:mm:ss.fffzzz";
+
+    // Terminal reason string constants written into the durable TerminalReason column.
+    // These are persisted verbatim into the endpoint response so the UI can render a
+    // specific outcome (Timeout vs OrphanedOnRestart) instead of a generic
+    // "not-approved" label.
+    internal const string ReasonHumanApproved = "HumanApproved";
+    internal const string ReasonHumanRejected = "HumanRejected";
+    internal const string ReasonHumanModified = "HumanModified";
+    internal const string ReasonTimeout = "Timeout";
+    internal const string ReasonOrphanedOnRestart = "OrphanedOnRestart";
 
     // Exponential backoff parameters for WaitForApprovalAsync
     internal static readonly TimeSpan InitialBackoff = TimeSpan.FromMilliseconds(250);
     internal static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(4);
     internal const double BackoffMultiplier = 2.0;
 
-    public SqliteApprovalGate(string dbPath, ILogger<SqliteApprovalGate> logger, TimeSpan? defaultTimeout = null)
+    /// <summary>
+    /// Stable identity of the process that owns this gate. Exposed so the
+    /// reconciliation service and tests can assert that reconciliation only touches
+    /// rows written by a DIFFERENT process.
+    /// </summary>
+    public string InstanceId => _instanceId;
+
+    public SqliteApprovalGate(
+        string dbPath,
+        ILogger<SqliteApprovalGate> logger,
+        TimeSpan? defaultTimeout = null,
+        TimeProvider? timeProvider = null)
     {
         _logger = logger;
         _defaultTimeout = defaultTimeout ?? TimeSpan.FromMinutes(5);
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _instanceId = Guid.NewGuid().ToString("N");
 
         string? dir = Path.GetDirectoryName(dbPath);
         if (!string.IsNullOrEmpty(dir))
@@ -51,44 +98,97 @@ public sealed class SqliteApprovalGate : IApprovalGate
     {
         await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString);
 
+        await using (SqliteCommand cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = """
+                CREATE TABLE IF NOT EXISTS ApprovalRequests (
+                    RequestId        TEXT PRIMARY KEY,
+                    AgentId          TEXT NOT NULL,
+                    UserId           TEXT NOT NULL,
+                    Action           TEXT NOT NULL,
+                    Impact           TEXT,
+                    Urgency          TEXT DEFAULT 'medium',
+                    Reasoning        TEXT,
+                    SessionId        TEXT,
+                    ConversationId   TEXT,
+                    AgentInstanceId  TEXT NOT NULL DEFAULT '',
+                    HeartbeatAt      TEXT,
+                    TimeoutSeconds   INTEGER NOT NULL DEFAULT 300,
+                    Decision         TEXT DEFAULT 'Pending',
+                    TerminalReason   TEXT,
+                    Comment          TEXT,
+                    CreatedAt        TEXT NOT NULL,
+                    ExpiresAt        TEXT NOT NULL,
+                    RespondedAt      TEXT
+                );
+
+                CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_UserId_Decision
+                    ON ApprovalRequests (UserId, Decision);
+
+                CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_CreatedAt
+                    ON ApprovalRequests (CreatedAt DESC);
+
+                CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_Decision_Instance
+                    ON ApprovalRequests (Decision, AgentInstanceId);
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Additive migration for databases created before the lifecycle-hardening schema
+        // landed. SQLite's ALTER TABLE ADD COLUMN is idempotent when guarded by the
+        // PRAGMA table_info sniff. Every added column has a defaultable value so the row
+        // set stays queryable during the migration.
+        HashSet<string> existingColumns = await ReadColumnsAsync(conn);
+        (string name, string ddl)[] additions =
+        [
+            ("SessionId",       "ALTER TABLE ApprovalRequests ADD COLUMN SessionId TEXT"),
+            ("ConversationId",  "ALTER TABLE ApprovalRequests ADD COLUMN ConversationId TEXT"),
+            ("AgentInstanceId", "ALTER TABLE ApprovalRequests ADD COLUMN AgentInstanceId TEXT NOT NULL DEFAULT ''"),
+            ("HeartbeatAt",     "ALTER TABLE ApprovalRequests ADD COLUMN HeartbeatAt TEXT"),
+            ("TimeoutSeconds",  "ALTER TABLE ApprovalRequests ADD COLUMN TimeoutSeconds INTEGER NOT NULL DEFAULT 300"),
+            ("TerminalReason",  "ALTER TABLE ApprovalRequests ADD COLUMN TerminalReason TEXT"),
+        ];
+        foreach ((string name, string ddl) in additions)
+        {
+            if (existingColumns.Contains(name))
+                continue;
+            await using SqliteCommand alter = conn.CreateCommand();
+            alter.CommandText = ddl;
+            await alter.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static async Task<HashSet<string>> ReadColumnsAsync(SqliteConnection conn)
+    {
+        var cols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         await using SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = """
-            CREATE TABLE IF NOT EXISTS ApprovalRequests (
-                RequestId   TEXT PRIMARY KEY,
-                AgentId     TEXT NOT NULL,
-                UserId      TEXT NOT NULL,
-                Action      TEXT NOT NULL,
-                Impact      TEXT,
-                Urgency     TEXT DEFAULT 'medium',
-                Reasoning   TEXT,
-                Decision    TEXT DEFAULT 'Pending',
-                Comment     TEXT,
-                CreatedAt   TEXT NOT NULL,
-                ExpiresAt   TEXT NOT NULL,
-                RespondedAt TEXT
-            );
-
-            CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_UserId_Decision
-                ON ApprovalRequests (UserId, Decision);
-
-            CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_CreatedAt
-                ON ApprovalRequests (CreatedAt DESC);
-            """;
-        await cmd.ExecuteNonQueryAsync();
+        cmd.CommandText = "PRAGMA table_info(ApprovalRequests)";
+        await using SqliteDataReader reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            cols.Add(reader.GetString(reader.GetOrdinal("name")));
+        }
+        return cols;
     }
 
     public async Task<ApprovalRequest> RequestApprovalAsync(ApprovalContext context, CancellationToken ct = default)
     {
         string requestId = Guid.NewGuid().ToString("N");
-        DateTimeOffset now = DateTimeOffset.UtcNow;
+        DateTimeOffset now = _timeProvider.GetUtcNow();
         DateTimeOffset expiresAt = now.Add(_defaultTimeout);
 
         await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
 
         await using SqliteCommand cmd = conn.CreateCommand();
         cmd.CommandText = """
-            INSERT INTO ApprovalRequests (RequestId, AgentId, UserId, Action, Impact, Urgency, Reasoning, Decision, CreatedAt, ExpiresAt)
-            VALUES (@id, @agentId, @userId, @action, @impact, @urgency, @reasoning, 'Pending', @createdAt, @expiresAt)
+            INSERT INTO ApprovalRequests (
+                RequestId, AgentId, UserId, Action, Impact, Urgency, Reasoning,
+                SessionId, ConversationId, AgentInstanceId, HeartbeatAt, TimeoutSeconds,
+                Decision, CreatedAt, ExpiresAt)
+            VALUES (
+                @id, @agentId, @userId, @action, @impact, @urgency, @reasoning,
+                @sessionId, @conversationId, @instanceId, @heartbeatAt, @timeoutSeconds,
+                'Pending', @createdAt, @expiresAt)
             """;
         cmd.Parameters.AddWithValue("@id", requestId);
         cmd.Parameters.AddWithValue("@agentId", context.AgentId);
@@ -97,13 +197,18 @@ public sealed class SqliteApprovalGate : IApprovalGate
         cmd.Parameters.AddWithValue("@impact", (object?)context.Impact ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@urgency", context.Urgency);
         cmd.Parameters.AddWithValue("@reasoning", (object?)context.Reasoning ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@sessionId", (object?)context.SessionId ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@conversationId", (object?)context.ConversationId ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@instanceId", _instanceId);
+        cmd.Parameters.AddWithValue("@heartbeatAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
+        cmd.Parameters.AddWithValue("@timeoutSeconds", (long)_defaultTimeout.TotalSeconds);
         cmd.Parameters.AddWithValue("@createdAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
         cmd.Parameters.AddWithValue("@expiresAt", expiresAt.ToString(_iso8601, CultureInfo.InvariantCulture));
         await cmd.ExecuteNonQueryAsync(ct);
 
         _logger.LogInformation(
-            "Approval request {RequestId} created for agent {AgentId}, user {UserId}, urgency {Urgency}",
-            requestId, context.AgentId, context.UserId, context.Urgency);
+            "Approval request {RequestId} created for agent {AgentId}, user {UserId}, urgency {Urgency}, instance {InstanceId}, timeout {TimeoutSeconds}s",
+            requestId, context.AgentId, context.UserId, context.Urgency, _instanceId, (long)_defaultTimeout.TotalSeconds);
 
         return new ApprovalRequest(requestId, context, now, expiresAt);
     }
@@ -119,13 +224,14 @@ public sealed class SqliteApprovalGate : IApprovalGate
             row.RequestId,
             row.Decision,
             row.Comment,
-            row.RespondedAt);
+            row.RespondedAt,
+            row.TerminalReason);
     }
 
     public async Task<ApprovalResult> WaitForApprovalAsync(string requestId, TimeSpan? timeout = null, CancellationToken ct = default)
     {
         TimeSpan effectiveTimeout = timeout ?? _defaultTimeout;
-        DateTimeOffset deadline = DateTimeOffset.UtcNow.Add(effectiveTimeout);
+        DateTimeOffset deadline = _timeProvider.GetUtcNow().Add(effectiveTimeout);
         TimeSpan backoff = InitialBackoff;
 
         _logger.LogInformation(
@@ -141,16 +247,27 @@ public sealed class SqliteApprovalGate : IApprovalGate
 
             if (row.Decision != ApprovalDecision.Pending)
             {
-                return new ApprovalResult(row.RequestId, row.Decision, row.Comment, row.RespondedAt);
+                return new ApprovalResult(row.RequestId, row.Decision, row.Comment, row.RespondedAt, row.TerminalReason);
             }
 
-            if (DateTimeOffset.UtcNow >= deadline)
+            // Heartbeat the row so operators can observe that this waiter is alive.
+            await UpdateHeartbeatAsync(conn, requestId, ct);
+
+            if (_timeProvider.GetUtcNow() >= deadline)
             {
-                await RespondAsync(requestId, ApprovalDecision.TimedOut, "Approval timed out — no response received.", ct);
-                return new ApprovalResult(requestId, ApprovalDecision.TimedOut, "Approval timed out — no response received.", DateTimeOffset.UtcNow);
+                // Race-safe timeout: conditional UPDATE from Pending. Whether we win or a
+                // human beat us to it, we then read the row and return the ACTUAL winner
+                // so the persisted row and this waiter agree on exactly one terminal
+                // outcome. Never returns TimedOut when a human decision landed first.
+                return await TransitionAndReadAsync(
+                    requestId,
+                    ApprovalDecision.TimedOut,
+                    ReasonTimeout,
+                    comment: "Approval timed out — no response received.",
+                    ct);
             }
 
-            await Task.Delay(backoff, ct);
+            await Task.Delay(backoff, _timeProvider, ct);
             backoff = TimeSpan.FromMilliseconds(Math.Min(backoff.TotalMilliseconds * BackoffMultiplier, MaxBackoff.TotalMilliseconds));
         }
 
@@ -160,32 +277,96 @@ public sealed class SqliteApprovalGate : IApprovalGate
 
     public async Task RespondAsync(string requestId, ApprovalDecision decision, string? comment = null, CancellationToken ct = default)
     {
-        DateTimeOffset now = DateTimeOffset.UtcNow;
-
-        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
-
-        await using SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = """
-            UPDATE ApprovalRequests
-            SET Decision = @decision, Comment = @comment, RespondedAt = @respondedAt
-            WHERE RequestId = @id AND Decision = 'Pending'
-            """;
-        cmd.Parameters.AddWithValue("@id", requestId);
-        cmd.Parameters.AddWithValue("@decision", decision.ToString());
-        cmd.Parameters.AddWithValue("@comment", (object?)comment ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("@respondedAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
-
-        int affected = await cmd.ExecuteNonQueryAsync(ct);
-        if (affected == 0)
+        string reason = decision switch
         {
-            _logger.LogWarning("Approval {RequestId} was not updated — it may already be resolved.", requestId);
+            ApprovalDecision.Approved => ReasonHumanApproved,
+            ApprovalDecision.Rejected => ReasonHumanRejected,
+            ApprovalDecision.Modified => ReasonHumanModified,
+            ApprovalDecision.TimedOut => ReasonTimeout,
+            ApprovalDecision.Orphaned => ReasonOrphanedOnRestart,
+            _ => throw new ArgumentOutOfRangeException(nameof(decision), decision, "Cannot record Pending as a terminal decision.")
+        };
+
+        (bool won, ApprovalRequest? current) = await TryConditionalTransitionAsync(requestId, decision, reason, comment, ct);
+        if (won)
+        {
+            _logger.LogInformation(
+                "Approval {RequestId} resolved as {Decision} ({Reason}) at {RespondedAt}",
+                requestId, decision, reason, current?.RespondedAt);
+        }
+        else if (current is null)
+        {
+            _logger.LogWarning("Approval {RequestId} was not updated — the request does not exist.", requestId);
         }
         else
         {
-            _logger.LogInformation(
-                "Approval {RequestId} resolved as {Decision} at {RespondedAt}",
-                requestId, decision, now);
+            _logger.LogWarning(
+                "Approval {RequestId} was not updated — it is already {Decision} ({Reason}).",
+                requestId, current.Decision, current.TerminalReason);
         }
+    }
+
+    /// <summary>
+    /// Called by <see cref="ApprovalReconciliationBackgroundService"/> before traffic.
+    /// Walks every Pending row and applies the configured
+    /// <see cref="IApprovalResumeStrategy"/> to rows whose <c>AgentInstanceId</c> is
+    /// not this process. Idempotent — a second call is a no-op because the earlier
+    /// call terminated (or resumed) every eligible row. Rows owned by the current
+    /// instance are always left alone: a genuinely live current-instance waiter
+    /// keeps its Pending row until it wins the terminal update itself.
+    /// </summary>
+    /// <returns>How many Pending rows were terminated during this pass.</returns>
+    public async Task<int> ReconcilePendingAsync(IApprovalResumeStrategy strategy, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(strategy);
+
+        List<ApprovalRequest> pending = await LoadPendingAsync(ct);
+        int terminated = 0;
+        foreach (ApprovalRequest row in pending)
+        {
+            if (row.Decision != ApprovalDecision.Pending)
+                continue;
+
+            // Read the owning instance id via a fresh probe — we deliberately do NOT hoist
+            // AgentInstanceId onto the ApprovalRequest record because the contract (used
+            // by the tool + endpoints) should stay lean. The probe is bounded by the
+            // number of Pending rows at startup, which is tiny.
+            string? owningInstance = await ReadOwningInstanceAsync(row.RequestId, ct);
+            if (owningInstance is null)
+                continue;
+            if (string.Equals(owningInstance, _instanceId, StringComparison.Ordinal))
+                continue;
+
+            ApprovalResumeAction action = await strategy.DecideAsync(row, ct);
+            switch (action)
+            {
+                case ApprovalResumeAction.OrphanTerminal:
+                    (bool won, _) = await TryConditionalTransitionAsync(
+                        row.RequestId,
+                        ApprovalDecision.Orphaned,
+                        ReasonOrphanedOnRestart,
+                        comment: "Approval closed by restart reconciliation — no in-process waiter survived.",
+                        ct);
+                    if (won)
+                    {
+                        terminated++;
+                        _logger.LogWarning(
+                            "Approval {RequestId} orphaned on restart (previous instance {PreviousInstance}, current {CurrentInstance})",
+                            row.RequestId, owningInstance, _instanceId);
+                    }
+                    break;
+                case ApprovalResumeAction.Resume:
+                    // Wave 2 seam. Refresh the owning instance so the resumed execution
+                    // takes ownership and the next reconciliation pass leaves the row alone.
+                    await AdoptRowAsync(row.RequestId, ct);
+                    _logger.LogInformation(
+                        "Approval {RequestId} adopted by current instance {CurrentInstance} for resume (was {PreviousInstance})",
+                        row.RequestId, _instanceId, owningInstance);
+                    break;
+            }
+        }
+
+        return terminated;
     }
 
     public async Task<IReadOnlyList<ApprovalRequest>> GetPendingAsync(string userId, CancellationToken ct = default)
@@ -219,6 +400,109 @@ public sealed class SqliteApprovalGate : IApprovalGate
         return await ReadAllAsync(cmd, ct);
     }
 
+    // ── Race-safe transitions ────────────────────────────────────────────
+
+    private async Task<ApprovalResult> TransitionAndReadAsync(
+        string requestId,
+        ApprovalDecision decision,
+        string reason,
+        string? comment,
+        CancellationToken ct)
+    {
+        (bool _, ApprovalRequest? current) = await TryConditionalTransitionAsync(requestId, decision, reason, comment, ct);
+        if (current is null)
+            throw new KeyNotFoundException($"Approval request '{requestId}' not found.");
+
+        return new ApprovalResult(current.RequestId, current.Decision, current.Comment, current.RespondedAt, current.TerminalReason);
+    }
+
+    private async Task<(bool won, ApprovalRequest? current)> TryConditionalTransitionAsync(
+        string requestId,
+        ApprovalDecision decision,
+        string reason,
+        string? comment,
+        CancellationToken ct)
+    {
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+
+        int affected;
+        await using (SqliteCommand update = conn.CreateCommand())
+        {
+            update.CommandText = """
+                UPDATE ApprovalRequests
+                SET Decision = @decision,
+                    TerminalReason = @reason,
+                    Comment = @comment,
+                    RespondedAt = @respondedAt
+                WHERE RequestId = @id AND Decision = 'Pending'
+                """;
+            update.Parameters.AddWithValue("@id", requestId);
+            update.Parameters.AddWithValue("@decision", decision.ToString());
+            update.Parameters.AddWithValue("@reason", reason);
+            update.Parameters.AddWithValue("@comment", (object?)comment ?? DBNull.Value);
+            update.Parameters.AddWithValue("@respondedAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
+            affected = await update.ExecuteNonQueryAsync(ct);
+        }
+
+        ApprovalRequest? current = await ReadRowAsync(conn, requestId, ct);
+        return (affected == 1, current);
+    }
+
+    private async Task UpdateHeartbeatAsync(SqliteConnection conn, string requestId, CancellationToken ct)
+    {
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        await using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            UPDATE ApprovalRequests
+            SET HeartbeatAt = @heartbeatAt
+            WHERE RequestId = @id AND AgentInstanceId = @instanceId AND Decision = 'Pending'
+            """;
+        cmd.Parameters.AddWithValue("@id", requestId);
+        cmd.Parameters.AddWithValue("@instanceId", _instanceId);
+        cmd.Parameters.AddWithValue("@heartbeatAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private async Task AdoptRowAsync(string requestId, CancellationToken ct)
+    {
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+        await using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            UPDATE ApprovalRequests
+            SET AgentInstanceId = @instanceId, HeartbeatAt = @heartbeatAt
+            WHERE RequestId = @id AND Decision = 'Pending'
+            """;
+        cmd.Parameters.AddWithValue("@id", requestId);
+        cmd.Parameters.AddWithValue("@instanceId", _instanceId);
+        cmd.Parameters.AddWithValue("@heartbeatAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private async Task<List<ApprovalRequest>> LoadPendingAsync(CancellationToken ct)
+    {
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+        await using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT * FROM ApprovalRequests
+            WHERE Decision = 'Pending'
+            ORDER BY CreatedAt ASC
+            """;
+        return await ReadAllAsync(cmd, ct);
+    }
+
+    private async Task<string?> ReadOwningInstanceAsync(string requestId, CancellationToken ct)
+    {
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+        await using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT AgentInstanceId FROM ApprovalRequests WHERE RequestId = @id";
+        cmd.Parameters.AddWithValue("@id", requestId);
+        object? raw = await cmd.ExecuteScalarAsync(ct);
+        return raw is null or DBNull ? null : (string?)raw;
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
 
     private static async Task<ApprovalRequest?> ReadRowAsync(SqliteConnection conn, string requestId, CancellationToken ct = default)
@@ -245,13 +529,17 @@ public sealed class SqliteApprovalGate : IApprovalGate
     private static ApprovalRequest MapRow(SqliteDataReader reader)
     {
         string requestId = reader.GetString(reader.GetOrdinal("RequestId"));
+        string? sessionId = TryGetString(reader, "SessionId");
+        string? conversationId = TryGetString(reader, "ConversationId");
         var context = new ApprovalContext(
             AgentId: reader.GetString(reader.GetOrdinal("AgentId")),
             UserId: reader.GetString(reader.GetOrdinal("UserId")),
             Action: reader.GetString(reader.GetOrdinal("Action")),
             Impact: reader.IsDBNull(reader.GetOrdinal("Impact")) ? "" : reader.GetString(reader.GetOrdinal("Impact")),
             Urgency: reader.IsDBNull(reader.GetOrdinal("Urgency")) ? "medium" : reader.GetString(reader.GetOrdinal("Urgency")),
-            Reasoning: reader.IsDBNull(reader.GetOrdinal("Reasoning")) ? "" : reader.GetString(reader.GetOrdinal("Reasoning"))
+            Reasoning: reader.IsDBNull(reader.GetOrdinal("Reasoning")) ? "" : reader.GetString(reader.GetOrdinal("Reasoning")),
+            SessionId: sessionId,
+            ConversationId: conversationId
         );
 
         string decisionStr = reader.GetString(reader.GetOrdinal("Decision"));
@@ -263,7 +551,16 @@ public sealed class SqliteApprovalGate : IApprovalGate
         DateTimeOffset? respondedAt = reader.IsDBNull(reader.GetOrdinal("RespondedAt"))
             ? null
             : DateTimeOffset.Parse(reader.GetString(reader.GetOrdinal("RespondedAt")), CultureInfo.InvariantCulture);
+        string? terminalReason = TryGetString(reader, "TerminalReason");
 
-        return new ApprovalRequest(requestId, context, createdAt, expiresAt, decision, comment, respondedAt);
+        return new ApprovalRequest(requestId, context, createdAt, expiresAt, decision, comment, respondedAt, terminalReason);
+    }
+
+    private static string? TryGetString(SqliteDataReader reader, string columnName)
+    {
+        int ordinal;
+        try { ordinal = reader.GetOrdinal(columnName); }
+        catch (IndexOutOfRangeException) { return null; }
+        return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
     }
 }

--- a/src/RetailPulse.Api/Approval/SqliteApprovalGate.cs
+++ b/src/RetailPulse.Api/Approval/SqliteApprovalGate.cs
@@ -39,11 +39,6 @@ public sealed class SqliteApprovalGate : IApprovalGate
     private readonly ILogger<SqliteApprovalGate> _logger;
     private readonly TimeSpan _defaultTimeout;
     private readonly TimeProvider _timeProvider;
-    // Per-process instance id — distinguishes waits owned by THIS process from
-    // waits still stored Pending after a restart. New GUID per gate instance so
-    // two gates (e.g., two independent tests) never collide, and a real restart
-    // gets a fresh id so reconciliation can see the previous owner is gone.
-    private readonly string _instanceId;
 
     private const string _iso8601 = "yyyy-MM-ddTHH:mm:ss.fffzzz";
 
@@ -63,11 +58,13 @@ public sealed class SqliteApprovalGate : IApprovalGate
     internal const double BackoffMultiplier = 2.0;
 
     /// <summary>
-    /// Stable identity of the process that owns this gate. Exposed so the
-    /// reconciliation service and tests can assert that reconciliation only touches
-    /// rows written by a DIFFERENT process.
+    /// Stable identity of the process that owns this gate. New GUID per gate
+    /// instance so two gates (e.g., two independent tests) never collide, and a
+    /// real restart gets a fresh id so reconciliation can see the previous owner
+    /// is gone. Exposed so the reconciliation service and tests can assert that
+    /// reconciliation only touches rows written by a DIFFERENT process.
     /// </summary>
-    public string InstanceId => _instanceId;
+    public string InstanceId { get; }
 
     public SqliteApprovalGate(
         string dbPath,
@@ -78,7 +75,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
         _logger = logger;
         _defaultTimeout = defaultTimeout ?? TimeSpan.FromMinutes(5);
         _timeProvider = timeProvider ?? TimeProvider.System;
-        _instanceId = Guid.NewGuid().ToString("N");
+        InstanceId = Guid.NewGuid().ToString("N");
 
         string? dir = Path.GetDirectoryName(dbPath);
         if (!string.IsNullOrEmpty(dir))
@@ -199,7 +196,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
         cmd.Parameters.AddWithValue("@reasoning", (object?)context.Reasoning ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@sessionId", (object?)context.SessionId ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@conversationId", (object?)context.ConversationId ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("@instanceId", _instanceId);
+        cmd.Parameters.AddWithValue("@instanceId", InstanceId);
         cmd.Parameters.AddWithValue("@heartbeatAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
         cmd.Parameters.AddWithValue("@timeoutSeconds", (long)_defaultTimeout.TotalSeconds);
         cmd.Parameters.AddWithValue("@createdAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
@@ -208,7 +205,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
 
         _logger.LogInformation(
             "Approval request {RequestId} created for agent {AgentId}, user {UserId}, urgency {Urgency}, instance {InstanceId}, timeout {TimeoutSeconds}s",
-            requestId, context.AgentId, context.UserId, context.Urgency, _instanceId, (long)_defaultTimeout.TotalSeconds);
+            requestId, context.AgentId, context.UserId, context.Urgency, InstanceId, (long)_defaultTimeout.TotalSeconds);
 
         return new ApprovalRequest(requestId, context, now, expiresAt);
     }
@@ -284,6 +281,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
             ApprovalDecision.Modified => ReasonHumanModified,
             ApprovalDecision.TimedOut => ReasonTimeout,
             ApprovalDecision.Orphaned => ReasonOrphanedOnRestart,
+            ApprovalDecision.Pending => throw new ArgumentOutOfRangeException(nameof(decision), decision, "Cannot record Pending as a terminal decision."),
             _ => throw new ArgumentOutOfRangeException(nameof(decision), decision, "Cannot record Pending as a terminal decision.")
         };
 
@@ -334,7 +332,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
             string? owningInstance = await ReadOwningInstanceAsync(row.RequestId, ct);
             if (owningInstance is null)
                 continue;
-            if (string.Equals(owningInstance, _instanceId, StringComparison.Ordinal))
+            if (string.Equals(owningInstance, InstanceId, StringComparison.Ordinal))
                 continue;
 
             ApprovalResumeAction action = await strategy.DecideAsync(row, ct);
@@ -352,7 +350,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
                         terminated++;
                         _logger.LogWarning(
                             "Approval {RequestId} orphaned on restart (previous instance {PreviousInstance}, current {CurrentInstance})",
-                            row.RequestId, owningInstance, _instanceId);
+                            row.RequestId, owningInstance, InstanceId);
                     }
                     break;
                 case ApprovalResumeAction.Resume:
@@ -361,8 +359,11 @@ public sealed class SqliteApprovalGate : IApprovalGate
                     await AdoptRowAsync(row.RequestId, ct);
                     _logger.LogInformation(
                         "Approval {RequestId} adopted by current instance {CurrentInstance} for resume (was {PreviousInstance})",
-                        row.RequestId, _instanceId, owningInstance);
+                        row.RequestId, InstanceId, owningInstance);
                     break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unknown {nameof(ApprovalResumeAction)} value '{action}' returned by resume strategy.");
             }
         }
 
@@ -410,10 +411,9 @@ public sealed class SqliteApprovalGate : IApprovalGate
         CancellationToken ct)
     {
         (bool _, ApprovalRequest? current) = await TryConditionalTransitionAsync(requestId, decision, reason, comment, ct);
-        if (current is null)
-            throw new KeyNotFoundException($"Approval request '{requestId}' not found.");
-
-        return new ApprovalResult(current.RequestId, current.Decision, current.Comment, current.RespondedAt, current.TerminalReason);
+        return current is null
+            ? throw new KeyNotFoundException($"Approval request '{requestId}' not found.")
+            : new ApprovalResult(current.RequestId, current.Decision, current.Comment, current.RespondedAt, current.TerminalReason);
     }
 
     private async Task<(bool won, ApprovalRequest? current)> TryConditionalTransitionAsync(
@@ -460,7 +460,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
             WHERE RequestId = @id AND AgentInstanceId = @instanceId AND Decision = 'Pending'
             """;
         cmd.Parameters.AddWithValue("@id", requestId);
-        cmd.Parameters.AddWithValue("@instanceId", _instanceId);
+        cmd.Parameters.AddWithValue("@instanceId", InstanceId);
         cmd.Parameters.AddWithValue("@heartbeatAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
         await cmd.ExecuteNonQueryAsync(ct);
     }
@@ -476,7 +476,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
             WHERE RequestId = @id AND Decision = 'Pending'
             """;
         cmd.Parameters.AddWithValue("@id", requestId);
-        cmd.Parameters.AddWithValue("@instanceId", _instanceId);
+        cmd.Parameters.AddWithValue("@instanceId", InstanceId);
         cmd.Parameters.AddWithValue("@heartbeatAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
         await cmd.ExecuteNonQueryAsync(ct);
     }

--- a/src/RetailPulse.Api/Approval/SqliteApprovalGate.cs
+++ b/src/RetailPulse.Api/Approval/SqliteApprovalGate.cs
@@ -17,9 +17,11 @@ namespace RetailPulse.Api.Approval;
 /// <see cref="TimeProvider"/>) instead of fixed-interval polling, and every
 /// Pending → terminal transition is a single conditional SQL update so a
 /// simultaneous human response and timeout race resolves to exactly one persisted
-/// winner. On losing the race the waiter re-reads the row and returns the actual
+/// winner. Both <see cref="WaitForApprovalAsync"/> and <see cref="RespondAsync"/>
+/// re-read the row after their conditional UPDATE and return the actual persisted
 /// winner, so the returned <see cref="ApprovalResult"/> and the stored row always
-/// agree — no double-resolution is possible.
+/// agree — no double-resolution is possible, and the endpoint layer can echo the
+/// returned result verbatim to HTTP callers and SignalR subscribers.
 ///
 /// <para>
 /// Restart safety: every row carries the id of the process that owns its waiter
@@ -272,7 +274,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
         throw new OperationCanceledException(ct);
     }
 
-    public async Task RespondAsync(string requestId, ApprovalDecision decision, string? comment = null, CancellationToken ct = default)
+    public async Task<ApprovalResult> RespondAsync(string requestId, ApprovalDecision decision, string? comment = null, CancellationToken ct = default)
     {
         string reason = decision switch
         {
@@ -286,22 +288,35 @@ public sealed class SqliteApprovalGate : IApprovalGate
         };
 
         (bool won, ApprovalRequest? current) = await TryConditionalTransitionAsync(requestId, decision, reason, comment, ct);
+        if (current is null)
+        {
+            _logger.LogWarning("Approval {RequestId} was not updated — the request does not exist.", requestId);
+            throw new KeyNotFoundException($"Approval request '{requestId}' not found.");
+        }
+
         if (won)
         {
             _logger.LogInformation(
                 "Approval {RequestId} resolved as {Decision} ({Reason}) at {RespondedAt}",
-                requestId, decision, reason, current?.RespondedAt);
-        }
-        else if (current is null)
-        {
-            _logger.LogWarning("Approval {RequestId} was not updated — the request does not exist.", requestId);
+                requestId, decision, reason, current.RespondedAt);
         }
         else
         {
+            // Requested decision lost the race — an earlier terminal write already
+            // owned this row (timeout, orphan reconciliation, or another human).
+            // Return the persisted winner so the caller (endpoint + SignalR) reports
+            // the actual user-visible outcome instead of a decision it did not win.
             _logger.LogWarning(
-                "Approval {RequestId} was not updated — it is already {Decision} ({Reason}).",
-                requestId, current.Decision, current.TerminalReason);
+                "Approval {RequestId} response '{Requested}' rejected — row already terminal as {Decision} ({Reason}).",
+                requestId, decision, current.Decision, current.TerminalReason);
         }
+
+        return new ApprovalResult(
+            current.RequestId,
+            current.Decision,
+            current.Comment,
+            current.RespondedAt,
+            current.TerminalReason);
     }
 
     /// <summary>

--- a/src/RetailPulse.Api/Endpoints/ApprovalEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ApprovalEndpoints.cs
@@ -42,7 +42,8 @@ public static class ApprovalEndpoints
                     requestId = result.RequestId,
                     decision = result.Decision.ToString().ToLowerInvariant(),
                     comment = result.Comment,
-                    respondedAt = result.RespondedAt
+                    respondedAt = result.RespondedAt,
+                    terminalReason = result.TerminalReason
                 });
             }
             catch (KeyNotFoundException)
@@ -56,7 +57,10 @@ public static class ApprovalEndpoints
 
         app.MapPost("/api/approvals/{requestId}/respond", async (string requestId, ApprovalResponseDto body, IApprovalGate gate, IHubContext<TelemetryHub> hubContext, CancellationToken ct) =>
         {
-            if (!Enum.TryParse(body.Decision, true, out ApprovalDecision decision) || decision == ApprovalDecision.Pending || decision == ApprovalDecision.TimedOut)
+            if (!Enum.TryParse(body.Decision, true, out ApprovalDecision decision)
+                || decision is ApprovalDecision.Pending
+                             or ApprovalDecision.TimedOut
+                             or ApprovalDecision.Orphaned)
             {
                 return Results.BadRequest(new { error = "Decision must be 'Approved', 'Rejected', or 'Modified'." });
             }
@@ -102,7 +106,8 @@ public static class ApprovalEndpoints
                 timeoutAt = r.ExpiresAt,
                 status = r.Decision.ToString().ToLowerInvariant(),
                 decidedAt = r.RespondedAt,
-                comment = r.Comment
+                comment = r.Comment,
+                terminalReason = r.TerminalReason
             }));
         })
         .WithName("GetApprovalHistory")

--- a/src/RetailPulse.Api/Endpoints/ApprovalEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ApprovalEndpoints.cs
@@ -67,18 +67,28 @@ public static class ApprovalEndpoints
 
             try
             {
-                await gate.RespondAsync(requestId, decision, body.Comment, ct);
+                // RespondAsync returns the actual persisted winner. If the conditional
+                // Pending → terminal write lost to a timeout, orphan reconciliation, or
+                // another human response, we must NOT echo the caller-requested decision
+                // — the HTTP response and the SignalR broadcast both report the actual
+                // stored outcome so exactly one user-visible resolution is observable.
+                ApprovalResult result = await gate.RespondAsync(requestId, decision, body.Comment, ct);
 
-                // Notify connected dashboard clients of the resolution
-                await hubContext.Clients.All.SendAsync("approval_resolved", new
+                var payload = new
                 {
-                    requestId,
-                    decision = decision.ToString().ToLowerInvariant(),
-                    comment = body.Comment,
-                    respondedAt = DateTimeOffset.UtcNow
-                });
+                    requestId = result.RequestId,
+                    decision = result.Decision.ToString().ToLowerInvariant(),
+                    comment = result.Comment,
+                    respondedAt = result.RespondedAt,
+                    terminalReason = result.TerminalReason
+                };
 
-                return Results.Ok(new { requestId, decision = decision.ToString().ToLowerInvariant(), comment = body.Comment });
+                // Notify connected dashboard clients of the resolution using the persisted
+                // winner so a lost-race response never advertises a decision that was not
+                // recorded.
+                await hubContext.Clients.All.SendAsync("approval_resolved", payload);
+
+                return Results.Ok(payload);
             }
             catch (KeyNotFoundException)
             {

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -604,10 +604,13 @@ builder.Services.AddSingleton(sp =>
         sp.GetRequiredService<TimeProvider>());
 });
 builder.Services.AddSingleton<IApprovalGate>(sp => sp.GetRequiredService<SqliteApprovalGate>());
-// Reconciliation runs before Kestrel accepts traffic (Kestrel is itself a hosted
-// service that starts after all prior IHostedService StartAsync calls complete),
-// so a Pending row abandoned by a previous process cannot slip through into a new
-// human response window.
+// Reconciliation runs during host startup as a hosted service. Ordering with the
+// web host is not strictly guaranteed here — traffic may briefly race the sweep —
+// so correctness does NOT depend on completing before Kestrel accepts requests.
+// Race-safety is enforced at the row: every Pending → terminal write is a single
+// conditional SQL UPDATE and RespondAsync returns the actual persisted winner,
+// so a late human response can never silently overwrite a row that reconciliation
+// (or a concurrent waiter) has already closed.
 builder.Services.AddHostedService<ApprovalReconciliationBackgroundService>();
 
 // Approval tool — available to specialist agents for high-impact recommendations

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -594,7 +594,7 @@ string approvalDbPath = Path.Combine(dataDirectory, "approvals.db");
 builder.Services.Configure<ApprovalOptions>(builder.Configuration.GetSection(ApprovalOptions.SectionName));
 builder.Services.TryAddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<IApprovalResumeStrategy, OrphanUnresumableStrategy>();
-builder.Services.AddSingleton<SqliteApprovalGate>(sp =>
+builder.Services.AddSingleton(sp =>
 {
     ApprovalOptions opts = sp.GetRequiredService<IOptions<ApprovalOptions>>().Value;
     return new SqliteApprovalGate(

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using RetailPulse.Api.Agents;
 using RetailPulse.Api.Agents.Specialists;
@@ -584,8 +585,30 @@ builder.Services.AddScoped(sp =>
 // durable backing. See DataDirectoryResolver.
 string dataDirectory = DataDirectoryResolver.Resolve(builder.Configuration, builder.Environment);
 string approvalDbPath = Path.Combine(dataDirectory, "approvals.db");
-builder.Services.AddSingleton<IApprovalGate>(sp =>
-    new SqliteApprovalGate(approvalDbPath, sp.GetRequiredService<ILogger<SqliteApprovalGate>>()));
+// Human-in-the-loop approval gate. Restart-safe (issue #91): every Pending row
+// carries the durable identity of the process that owns its in-process waiter, the
+// authoritative timeout used to create it, and a heartbeat; the startup
+// reconciliation service closes rows abandoned by a previous process through the
+// configured resume strategy so an approval never silently loses its execution.
+// TimeProvider is injected so timeout/backoff tests never touch the wall clock.
+builder.Services.Configure<ApprovalOptions>(builder.Configuration.GetSection(ApprovalOptions.SectionName));
+builder.Services.TryAddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<IApprovalResumeStrategy, OrphanUnresumableStrategy>();
+builder.Services.AddSingleton<SqliteApprovalGate>(sp =>
+{
+    ApprovalOptions opts = sp.GetRequiredService<IOptions<ApprovalOptions>>().Value;
+    return new SqliteApprovalGate(
+        approvalDbPath,
+        sp.GetRequiredService<ILogger<SqliteApprovalGate>>(),
+        opts.DefaultTimeout,
+        sp.GetRequiredService<TimeProvider>());
+});
+builder.Services.AddSingleton<IApprovalGate>(sp => sp.GetRequiredService<SqliteApprovalGate>());
+// Reconciliation runs before Kestrel accepts traffic (Kestrel is itself a hosted
+// service that starts after all prior IHostedService StartAsync calls complete),
+// so a Pending row abandoned by a previous process cannot slip through into a new
+// human response window.
+builder.Services.AddHostedService<ApprovalReconciliationBackgroundService>();
 
 // Approval tool — available to specialist agents for high-impact recommendations
 builder.Services.AddScoped(sp =>

--- a/src/RetailPulse.Api/appsettings.json
+++ b/src/RetailPulse.Api/appsettings.json
@@ -218,6 +218,33 @@
     "MaxSessionsPerList": 200
   },
 
+  // ---- Human-in-the-loop approval lifecycle (issue #91) -----------------
+  // Every approval request carries a persisted timeout, the owning-process
+  // identity, and a heartbeat. The startup reconciliation service closes any
+  // Pending row abandoned by a previous process through the configured resume
+  // strategy — Wave 1 orphans deterministically (terminal reason
+  // OrphanedOnRestart); Wave 2 (issues #93/#94) will resume from a session/
+  // conversation checkpoint by replacing the strategy registration. All timeout
+  // and backoff behaviour uses an injected TimeProvider so no wall-clock sleep
+  // is required in tests.
+  //
+  //   DefaultTimeout      (default: 5 minutes) — used when the caller omits a
+  //                       timeout; persisted alongside every row so a waiter
+  //                       created after restart honours the row's original SLA.
+  //   HeartbeatInterval   (default: 30 seconds) — observability only; the
+  //                       durable AgentInstanceId is the authoritative liveness
+  //                       signal for reconciliation.
+  //   ReconcileOnStartup  (default: true) — do NOT turn off in production;
+  //                       exposed so tests can construct the gate without the
+  //                       hosted service. Turning it off reintroduces the
+  //                       silent-Pending-across-restart bug this feature exists
+  //                       to fix.
+  "Approval": {
+    "DefaultTimeout": "00:05:00",
+    "HeartbeatInterval": "00:00:30",
+    "ReconcileOnStartup": true
+  },
+
   // ---- Tool-result cache ------------------------------------------------
   "ToolCache": {
     "Enabled": true,

--- a/src/RetailPulse.Contracts/Approval/IApprovalGate.cs
+++ b/src/RetailPulse.Contracts/Approval/IApprovalGate.cs
@@ -29,9 +29,23 @@ public interface IApprovalGate
     Task<ApprovalResult> WaitForApprovalAsync(string requestId, TimeSpan? timeout = null, CancellationToken ct = default);
 
     /// <summary>
-    /// Records a human decision for a pending approval request.
+    /// Records a human decision for a pending approval request via a conditional
+    /// <c>Pending → terminal</c> update, and returns the actual persisted winner
+    /// so callers cannot echo a decision they did not win.
+    ///
+    /// <para>
+    /// If the requested decision wins the race, the returned
+    /// <see cref="ApprovalResult"/> reflects that decision, its terminal reason
+    /// (<c>HumanApproved</c>/<c>HumanRejected</c>/<c>HumanModified</c>), the comment
+    /// supplied here, and the timestamp of the write. If the row was already
+    /// terminal (timeout, orphan reconciliation, or an earlier human response),
+    /// the returned result is the previously persisted winner — never a synthetic
+    /// echo of <paramref name="decision"/>. Endpoint and SignalR payloads must
+    /// report the returned <see cref="ApprovalResult"/>, not the caller-requested
+    /// decision, so exactly one user-visible outcome is observable end-to-end.
+    /// </para>
     /// </summary>
-    Task RespondAsync(string requestId, ApprovalDecision decision, string? comment = null, CancellationToken ct = default);
+    Task<ApprovalResult> RespondAsync(string requestId, ApprovalDecision decision, string? comment = null, CancellationToken ct = default);
 
     /// <summary>
     /// Lists all pending approval requests for a given user.

--- a/src/RetailPulse.Contracts/Approval/IApprovalGate.cs
+++ b/src/RetailPulse.Contracts/Approval/IApprovalGate.cs
@@ -19,7 +19,12 @@ public interface IApprovalGate
 
     /// <summary>
     /// Polls until a decision is recorded or the timeout elapses.
-    /// If the timeout expires, the decision is automatically set to <see cref="ApprovalDecision.TimedOut"/>.
+    /// If the timeout expires, the waiter attempts to transition the request to
+    /// <see cref="ApprovalDecision.TimedOut"/> via a single conditional SQL update
+    /// from <see cref="ApprovalDecision.Pending"/>. On losing that race (a human
+    /// resolved concurrently), the returned <see cref="ApprovalResult"/> reflects
+    /// the actual persisted winner so the caller and the row agree on exactly one
+    /// terminal outcome — never a double resolution.
     /// </summary>
     Task<ApprovalResult> WaitForApprovalAsync(string requestId, TimeSpan? timeout = null, CancellationToken ct = default);
 
@@ -48,7 +53,12 @@ public record ApprovalContext(
     string Action,
     string Impact,
     string Urgency,
-    string Reasoning
+    string Reasoning,
+    // Optional correlation to the durable session/conversation store (issue #90). Wave 1
+    // producers may leave both null; Wave 2 populates them so the resume strategy can
+    // rehydrate a checkpointed execution instead of orphaning on restart.
+    string? SessionId = null,
+    string? ConversationId = null
 );
 
 /// <summary>
@@ -61,7 +71,12 @@ public record ApprovalRequest(
     DateTimeOffset ExpiresAt,
     ApprovalDecision Decision = ApprovalDecision.Pending,
     string? Comment = null,
-    DateTimeOffset? RespondedAt = null
+    DateTimeOffset? RespondedAt = null,
+    // Human-readable reason for the terminal state (e.g., "HumanApproved",
+    // "HumanRejected", "HumanModified", "Timeout", "OrphanedOnRestart"). Null while
+    // the request is still <see cref="ApprovalDecision.Pending"/>. Additive with a
+    // default so existing constructors continue to compile.
+    string? TerminalReason = null
 );
 
 /// <summary>
@@ -71,7 +86,11 @@ public record ApprovalResult(
     string RequestId,
     ApprovalDecision Decision,
     string? Comment,
-    DateTimeOffset? RespondedAt
+    DateTimeOffset? RespondedAt,
+    // Distinguishable terminal reason (see <see cref="ApprovalRequest.TerminalReason"/>).
+    // Additive with a default so the existing surface remains binary-compatible for
+    // callers that only care about <see cref="Decision"/>.
+    string? TerminalReason = null
 );
 
 public enum ApprovalDecision
@@ -80,5 +99,9 @@ public enum ApprovalDecision
     Approved,
     Rejected,
     Modified,
-    TimedOut
+    TimedOut,
+    // Startup reconciliation terminated a request whose owning execution did not
+    // survive a restart and could not be resumed from a checkpoint. See
+    // <see cref="IApprovalResumeStrategy"/> for how Wave 2 replaces this default.
+    Orphaned
 }

--- a/src/RetailPulse.Contracts/Approval/IApprovalResumeStrategy.cs
+++ b/src/RetailPulse.Contracts/Approval/IApprovalResumeStrategy.cs
@@ -1,0 +1,56 @@
+namespace RetailPulse.Contracts.Approval;
+
+/// <summary>
+/// Wave 2 resume seam for approval reconciliation (see issues #93/#94). At startup
+/// the approval gate walks every <see cref="ApprovalDecision.Pending"/> row that
+/// was written by a previous process (identified via the persisted agent-instance
+/// id) and asks this strategy what to do with it.
+///
+/// <para>
+/// Wave 1 ships <c>OrphanUnresumableStrategy</c>, which always returns
+/// <see cref="ApprovalResumeAction.OrphanTerminal"/> — no execution checkpoint
+/// layer exists yet, so a request whose in-process waiter died cannot be resumed
+/// and must be closed deterministically. This preserves the user-visible contract
+/// (exactly one terminal outcome per request) instead of leaving a silent orphan.
+/// </para>
+///
+/// <para>
+/// Wave 2 replaces the registration with a strategy that consults the durable
+/// session/conversation store (issue #90) via
+/// <see cref="ApprovalContext.SessionId"/> / <see cref="ApprovalContext.ConversationId"/>
+/// to rehydrate a checkpointed execution and return
+/// <see cref="ApprovalResumeAction.Resume"/>. The gate keeps the row Pending in that
+/// case and the resumed execution owns the terminal transition. No schema or gate
+/// changes are required for the swap.
+/// </para>
+/// </summary>
+public interface IApprovalResumeStrategy
+{
+    /// <summary>
+    /// Decide the reconciliation action for a Pending approval whose owning agent
+    /// instance is no longer this process. Implementations must be idempotent and
+    /// side-effect free — the gate performs the SQL transition itself, so a strategy
+    /// that runs twice for the same request produces the same answer.
+    /// </summary>
+    Task<ApprovalResumeAction> DecideAsync(ApprovalRequest orphaned, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Outcome the resume strategy asks the gate to apply.
+/// </summary>
+public enum ApprovalResumeAction
+{
+    /// <summary>
+    /// Transition the row to <see cref="ApprovalDecision.Orphaned"/> with terminal
+    /// reason <c>OrphanedOnRestart</c>. The history surface shows a clear terminal
+    /// state instead of a silent stuck Pending.
+    /// </summary>
+    OrphanTerminal,
+
+    /// <summary>
+    /// Leave the row Pending — Wave 2 will rehydrate the checkpointed execution and
+    /// the resumed waiter owns the terminal transition. The gate refreshes the row's
+    /// owning instance and heartbeat so the next reconciliation pass leaves it alone.
+    /// </summary>
+    Resume
+}

--- a/tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs
+++ b/tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs
@@ -395,6 +395,156 @@ public sealed class ApprovalLifecycleTests : IDisposable
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // Endpoint / result contract — RespondAsync must return the persisted
+    // winner (never a caller-echoed decision) so the HTTP response and
+    // SignalR broadcast advertise exactly one user-visible outcome.
+    // See #91 approval hardening.
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Respond_LateHumanResponseAfterTimeout_ReturnsPersistedTimedOutResult()
+    {
+        // Timeout fired via the waiter first; a subsequent human response arrives at
+        // the endpoint. The endpoint must report the persisted TimedOut winner,
+        // not the caller-echoed Approved decision the operator clicked.
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock, TimeSpan.FromSeconds(60));
+        ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
+
+        Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+        for (int i = 0; i < 5; i++)
+        {
+            await Task.Yield();
+            clock.Advance(TimeSpan.FromSeconds(30));
+        }
+        ApprovalResult waiter = await waitTask.WaitAsync(TimeSpan.FromSeconds(5));
+        waiter.Decision.Should().Be(ApprovalDecision.TimedOut);
+
+        ApprovalResult endpointResult = await gate.RespondAsync(req.RequestId, ApprovalDecision.Approved, "late human");
+
+        endpointResult.Decision.Should().Be(ApprovalDecision.TimedOut, "the persisted winner is Timeout — the endpoint MUST NOT echo the caller-requested Approved");
+        endpointResult.TerminalReason.Should().Be(SqliteApprovalGate.ReasonTimeout);
+        endpointResult.Comment.Should().NotBe("late human");
+        endpointResult.RequestId.Should().Be(req.RequestId);
+
+        ApprovalResult stored = await gate.GetResultAsync(req.RequestId);
+        stored.Decision.Should().Be(endpointResult.Decision);
+        stored.TerminalReason.Should().Be(endpointResult.TerminalReason);
+        stored.Comment.Should().Be(endpointResult.Comment);
+        stored.RespondedAt.Should().Be(endpointResult.RespondedAt);
+    }
+
+    [Fact]
+    public async Task Respond_LateHumanResponseAfterOrphan_ReturnsPersistedOrphanedResult()
+    {
+        // Startup reconciliation orphaned the row before the human clicked Approve.
+        // The endpoint must return the persisted Orphaned outcome, not silently
+        // pretend the click succeeded.
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate firstGate = CreateGate(clock);
+        ApprovalRequest req = await firstGate.RequestApprovalAsync(MakeContext(sessionId: "s-orphan"));
+
+        SqliteApprovalGate secondGate = CreateGate(clock);
+        int terminated = await secondGate.ReconcilePendingAsync(new OrphanUnresumableStrategy());
+        terminated.Should().Be(1);
+
+        ApprovalResult endpointResult = await secondGate.RespondAsync(req.RequestId, ApprovalDecision.Approved, "late click");
+
+        endpointResult.Decision.Should().Be(ApprovalDecision.Orphaned, "reconciliation already closed the row — the endpoint MUST NOT echo Approved");
+        endpointResult.TerminalReason.Should().Be(SqliteApprovalGate.ReasonOrphanedOnRestart);
+        endpointResult.Comment.Should().NotBe("late click");
+
+        ApprovalResult stored = await secondGate.GetResultAsync(req.RequestId);
+        stored.Decision.Should().Be(endpointResult.Decision);
+        stored.TerminalReason.Should().Be(endpointResult.TerminalReason);
+        stored.Comment.Should().Be(endpointResult.Comment);
+    }
+
+    [Fact]
+    public async Task Respond_SecondHumanResponse_ReturnsFirstPersistedWinner()
+    {
+        // Two humans (or the same operator double-clicking) racing on one request —
+        // the second RespondAsync must return the FIRST persisted decision, not a
+        // synthetic echo of its own requested decision.
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock);
+        ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
+
+        ApprovalResult first = await gate.RespondAsync(req.RequestId, ApprovalDecision.Approved, "first click");
+        ApprovalResult second = await gate.RespondAsync(req.RequestId, ApprovalDecision.Rejected, "second click");
+
+        first.Decision.Should().Be(ApprovalDecision.Approved);
+        first.Comment.Should().Be("first click");
+        first.TerminalReason.Should().Be(SqliteApprovalGate.ReasonHumanApproved);
+
+        second.Decision.Should().Be(ApprovalDecision.Approved, "the second response MUST return the first persisted winner, not its own requested Rejected");
+        second.Comment.Should().Be("first click");
+        second.TerminalReason.Should().Be(SqliteApprovalGate.ReasonHumanApproved);
+        second.RespondedAt.Should().Be(first.RespondedAt);
+    }
+
+    [Fact]
+    public async Task Respond_MissingRequestId_ThrowsSoEndpointReturnsNotFound()
+    {
+        // The endpoint catches KeyNotFoundException and returns 404; RespondAsync
+        // must surface that condition instead of silently swallowing it.
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock);
+
+        Func<Task<ApprovalResult>> act = () => gate.RespondAsync("does-not-exist", ApprovalDecision.Approved, "ghost");
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task Race_ConcurrentEndpointRespondVsWaiterTimeout_EndpointAndWaiterAgreeExactlyOnce()
+    {
+        // Concurrent human-vs-timeout at the endpoint boundary. RespondAsync (the
+        // endpoint call) and WaitForApprovalAsync (the agent's blocking waiter) must
+        // return the same terminal decision, matching the durable row exactly.
+        for (int trial = 0; trial < 15; trial++)
+        {
+            string dbPath = Path.Combine(Path.GetTempPath(), $"approval_endpoint_race_{Guid.NewGuid():N}.db");
+            try
+            {
+                var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+                SqliteApprovalGate gate = new(dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(), TimeSpan.FromSeconds(60), clock);
+                ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
+
+                Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+                Task<ApprovalResult> endpointTask = Task.Run(async () =>
+                {
+                    await Task.Yield();
+                    return await gate.RespondAsync(req.RequestId, ApprovalDecision.Approved, "raced-endpoint");
+                });
+
+                clock.Advance(TimeSpan.FromSeconds(120));
+                await Task.WhenAll(waitTask, endpointTask).WaitAsync(TimeSpan.FromSeconds(5));
+
+                ApprovalResult waiter = await waitTask;
+                ApprovalResult endpoint = await endpointTask;
+                ApprovalResult stored = await gate.GetResultAsync(req.RequestId);
+
+                waiter.Decision.Should().BeOneOf(ApprovalDecision.Approved, ApprovalDecision.TimedOut);
+                endpoint.Decision.Should().Be(waiter.Decision, "the endpoint MUST report the same terminal outcome the waiter observes");
+                endpoint.TerminalReason.Should().Be(waiter.TerminalReason);
+                endpoint.Comment.Should().Be(waiter.Comment);
+                endpoint.RespondedAt.Should().Be(waiter.RespondedAt);
+
+                stored.Decision.Should().Be(endpoint.Decision, "the endpoint result MUST match the durable row exactly");
+                stored.TerminalReason.Should().Be(endpoint.TerminalReason);
+                stored.Comment.Should().Be(endpoint.Comment);
+                stored.RespondedAt.Should().Be(endpoint.RespondedAt);
+            }
+            finally
+            {
+                try { File.Delete(dbPath); } catch { }
+                try { File.Delete(dbPath + "-wal"); } catch { }
+                try { File.Delete(dbPath + "-shm"); } catch { }
+            }
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // Test fixtures — resume strategies + fake clock. The clock also supports
     // Task.Delay(TimeSpan, TimeProvider, CancellationToken) by scheduling every
     // callback registered through CreateTimer and firing them when Advance

--- a/tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs
+++ b/tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs
@@ -1,0 +1,510 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Approval;
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Tests.Approval;
+
+/// <summary>
+/// Issue #91 — approval lifecycle hardening. Exercises the durable-restart,
+/// idempotent-reconciliation, deterministic-clock-timeout, and simultaneous
+/// approve-vs-timeout race invariants using an injected <see cref="TimeProvider"/>
+/// so no test touches the wall clock.
+/// </summary>
+public sealed class ApprovalLifecycleTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public ApprovalLifecycleTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"approval_lifecycle_{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { }
+        try { File.Delete(_dbPath + "-wal"); } catch { }
+        try { File.Delete(_dbPath + "-shm"); } catch { }
+    }
+
+    private SqliteApprovalGate CreateGate(TimeProvider clock, TimeSpan? defaultTimeout = null)
+        => new(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(), defaultTimeout ?? TimeSpan.FromMinutes(5), clock);
+
+    private static ApprovalContext MakeContext(
+        string agentId = "agent-1",
+        string userId = "user-1",
+        string action = "Test action",
+        string? sessionId = null,
+        string? conversationId = null) =>
+        new(agentId, userId, action, "Low", "medium", "Testing", sessionId, conversationId);
+
+    // ────────────────────────────────────────────────────────────────────
+    // Restart reconciliation — the core scenario the bug describes:
+    // create a request, drop the gate (simulated crash), a fresh gate
+    // reconciles the abandoned row so a later approval attempt cannot
+    // silently succeed on a request whose execution is gone.
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Restart_AbandonedPendingRow_IsOrphanedByReconciliation()
+    {
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+
+        string requestId;
+        SqliteApprovalGate firstGate = CreateGate(clock);
+        ApprovalRequest req = await firstGate.RequestApprovalAsync(MakeContext(sessionId: "s-1", conversationId: "c-1"));
+        requestId = req.RequestId;
+        // Simulate process exit: drop the reference to the gate; the row is still
+        // Pending on disk owned by firstGate.InstanceId.
+        string previousInstance = firstGate.InstanceId;
+
+        SqliteApprovalGate secondGate = CreateGate(clock);
+        int terminated = await secondGate.ReconcilePendingAsync(new OrphanUnresumableStrategy());
+
+        terminated.Should().Be(1);
+        ApprovalResult result = await secondGate.GetResultAsync(requestId);
+        result.Decision.Should().Be(ApprovalDecision.Orphaned);
+        result.TerminalReason.Should().Be(SqliteApprovalGate.ReasonOrphanedOnRestart);
+        secondGate.InstanceId.Should().NotBe(previousInstance);
+    }
+
+    [Fact]
+    public async Task Restart_ApprovingOrphanedRow_HasNoEffect()
+    {
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate firstGate = CreateGate(clock);
+        ApprovalRequest req = await firstGate.RequestApprovalAsync(MakeContext());
+
+        SqliteApprovalGate secondGate = CreateGate(clock);
+        await secondGate.ReconcilePendingAsync(new OrphanUnresumableStrategy());
+
+        // A human trying to approve a row that reconciliation already closed must NOT
+        // silently overwrite the terminal outcome. This is the user-visible guarantee
+        // that a late "approve" cannot mislead the caller into thinking a dead
+        // execution resumed.
+        await secondGate.RespondAsync(req.RequestId, ApprovalDecision.Approved, "late");
+
+        ApprovalResult result = await secondGate.GetResultAsync(req.RequestId);
+        result.Decision.Should().Be(ApprovalDecision.Orphaned);
+        result.TerminalReason.Should().Be(SqliteApprovalGate.ReasonOrphanedOnRestart);
+        result.Comment.Should().NotBe("late");
+    }
+
+    [Fact]
+    public async Task Reconciliation_LeavesCurrentInstancePendingRowsAlone()
+    {
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock);
+
+        ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
+
+        // Same gate reconciles: the row belongs to this instance, so it must stay Pending.
+        int terminated = await gate.ReconcilePendingAsync(new OrphanUnresumableStrategy());
+
+        terminated.Should().Be(0);
+        ApprovalResult result = await gate.GetResultAsync(req.RequestId);
+        result.Decision.Should().Be(ApprovalDecision.Pending);
+    }
+
+    [Fact]
+    public async Task Reconciliation_IsIdempotent()
+    {
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate firstGate = CreateGate(clock);
+        ApprovalRequest req = await firstGate.RequestApprovalAsync(MakeContext());
+
+        SqliteApprovalGate secondGate = CreateGate(clock);
+        var strategy = new CountingStrategy();
+
+        int first = await secondGate.ReconcilePendingAsync(strategy);
+        int second = await secondGate.ReconcilePendingAsync(strategy);
+        int third = await secondGate.ReconcilePendingAsync(strategy);
+
+        first.Should().Be(1);
+        second.Should().Be(0, "second sweep has no Pending rows left to orphan");
+        third.Should().Be(0);
+        // The strategy is only consulted for candidate Pending rows on each pass, and
+        // after the first pass there are no such rows — so it was called exactly once.
+        strategy.Calls.Should().Be(1);
+
+        ApprovalResult result = await secondGate.GetResultAsync(req.RequestId);
+        result.Decision.Should().Be(ApprovalDecision.Orphaned);
+    }
+
+    [Fact]
+    public async Task Reconciliation_ResumeAction_AdoptsRowInsteadOfOrphaning()
+    {
+        // Wave 2 seam behaviour: a resume strategy keeps the row Pending and the
+        // reconciliation transfers ownership to the current instance so the next
+        // sweep leaves it alone.
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate firstGate = CreateGate(clock);
+        ApprovalRequest req = await firstGate.RequestApprovalAsync(MakeContext(sessionId: "s-42"));
+
+        SqliteApprovalGate secondGate = CreateGate(clock);
+        var resumeStrategy = new ResumeStrategy();
+
+        int firstSweep = await secondGate.ReconcilePendingAsync(resumeStrategy);
+        int secondSweep = await secondGate.ReconcilePendingAsync(resumeStrategy);
+
+        firstSweep.Should().Be(0, "resume keeps the row Pending");
+        secondSweep.Should().Be(0, "second sweep sees the row is now owned by this instance");
+        resumeStrategy.Calls.Should().Be(1);
+
+        ApprovalResult result = await secondGate.GetResultAsync(req.RequestId);
+        result.Decision.Should().Be(ApprovalDecision.Pending);
+
+        // And a subsequent human response is now honoured because the resumed
+        // execution owns the row.
+        await secondGate.RespondAsync(req.RequestId, ApprovalDecision.Approved, "resumed");
+        ApprovalResult after = await secondGate.GetResultAsync(req.RequestId);
+        after.Decision.Should().Be(ApprovalDecision.Approved);
+        after.TerminalReason.Should().Be(SqliteApprovalGate.ReasonHumanApproved);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Injected-clock timeout — the waiter advances only because the fake
+    // clock advances; no wall-clock sleep is involved.
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task InjectedClock_TimeoutFires_Deterministically()
+    {
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock, TimeSpan.FromSeconds(60));
+        ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
+
+        Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+
+        // Nudge scheduled work by advancing the fake clock past the deadline in slices.
+        for (int i = 0; i < 5; i++)
+        {
+            await Task.Yield();
+            clock.Advance(TimeSpan.FromSeconds(30));
+        }
+
+        ApprovalResult result = await waitTask.WaitAsync(TimeSpan.FromSeconds(5));
+        result.Decision.Should().Be(ApprovalDecision.TimedOut);
+        result.TerminalReason.Should().Be(SqliteApprovalGate.ReasonTimeout);
+    }
+
+    [Fact]
+    public async Task InjectedClock_HumanResponseBeforeDeadline_WinsAndAgreesWithRow()
+    {
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock, TimeSpan.FromSeconds(60));
+        ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
+
+        Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+
+        await Task.Yield();
+        await gate.RespondAsync(req.RequestId, ApprovalDecision.Approved, "green-lit");
+
+        // Advance clock enough to release the next backoff tick without crossing the deadline.
+        clock.Advance(TimeSpan.FromSeconds(1));
+
+        ApprovalResult result = await waitTask.WaitAsync(TimeSpan.FromSeconds(5));
+        result.Decision.Should().Be(ApprovalDecision.Approved);
+        result.Comment.Should().Be("green-lit");
+        result.TerminalReason.Should().Be(SqliteApprovalGate.ReasonHumanApproved);
+
+        ApprovalResult stored = await gate.GetResultAsync(req.RequestId);
+        stored.Decision.Should().Be(result.Decision);
+        stored.TerminalReason.Should().Be(result.TerminalReason);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Simultaneous approve-vs-timeout race — the exact invariant issue
+    // #91 calls out. Whichever side wins the conditional UPDATE first,
+    // the waiter and the row must agree on exactly one terminal outcome.
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Race_ApproveAtTheDeadline_ExactlyOneTerminalOutcome_HumanWins()
+    {
+        // The waiter's timeout branch does UPDATE ... WHERE Decision = 'Pending'.
+        // If the human beat the waiter to the UPDATE, the waiter's UPDATE affects 0
+        // rows and it must return the human's persisted decision — not TimedOut.
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock, TimeSpan.FromSeconds(60));
+        ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
+
+        // Simulate the human sneaking in first: the row is already Modified.
+        await gate.RespondAsync(req.RequestId, ApprovalDecision.Modified, "scoped down");
+
+        Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+        clock.Advance(TimeSpan.FromSeconds(120));
+
+        ApprovalResult result = await waitTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        result.Decision.Should().Be(ApprovalDecision.Modified, "the human already resolved the row before the waiter tried to time out");
+        result.TerminalReason.Should().Be(SqliteApprovalGate.ReasonHumanModified);
+        result.Comment.Should().Be("scoped down");
+
+        ApprovalResult stored = await gate.GetResultAsync(req.RequestId);
+        stored.Decision.Should().Be(result.Decision);
+        stored.TerminalReason.Should().Be(result.TerminalReason);
+        stored.Comment.Should().Be(result.Comment);
+    }
+
+    [Fact]
+    public async Task Race_HumanApproveAndWaiterTimeout_InterleavedFireOnce_ExactlyOneWinner()
+    {
+        // Kick both terminal writers at the exact deadline moment repeatedly to
+        // maximise the odds of an interleaving; assert the invariant on every
+        // iteration: the row and the waiter always report one and only one
+        // terminal decision and it is one of {Approved, TimedOut}.
+        for (int trial = 0; trial < 15; trial++)
+        {
+            string dbPath = Path.Combine(Path.GetTempPath(), $"approval_race_{Guid.NewGuid():N}.db");
+            try
+            {
+                var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+                SqliteApprovalGate gate = new(dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(), TimeSpan.FromSeconds(60), clock);
+                ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
+
+                Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+                var humanTask = Task.Run(async () =>
+                {
+                    // Give the waiter a moment to see Pending once, then race the
+                    // human response against the timeout.
+                    await Task.Yield();
+                    await gate.RespondAsync(req.RequestId, ApprovalDecision.Approved, "raced");
+                });
+
+                clock.Advance(TimeSpan.FromSeconds(120));
+                await Task.WhenAll(waitTask, humanTask).WaitAsync(TimeSpan.FromSeconds(5));
+
+                ApprovalResult waiter = await waitTask;
+                ApprovalResult stored = await gate.GetResultAsync(req.RequestId);
+
+                waiter.Decision.Should().BeOneOf(ApprovalDecision.Approved, ApprovalDecision.TimedOut);
+                stored.Decision.Should().Be(waiter.Decision, "the returned result must match the durable row exactly");
+                stored.TerminalReason.Should().Be(waiter.TerminalReason);
+                stored.Comment.Should().Be(waiter.Comment);
+                stored.RespondedAt.Should().Be(waiter.RespondedAt);
+            }
+            finally
+            {
+                try { File.Delete(dbPath); } catch { }
+                try { File.Delete(dbPath + "-wal"); } catch { }
+                try { File.Delete(dbPath + "-shm"); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Race_TwoWaitersOnSameRequest_SameTerminalOutcome()
+    {
+        // Two waiters (e.g., a retry) observing the same request must both return
+        // the same terminal outcome — the conditional UPDATE guarantees at most one
+        // writer flips Pending, and the other side re-reads the actual winner.
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock, TimeSpan.FromSeconds(60));
+        ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
+
+        Task<ApprovalResult> a = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+        Task<ApprovalResult> b = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+
+        clock.Advance(TimeSpan.FromSeconds(120));
+        ApprovalResult[] results = await Task.WhenAll(a, b).WaitAsync(TimeSpan.FromSeconds(5));
+
+        results[0].Decision.Should().Be(results[1].Decision);
+        results[0].Decision.Should().Be(ApprovalDecision.TimedOut);
+        results[0].TerminalReason.Should().Be(SqliteApprovalGate.ReasonTimeout);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Configuration surface
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConfiguredDefaultTimeout_IsUsedByRequestAndWait()
+    {
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock, TimeSpan.FromSeconds(45));
+
+        ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
+        // Expiration on the returned record uses the configured default.
+        (req.ExpiresAt - req.CreatedAt).Should().Be(TimeSpan.FromSeconds(45));
+
+        Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId);
+        clock.Advance(TimeSpan.FromSeconds(90));
+
+        ApprovalResult result = await waitTask.WaitAsync(TimeSpan.FromSeconds(5));
+        result.Decision.Should().Be(ApprovalDecision.TimedOut);
+    }
+
+    [Fact]
+    public async Task Correlation_SessionAndConversationIdsRoundTrip()
+    {
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock);
+        ApprovalContext ctx = MakeContext(sessionId: "sess-abc", conversationId: "conv-xyz");
+
+        await gate.RequestApprovalAsync(ctx);
+
+        IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync("user-1");
+        pending.Should().ContainSingle();
+        pending[0].Context.SessionId.Should().Be("sess-abc");
+        pending[0].Context.ConversationId.Should().Be("conv-xyz");
+    }
+
+    [Fact]
+    public async Task StartupService_Skipped_WhenReconcileDisabled()
+    {
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate firstGate = CreateGate(clock);
+        ApprovalRequest req = await firstGate.RequestApprovalAsync(MakeContext());
+
+        SqliteApprovalGate secondGate = CreateGate(clock);
+        IOptions<ApprovalOptions> opts = Options.Create(new ApprovalOptions { ReconcileOnStartup = false });
+        var svc = new ApprovalReconciliationBackgroundService(
+            secondGate,
+            new OrphanUnresumableStrategy(),
+            opts,
+            Mock.Of<ILogger<ApprovalReconciliationBackgroundService>>());
+
+        await svc.StartAsync(CancellationToken.None);
+
+        ApprovalResult result = await secondGate.GetResultAsync(req.RequestId);
+        result.Decision.Should().Be(ApprovalDecision.Pending, "reconciliation disabled leaves rows alone");
+    }
+
+    [Fact]
+    public async Task StartupService_Enabled_OrphansAbandonedRow()
+    {
+        var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate firstGate = CreateGate(clock);
+        ApprovalRequest req = await firstGate.RequestApprovalAsync(MakeContext());
+
+        SqliteApprovalGate secondGate = CreateGate(clock);
+        var svc = new ApprovalReconciliationBackgroundService(
+            secondGate,
+            new OrphanUnresumableStrategy(),
+            Options.Create(new ApprovalOptions()),
+            Mock.Of<ILogger<ApprovalReconciliationBackgroundService>>());
+
+        await svc.StartAsync(CancellationToken.None);
+
+        ApprovalResult result = await secondGate.GetResultAsync(req.RequestId);
+        result.Decision.Should().Be(ApprovalDecision.Orphaned);
+        result.TerminalReason.Should().Be(SqliteApprovalGate.ReasonOrphanedOnRestart);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Test fixtures — resume strategies + fake clock. The clock also supports
+    // Task.Delay(TimeSpan, TimeProvider, CancellationToken) by scheduling every
+    // callback registered through CreateTimer and firing them when Advance
+    // crosses their due time.
+    // ────────────────────────────────────────────────────────────────────
+
+    private sealed class CountingStrategy : IApprovalResumeStrategy
+    {
+        public int Calls { get; private set; }
+        public Task<ApprovalResumeAction> DecideAsync(ApprovalRequest orphaned, CancellationToken ct = default)
+        {
+            Calls++;
+            return Task.FromResult(ApprovalResumeAction.OrphanTerminal);
+        }
+    }
+
+    private sealed class ResumeStrategy : IApprovalResumeStrategy
+    {
+        public int Calls { get; private set; }
+        public Task<ApprovalResumeAction> DecideAsync(ApprovalRequest orphaned, CancellationToken ct = default)
+        {
+            Calls++;
+            return Task.FromResult(ApprovalResumeAction.Resume);
+        }
+    }
+
+    /// <summary>
+    /// Deterministic <see cref="TimeProvider"/> used across the lifecycle suite.
+    /// Supports <see cref="Task.Delay(TimeSpan, TimeProvider, CancellationToken)"/>
+    /// by firing every scheduled timer when <see cref="Advance"/> covers its due time,
+    /// so the exponential-backoff loop in <see cref="SqliteApprovalGate.WaitForApprovalAsync"/>
+    /// runs synchronously with the test's clock advances — never with the wall clock.
+    /// </summary>
+    internal sealed class FakeClock : TimeProvider
+    {
+        private DateTimeOffset _now;
+        private readonly Lock _lock = new();
+        private readonly List<FakeTimer> _timers = [];
+
+        public FakeClock(DateTimeOffset start) { _now = start; }
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            lock (_lock) return _now;
+        }
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var t = new FakeTimer(this, callback, state, dueTime, period);
+            lock (_lock) _timers.Add(t);
+            return t;
+        }
+
+        public void Advance(TimeSpan delta)
+        {
+            List<FakeTimer> snapshot;
+            lock (_lock)
+            {
+                _now += delta;
+                snapshot = [.. _timers];
+            }
+            foreach (FakeTimer t in snapshot) t.Tick(delta);
+        }
+
+        internal void Remove(FakeTimer t)
+        {
+            lock (_lock) _timers.Remove(t);
+        }
+    }
+
+    internal sealed class FakeTimer : ITimer
+    {
+        private readonly FakeClock _clock;
+        private readonly TimerCallback _callback;
+        private readonly object? _state;
+        private TimeSpan _dueTime;
+        private TimeSpan _period;
+        private TimeSpan _accum;
+        private bool _disposed;
+
+        public FakeTimer(FakeClock clock, TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            _clock = clock;
+            _callback = callback;
+            _state = state;
+            _dueTime = dueTime;
+            _period = period;
+        }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            _dueTime = dueTime;
+            _period = period;
+            _accum = TimeSpan.Zero;
+            return true;
+        }
+
+        public void Tick(TimeSpan delta)
+        {
+            if (_disposed) return;
+            _accum += delta;
+            while (!_disposed && _accum >= _dueTime && _dueTime > TimeSpan.Zero)
+            {
+                _accum -= _dueTime;
+                _dueTime = _period > TimeSpan.Zero ? _period : Timeout.InfiniteTimeSpan;
+                _callback(_state);
+            }
+        }
+
+        public void Dispose() { _disposed = true; _clock.Remove(this); }
+        public ValueTask DisposeAsync() { Dispose(); return ValueTask.CompletedTask; }
+    }
+}


### PR DESCRIPTION
## Summary

- persist approval ownership, heartbeat, session/conversation correlation, authoritative timeout, and terminal reason
- reconcile prior-instance pending approvals idempotently at startup, with a replaceable resume strategy
- make timeout, human response, and orphan reconciliation share one atomic pending-to-terminal transition and return the persisted winner
- expose the actual terminal outcome consistently through waiter results, HTTP responses, SignalR, status, and history
- add deterministic injected-clock restart, idempotency, timeout, happy-path, and simultaneous human-vs-timeout race coverage

## Lifecycle contract

Every resolution executes a conditional SQLite update from `Pending` and then reads the persisted row. Timeout, approve/reject/modify, startup orphaning, and late/concurrent responses therefore converge on exactly one terminal winner; losing actors return that winner rather than reporting the decision they attempted.

Startup reconciliation identifies rows owned by a prior API instance. Wave 1 resolves unresumable rows as `Orphaned` with a clear terminal reason. Current-instance waits are left untouched, and reconciliation can run repeatedly without changing terminal records.

## Wave 2 resume seam

`IApprovalResumeStrategy` is the upgrade seam for #93/#94. Approval rows already persist `SessionId` and `ConversationId`; a checkpoint-aware strategy can use those values to locate durable execution state and return `Resume`. Reconciliation then adopts the row into the current process instead of orphaning it. Replacing the DI strategy is sufficient—no approval schema or transition rewrite is required.

## Configuration

`Approval:DefaultTimeout` defaults to five minutes. `HeartbeatInterval` and `ReconcileOnStartup` are also explicit and documented in `appsettings.json`.

## Validation

- `dotnet test tests\RetailPulse.Tests\RetailPulse.Tests.csproj --nologo` — 2,874 passed
- focused approval suites — 107 passed
- `dotnet build src\RetailPulse.Api\RetailPulse.Api.csproj` — 0 warnings, 0 errors
- `dotnet format --verify-no-changes RetailPulse.slnx`
- Publix review: approved
- Kroger final architecture/code review: approved

Working as Costco (Backend Dev), routed and reviewed by Kroger (Lead).

Closes #91