### PR TITLE
feat(rag): optional Azure AI Search knowledge provider (issue #103)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Azure.AI.Projects" Version="2.0.1" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
+    <PackageVersion Include="Azure.Search.Documents" Version="12.0.0" />
     <!-- Microsoft Agents Framework -->
     <PackageVersion Include="Microsoft.Agents.AI" Version="1.18.0" />
     <PackageVersion Include="Microsoft.Agents.AI.Abstractions" Version="1.18.0" />

--- a/azd-hooks/postprovision.ps1
+++ b/azd-hooks/postprovision.ps1
@@ -156,6 +156,44 @@ if ($contentSafetyEnabled -and $contentSafetyEnabled.Trim().ToLowerInvariant() -
     }
 }
 
+# ── Optional Azure AI Search RBAC (issue #103) ─────────────────────────────
+# When AZURE_AI_SEARCH_ENABLED=true, grant every container app's system-assigned
+# identity the two roles required by the API:
+#   * "Search Service Contributor" — needed once, so the app can auto-create /
+#     inspect the index (Program.cs ensures the index exists at first probe).
+#   * "Search Index Data Contributor" — required for ingest + delete + document
+#     CRUD against the target index.
+# Both assignments are idempotent (JMESPath filter on principalId + role name
+# client-side), so a re-provision never duplicates the role.
+$aiSearchEnabled = [Environment]::GetEnvironmentVariable('AZURE_AI_SEARCH_ENABLED')
+$aiSearchResourceId = [Environment]::GetEnvironmentVariable('AZURE_AI_SEARCH_RESOURCE_ID')
+if ($aiSearchEnabled -and $aiSearchEnabled.Trim().ToLowerInvariant() -eq 'true' -and -not [string]::IsNullOrWhiteSpace($aiSearchResourceId)) {
+    Write-Host ''
+    Write-Host 'Granting Azure AI Search roles to each container app system identity...'
+    foreach ($app in $apps) {
+        $searchPrincipalId = (Invoke-Az `
+            -Arguments @('containerapp', 'show', '--name', $app, '--resource-group', $resourceGroup, '--query', 'identity.principalId', '--output', 'tsv') `
+            -FailureMessage "Failed to read container app '$app' principalId for AI Search role assignment" | Out-String).Trim()
+        if ([string]::IsNullOrWhiteSpace($searchPrincipalId)) { continue }
+
+        foreach ($role in @('Search Service Contributor', 'Search Index Data Contributor')) {
+            $searchExisting = (Invoke-Az `
+                -Arguments @('role', 'assignment', 'list', '--scope', $aiSearchResourceId, '--query', "[?principalId=='$searchPrincipalId' && roleDefinitionName=='$role'].id", '--output', 'tsv') `
+                -FailureMessage "Failed to list AI Search role assignments for '$app'" | Out-String).Trim()
+
+            if ([string]::IsNullOrWhiteSpace($searchExisting)) {
+                Write-Host "-> $app : granting '$role' to $searchPrincipalId"
+                Invoke-Az `
+                    -Arguments @('role', 'assignment', 'create', '--assignee-object-id', $searchPrincipalId, '--assignee-principal-type', 'ServicePrincipal', '--role', $role, '--scope', $aiSearchResourceId, '--output', 'none') `
+                    -FailureMessage "Failed to grant '$role' to '$app' on the AI Search service" | Out-Null
+            }
+            else {
+                Write-Host "-> $app : '$role' already present"
+            }
+        }
+    }
+}
+
 # ── Mandatory APIM AI Gateway live gate (issue #67) ────────────────────────
 # `azd provision` reporting "Succeeded" only means the ARM deployments
 # succeeded — it says nothing about whether the AI Gateway invariants

--- a/azd-hooks/postprovision.sh
+++ b/azd-hooks/postprovision.sh
@@ -164,6 +164,51 @@ if [ "$content_safety_enabled" = "true" ] && [ -n "$content_safety_resource_id" 
     done
 fi
 
+# ── Optional Azure AI Search RBAC (issue #103) ─────────────────────────────
+# When AZURE_AI_SEARCH_ENABLED=true, grant every container app's system-assigned
+# identity the two roles required by the API:
+#   * "Search Service Contributor" — needed once, so the app can auto-create /
+#     inspect the index (Program.cs ensures the index exists at first probe).
+#   * "Search Index Data Contributor" — required for ingest + delete +
+#     document CRUD against the target index.
+# Both assignments are idempotent (JMESPath filter on principalId + role name
+# client-side), so a re-provision never duplicates the role.
+ai_search_enabled=$(printf '%s' "${AZURE_AI_SEARCH_ENABLED:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+ai_search_resource_id="${AZURE_AI_SEARCH_RESOURCE_ID:-}"
+if [ "$ai_search_enabled" = "true" ] && [ -n "$ai_search_resource_id" ]; then
+    echo ''
+    echo 'Granting Azure AI Search roles to each container app system identity...'
+    for app in "$AZURE_API_APP_NAME" "$AZURE_MCP_SERVER_APP_NAME" "$AZURE_TEAMS_BOT_APP_NAME"; do
+        search_principal_id=$(az containerapp show \
+            --name "$app" \
+            --resource-group "$resource_group" \
+            --query 'identity.principalId' \
+            --output tsv)
+        if [ -z "$search_principal_id" ]; then
+            continue
+        fi
+
+        for role in 'Search Service Contributor' 'Search Index Data Contributor'; do
+            search_existing=$(az role assignment list \
+                --scope "$ai_search_resource_id" \
+                --query "[?principalId=='$search_principal_id' && roleDefinitionName=='$role'].id" \
+                --output tsv)
+
+            if [ -z "$search_existing" ]; then
+                echo "-> $app : granting '$role' to $search_principal_id"
+                az role assignment create \
+                    --assignee-object-id "$search_principal_id" \
+                    --assignee-principal-type ServicePrincipal \
+                    --role "$role" \
+                    --scope "$ai_search_resource_id" \
+                    --output none
+            else
+                echo "-> $app : '$role' already present"
+            fi
+        done
+    done
+fi
+
 # ── Mandatory APIM AI Gateway live gate (issue #67) ────────────────────────
 # See postprovision.ps1 for the full rationale: a successful `azd provision`
 # only means the ARM deployments succeeded, not that the AI Gateway

--- a/docs/adr/012-azure-ai-search-provider.md
+++ b/docs/adr/012-azure-ai-search-provider.md
@@ -1,0 +1,208 @@
+# ADR-012: Optional Azure AI Search knowledge provider
+
+## Status
+
+Accepted (issue #103 — Wave 5 cloud-provider implementation).
+
+## Context
+
+ADR-009 shipped the provider seam behind `IKnowledgeBase` and left the
+cloud implementations for follow-on issues. `InMemoryKnowledgeBase` scores
+documents with BM25 over a `ConcurrentDictionary`, capped at 100 documents
+and 5,000 chunks, and is entirely volatile.
+
+For deployments that want to ground responses in a substantial corpus
+(planogram standards, supplier terms, merchandising playbooks, category
+guidelines) the in-memory provider has two hard ceilings the abstraction
+layer cannot paper over:
+
+- Lexical BM25 misses paraphrase. "How do I coordinate with vendors on
+  shelf layouts?" and "Category management defines the role and metrics
+  for every merchandising category." belong together, but BM25 finds few
+  overlapping terms and scores them apart.
+- The corpus does not survive a restart. Uploaded documents live in
+  process memory only.
+
+We want an opt-in provider that adds durable, semantically-retrievable
+storage without turning cloud resources into a hard dependency. The
+laptop demo must remain a laptop demo — no `azd up` required.
+
+## Decision
+
+Implement `AzureAISearchKnowledgeBase` as an opt-in `IKnowledgeBase`
+provider that plugs into the ADR-009 seam. The provider is fully
+optional at every layer:
+
+- Configuration: `Knowledge:AzureAISearch:Endpoint` blank → nothing
+  registered.
+- DI: When the endpoint is blank the extension method is a no-op — no
+  Search SDK client, no HTTP handler, no credential, no
+  `IKnowledgeProviderContribution`.
+- Infrastructure: `aiSearchEnabled=false` (the default) leaves the Bicep
+  path unchanged — no Search service, no role assignments, no cost.
+- Runtime: `Knowledge:Provider:Mode` defaults to `InMemory`; selecting
+  `AzureAISearch` without wiring the extension throws with an actionable
+  message via `KnowledgeProviderRegistry` (never a silent degradation).
+
+### 1. Retrieval
+
+Queries use Azure AI Search's hybrid ranking:
+
+1. Compute the query embedding via the APIM AI Gateway.
+2. Issue a hybrid Search query that combines a BM25 lexical pass over
+   `title` + `content` with a k-nearest-neighbour vector pass over
+   `contentVector`.
+3. When `SemanticRankingEnabled=true`, the top-k RRF-fused hits are
+   reranked by the semantic ranker.
+
+Scores are provider-local: the RRF score has no relationship to a BM25
+score, and the semantic reranker returns its own scale. `GetCapabilities`
+reports the honest range and includes the ADR-009 reminder that scores
+are NOT comparable across providers.
+
+### 2. Index schema
+
+A single index holds one document per chunk. Fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | Edm.String, key, filterable | `<documentId>_<chunkIndex:D4>` |
+| `documentId` | Edm.String, filterable | Groups chunks per document |
+| `chunkIndex` | Edm.Int32, filterable, sortable | Ordering |
+| `title` | Edm.String, searchable+filterable+sortable, en.lucene | |
+| `content` | Edm.String, searchable, en.lucene | Chunk text |
+| `source` | Edm.String, filterable, facetable | Ingest source |
+| `sectionHeader` | Edm.String, retrievable | From DocumentChunker |
+| `ingestedAt` | Edm.DateTimeOffset, filterable, sortable | |
+| `schemaVersion` | Edm.String, filterable | Bumped on schema change |
+| `agentScope` | Collection(Edm.String), filterable | Reserved for #105 |
+| `contentVector` | Collection(Edm.Single) w/ HNSW | Vector search |
+
+HNSW uses cosine similarity. When semantic ranking is enabled the index
+carries one semantic configuration prioritising the title field with the
+content as the content field.
+
+`AzureAISearchIndexSchema.Build` is the single source of truth for the
+shape; `DetectMismatch` inspects a live index and returns the first
+offending drift so operators know exactly what to reindex — the provider
+never silently mutates an existing index.
+
+### 3. Ingestion
+
+Ingestion reuses `DocumentChunker` so chunk boundaries stay identical
+across providers. For each chunk:
+
+1. Compute the embedding through `ApimEmbeddingClient` (single batched
+   HTTP call per document).
+2. `MergeOrUpload` a `SearchDocument` with the schema fields above.
+3. Verify all documents succeeded; a partial failure surfaces with the
+   first backend error message.
+
+### 4. Embedding through APIM
+
+Embeddings MUST traverse the APIM AI Gateway. The client uses the Azure
+OpenAI `/openai/deployments/{deployment}/embeddings` shape and sends a
+managed-identity bearer token (with an optional `api-key` header for
+local dev). Every successful call raises a `UsageEvent` on the shared
+`ICostTracker` so embedding token spend rolls into the same cost
+dashboard as completions. Failures wrap in
+`KnowledgeProviderUnavailableException` so the degradation policy sees a
+single contract signal — never an empty result.
+
+### 5. Resilience
+
+- Search SDK: built-in retry with exponential backoff; per-call network
+  timeout bounded by `RequestTimeoutMs`.
+- Embeddings HTTP path: `AddKnowledgeEmbeddingsResilienceHandler` adds
+  bounded timeout + retry-inside-circuit-breaker with breaker state
+  reported on `CircuitBreakerHealthCheck` alongside MCP and Content
+  Safety.
+
+### 6. Index lifecycle
+
+- **Create.** `AutoCreateIndex=true` (default) creates the index on the
+  first probe.
+- **Migrate.** Any change to a field name, type, analyzer, or vector
+  dimension requires bumping `SchemaVersion` and running the reindex
+  procedure documented in `docs/rag/azure-ai-search-index.md`.
+- **Drift.** `DetectMismatch` runs on every ProbeAsync so a live index
+  that no longer matches the code shape surfaces as a
+  `KnowledgeProviderUnavailableException` rather than a search-time 404.
+
+### 7. Managed identity everywhere
+
+`disableLocalAuth=true` on the Search service (Bicep) forces every
+caller through Entra tokens. The postprovision hook grants each
+container app system identity two roles idempotently:
+
+- `Search Service Contributor` — needed for
+  `SearchIndexClient.CreateIndexAsync`.
+- `Search Index Data Contributor` — needed for document CRUD.
+
+No admin keys, no query keys, no keys in configuration.
+
+### 8. Cost tracking extension
+
+Embedding usage flows through the same `ICostTracker.TrackUsageAsync`
+path as chat completions. The `AgentId` is
+`azure-ai-search:embeddings`, and `Model` defaults to the deployment
+name so `TokenPricing` picks it up. Two default pricing rows
+(`text-embedding-3-small`, `text-embedding-3-large`) ship in
+`appsettings.json`.
+
+## Consequences
+
+### Positive
+
+- The laptop demo is unchanged: default mode is InMemory, no Search
+  package restore, no Bicep resource, no cost.
+- Turning the provider on is a matter of `azd env set
+  AZURE_AI_SEARCH_ENABLED true`, `azd env set Knowledge__Provider__Mode
+  AzureAISearch`, and setting the endpoint/embeddings inputs — no code
+  changes.
+- The provider is honest about score semantics and drift. An
+  unreachable backend never returns an empty result.
+- Reuse of `DocumentChunker` keeps chunk boundaries identical to the
+  in-memory provider so retrieval behaviour is portable across
+  providers.
+
+### Negative
+
+- Adds an `Azure.Search.Documents` dependency to `RetailPulse.Api`
+  (bundled with the SDK; no direct Nuget.org access needed).
+- Startup on the enabled path needs the Search service reachable to
+  probe successfully. Operators who want fallback behaviour set
+  `Knowledge:Provider:Degradation=FallbackToInMemory` — ADR-009 covers
+  the semantics.
+- Semantic reranking is a paid feature; the default is off, and the
+  `basic` SKU includes the `free` tier for demo use.
+
+### Explicitly out of scope
+
+- Per-agent knowledge binding lands in #105. The provider already
+  publishes the `agentScope` field so #105 can filter without another
+  schema bump.
+- Foundry IQ implementation is #104.
+- No changes to BM25 semantics or the InMemory quotas.
+- No changes under `src/RetailPulse.Api/Agents/` in this PR (concurrent
+  work per issue #93).
+
+## Compliance with umbrella constraints (#87)
+
+- **No new hard cloud dependencies.** Provider is fully optional.
+- **No regressions.** Existing InMemory tests pass unmodified; the
+  disabled-default startup test proves the DI graph shape is unchanged
+  when the endpoint is blank.
+- **Feature-disabled test coverage.**
+  `AzureAISearchDefaultDisabledStartupTests` and the DI shape tests
+  encode the disabled contract.
+- **Documentation is part of done.** This ADR, `docs/architecture.md`,
+  `docs/rag/azure-ai-search-index.md`, and `docs/deployment-azd.md`
+  ship in the same PR.
+
+## References
+
+- ADR-009 (provider seam)
+- Issue #87 (Wave 5 umbrella)
+- Issue #103 (this ADR)
+- Issue #105 (per-agent knowledge binding — future)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -739,6 +739,45 @@ The `ConsensusOrchestrator` uses direct LLM calls (not full agent execution) for
 
 ---
 
+## Knowledge Providers (RAG)
+
+`IKnowledgeBase` (in `RetailPulse.Contracts.Rag`) is the single surface
+every RAG consumer talks to (`RagContextProvider`, `/api/knowledge/*`
+endpoints, and the Teams message extension). The concrete provider is
+selected by configuration and materialised by
+`KnowledgeProviderSelector` + `KnowledgeProviderRegistry`. A
+`DegradingKnowledgeBase` decorator applies the configured
+`KnowledgeDegradationMode` policy so an unreachable backend either
+propagates loudly or falls back to the in-memory provider — it never
+silently returns an empty result.
+
+| Mode | Persistent | Cloud dep | Relevance | Use when |
+|---|---|---|---|---|
+| `InMemory` (default) | ❌ (volatile, seeded at startup) | ❌ | Lexical BM25 | Laptop demo, tests, default `azd up` |
+| `AzureAISearch` | ✅ | ✅ (Search + APIM embeddings) | Hybrid vector + BM25, optional semantic reranker | Real semantic retrieval over a substantial corpus |
+| `FoundryIQ` | reserved (#104) | ✅ | reserved | Foundry-managed corpora — not shipped yet |
+
+**Optional-default guarantee.** With no configuration a clean `dotnet
+run --project src/RetailPulse.AppHost` uses `InMemory`, boots without
+any cloud resource, and passes the full test suite. Selecting
+`AzureAISearch` without setting
+`Knowledge:AzureAISearch:Endpoint` fails startup with a clear message
+from `KnowledgeProviderRegistry` — never a silent degradation.
+
+**Consistent chunking.** Every provider chunks with the same
+`DocumentChunker`, so chunk boundaries stay portable across providers.
+
+**Score semantics.** Scores are provider-local and NOT comparable
+across providers. Consumers rank within a single provider's result set
+only; the contract exposes `KnowledgeBaseCapabilities.ScoreSemantics`
+for UI copy.
+
+See ADR-009 (seam) and ADR-012 (Azure AI Search implementation) for
+the full design. Reindex and lifecycle procedure lives in
+`docs/rag/azure-ai-search-index.md`.
+
+---
+
 ## Caching Architecture (Sprint 1)
 
 ### MCP Response Cache

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -91,8 +91,27 @@ infra/
     ├── container-registry.bicep # Dedicated Basic-SKU Azure Container Registry
     ├── container-apps-env.bicep # Container Apps Environment
     ├── container-apps.bicep     # API, MCP server, Teams Bot container apps
-    └── static-web-app.bicep    # Standard-SKU static frontend hosting (direct-CORS to the API)
+    ├── static-web-app.bicep    # Standard-SKU static frontend hosting (direct-CORS to the API)
+    ├── content-safety.bicep    # Optional Azure AI Content Safety (issue #100). Provisioned only when AZURE_CONTENT_SAFETY_ENABLED=true.
+    └── ai-search.bicep          # Optional Azure AI Search knowledge provider (issue #103). Provisioned only when AZURE_AI_SEARCH_ENABLED=true.
 ```
+
+### Optional features (opt-in, disabled by default)
+
+Two Wave-5 cloud-backed features ship as fully-optional modules. Each is
+gated by a single `azd env set` toggle; the default `azd up` leaves them
+off so no additional resources are provisioned and no additional cost is
+incurred.
+
+| Feature | Toggle | Provisioned when on | Docs |
+|---|---|---|---|
+| Azure AI Content Safety (input/output moderation, Prompt Shields) | `azd env set AZURE_CONTENT_SAFETY_ENABLED true` | `infra/modules/content-safety.bicep` — Cognitive Services (`kind=ContentSafety`), managed identity, `disableLocalAuth=true`. Postprovision hooks grant `Cognitive Services User`. | ADR-010 |
+| Azure AI Search knowledge provider (durable hybrid retrieval) | `azd env set AZURE_AI_SEARCH_ENABLED true` and `azd env set Knowledge__Provider__Mode AzureAISearch` | `infra/modules/ai-search.bicep` — Basic-SKU Search service with system identity and `disableLocalAuth=true`. Postprovision hooks grant `Search Service Contributor` + `Search Index Data Contributor`. Also requires `Knowledge__AzureAISearch__Endpoint` and `Knowledge__AzureAISearch__Embeddings__Endpoint`. | ADR-012, `docs/rag/azure-ai-search-index.md` |
+
+Neither feature is referenced by the default runtime path: with both
+toggles left at `false`, the API boots against the InMemory BM25
+knowledge base and the regex-only guardrails baseline — exactly the
+laptop-demo path.
 
 ### azd environment aliases (Bicep outputs → azure.yaml / Vite build)
 

--- a/docs/rag/azure-ai-search-index.md
+++ b/docs/rag/azure-ai-search-index.md
@@ -1,0 +1,174 @@
+# Azure AI Search — index lifecycle & reindex procedure
+
+This document describes how the Retail Pulse Azure AI Search knowledge
+provider (issue #103) manages its index. See ADR-012 for the full design
+decision and ADR-009 for the provider abstraction contract.
+
+## Configuration surface
+
+All settings bind to `Knowledge:AzureAISearch` and are documented inline
+in `src/RetailPulse.Api/appsettings.json`. A blank `Endpoint` disables
+the provider entirely — the demo path stays byte-for-byte unchanged.
+
+```json
+"Knowledge": {
+  "Provider": { "Mode": "AzureAISearch", "Degradation": "FailLoud" },
+  "AzureAISearch": {
+    "Endpoint": "https://<search>.search.windows.net",
+    "IndexName": "retail-pulse-knowledge",
+    "AutoCreateIndex": true,
+    "SchemaVersion": "v1",
+    "SemanticRankingEnabled": true,
+    "Embeddings": {
+      "Endpoint": "https://<apim>.azure-api.net/inference",
+      "Deployment": "text-embedding-3-small",
+      "Dimensions": 1536
+    }
+  }
+}
+```
+
+## Index shape
+
+The complete schema is expressed in
+`src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchIndexSchema.cs`. It
+carries every field the provider reads at runtime plus a
+`schemaVersion` string on every chunk, an `agentScope` collection
+reserved for #105, and a `contentVector` field configured for cosine
+similarity through an HNSW profile.
+
+### Fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | Edm.String, key | `<documentId>_<chunkIndex:D4>` |
+| `documentId` | Edm.String, filterable | Group chunks per document |
+| `chunkIndex` | Edm.Int32, filterable, sortable | Ordering |
+| `title` | Edm.String, searchable + filterable + sortable, en.lucene | |
+| `content` | Edm.String, searchable, en.lucene | Chunk text |
+| `source` | Edm.String, filterable, facetable | Ingest source |
+| `sectionHeader` | Edm.String, retrievable | From DocumentChunker |
+| `ingestedAt` | Edm.DateTimeOffset, filterable, sortable | UTC |
+| `schemaVersion` | Edm.String, filterable | Bumped on schema change |
+| `agentScope` | Collection(Edm.String), filterable | Reserved for #105 |
+| `contentVector` | Collection(Edm.Single) HNSW | Vector search |
+
+### Vector search profile
+
+- Algorithm: HNSW, cosine metric.
+- Dimensions: `Knowledge:AzureAISearch:Embeddings:Dimensions`. Must
+  match the embedding deployment output size — the client rejects a
+  vector of the wrong length rather than writing bad data.
+
+### Semantic configuration
+
+When `SemanticRankingEnabled=true` the index carries one semantic
+configuration (`retail-pulse-semantic` by default) that prioritises the
+title field and uses `content` as the content field. Requires the
+Search service to be provisioned with the semantic search feature
+enabled (Basic-SKU includes the free tier).
+
+## Index creation
+
+The provider creates the index at first probe when `AutoCreateIndex` is
+true. The call is idempotent and never mutates an existing index. When
+`AutoCreateIndex` is false and the index does not exist,
+`ProbeAsync` throws `KnowledgeProviderUnavailableException` — startup
+fails loud so operators run the migration explicitly.
+
+## Drift detection
+
+`AzureAISearchIndexSchema.DetectMismatch` runs on every probe. It
+returns the first field the live index is missing (or the first type /
+vector-dimension mismatch) with an actionable message. The provider
+surfaces the mismatch as an unavailable-provider exception rather than
+attempt an in-place mutation.
+
+## Reindex procedure
+
+Any change to the schema (field, type, analyzer, or vector dimension)
+requires a reindex:
+
+1. Bump `Knowledge:AzureAISearch:SchemaVersion` in the deployment config
+   for the new shape.
+2. Update `AzureAISearchIndexSchema.cs` to reflect the new shape.
+3. Choose a new `IndexName` (e.g. `retail-pulse-knowledge-v2`) for the
+   next generation index. Deploy the API with the new index name.
+4. The provider auto-creates the new index on first probe and starts
+   ingesting into it. Old chunks continue to serve reads from the
+   previous index until you re-point clients.
+5. Re-ingest the corpus into the new index (via the ingest endpoint or
+   your ingestion pipeline).
+6. When traffic has moved and the previous index is no longer needed,
+   delete it in the Azure portal or via `az search index delete`.
+
+### Why not in-place migrations?
+
+Azure AI Search does not support field mutation on an existing index —
+adding a field is possible, changing type or dimension is not. Trying
+to shoe-horn schema changes into an in-place update risks corrupting
+the retrieval quality gradient. The explicit new-index path keeps
+the two shapes side-by-side while traffic moves.
+
+## Managed identity & RBAC
+
+`disableLocalAuth=true` is set on the Search service; only Entra tokens
+are accepted. The postprovision hook grants each container app's
+system-assigned identity two roles idempotently:
+
+- `Search Service Contributor` — needed for
+  `SearchIndexClient.CreateIndexAsync`.
+- `Search Index Data Contributor` — needed for document CRUD.
+
+No admin keys, no query keys, no keys in configuration.
+
+## Failure modes
+
+| Failure | Provider signal | Consumer effect |
+| --- | --- | --- |
+| Service unreachable | `KnowledgeProviderUnavailableException` | `FailLoud` propagates; `FallbackToInMemory` swaps to in-memory |
+| Index missing (AutoCreate=false) | `KnowledgeProviderUnavailableException` | Same as above |
+| Schema drift | `KnowledgeProviderUnavailableException` with drift message | Same as above |
+| Embedding call throttled | Retried inside the circuit breaker; if breaker opens, wrap as unavailable | Same as above |
+| Embedding dimension mismatch | `KnowledgeProviderUnavailableException` (loud) | Startup fails — bump SchemaVersion + reindex |
+| Search returns 404 on index during query | `KnowledgeProviderUnavailableException` | Same as above |
+
+## Cost tracking
+
+Every successful embedding call raises a `UsageEvent` on
+`ICostTracker`:
+
+```
+AgentId  = azure-ai-search:embeddings
+Model    = <deployment name, or Embeddings.ModelId when set>
+InputTokens = prompt_tokens from Azure OpenAI response
+OutputTokens = 0
+ToolName = embeddings
+```
+
+`TokenPricing` ships two default rows (`text-embedding-3-small`,
+`text-embedding-3-large`) so cost math works out of the box.
+
+## Retrieval quality expectations
+
+The provider does hybrid vector + BM25 with optional semantic
+reranking. The in-memory BM25 baseline is expected to underperform on
+paraphrased queries (the executable "why we need semantic" test lives
+in
+`tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchRetrievalQualityComparisonTests.cs`).
+The comparison harness records Recall@3 for both providers on a fixed
+query set when the live environment is configured; the numbers are
+reported to the CI test output and to the PR body honestly.
+
+Do not compare hybrid scores to BM25 scores directly. Scores are
+provider-local — this is codified in `GetCapabilities().ScoreSemantics`
+and the shared conformance suite.
+
+## References
+
+- ADR-009: pluggable knowledge providers
+- ADR-012: Azure AI Search provider
+- `src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchIndexSchema.cs`
+- `tests/RetailPulse.Tests/Rag/AzureAISearch/`
+- `infra/modules/ai-search.bicep`
+- `azd-hooks/postprovision.*`

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -49,6 +49,9 @@ param teamsBotImageName string = 'mcr.microsoft.com/k8se/quickstart:latest'
 @description('Enable the optional Azure AI Content Safety second layer. Disabled by default; no Content Safety account is provisioned when false.')
 param contentSafetyEnabled bool = false
 
+@description('Enable the optional Azure AI Search knowledge provider. Disabled by default; no Search resource is provisioned when false.')
+param aiSearchEnabled bool = false
+
 var abbrs = loadJsonContent('abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var tags = {
@@ -201,6 +204,29 @@ output AZURE_CONTENT_SAFETY_ENABLED bool = contentSafetyEnabled
 output AZURE_CONTENT_SAFETY_ENDPOINT string = contentSafetyEnabled ? contentSafety!.outputs.endpoint : ''
 output AZURE_CONTENT_SAFETY_NAME string = contentSafetyEnabled ? contentSafety!.outputs.name : ''
 output AZURE_CONTENT_SAFETY_RESOURCE_ID string = contentSafetyEnabled ? contentSafety!.outputs.resourceId : ''
+
+// ── Optional Azure AI Search knowledge provider (issue #103) ───────────────
+// Provisioned only when aiSearchEnabled = true so a default `azd up` remains
+// byte-for-byte identical to the InMemory-only baseline. The module disables
+// local auth (no admin/query keys anywhere) and forces every caller through
+// managed identity. The postprovision hook grants each container app's
+// system identity the roles required to auto-create the index and to read
+// and write documents. When disabled, endpoint/name/resource-id outputs are
+// empty so downstream consumers can safely branch on the enabled flag.
+module aiSearch './modules/ai-search.bicep' = if (aiSearchEnabled) {
+  name: 'ai-search'
+  scope: rg
+  params: {
+    location: location
+    resourceToken: resourceToken
+    tags: tags
+  }
+}
+
+output AZURE_AI_SEARCH_ENABLED bool = aiSearchEnabled
+output AZURE_AI_SEARCH_ENDPOINT string = aiSearchEnabled ? aiSearch!.outputs.endpoint : ''
+output AZURE_AI_SEARCH_NAME string = aiSearchEnabled ? aiSearch!.outputs.name : ''
+output AZURE_AI_SEARCH_RESOURCE_ID string = aiSearchEnabled ? aiSearch!.outputs.resourceId : ''
 
 // ── azd environment aliases ────────────────────────────────────────────────
 // These outputs are captured into the azd environment (.azure/<env>/.env) and

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -30,3 +30,8 @@ param teamsBotImageName = readEnvironmentVariable('SERVICE_TEAMSBOT_IMAGE_NAME',
 // default so `azd up` keeps working unchanged. Enable per environment with
 // `azd env set AZURE_CONTENT_SAFETY_ENABLED true`.
 param contentSafetyEnabled = toLower(readEnvironmentVariable('AZURE_CONTENT_SAFETY_ENABLED', 'false')) == 'true'
+
+// Optional Azure AI Search knowledge provider (issue #103). Disabled by
+// default so `azd up` keeps working unchanged (no Search resource, no cost).
+// Enable per environment with `azd env set AZURE_AI_SEARCH_ENABLED true`.
+param aiSearchEnabled = toLower(readEnvironmentVariable('AZURE_AI_SEARCH_ENABLED', 'false')) == 'true'

--- a/infra/modules/ai-search.bicep
+++ b/infra/modules/ai-search.bicep
@@ -1,0 +1,65 @@
+@description('Location for the Azure AI Search service.')
+param location string
+
+@description('Deterministic azd resource token used for stable name generation.')
+param resourceToken string
+
+@description('Common tags applied to every resource.')
+param tags object
+
+@description('SKU for the Search service. Basic includes semantic search (free tier) and 2 GB of storage — enough for the demo corpus.')
+@allowed([
+  'basic'
+  'standard'
+  'standard2'
+  'standard3'
+])
+param skuName string = 'basic'
+
+@description('Replica count for query throughput. Basic supports 1 replica.')
+param replicaCount int = 1
+
+@description('Partition count for index size. Basic supports 1 partition.')
+param partitionCount int = 1
+
+@description('Semantic search tier. "free" is included with Basic+ SKUs and enables the semantic ranker demo.')
+@allowed([
+  'disabled'
+  'free'
+  'standard'
+])
+param semanticSearch string = 'free'
+
+// Only the layering rationale is documented in ADR-012 / docs/architecture.md;
+// this module owns the provisioning contract. Key-based auth is disabled so
+// callers MUST use Entra tokens obtained via managed identity — the exact
+// contract asserted by the deployment contract tests.
+var searchServiceName = 'srch-${resourceToken}'
+
+resource searchService 'Microsoft.Search/searchServices@2024-06-01-preview' = {
+  name: searchServiceName
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    replicaCount: replicaCount
+    partitionCount: partitionCount
+    hostingMode: 'default'
+    publicNetworkAccess: 'enabled'
+    // disableLocalAuth forces every caller through Entra tokens — no admin
+    // keys, no query keys. The API authenticates via DefaultAzureCredential.
+    disableLocalAuth: true
+    semanticSearch: semanticSearch
+    authOptions: null
+  }
+}
+
+output endpoint string = 'https://${searchService.name}.search.windows.net'
+output name string = searchService.name
+output resourceId string = searchService.id
+output principalId string = searchService.identity.principalId

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -33,6 +33,7 @@ using RetailPulse.Api.Observability;
 using RetailPulse.Api.OpenAI;
 using RetailPulse.Api.Persistence;
 using RetailPulse.Api.Rag;
+using RetailPulse.Api.Rag.AzureAISearch;
 using RetailPulse.Api.Resilience;
 using RetailPulse.Api.Scorecard;
 using RetailPulse.Api.Security;
@@ -730,14 +731,24 @@ builder.Services.AddSingleton(sp =>
     // Every process registers the in-memory factory automatically so it is
     // always available as the default primary and as the fallback target for
     // KnowledgeDegradationMode.FallbackToInMemory. Cloud modules (#103/#104)
-    // register their own factories from their opt-in extension methods.
+    // register their own factories from their opt-in extension methods via
+    // the IKnowledgeProviderContribution seam.
     var registry = new KnowledgeProviderRegistry();
     registry.Register(
         KnowledgeProviderMode.InMemory,
         s => s.GetRequiredService<InMemoryKnowledgeBase>());
+    foreach (IKnowledgeProviderContribution contribution in sp.GetServices<IKnowledgeProviderContribution>())
+    {
+        contribution.Register(registry);
+    }
     return registry;
 });
 builder.Services.AddSingleton<KnowledgeProviderSelector>();
+// Optional Azure AI Search provider (issue #103). The extension is a no-op
+// when Knowledge:AzureAISearch:Endpoint is blank, so the default demo path
+// stays byte-for-byte unchanged — nothing about the InMemory-only flow is
+// touched by adding this call.
+builder.Services.AddAzureAISearchKnowledgeProvider(builder.Configuration);
 builder.Services.AddSingleton(sp =>
 {
     KnowledgeProviderSelector selector = sp.GetRequiredService<KnowledgeProviderSelector>();

--- a/src/RetailPulse.Api/Rag/AzureAISearch/ApimEmbeddingClient.cs
+++ b/src/RetailPulse.Api/Rag/AzureAISearch/ApimEmbeddingClient.cs
@@ -1,0 +1,246 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Api.Rag.AzureAISearch;
+
+/// <summary>
+/// Embeds text via the APIM AI Gateway using the Azure OpenAI embeddings API
+/// shape (<c>/openai/deployments/{deployment}/embeddings</c>). Routing through
+/// APIM is a hard requirement — it keeps embedding tokens metered,
+/// rate-limited, and audited under the same policy that governs completions.
+///
+/// Every successful call raises an <see cref="UsageEvent"/> on the shared
+/// <see cref="ICostTracker"/> so embedding token spend rolls into the same
+/// cost dashboard as chat completions.
+/// </summary>
+public sealed class ApimEmbeddingClient
+{
+    /// <summary>Named <see cref="HttpClient"/> registration for embeddings.</summary>
+    public const string HttpClientName = "KnowledgeEmbeddings";
+
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly HttpClient _http;
+    private readonly AzureAISearchOptions _options;
+    private readonly CognitiveServicesTokenProvider? _tokenProvider;
+    private readonly ICostTracker _costTracker;
+    private readonly ILogger<ApimEmbeddingClient> _logger;
+
+    public ApimEmbeddingClient(
+        HttpClient http,
+        AzureAISearchOptions options,
+        ICostTracker costTracker,
+        ILogger<ApimEmbeddingClient> logger,
+        CognitiveServicesTokenProvider? tokenProvider = null)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _costTracker = costTracker ?? throw new ArgumentNullException(nameof(costTracker));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _tokenProvider = tokenProvider;
+    }
+
+    /// <summary>
+    /// Embeds a single string. Wraps transport failures in
+    /// <see cref="KnowledgeProviderUnavailableException"/> so the degradation
+    /// policy can react — never returns an empty / zero vector to signal
+    /// outage.
+    /// </summary>
+    public async Task<ReadOnlyMemory<float>> EmbedAsync(string input, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(input);
+        IReadOnlyList<ReadOnlyMemory<float>> vectors = await EmbedBatchAsync([input], ct).ConfigureAwait(false);
+        return vectors[0];
+    }
+
+    /// <summary>
+    /// Embeds a batch of strings in a single APIM call. Batch order is
+    /// preserved. Empty batch returns an empty list without a network call.
+    /// </summary>
+    public async Task<IReadOnlyList<ReadOnlyMemory<float>>> EmbedBatchAsync(
+        IReadOnlyList<string> inputs, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        if (inputs.Count == 0)
+        {
+            return [];
+        }
+
+        AzureAISearchEmbeddingsOptions embeddings = _options.Embeddings;
+        string path = $"openai/deployments/{Uri.EscapeDataString(embeddings.Deployment)}/embeddings?api-version={Uri.EscapeDataString(embeddings.ApiVersion)}";
+
+        using HttpRequestMessage request = new(HttpMethod.Post, path);
+        request.Content = JsonContent.Create(
+            new EmbeddingRequestBody(inputs, embeddings.Dimensions),
+            options: _jsonOptions);
+
+        if (embeddings.UseManagedIdentity && _tokenProvider is not null)
+        {
+            string token = await _tokenProvider.GetBearerAsync(ct).ConfigureAwait(false);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        if (!string.IsNullOrWhiteSpace(embeddings.ApimSubscriptionKey))
+        {
+            // APIM inference APIs authenticate the caller via api-key. When
+            // provided we always send it — it lets local dev bypass MI while
+            // preserving APIM's token metering and diagnostics.
+            request.Headers.Remove("api-key");
+            request.Headers.Add("api-key", embeddings.ApimSubscriptionKey);
+        }
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new KnowledgeProviderUnavailableException(
+                AzureAISearchKnowledgeBase.ProviderName,
+                $"Embedding request to APIM AI Gateway failed at transport: {ex.Message}",
+                ex);
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            throw new KnowledgeProviderUnavailableException(
+                AzureAISearchKnowledgeBase.ProviderName,
+                "Embedding request to APIM AI Gateway timed out.",
+                ex);
+        }
+
+        await using Stream stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            string body = await ReadShortBodyAsync(stream, ct).ConfigureAwait(false);
+            if (IsTransport(response.StatusCode))
+            {
+                throw new KnowledgeProviderUnavailableException(
+                    AzureAISearchKnowledgeBase.ProviderName,
+                    $"Embedding request returned {(int)response.StatusCode} {response.StatusCode}: {body}");
+            }
+
+            throw new HttpRequestException(
+                $"Embedding request returned {(int)response.StatusCode} {response.StatusCode}: {body}");
+        }
+
+        EmbeddingResponseBody? payload;
+        try
+        {
+            payload = await JsonSerializer.DeserializeAsync<EmbeddingResponseBody>(
+                stream, _jsonOptions, ct).ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            throw new KnowledgeProviderUnavailableException(
+                AzureAISearchKnowledgeBase.ProviderName,
+                "Embedding response was not valid JSON.",
+                ex);
+        }
+
+        if (payload?.Data is null || payload.Data.Count != inputs.Count)
+        {
+            throw new KnowledgeProviderUnavailableException(
+                AzureAISearchKnowledgeBase.ProviderName,
+                $"Embedding response returned {payload?.Data?.Count ?? 0} vectors for {inputs.Count} inputs.");
+        }
+
+        int promptTokens = payload.Usage?.PromptTokens ?? 0;
+        int totalTokens = payload.Usage?.TotalTokens ?? promptTokens;
+        await RecordCostAsync(embeddings, promptTokens, totalTokens, ct).ConfigureAwait(false);
+
+        // Order-preserve by index because Azure OpenAI does not guarantee
+        // response-item order without honouring the "index" field.
+        var result = new ReadOnlyMemory<float>[inputs.Count];
+        foreach (EmbeddingResponseItem item in payload.Data)
+        {
+            if (item.Index < 0 || item.Index >= result.Length)
+            {
+                throw new KnowledgeProviderUnavailableException(
+                    AzureAISearchKnowledgeBase.ProviderName,
+                    $"Embedding response referenced index {item.Index} outside batch of {inputs.Count}.");
+            }
+            if (item.Embedding is null || item.Embedding.Length != embeddings.Dimensions)
+            {
+                throw new KnowledgeProviderUnavailableException(
+                    AzureAISearchKnowledgeBase.ProviderName,
+                    $"Embedding response returned vector of length {item.Embedding?.Length ?? 0}, expected {embeddings.Dimensions}. Confirm Knowledge:AzureAISearch:Embeddings:Dimensions matches the deployment.");
+            }
+            result[item.Index] = item.Embedding;
+        }
+
+        return result;
+    }
+
+    private Task RecordCostAsync(AzureAISearchEmbeddingsOptions embeddings, int promptTokens, int totalTokens, CancellationToken ct)
+    {
+        int inputTokens = promptTokens > 0 ? promptTokens : totalTokens;
+        if (inputTokens <= 0)
+        {
+            _logger.LogDebug("Embedding response did not report token usage — skipping cost event.");
+            return Task.CompletedTask;
+        }
+
+        var usage = new UsageEvent(
+            AgentId: embeddings.CostTrackingAgentId,
+            Model: embeddings.ResolveModelId(),
+            InputTokens: inputTokens,
+            OutputTokens: 0,
+            ToolName: "embeddings",
+            Timestamp: DateTime.UtcNow);
+
+        return _costTracker.TrackUsageAsync(usage, ct);
+    }
+
+    private static bool IsTransport(HttpStatusCode status) =>
+        status == HttpStatusCode.RequestTimeout ||
+        status == HttpStatusCode.TooManyRequests ||
+        (int)status >= 500;
+
+    private static async Task<string> ReadShortBodyAsync(Stream stream, CancellationToken ct)
+    {
+        using var reader = new StreamReader(stream);
+        char[] buffer = new char[512];
+        int read = await reader.ReadBlockAsync(buffer, ct).ConfigureAwait(false);
+        return new string(buffer, 0, read).Trim();
+    }
+
+    private sealed record EmbeddingRequestBody(
+        [property: JsonPropertyName("input")] IReadOnlyList<string> Input,
+        [property: JsonPropertyName("dimensions")] int? Dimensions);
+
+    private sealed class EmbeddingResponseBody
+    {
+        [JsonPropertyName("data")]
+        public List<EmbeddingResponseItem>? Data { get; set; }
+
+        [JsonPropertyName("usage")]
+        public EmbeddingUsage? Usage { get; set; }
+    }
+
+    private sealed class EmbeddingResponseItem
+    {
+        [JsonPropertyName("index")]
+        public int Index { get; set; }
+
+        [JsonPropertyName("embedding")]
+        public float[]? Embedding { get; set; }
+    }
+
+    private sealed class EmbeddingUsage
+    {
+        [JsonPropertyName("prompt_tokens")]
+        public int PromptTokens { get; set; }
+
+        [JsonPropertyName("total_tokens")]
+        public int TotalTokens { get; set; }
+    }
+}

--- a/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchIndexSchema.cs
+++ b/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchIndexSchema.cs
@@ -1,0 +1,174 @@
+using Azure.Search.Documents.Indexes.Models;
+
+namespace RetailPulse.Api.Rag.AzureAISearch;
+
+/// <summary>
+/// Owns the shape of the Azure AI Search index used by the Retail Pulse
+/// knowledge provider. Codified so index creation and drift detection agree,
+/// and so a bumped schema version documents itself in the source tree.
+///
+/// Changing any field name, type, analyzer, or vector dimension requires
+/// bumping <see cref="AzureAISearchOptions.SchemaVersion"/> and running the
+/// documented reindex procedure — the provider never silently mutates an
+/// existing index.
+/// </summary>
+public static class AzureAISearchIndexSchema
+{
+    public const string DocumentIdField = "documentId";
+    public const string ChunkIdField = "id";
+    public const string ChunkIndexField = "chunkIndex";
+    public const string TitleField = "title";
+    public const string ContentField = "content";
+    public const string SourceField = "source";
+    public const string SectionHeaderField = "sectionHeader";
+    public const string IngestedAtField = "ingestedAt";
+    public const string SchemaVersionField = "schemaVersion";
+    public const string AgentScopeField = "agentScope";
+    public const string VectorField = "contentVector";
+
+    /// <summary>
+    /// Builds the <see cref="SearchIndex"/> for the configured target index
+    /// name, vector dimensions, and semantic configuration. The result is
+    /// deterministic — a second call with the same options produces the same
+    /// structural shape.
+    /// </summary>
+    public static SearchIndex Build(AzureAISearchOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        int dimensions = options.Embeddings.Dimensions;
+
+        var fields = new List<SearchField>
+        {
+            new(ChunkIdField, SearchFieldDataType.String)
+            {
+                IsKey = true,
+                IsFilterable = true,
+            },
+            new(DocumentIdField, SearchFieldDataType.String)
+            {
+                IsFilterable = true,
+                IsSortable = false,
+                IsFacetable = false,
+            },
+            new(ChunkIndexField, SearchFieldDataType.Int32)
+            {
+                IsFilterable = true,
+                IsSortable = true,
+            },
+            new(TitleField, SearchFieldDataType.String)
+            {
+                IsSearchable = true,
+                IsFilterable = true,
+                IsSortable = true,
+                AnalyzerName = LexicalAnalyzerName.EnLucene,
+            },
+            new(ContentField, SearchFieldDataType.String)
+            {
+                IsSearchable = true,
+                AnalyzerName = LexicalAnalyzerName.EnLucene,
+            },
+            new(SourceField, SearchFieldDataType.String)
+            {
+                IsFilterable = true,
+                IsSortable = false,
+                IsFacetable = true,
+            },
+            new(SectionHeaderField, SearchFieldDataType.String)
+            {
+                IsFilterable = false,
+                IsSortable = false,
+            },
+            new(IngestedAtField, SearchFieldDataType.DateTimeOffset)
+            {
+                IsFilterable = true,
+                IsSortable = true,
+            },
+            new(SchemaVersionField, SearchFieldDataType.String)
+            {
+                IsFilterable = true,
+            },
+            // agentScope is the seam per-agent knowledge binding (#105) uses to
+            // filter chunks to a subset of authorized agents. Multi-valued so a
+            // single chunk can serve several agents without duplication.
+            new(AgentScopeField, SearchFieldDataType.Collection(SearchFieldDataType.String))
+            {
+                IsFilterable = true,
+                IsFacetable = true,
+            },
+            new VectorSearchField(VectorField, dimensions, options.VectorProfileName),
+        };
+
+        var index = new SearchIndex(options.IndexName, fields)
+        {
+            VectorSearch = new VectorSearch
+            {
+                Algorithms =
+                {
+                    new HnswAlgorithmConfiguration(options.HnswAlgorithmName)
+                    {
+                        Parameters = new HnswParameters
+                        {
+                            Metric = VectorSearchAlgorithmMetric.Cosine,
+                        },
+                    },
+                },
+                Profiles =
+                {
+                    new VectorSearchProfile(options.VectorProfileName, options.HnswAlgorithmName),
+                },
+            },
+        };
+
+        if (options.SemanticRankingEnabled)
+        {
+            var prioritizedFields = new SemanticPrioritizedFields
+            {
+                TitleField = new SemanticField(TitleField),
+            };
+            prioritizedFields.ContentFields.Add(new SemanticField(ContentField));
+
+            index.SemanticSearch = new SemanticSearch
+            {
+                Configurations =
+                {
+                    new SemanticConfiguration(options.SemanticConfigurationName, prioritizedFields),
+                },
+            };
+        }
+
+        return index;
+    }
+
+    /// <summary>
+    /// Confirms the live index carries the fields this provider depends on
+    /// (name and type) so a drifted schema surfaces as a clear message rather
+    /// than a search-time 404 on a missing field. Returns the first offending
+    /// difference so operators know what to reindex.
+    /// </summary>
+    public static string? DetectMismatch(SearchIndex live, AzureAISearchOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(live);
+        SearchIndex expected = Build(options);
+
+        foreach (SearchField expectedField in expected.Fields)
+        {
+            SearchField? liveField = live.Fields.FirstOrDefault(
+                f => string.Equals(f.Name, expectedField.Name, StringComparison.OrdinalIgnoreCase));
+            if (liveField is null)
+            {
+                return $"Index '{live.Name}' is missing required field '{expectedField.Name}'.";
+            }
+            if (liveField.Type != expectedField.Type)
+            {
+                return $"Index '{live.Name}' field '{expectedField.Name}' has type {liveField.Type}, expected {expectedField.Type}.";
+            }
+            if (expectedField.Name == VectorField && liveField.VectorSearchDimensions != expectedField.VectorSearchDimensions)
+            {
+                return $"Index '{live.Name}' vector dimension mismatch: live={liveField.VectorSearchDimensions}, expected={expectedField.VectorSearchDimensions}. Bump SchemaVersion and reindex.";
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchKnowledgeBase.cs
+++ b/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchKnowledgeBase.cs
@@ -262,7 +262,7 @@ public sealed class AzureAISearchKnowledgeBase : IKnowledgeBase
         }
 
         var results = new List<SearchResult>(topK);
-        await foreach (Azure.Search.Documents.Models.SearchResult<SearchDocument> hit in raw.GetResultsAsync().ConfigureAwait(false))
+        await foreach (SearchResult<SearchDocument> hit in raw.GetResultsAsync().ConfigureAwait(false))
         {
             SearchDocument doc = hit.Document;
             double score = ResolveScore(hit);
@@ -319,7 +319,7 @@ public sealed class AzureAISearchKnowledgeBase : IKnowledgeBase
         }
 
         var docs = new Dictionary<string, DocumentAggregate>(StringComparer.OrdinalIgnoreCase);
-        await foreach (Azure.Search.Documents.Models.SearchResult<SearchDocument> hit in raw.GetResultsAsync().ConfigureAwait(false))
+        await foreach (SearchResult<SearchDocument> hit in raw.GetResultsAsync().ConfigureAwait(false))
         {
             SearchDocument doc = hit.Document;
             if (!doc.TryGetValue(AzureAISearchIndexSchema.DocumentIdField, out object? idValue) || idValue is null)
@@ -386,7 +386,7 @@ public sealed class AzureAISearchKnowledgeBase : IKnowledgeBase
         }
 
         var chunkIds = new List<string>();
-        await foreach (Azure.Search.Documents.Models.SearchResult<SearchDocument> hit in raw.GetResultsAsync().ConfigureAwait(false))
+        await foreach (SearchResult<SearchDocument> hit in raw.GetResultsAsync().ConfigureAwait(false))
         {
             if (hit.Document.TryGetValue(AzureAISearchIndexSchema.ChunkIdField, out object? id) && id is not null)
             {
@@ -400,13 +400,12 @@ public sealed class AzureAISearchKnowledgeBase : IKnowledgeBase
             return;
         }
 
-        var deleteActions = chunkIds
+        IndexDocumentsAction<SearchDocument>[] deleteActions = [.. chunkIds
             .Select(id =>
             {
                 var d = new SearchDocument { [AzureAISearchIndexSchema.ChunkIdField] = id };
                 return IndexDocumentsAction.Delete(d);
-            })
-            .ToArray();
+            })];
 
         try
         {
@@ -425,7 +424,7 @@ public sealed class AzureAISearchKnowledgeBase : IKnowledgeBase
         _logger.LogInformation("Deleted document {DocumentId} ({ChunkCount} chunks) from Azure AI Search", documentId, chunkIds.Count);
     }
 
-    private static double ResolveScore(Azure.Search.Documents.Models.SearchResult<SearchDocument> hit)
+    private static double ResolveScore(SearchResult<SearchDocument> hit)
     {
         // Semantic reranker scores appear on SemanticSearch.RerankerScore when
         // semantic ranking is enabled; otherwise the hybrid RRF Score is used.
@@ -438,10 +437,10 @@ public sealed class AzureAISearchKnowledgeBase : IKnowledgeBase
         value.Replace("'", "''", StringComparison.Ordinal);
 
     private static bool IsTransport(RequestFailedException ex) =>
-        ex.Status == 0 ||
-        ex.Status == 408 ||
-        ex.Status == 429 ||
-        ex.Status >= 500;
+        ex.Status is 0 or
+        408 or
+        429 or
+        >= 500;
 
     /// <summary>
     /// Ensures the target index exists and its schema matches this build.

--- a/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchKnowledgeBase.cs
+++ b/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchKnowledgeBase.cs
@@ -1,0 +1,537 @@
+using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes;
+using Azure.Search.Documents.Indexes.Models;
+using Azure.Search.Documents.Models;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Api.Rag.AzureAISearch;
+
+/// <summary>
+/// Durable, semantically-retrievable <see cref="IKnowledgeBase"/> backed by
+/// Azure AI Search. Uses the same <see cref="DocumentChunker"/> as the in-memory
+/// provider so chunk boundaries stay consistent across providers.
+///
+/// Retrieval combines vector similarity (via APIM-generated embeddings) with
+/// lexical BM25 in a hybrid query. When
+/// <see cref="AzureAISearchOptions.SemanticRankingEnabled"/> is true, the
+/// hybrid result set is reranked by Azure AI Search's semantic ranker.
+///
+/// Score semantics are provider-local: hybrid + semantic scores are not
+/// comparable to the in-memory BM25 score. Callers must respect
+/// <see cref="KnowledgeBaseCapabilities.ScoreSemantics"/> and never cross-rank
+/// results from different providers.
+/// </summary>
+public sealed class AzureAISearchKnowledgeBase : IKnowledgeBase
+{
+    /// <summary>Stable name reported in <see cref="GetCapabilities"/>.</summary>
+    public const string ProviderName = "AzureAISearch";
+
+    private readonly SearchIndexClient _indexClient;
+    private readonly SearchClient _searchClient;
+    private readonly ApimEmbeddingClient _embeddingClient;
+    private readonly AzureAISearchOptions _options;
+    private readonly KnowledgeOptions _quotas;
+    private readonly ILogger<AzureAISearchKnowledgeBase> _logger;
+    private readonly SemaphoreSlim _indexInit = new(1, 1);
+    private bool _indexEnsured;
+
+    public AzureAISearchKnowledgeBase(
+        SearchIndexClient indexClient,
+        SearchClient searchClient,
+        ApimEmbeddingClient embeddingClient,
+        AzureAISearchOptions options,
+        KnowledgeOptions quotas,
+        ILogger<AzureAISearchKnowledgeBase> logger)
+    {
+        _indexClient = indexClient ?? throw new ArgumentNullException(nameof(indexClient));
+        _searchClient = searchClient ?? throw new ArgumentNullException(nameof(searchClient));
+        _embeddingClient = embeddingClient ?? throw new ArgumentNullException(nameof(embeddingClient));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _quotas = quotas ?? throw new ArgumentNullException(nameof(quotas));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public KnowledgeBaseCapabilities GetCapabilities() => new(
+        ProviderName: ProviderName,
+        Relevance: _options.SemanticRankingEnabled
+            ? KnowledgeRelevanceKind.Hybrid
+            : KnowledgeRelevanceKind.Hybrid,
+        Persistent: true,
+        RequiresCloud: true,
+        Quotas: new KnowledgeQuotas(
+            MaxDocuments: _quotas.MaxDocuments,
+            MaxChunks: _quotas.MaxChunks,
+            MaxDocumentSizeBytes: _quotas.MaxDocumentSizeBytes),
+        ScoreSemantics: _options.SemanticRankingEnabled
+            ? "Hybrid vector + BM25 score reranked by Azure AI Search semantic ranker. Higher is better. Scores are provider-local and NOT comparable across providers."
+            : "Hybrid vector + BM25 score via Reciprocal Rank Fusion. Higher is better. Scores are provider-local and NOT comparable across providers.");
+
+    /// <inheritdoc />
+    public async Task ProbeAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await EnsureIndexAsync(ct).ConfigureAwait(false);
+        }
+        catch (KnowledgeProviderUnavailableException)
+        {
+            throw;
+        }
+        catch (RequestFailedException ex) when (IsTransport(ex))
+        {
+            throw new KnowledgeProviderUnavailableException(
+                ProviderName,
+                $"Azure AI Search probe failed at transport: {ex.Status} {ex.ErrorCode ?? "n/a"}.",
+                ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string> IngestDocumentAsync(string title, string content, string source, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        ArgumentException.ThrowIfNullOrWhiteSpace(content);
+        ArgumentException.ThrowIfNullOrWhiteSpace(source);
+
+        long sizeBytes = System.Text.Encoding.UTF8.GetByteCount(content);
+        if (sizeBytes > _quotas.MaxDocumentSizeBytes)
+        {
+            throw new InvalidOperationException(
+                $"Document '{title}' is {sizeBytes:N0} bytes, which exceeds the {_quotas.MaxDocumentSizeBytes:N0}-byte limit.");
+        }
+
+        await EnsureIndexAsync(ct).ConfigureAwait(false);
+
+        IReadOnlyList<DocumentChunker.DocumentChunk> chunks = DocumentChunker.Chunk(content);
+        string documentId = Guid.NewGuid().ToString("N")[..12];
+        if (chunks.Count == 0)
+        {
+            _logger.LogWarning("Document '{Title}' produced no chunks — skipping", title);
+            return documentId;
+        }
+
+        // Precompute embeddings for every chunk in a single batch to minimize
+        // APIM round-trips and preserve chunk-order deterministically.
+        List<string> chunkTexts = [.. chunks.Select(c => c.Text)];
+        IReadOnlyList<ReadOnlyMemory<float>> embeddings;
+        try
+        {
+            embeddings = await _embeddingClient.EmbedBatchAsync(chunkTexts, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new KnowledgeProviderUnavailableException(
+                ProviderName,
+                $"Failed to compute embeddings for document '{title}': {ex.Message}",
+                ex);
+        }
+
+        DateTimeOffset ingestedAt = DateTimeOffset.UtcNow;
+        var actions = new List<IndexDocumentsAction<SearchDocument>>(chunks.Count);
+        for (int i = 0; i < chunks.Count; i++)
+        {
+            DocumentChunker.DocumentChunk chunk = chunks[i];
+            string chunkId = $"{documentId}_{i:D4}";
+            var doc = new SearchDocument
+            {
+                [AzureAISearchIndexSchema.ChunkIdField] = chunkId,
+                [AzureAISearchIndexSchema.DocumentIdField] = documentId,
+                [AzureAISearchIndexSchema.ChunkIndexField] = chunk.Index,
+                [AzureAISearchIndexSchema.TitleField] = title,
+                [AzureAISearchIndexSchema.ContentField] = chunk.Text,
+                [AzureAISearchIndexSchema.SourceField] = source,
+                [AzureAISearchIndexSchema.SectionHeaderField] = chunk.SectionHeader ?? string.Empty,
+                [AzureAISearchIndexSchema.IngestedAtField] = ingestedAt,
+                [AzureAISearchIndexSchema.SchemaVersionField] = _options.SchemaVersion,
+                [AzureAISearchIndexSchema.AgentScopeField] = Array.Empty<string>(),
+                [AzureAISearchIndexSchema.VectorField] = embeddings[i].ToArray(),
+            };
+            actions.Add(IndexDocumentsAction.MergeOrUpload(doc));
+        }
+
+        try
+        {
+            Response<IndexDocumentsResult> result = await _searchClient.IndexDocumentsAsync(
+                IndexDocumentsBatch.Create(actions.ToArray()),
+                cancellationToken: ct).ConfigureAwait(false);
+
+            var failures = result.Value.Results.Where(r => !r.Succeeded).ToList();
+            if (failures.Count > 0)
+            {
+                string first = failures[0].ErrorMessage ?? "unknown";
+                throw new InvalidOperationException(
+                    $"Azure AI Search rejected {failures.Count}/{chunks.Count} chunk uploads for document '{title}'. First error: {first}");
+            }
+        }
+        catch (RequestFailedException ex) when (IsTransport(ex))
+        {
+            throw new KnowledgeProviderUnavailableException(
+                ProviderName,
+                $"Azure AI Search ingest failed at transport for document '{title}': {ex.Status} {ex.ErrorCode ?? "n/a"}.",
+                ex);
+        }
+
+        _logger.LogInformation(
+            "Ingested document '{Title}' ({Source}) into Azure AI Search index '{Index}': {ChunkCount} chunks, id={Id}",
+            title, source, _options.IndexName, chunks.Count, documentId);
+
+        return documentId;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SearchResult>> SearchAsync(string query, int topK = 5, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return [];
+        }
+
+        await EnsureIndexAsync(ct).ConfigureAwait(false);
+
+        ReadOnlyMemory<float> queryVector;
+        try
+        {
+            queryVector = await _embeddingClient.EmbedAsync(query, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new KnowledgeProviderUnavailableException(
+                ProviderName,
+                $"Failed to compute query embedding: {ex.Message}",
+                ex);
+        }
+
+        var searchOptions = new SearchOptions
+        {
+            Size = topK,
+            IncludeTotalCount = false,
+            VectorSearch = new VectorSearchOptions
+            {
+                Queries =
+                {
+                    new VectorizedQuery(queryVector)
+                    {
+                        KNearestNeighborsCount = Math.Max(topK, 50),
+                        Fields = { AzureAISearchIndexSchema.VectorField },
+                    },
+                },
+            },
+        };
+        searchOptions.Select.Add(AzureAISearchIndexSchema.ChunkIdField);
+        searchOptions.Select.Add(AzureAISearchIndexSchema.DocumentIdField);
+        searchOptions.Select.Add(AzureAISearchIndexSchema.ChunkIndexField);
+        searchOptions.Select.Add(AzureAISearchIndexSchema.TitleField);
+        searchOptions.Select.Add(AzureAISearchIndexSchema.ContentField);
+        searchOptions.Select.Add(AzureAISearchIndexSchema.SourceField);
+        searchOptions.SearchFields.Add(AzureAISearchIndexSchema.TitleField);
+        searchOptions.SearchFields.Add(AzureAISearchIndexSchema.ContentField);
+
+        if (_options.SemanticRankingEnabled)
+        {
+            searchOptions.QueryType = SearchQueryType.Semantic;
+            searchOptions.SemanticSearch = new SemanticSearchOptions
+            {
+                SemanticConfigurationName = _options.SemanticConfigurationName,
+            };
+        }
+
+        SearchResults<SearchDocument> raw;
+        try
+        {
+            Response<SearchResults<SearchDocument>> response = await _searchClient
+                .SearchAsync<SearchDocument>(query, searchOptions, ct)
+                .ConfigureAwait(false);
+            raw = response.Value;
+        }
+        catch (RequestFailedException ex) when (IsTransport(ex))
+        {
+            throw new KnowledgeProviderUnavailableException(
+                ProviderName,
+                $"Azure AI Search query failed at transport: {ex.Status} {ex.ErrorCode ?? "n/a"}.",
+                ex);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            throw new KnowledgeProviderUnavailableException(
+                ProviderName,
+                $"Azure AI Search index '{_options.IndexName}' returned 404 during query. Confirm the index exists or set Knowledge:AzureAISearch:AutoCreateIndex=true.",
+                ex);
+        }
+
+        var results = new List<SearchResult>(topK);
+        await foreach (Azure.Search.Documents.Models.SearchResult<SearchDocument> hit in raw.GetResultsAsync().ConfigureAwait(false))
+        {
+            SearchDocument doc = hit.Document;
+            double score = ResolveScore(hit);
+
+            results.Add(new SearchResult(
+                DocumentId: doc.TryGetValue(AzureAISearchIndexSchema.DocumentIdField, out object? docId) ? docId?.ToString() ?? string.Empty : string.Empty,
+                Title: doc.TryGetValue(AzureAISearchIndexSchema.TitleField, out object? title) ? title?.ToString() ?? string.Empty : string.Empty,
+                Chunk: doc.TryGetValue(AzureAISearchIndexSchema.ContentField, out object? content) ? content?.ToString() ?? string.Empty : string.Empty,
+                Score: score,
+                Source: doc.TryGetValue(AzureAISearchIndexSchema.SourceField, out object? source) ? source?.ToString() ?? string.Empty : string.Empty,
+                ChunkIndex: doc.TryGetValue(AzureAISearchIndexSchema.ChunkIndexField, out object? chunkIndex) && chunkIndex is not null
+                    ? Convert.ToInt32(chunkIndex, System.Globalization.CultureInfo.InvariantCulture)
+                    : 0));
+
+            if (results.Count >= topK)
+            {
+                break;
+            }
+        }
+
+        return results;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DocumentInfo>> ListDocumentsAsync(CancellationToken ct = default)
+    {
+        await EnsureIndexAsync(ct).ConfigureAwait(false);
+
+        var options = new SearchOptions
+        {
+            Size = Math.Max(_quotas.MaxDocuments * 4, 200),
+            IncludeTotalCount = false,
+        };
+        options.Select.Add(AzureAISearchIndexSchema.DocumentIdField);
+        options.Select.Add(AzureAISearchIndexSchema.TitleField);
+        options.Select.Add(AzureAISearchIndexSchema.SourceField);
+        options.Select.Add(AzureAISearchIndexSchema.IngestedAtField);
+        options.OrderBy.Add($"{AzureAISearchIndexSchema.IngestedAtField} desc");
+
+        SearchResults<SearchDocument> raw;
+        try
+        {
+            Response<SearchResults<SearchDocument>> response = await _searchClient
+                .SearchAsync<SearchDocument>("*", options, ct)
+                .ConfigureAwait(false);
+            raw = response.Value;
+        }
+        catch (RequestFailedException ex) when (IsTransport(ex))
+        {
+            throw new KnowledgeProviderUnavailableException(
+                ProviderName,
+                $"Azure AI Search list failed at transport: {ex.Status} {ex.ErrorCode ?? "n/a"}.",
+                ex);
+        }
+
+        var docs = new Dictionary<string, DocumentAggregate>(StringComparer.OrdinalIgnoreCase);
+        await foreach (Azure.Search.Documents.Models.SearchResult<SearchDocument> hit in raw.GetResultsAsync().ConfigureAwait(false))
+        {
+            SearchDocument doc = hit.Document;
+            if (!doc.TryGetValue(AzureAISearchIndexSchema.DocumentIdField, out object? idValue) || idValue is null)
+            {
+                continue;
+            }
+            string documentId = idValue.ToString()!;
+            string title = doc.TryGetValue(AzureAISearchIndexSchema.TitleField, out object? t) ? t?.ToString() ?? string.Empty : string.Empty;
+            string source = doc.TryGetValue(AzureAISearchIndexSchema.SourceField, out object? s) ? s?.ToString() ?? string.Empty : string.Empty;
+            DateTime ingestedAt = doc.TryGetValue(AzureAISearchIndexSchema.IngestedAtField, out object? ia) && ia is DateTimeOffset dto
+                ? dto.UtcDateTime
+                : DateTime.UtcNow;
+
+            if (docs.TryGetValue(documentId, out DocumentAggregate? agg))
+            {
+                agg.ChunkCount++;
+                if (ingestedAt < agg.IngestedAt) agg.IngestedAt = ingestedAt;
+            }
+            else
+            {
+                docs[documentId] = new DocumentAggregate
+                {
+                    Id = documentId,
+                    Title = title,
+                    Source = source,
+                    IngestedAt = ingestedAt,
+                    ChunkCount = 1,
+                };
+            }
+        }
+
+        return [.. docs.Values
+            .OrderByDescending(d => d.IngestedAt)
+            .Select(d => new DocumentInfo(d.Id, d.Title, d.Source, d.IngestedAt, d.ChunkCount))];
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteDocumentAsync(string documentId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(documentId);
+        await EnsureIndexAsync(ct).ConfigureAwait(false);
+
+        var listOptions = new SearchOptions
+        {
+            Size = _quotas.MaxChunks,
+            Filter = $"{AzureAISearchIndexSchema.DocumentIdField} eq '{EscapeODataString(documentId)}'",
+        };
+        listOptions.Select.Add(AzureAISearchIndexSchema.ChunkIdField);
+
+        SearchResults<SearchDocument> raw;
+        try
+        {
+            Response<SearchResults<SearchDocument>> response = await _searchClient
+                .SearchAsync<SearchDocument>(searchText: null, listOptions, ct)
+                .ConfigureAwait(false);
+            raw = response.Value;
+        }
+        catch (RequestFailedException ex) when (IsTransport(ex))
+        {
+            throw new KnowledgeProviderUnavailableException(
+                ProviderName,
+                $"Azure AI Search delete-lookup failed at transport: {ex.Status} {ex.ErrorCode ?? "n/a"}.",
+                ex);
+        }
+
+        var chunkIds = new List<string>();
+        await foreach (Azure.Search.Documents.Models.SearchResult<SearchDocument> hit in raw.GetResultsAsync().ConfigureAwait(false))
+        {
+            if (hit.Document.TryGetValue(AzureAISearchIndexSchema.ChunkIdField, out object? id) && id is not null)
+            {
+                chunkIds.Add(id.ToString()!);
+            }
+        }
+
+        if (chunkIds.Count == 0)
+        {
+            _logger.LogInformation("Delete requested for unknown documentId {DocumentId} — no chunks removed", documentId);
+            return;
+        }
+
+        var deleteActions = chunkIds
+            .Select(id =>
+            {
+                var d = new SearchDocument { [AzureAISearchIndexSchema.ChunkIdField] = id };
+                return IndexDocumentsAction.Delete(d);
+            })
+            .ToArray();
+
+        try
+        {
+            await _searchClient.IndexDocumentsAsync(
+                IndexDocumentsBatch.Create(deleteActions),
+                cancellationToken: ct).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex) when (IsTransport(ex))
+        {
+            throw new KnowledgeProviderUnavailableException(
+                ProviderName,
+                $"Azure AI Search delete failed at transport for document '{documentId}': {ex.Status} {ex.ErrorCode ?? "n/a"}.",
+                ex);
+        }
+
+        _logger.LogInformation("Deleted document {DocumentId} ({ChunkCount} chunks) from Azure AI Search", documentId, chunkIds.Count);
+    }
+
+    private static double ResolveScore(Azure.Search.Documents.Models.SearchResult<SearchDocument> hit)
+    {
+        // Semantic reranker scores appear on SemanticSearch.RerankerScore when
+        // semantic ranking is enabled; otherwise the hybrid RRF Score is used.
+        double? reranker = hit.SemanticSearch?.RerankerScore;
+        double raw = reranker ?? hit.Score ?? 0.0;
+        return raw < 0 ? 0.0 : raw;
+    }
+
+    private static string EscapeODataString(string value) =>
+        value.Replace("'", "''", StringComparison.Ordinal);
+
+    private static bool IsTransport(RequestFailedException ex) =>
+        ex.Status == 0 ||
+        ex.Status == 408 ||
+        ex.Status == 429 ||
+        ex.Status >= 500;
+
+    /// <summary>
+    /// Ensures the target index exists and its schema matches this build.
+    /// Runs at most once per process on the happy path; a probe failure resets
+    /// the latch so a later ProbeAsync/data call retries.
+    /// </summary>
+    internal async Task EnsureIndexAsync(CancellationToken ct)
+    {
+        if (_indexEnsured)
+        {
+            return;
+        }
+
+        await _indexInit.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_indexEnsured)
+            {
+                return;
+            }
+
+            SearchIndex? existing = null;
+            try
+            {
+                Response<SearchIndex> response = await _indexClient.GetIndexAsync(_options.IndexName, ct).ConfigureAwait(false);
+                existing = response.Value;
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                existing = null;
+            }
+            catch (RequestFailedException ex) when (IsTransport(ex))
+            {
+                throw new KnowledgeProviderUnavailableException(
+                    ProviderName,
+                    $"Azure AI Search unreachable while inspecting index '{_options.IndexName}': {ex.Status}",
+                    ex);
+            }
+
+            if (existing is null)
+            {
+                if (!_options.AutoCreateIndex)
+                {
+                    throw new KnowledgeProviderUnavailableException(
+                        ProviderName,
+                        $"Azure AI Search index '{_options.IndexName}' does not exist and AutoCreateIndex is false.");
+                }
+
+                SearchIndex desired = AzureAISearchIndexSchema.Build(_options);
+                try
+                {
+                    await _indexClient.CreateIndexAsync(desired, ct).ConfigureAwait(false);
+                }
+                catch (RequestFailedException ex)
+                {
+                    throw new KnowledgeProviderUnavailableException(
+                        ProviderName,
+                        $"Failed to create Azure AI Search index '{_options.IndexName}': {ex.Status} {ex.ErrorCode ?? "n/a"}.",
+                        ex);
+                }
+                _logger.LogInformation(
+                    "Created Azure AI Search index '{Index}' (dim={Dim}, semantic={Semantic}, schemaVersion={SchemaVersion})",
+                    _options.IndexName, _options.Embeddings.Dimensions,
+                    _options.SemanticRankingEnabled, _options.SchemaVersion);
+            }
+            else
+            {
+                string? mismatch = AzureAISearchIndexSchema.DetectMismatch(existing, _options);
+                if (mismatch is not null)
+                {
+                    throw new KnowledgeProviderUnavailableException(
+                        ProviderName,
+                        $"{mismatch} Follow docs/rag/azure-ai-search-index.md to reindex — the provider will not silently corrupt an existing index.");
+                }
+            }
+
+            _indexEnsured = true;
+        }
+        finally
+        {
+            _indexInit.Release();
+        }
+    }
+
+    private sealed class DocumentAggregate
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Source { get; set; } = string.Empty;
+        public DateTime IngestedAt { get; set; }
+        public int ChunkCount { get; set; }
+    }
+}

--- a/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchOptions.cs
+++ b/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchOptions.cs
@@ -1,0 +1,181 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace RetailPulse.Api.Rag.AzureAISearch;
+
+/// <summary>
+/// Configuration surface for the optional Azure AI Search knowledge provider
+/// (issue #103). Bound to the <c>Knowledge:AzureAISearch</c> section.
+///
+/// The provider is FULLY OPTIONAL. When <see cref="Endpoint"/> is blank the
+/// provider is not registered and no Azure.Search SDK client, HTTP handler,
+/// or credential is materialized — the default in-memory BM25 path stays
+/// byte-for-byte unchanged. See docs/adr/012-azure-ai-search-provider.md.
+/// </summary>
+public sealed class AzureAISearchOptions
+{
+    /// <summary>Configuration section: <c>Knowledge:AzureAISearch</c>.</summary>
+    public const string SectionName = "Knowledge:AzureAISearch";
+
+    /// <summary>Fully-qualified Azure AI Search endpoint (e.g. <c>https://mysearch.search.windows.net</c>).</summary>
+    public string? Endpoint { get; set; }
+
+    /// <summary>Index name used for chunk documents.</summary>
+    public string IndexName { get; set; } = "retail-pulse-knowledge";
+
+    /// <summary>
+    /// Automatically create the target index at startup if it does not exist. The
+    /// creation call is idempotent and never touches an existing index — a schema
+    /// mismatch is surfaced by <see cref="Contracts.Rag.KnowledgeProviderUnavailableException"/>
+    /// so operators run the documented reindex procedure explicitly.
+    /// </summary>
+    public bool AutoCreateIndex { get; set; } = true;
+
+    /// <summary>
+    /// Schema version stamped on every ingested document so a targeted reindex
+    /// can identify chunks written by a prior schema shape. Any change to the
+    /// index fields MUST bump this string.
+    /// </summary>
+    public string SchemaVersion { get; set; } = "v1";
+
+    /// <summary>Per-request timeout applied to Search SDK calls (milliseconds).</summary>
+    [Range(500, 120_000)]
+    public int RequestTimeoutMs { get; set; } = 20_000;
+
+    /// <summary>
+    /// Enable semantic ranking on hybrid queries. Requires the Search service
+    /// to be provisioned with the semanticSearch SKU (Free tier is included on
+    /// Basic+ services). When disabled, the provider still performs hybrid
+    /// lexical + vector ranking without the semantic reranker.
+    /// </summary>
+    public bool SemanticRankingEnabled { get; set; }
+
+    /// <summary>Semantic configuration name declared on the index.</summary>
+    public string SemanticConfigurationName { get; set; } = "retail-pulse-semantic";
+
+    /// <summary>Vector search profile name declared on the index.</summary>
+    public string VectorProfileName { get; set; } = "retail-pulse-vector";
+
+    /// <summary>HNSW algorithm configuration name declared on the index.</summary>
+    public string HnswAlgorithmName { get; set; } = "retail-pulse-hnsw";
+
+    /// <summary>Embedding subsection binding.</summary>
+    public AzureAISearchEmbeddingsOptions Embeddings { get; set; } = new();
+
+    /// <summary>
+    /// Blank <see cref="Endpoint"/> means the provider is not configured. The
+    /// registration extension short-circuits without materializing any client,
+    /// credential, or HTTP handler.
+    /// </summary>
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(Endpoint);
+
+    /// <summary>
+    /// Fails fast with an actionable message when a required field is missing
+    /// on the enabled path. Called only after <see cref="IsConfigured"/> returned
+    /// true — the disabled path never runs this.
+    /// </summary>
+    public void ValidateEnabled()
+    {
+        if (string.IsNullOrWhiteSpace(Endpoint))
+        {
+            throw new InvalidOperationException(
+                $"{SectionName}:Endpoint is required to enable the Azure AI Search knowledge provider.");
+        }
+
+        if (!Uri.TryCreate(Endpoint, UriKind.Absolute, out Uri? uri) ||
+            (uri.Scheme != Uri.UriSchemeHttps && uri.Scheme != Uri.UriSchemeHttp))
+        {
+            throw new InvalidOperationException(
+                $"{SectionName}:Endpoint '{Endpoint}' must be an absolute http(s) URL.");
+        }
+
+        if (string.IsNullOrWhiteSpace(IndexName))
+        {
+            throw new InvalidOperationException($"{SectionName}:IndexName is required.");
+        }
+
+        Embeddings.ValidateEnabled();
+    }
+}
+
+/// <summary>
+/// Embedding generation settings. Embeddings MUST be routed through the APIM
+/// AI Gateway so tokens are metered, rate-limited, and audited alongside chat
+/// completions.
+/// </summary>
+public sealed class AzureAISearchEmbeddingsOptions
+{
+    /// <summary>
+    /// APIM inference endpoint used to call the embedding model. Reuses the
+    /// gateway that already fronts chat completions — the same subscription
+    /// key, backend policy, and diagnostics apply.
+    /// </summary>
+    public string? Endpoint { get; set; }
+
+    /// <summary>Azure OpenAI deployment name for the embedding model.</summary>
+    public string Deployment { get; set; } = "text-embedding-3-small";
+
+    /// <summary>
+    /// Vector dimensions produced by the embedding model. Must match the
+    /// <c>contentVector</c> field on the index. Changing this requires a
+    /// schema-version bump and a reindex.
+    /// </summary>
+    [Range(64, 4096)]
+    public int Dimensions { get; set; } = 1536;
+
+    /// <summary>Azure OpenAI REST api-version query parameter.</summary>
+    public string ApiVersion { get; set; } = "2024-06-01";
+
+    /// <summary>
+    /// Cost-tracking model identifier fed into <see cref="Contracts.Observability.UsageEvent.Model"/>
+    /// so per-model pricing in <see cref="Observability.TokenPricing"/> applies.
+    /// Defaults to the deployment name when blank.
+    /// </summary>
+    public string ModelId { get; set; } = string.Empty;
+
+    /// <summary>Per-request timeout applied to the embeddings HTTP call (milliseconds).</summary>
+    [Range(500, 120_000)]
+    public int TimeoutMs { get; set; } = 10_000;
+
+    /// <summary>
+    /// Optional APIM subscription key. Preferred: managed identity via the
+    /// gateway policy. When set, sent as the <c>api-key</c> header alongside
+    /// the MI bearer token if the operator opts into hybrid auth for local
+    /// testing.
+    /// </summary>
+    public string? ApimSubscriptionKey { get; set; }
+
+    /// <summary>
+    /// Whether to use managed identity for the embeddings call. Default true —
+    /// the deployment contract mandates MI-only for hosted environments.
+    /// </summary>
+    public bool UseManagedIdentity { get; set; } = true;
+
+    /// <summary>Agent identifier stamped on cost events raised for embeddings.</summary>
+    public string CostTrackingAgentId { get; set; } = "azure-ai-search:embeddings";
+
+    /// <summary>Resolves the model identifier used for cost tracking.</summary>
+    public string ResolveModelId() =>
+        string.IsNullOrWhiteSpace(ModelId) ? Deployment : ModelId;
+
+    internal void ValidateEnabled()
+    {
+        if (string.IsNullOrWhiteSpace(Endpoint))
+        {
+            throw new InvalidOperationException(
+                $"{AzureAISearchOptions.SectionName}:Embeddings:Endpoint is required to enable the Azure AI Search knowledge provider — embeddings must traverse the APIM AI Gateway.");
+        }
+
+        if (!Uri.TryCreate(Endpoint, UriKind.Absolute, out Uri? uri) ||
+            (uri.Scheme != Uri.UriSchemeHttps && uri.Scheme != Uri.UriSchemeHttp))
+        {
+            throw new InvalidOperationException(
+                $"{AzureAISearchOptions.SectionName}:Embeddings:Endpoint '{Endpoint}' must be an absolute http(s) URL.");
+        }
+
+        if (string.IsNullOrWhiteSpace(Deployment))
+        {
+            throw new InvalidOperationException(
+                $"{AzureAISearchOptions.SectionName}:Embeddings:Deployment is required.");
+        }
+    }
+}

--- a/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
+++ b/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
@@ -101,7 +101,7 @@ public static class AzureAISearchServiceCollectionExtensions
                 {
                     NetworkTimeout = TimeSpan.FromMilliseconds(opts.RequestTimeoutMs),
                     MaxRetries = 3,
-                    Mode = Azure.Core.RetryMode.Exponential,
+                    Mode = RetryMode.Exponential,
                 },
             };
             return new SearchIndexClient(new Uri(opts.Endpoint!, UriKind.Absolute), credential, clientOptions);
@@ -117,13 +117,13 @@ public static class AzureAISearchServiceCollectionExtensions
                 {
                     NetworkTimeout = TimeSpan.FromMilliseconds(opts.RequestTimeoutMs),
                     MaxRetries = 3,
-                    Mode = Azure.Core.RetryMode.Exponential,
+                    Mode = RetryMode.Exponential,
                 },
             };
             return new SearchClient(new Uri(opts.Endpoint!, UriKind.Absolute), opts.IndexName, credential, clientOptions);
         });
 
-        services.TryAddSingleton<AzureAISearchKnowledgeBase>(sp => new AzureAISearchKnowledgeBase(
+        services.TryAddSingleton(sp => new AzureAISearchKnowledgeBase(
             sp.GetRequiredService<SearchIndexClient>(),
             sp.GetRequiredService<SearchClient>(),
             sp.GetRequiredService<ApimEmbeddingClient>(),

--- a/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
+++ b/src/RetailPulse.Api/Rag/AzureAISearch/AzureAISearchServiceCollectionExtensions.cs
@@ -1,0 +1,160 @@
+using Azure.Core;
+using Azure.Identity;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Resilience;
+using RetailPulse.Contracts.Observability;
+
+namespace RetailPulse.Api.Rag.AzureAISearch;
+
+/// <summary>
+/// Opt-in registration of the Azure AI Search knowledge provider.
+///
+/// The provider is FULLY OPTIONAL. When the <c>Knowledge:AzureAISearch:Endpoint</c>
+/// configuration value is blank, this extension is a no-op: no Search SDK
+/// client, embeddings HTTP client, credential, or token provider is
+/// materialized, and the <see cref="KnowledgeProviderRegistry"/> stays
+/// InMemory-only. Selecting <see cref="KnowledgeProviderMode.AzureAISearch"/>
+/// without configuring the endpoint fails startup with the shared
+/// unregistered-mode message from <see cref="KnowledgeProviderRegistry"/>.
+/// </summary>
+public static class AzureAISearchServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Azure AI Search knowledge provider (idempotent).
+    ///
+    /// Behaviour by configuration state:
+    /// <list type="bullet">
+    ///   <item><description>Blank endpoint — no registrations added. Default demo path unchanged.</description></item>
+    ///   <item><description>Endpoint set — registers <see cref="AzureAISearchKnowledgeBase"/> and the
+    ///   supporting Search SDK / embeddings HTTP path; adds the factory to
+    ///   <see cref="KnowledgeProviderRegistry"/> so
+    ///   <c>Mode=AzureAISearch</c> resolves it.</description></item>
+    /// </list>
+    /// </summary>
+    public static IServiceCollection AddAzureAISearchKnowledgeProvider(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var options = new AzureAISearchOptions();
+        configuration.GetSection(AzureAISearchOptions.SectionName).Bind(options);
+        if (!options.IsConfigured)
+        {
+            // Fully-optional gate. The registration is a no-op so selecting a
+            // non-InMemory mode without wiring the provider fails loudly via
+            // KnowledgeProviderRegistry.Create — never a silent degradation.
+            return services;
+        }
+
+        options.ValidateEnabled();
+
+        // Bind the strongly-typed options for consumers and register a
+        // singleton copy for direct-inject sites (index-schema tests, DI
+        // shape assertions).
+        services.Configure<AzureAISearchOptions>(
+            configuration.GetSection(AzureAISearchOptions.SectionName));
+        services.TryAddSingleton(sp => sp.GetRequiredService<IOptions<AzureAISearchOptions>>().Value);
+
+        // Single credential for the whole process — the Search SDK, the
+        // embeddings HTTP path, and any other MI-authenticated caller share
+        // one login stream. Kept as TokenCredential so tests can substitute
+        // deterministic credentials.
+        services.TryAddSingleton<TokenCredential>(_ => new DefaultAzureCredential());
+        services.TryAddSingleton<CognitiveServicesTokenProvider>();
+
+        // Named HTTP client with bounded timeout + retry + circuit breaker
+        // shared between the raw embeddings path and any future direct APIM
+        // caller — one breaker per external dependency.
+        services.AddHttpClient(ApimEmbeddingClient.HttpClientName, (sp, client) =>
+        {
+            AzureAISearchOptions opts = sp.GetRequiredService<AzureAISearchOptions>();
+            client.BaseAddress = new Uri(TrimTrailingSlash(opts.Embeddings.Endpoint!) + "/", UriKind.Absolute);
+            client.Timeout = TimeSpan.FromMilliseconds(Math.Max(1_000, opts.Embeddings.TimeoutMs * 4));
+        }).AddKnowledgeEmbeddingsResilienceHandler(options.Embeddings.TimeoutMs);
+
+        services.TryAddSingleton(sp =>
+        {
+            IHttpClientFactory factory = sp.GetRequiredService<IHttpClientFactory>();
+            HttpClient http = factory.CreateClient(ApimEmbeddingClient.HttpClientName);
+            return new ApimEmbeddingClient(
+                http,
+                sp.GetRequiredService<AzureAISearchOptions>(),
+                sp.GetRequiredService<ICostTracker>(),
+                sp.GetRequiredService<ILogger<ApimEmbeddingClient>>(),
+                sp.GetRequiredService<CognitiveServicesTokenProvider>());
+        });
+
+        services.TryAddSingleton(sp =>
+        {
+            AzureAISearchOptions opts = sp.GetRequiredService<AzureAISearchOptions>();
+            TokenCredential credential = sp.GetRequiredService<TokenCredential>();
+            var clientOptions = new SearchClientOptions
+            {
+                Retry =
+                {
+                    NetworkTimeout = TimeSpan.FromMilliseconds(opts.RequestTimeoutMs),
+                    MaxRetries = 3,
+                    Mode = Azure.Core.RetryMode.Exponential,
+                },
+            };
+            return new SearchIndexClient(new Uri(opts.Endpoint!, UriKind.Absolute), credential, clientOptions);
+        });
+
+        services.TryAddSingleton(sp =>
+        {
+            AzureAISearchOptions opts = sp.GetRequiredService<AzureAISearchOptions>();
+            TokenCredential credential = sp.GetRequiredService<TokenCredential>();
+            var clientOptions = new SearchClientOptions
+            {
+                Retry =
+                {
+                    NetworkTimeout = TimeSpan.FromMilliseconds(opts.RequestTimeoutMs),
+                    MaxRetries = 3,
+                    Mode = Azure.Core.RetryMode.Exponential,
+                },
+            };
+            return new SearchClient(new Uri(opts.Endpoint!, UriKind.Absolute), opts.IndexName, credential, clientOptions);
+        });
+
+        services.TryAddSingleton<AzureAISearchKnowledgeBase>(sp => new AzureAISearchKnowledgeBase(
+            sp.GetRequiredService<SearchIndexClient>(),
+            sp.GetRequiredService<SearchClient>(),
+            sp.GetRequiredService<ApimEmbeddingClient>(),
+            sp.GetRequiredService<AzureAISearchOptions>(),
+            sp.GetRequiredService<IOptions<KnowledgeOptions>>().Value,
+            sp.GetRequiredService<ILogger<AzureAISearchKnowledgeBase>>()));
+
+        // Contribute the factory to the shared KnowledgeProviderRegistry via
+        // the IKnowledgeProviderContribution seam so selecting
+        // Knowledge:Provider:Mode=AzureAISearch resolves this KB.
+        services.AddSingleton<IKnowledgeProviderContribution, AzureAISearchProviderContribution>();
+
+        return services;
+    }
+
+    private static string TrimTrailingSlash(string value) =>
+        value.EndsWith('/') ? value[..^1] : value;
+}
+
+/// <summary>
+/// Contributes the Azure AI Search provider factory to the shared
+/// <see cref="KnowledgeProviderRegistry"/>. Consumed by the registry singleton
+/// factory in <c>Program.cs</c>.
+/// </summary>
+internal sealed class AzureAISearchProviderContribution : IKnowledgeProviderContribution
+{
+    public void Register(KnowledgeProviderRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        registry.Register(
+            KnowledgeProviderMode.AzureAISearch,
+            sp => sp.GetRequiredService<AzureAISearchKnowledgeBase>());
+    }
+}

--- a/src/RetailPulse.Api/Rag/AzureAISearch/CognitiveServicesTokenProvider.cs
+++ b/src/RetailPulse.Api/Rag/AzureAISearch/CognitiveServicesTokenProvider.cs
@@ -1,0 +1,59 @@
+using Azure.Core;
+
+namespace RetailPulse.Api.Rag.AzureAISearch;
+
+/// <summary>
+/// Async, thread-safe access-token cache used by the embeddings HTTP path so
+/// it authenticates through the same <see cref="TokenCredential"/> singleton
+/// that the Azure.Search SDK uses. Mirrors the ContentSafety token provider
+/// pattern so a single managed-identity login stream serves every path.
+/// </summary>
+public sealed class CognitiveServicesTokenProvider
+{
+    /// <summary>Refresh a cached token when this much lifetime remains.</summary>
+    public static readonly TimeSpan RefreshBuffer = TimeSpan.FromMinutes(5);
+
+    /// <summary>OAuth scope for the Azure OpenAI data plane (chat + embeddings).</summary>
+    public const string Scope = "https://cognitiveservices.azure.com/.default";
+
+    private static readonly string[] _scopes = [Scope];
+
+    private readonly TokenCredential _credential;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private AccessToken _cached;
+
+    public CognitiveServicesTokenProvider(TokenCredential credential)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        _credential = credential;
+    }
+
+    /// <summary>Returns a valid bearer token, refreshing under the semaphore if necessary.</summary>
+    public async ValueTask<string> GetBearerAsync(CancellationToken cancellationToken)
+    {
+        if (HasSufficientLifetime(_cached))
+        {
+            return _cached.Token;
+        }
+
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (HasSufficientLifetime(_cached))
+            {
+                return _cached.Token;
+            }
+            _cached = await _credential.GetTokenAsync(
+                new TokenRequestContext(_scopes),
+                cancellationToken).ConfigureAwait(false);
+            return _cached.Token;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    private static bool HasSufficientLifetime(AccessToken token) =>
+        token.Token is { Length: > 0 } && token.ExpiresOn - RefreshBuffer > DateTimeOffset.UtcNow;
+}

--- a/src/RetailPulse.Api/Rag/IKnowledgeProviderContribution.cs
+++ b/src/RetailPulse.Api/Rag/IKnowledgeProviderContribution.cs
@@ -1,0 +1,14 @@
+namespace RetailPulse.Api.Rag;
+
+/// <summary>
+/// Extension seam that lets opt-in provider modules (Azure AI Search, Foundry
+/// IQ) add themselves to the shared <see cref="KnowledgeProviderRegistry"/>
+/// without editing <c>Program.cs</c>. The registry factory enumerates every
+/// registered contribution at construction time so the order in which the
+/// extension methods are called does not matter.
+/// </summary>
+public interface IKnowledgeProviderContribution
+{
+    /// <summary>Registers this contribution's provider factory on the shared registry.</summary>
+    void Register(KnowledgeProviderRegistry registry);
+}

--- a/src/RetailPulse.Api/Resilience/CircuitBreakerHealthCheck.cs
+++ b/src/RetailPulse.Api/Resilience/CircuitBreakerHealthCheck.cs
@@ -12,6 +12,8 @@ public class CircuitBreakerHealthCheck : IHealthCheck
     private static DateTimeOffset _lastStateChange = DateTimeOffset.UtcNow;
     private static CircuitBreakerState _contentSafetyState = CircuitBreakerState.Closed;
     private static DateTimeOffset _contentSafetyLastChange = DateTimeOffset.UtcNow;
+    private static CircuitBreakerState _knowledgeState = CircuitBreakerState.Closed;
+    private static DateTimeOffset _knowledgeLastChange = DateTimeOffset.UtcNow;
 
     public static void ReportState(CircuitBreakerState state)
     {
@@ -38,6 +40,22 @@ public class CircuitBreakerHealthCheck : IHealthCheck
         }
     }
 
+    /// <summary>
+    /// Reports the Azure AI Search embeddings breaker state on the same health
+    /// probe so a knowledge-provider outage is visible alongside MCP and
+    /// Content Safety. Exposed under <c>knowledgeCircuitState</c>. State never
+    /// escalates the overall health check status — the degradation policy at
+    /// the knowledge base decides fail-loud vs fallback.
+    /// </summary>
+    public static void ReportKnowledgeState(CircuitBreakerState state)
+    {
+        if (_knowledgeState != state)
+        {
+            _knowledgeState = state;
+            _knowledgeLastChange = DateTimeOffset.UtcNow;
+        }
+    }
+
     public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken ct = default)
     {
         var data = new Dictionary<string, object>
@@ -45,7 +63,9 @@ public class CircuitBreakerHealthCheck : IHealthCheck
             ["circuitState"] = _state.ToString(),
             ["lastStateChange"] = _lastStateChange.ToString("O"),
             ["contentSafetyCircuitState"] = _contentSafetyState.ToString(),
-            ["contentSafetyLastStateChange"] = _contentSafetyLastChange.ToString("O")
+            ["contentSafetyLastStateChange"] = _contentSafetyLastChange.ToString("O"),
+            ["knowledgeCircuitState"] = _knowledgeState.ToString(),
+            ["knowledgeLastStateChange"] = _knowledgeLastChange.ToString("O")
         };
 
         HealthCheckResult result = _state switch

--- a/src/RetailPulse.Api/Resilience/ResilienceExtensions.cs
+++ b/src/RetailPulse.Api/Resilience/ResilienceExtensions.cs
@@ -105,4 +105,59 @@ public static class ResilienceExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Bounded timeout + retry + circuit breaker for the Azure AI Search
+    /// embeddings HTTP client (embeddings must traverse the APIM AI Gateway).
+    /// Mirrors the MCP retry-inside-breaker composition so a transient blip
+    /// retries within the breaker's protection while a sustained outage trips
+    /// the breaker without hammering APIM. Breaker state is surfaced under
+    /// <c>knowledgeCircuitState</c> on <see cref="CircuitBreakerHealthCheck"/>.
+    /// </summary>
+    public static IHttpClientBuilder AddKnowledgeEmbeddingsResilienceHandler(
+        this IHttpClientBuilder builder,
+        int timeoutMs)
+    {
+        int boundedTimeoutMs = Math.Max(500, timeoutMs);
+        builder.AddResilienceHandler("KnowledgeEmbeddingsResilience", pipelineBuilder =>
+        {
+            pipelineBuilder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
+            {
+                FailureRatio = 0.5,
+                SamplingDuration = TimeSpan.FromSeconds(30),
+                MinimumThroughput = 5,
+                BreakDuration = TimeSpan.FromSeconds(30),
+                OnOpened = args =>
+                {
+                    CircuitBreakerHealthCheck.ReportKnowledgeState(CircuitBreakerState.Open);
+                    return ValueTask.CompletedTask;
+                },
+                OnClosed = args =>
+                {
+                    CircuitBreakerHealthCheck.ReportKnowledgeState(CircuitBreakerState.Closed);
+                    return ValueTask.CompletedTask;
+                },
+                OnHalfOpened = args =>
+                {
+                    CircuitBreakerHealthCheck.ReportKnowledgeState(CircuitBreakerState.HalfOpen);
+                    return ValueTask.CompletedTask;
+                }
+            });
+
+            pipelineBuilder.AddRetry(new HttpRetryStrategyOptions
+            {
+                MaxRetryAttempts = 2,
+                Delay = TimeSpan.FromMilliseconds(500),
+                BackoffType = DelayBackoffType.Exponential,
+                UseJitter = true,
+            });
+
+            pipelineBuilder.AddTimeout(new HttpTimeoutStrategyOptions
+            {
+                Timeout = TimeSpan.FromMilliseconds(boundedTimeoutMs),
+            });
+        });
+
+        return builder;
+    }
 }

--- a/src/RetailPulse.Api/RetailPulse.Api.csproj
+++ b/src/RetailPulse.Api/RetailPulse.Api.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.AI.Projects" />
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Search.Documents" />
     <PackageReference Include="Microsoft.Agents.AI" />
     <PackageReference Include="Microsoft.Agents.AI.Abstractions" />
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" />

--- a/src/RetailPulse.Api/appsettings.json
+++ b/src/RetailPulse.Api/appsettings.json
@@ -180,6 +180,63 @@
     "Provider": {
       "Mode": "InMemory",
       "Degradation": "FailLoud"
+    },
+
+    // ---- Azure AI Search knowledge provider (issue #103) ---------------
+    // FULLY OPTIONAL cloud provider. When Endpoint is blank, NOTHING about
+    // this section is materialized — no Search SDK client, no HTTP handler,
+    // no credential — so the default demo path stays byte-for-byte identical
+    // to the InMemory-only baseline. Enable by setting
+    // Knowledge:Provider:Mode="AzureAISearch" AND supplying Endpoint below.
+    //
+    //   Endpoint            Search service URL (https://<name>.search.windows.net).
+    //   IndexName           Target index. Auto-created on first probe when
+    //                       AutoCreateIndex=true. Never silently mutated.
+    //   AutoCreateIndex     Create the index at startup if missing. When false
+    //                       and the index is absent, ProbeAsync fails loud.
+    //   SchemaVersion       Stamped on every ingested chunk. Bump when the
+    //                       index schema changes and run the reindex
+    //                       procedure (docs/rag/azure-ai-search-index.md).
+    //   RequestTimeoutMs    Per-call ceiling for Search SDK operations.
+    //   SemanticRankingEnabled  Turn on semantic reranking. Requires the
+    //                       Search service to be provisioned with the
+    //                       Semantic Search (semanticSearch) feature.
+    //   Embeddings          Vector generation. MUST traverse the APIM AI
+    //                       Gateway so tokens are metered/rate-limited/
+    //                       audited like completions.
+    //     Endpoint          APIM inference base URL, same host as OpenAI
+    //                       chat completions.
+    //     Deployment        Azure OpenAI embedding deployment name.
+    //     Dimensions        Vector length; must match the deployment.
+    //     ApiVersion        Azure OpenAI api-version.
+    //     TimeoutMs         Per-request timeout for the embeddings call.
+    //     UseManagedIdentity  Preferred; obtains bearer via DefaultAzureCredential.
+    //     ApimSubscriptionKey Optional local-dev fallback (never a secret in
+    //                       committed config).
+    //     ModelId           Cost-tracking model key. Defaults to Deployment
+    //                       when blank; must match a TokenPricing entry to
+    //                       accrue cost.
+    "AzureAISearch": {
+      "Endpoint": "",
+      "IndexName": "retail-pulse-knowledge",
+      "AutoCreateIndex": true,
+      "SchemaVersion": "v1",
+      "RequestTimeoutMs": 20000,
+      "SemanticRankingEnabled": false,
+      "SemanticConfigurationName": "retail-pulse-semantic",
+      "VectorProfileName": "retail-pulse-vector",
+      "HnswAlgorithmName": "retail-pulse-hnsw",
+      "Embeddings": {
+        "Endpoint": "",
+        "Deployment": "text-embedding-3-small",
+        "Dimensions": 1536,
+        "ApiVersion": "2024-06-01",
+        "TimeoutMs": 10000,
+        "UseManagedIdentity": true,
+        "ApimSubscriptionKey": "",
+        "ModelId": "",
+        "CostTrackingAgentId": "azure-ai-search:embeddings"
+      }
     }
   },
 
@@ -286,7 +343,11 @@
     "gpt-4o-mini": { "InputPerMillion": 0.15, "OutputPerMillion": 0.60 },
     "claude-opus-4.6": { "InputPerMillion": 5.00, "OutputPerMillion": 25.00 },
     "claude-sonnet-4.6": { "InputPerMillion": 3.00, "OutputPerMillion": 15.00 },
-    "claude-haiku-4.5": { "InputPerMillion": 1.00, "OutputPerMillion": 5.00 }
+    "claude-haiku-4.5": { "InputPerMillion": 1.00, "OutputPerMillion": 5.00 },
+    // Embedding models used by the optional Azure AI Search knowledge
+    // provider (issue #103). Output tokens are always zero for embeddings.
+    "text-embedding-3-small": { "InputPerMillion": 0.02, "OutputPerMillion": 0.00 },
+    "text-embedding-3-large": { "InputPerMillion": 0.13, "OutputPerMillion": 0.00 }
   },
 
   // ---- Guardrails: runtime + load-time (issue #99) ----------------------

--- a/tests/RetailPulse.Tests/Deployment/AzureAISearchDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Deployment/AzureAISearchDeploymentContractTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+
+namespace RetailPulse.Tests.Deployment;
+
+/// <summary>
+/// Issue #103 — Azure AI Search deployment gate. When the feature is gated by
+/// <c>aiSearchEnabled = false</c> (the default), a clean <c>azd up</c> must
+/// not provision a Search service. When enabled, the module must express the
+/// RBAC-first contract (managed identity, no local keys) and the postprovision
+/// hooks must grant <c>Search Service Contributor</c> + <c>Search Index Data
+/// Contributor</c> to every container app system identity idempotently.
+/// </summary>
+public class AzureAISearchDeploymentContractTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void AiSearchModule_Exists()
+    {
+        File.Exists(Path.Combine(RepoRoot, "infra", "modules", "ai-search.bicep"))
+            .Should().BeTrue("infra/modules/ai-search.bicep is the provisioning contract");
+    }
+
+    [Fact]
+    public void AiSearchModule_UsesManagedIdentityAndDisablesLocalAuth()
+    {
+        string module = File.ReadAllText(Path.Combine(RepoRoot, "infra", "modules", "ai-search.bicep"));
+
+        module.Should().Contain("Microsoft.Search/searchServices",
+            "the module must declare an Azure AI Search service");
+        module.Should().Contain("type: 'SystemAssigned'",
+            "the service must carry a system-assigned identity");
+        module.Should().Contain("disableLocalAuth: true",
+            "key-based auth must be disabled so callers must use managed identity");
+        module.Should().NotContain("listAdminKeys(",
+            "the module must not surface admin keys");
+        module.Should().NotContain("listQueryKeys(",
+            "the module must not surface query keys");
+    }
+
+    [Fact]
+    public void MainBicep_GatesAiSearchBehindDisabledDefault()
+    {
+        string main = File.ReadAllText(Path.Combine(RepoRoot, "infra", "main.bicep"));
+
+        main.Should().Contain("param aiSearchEnabled bool = false",
+            "AI Search must ship disabled-by-default so a clean azd up is unchanged");
+        main.Should().Contain("if (aiSearchEnabled)",
+            "the AI Search module must be conditional on the enabled flag");
+        main.Should().Contain("AZURE_AI_SEARCH_ENDPOINT",
+            "provisioning must publish the endpoint output so the API can consume it");
+        main.Should().Contain("AZURE_AI_SEARCH_RESOURCE_ID",
+            "provisioning must publish the resource id so the postprovision hook can scope RBAC");
+    }
+
+    [Fact]
+    public void BicepParam_ReadsAiSearchToggleFromEnvironment()
+    {
+        string param = File.ReadAllText(Path.Combine(RepoRoot, "infra", "main.bicepparam"));
+
+        param.Should().Contain("AZURE_AI_SEARCH_ENABLED",
+            "operators toggle AI Search with azd env set AZURE_AI_SEARCH_ENABLED=true");
+    }
+
+    [Theory]
+    [InlineData("postprovision.ps1")]
+    [InlineData("postprovision.sh")]
+    public void PostprovisionHook_GrantsSearchRolesWhenEnabled(string hookFile)
+    {
+        string script = File.ReadAllText(Path.Combine(RepoRoot, "azd-hooks", hookFile));
+
+        script.Should().Contain("AZURE_AI_SEARCH_ENABLED",
+            $"{hookFile} must gate the AI Search role assignments on the enabled flag");
+        script.Should().Contain("Search Service Contributor",
+            $"{hookFile} must grant Search Service Contributor for index create/inspect");
+        script.Should().Contain("Search Index Data Contributor",
+            $"{hookFile} must grant Search Index Data Contributor for document CRUD");
+        script.Should().Contain("AZURE_AI_SEARCH_RESOURCE_ID",
+            $"{hookFile} must scope the role assignments to the Search service resource id");
+        (script.Contains("role assignment list") || script.Contains("'role', 'assignment', 'list'"))
+            .Should().BeTrue($"{hookFile} must check for an existing grant so the hook stays idempotent");
+    }
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "RetailPulse.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new InvalidOperationException("Could not locate repo root walking up from " + AppContext.BaseDirectory);
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/ApimEmbeddingClientTests.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/ApimEmbeddingClientTests.cs
@@ -1,0 +1,181 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Rag.AzureAISearch;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Tests.Rag.AzureAISearch;
+
+/// <summary>
+/// Embeddings client contract:
+/// <list type="bullet">
+///   <item>Sends the request to the APIM AI Gateway using the AOAI-style path.</item>
+///   <item>Wraps transport failures in <see cref="KnowledgeProviderUnavailableException"/>.</item>
+///   <item>Never returns an empty / zero vector on failure — degradation is the wrapper's job.</item>
+///   <item>Rejects dimension mismatch loud.</item>
+///   <item>Emits a <see cref="UsageEvent"/> per successful call so embedding tokens are metered.</item>
+/// </list>
+/// </summary>
+public class ApimEmbeddingClientTests
+{
+    [Fact]
+    public async Task Embed_SendsCorrectPath_AndRecordsCost()
+    {
+        (ApimEmbeddingClient client, CapturingHandler handler, InMemoryCostTracker tracker) = CreateClient(
+            deploymentReplyMs: 0,
+            respondJson: BuildSuccessJson(dim: 8, inputs: 1, promptTokens: 42));
+
+        ReadOnlyMemory<float> vec = await client.EmbedAsync("hello world", CancellationToken.None);
+
+        vec.Length.Should().Be(8);
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.PathAndQuery.Should()
+            .Contain("openai/deployments/text-embedding-3-small/embeddings")
+            .And.Contain("api-version=2024-06-01");
+
+        CostSummary summary = await tracker.GetSummaryAsync(CostPeriod.All);
+        summary.RequestCount.Should().Be(1);
+        summary.TotalTokens.Should().Be(42,
+            "embedding prompt-token usage must roll into the cost dashboard so tokens are metered like completions");
+    }
+
+    [Fact]
+    public async Task EmbedBatch_PreservesInputOrder_ByIndex()
+    {
+        // Return the response with items in reversed order — the client must
+        // reorder by the index field so caller-order is preserved.
+        string body = """
+        {
+          "data": [
+            { "index": 1, "embedding": [0.1, 0.2, 0.3, 0.4] },
+            { "index": 0, "embedding": [0.9, 0.8, 0.7, 0.6] }
+          ],
+          "usage": { "prompt_tokens": 5, "total_tokens": 5 }
+        }
+        """;
+        (ApimEmbeddingClient client, _, _) = CreateClient(respondJson: body, dimensions: 4);
+
+        IReadOnlyList<ReadOnlyMemory<float>> vectors = await client.EmbedBatchAsync(["first", "second"], CancellationToken.None);
+
+        vectors[0].ToArray().Should().Equal(0.9f, 0.8f, 0.7f, 0.6f);
+        vectors[1].ToArray().Should().Equal(0.1f, 0.2f, 0.3f, 0.4f);
+    }
+
+    [Fact]
+    public async Task Embed_TransportFailure_WrapsAsProviderUnavailable()
+    {
+        (ApimEmbeddingClient client, CapturingHandler handler, _) = CreateClient(
+            respondStatus: HttpStatusCode.ServiceUnavailable,
+            respondJson: "{\"error\":\"backend unreachable\"}");
+
+        Func<Task> act = () => client.EmbedAsync("hi", CancellationToken.None);
+
+        await act.Should().ThrowAsync<KnowledgeProviderUnavailableException>()
+            .Where(ex => ex.ProviderName == AzureAISearchKnowledgeBase.ProviderName);
+    }
+
+    [Fact]
+    public async Task Embed_DimensionMismatch_FailsLoud()
+    {
+        (ApimEmbeddingClient client, _, _) = CreateClient(
+            respondJson: BuildSuccessJson(dim: 3, inputs: 1, promptTokens: 1),
+            dimensions: 8);
+
+        Func<Task> act = () => client.EmbedAsync("hi", CancellationToken.None);
+
+        await act.Should().ThrowAsync<KnowledgeProviderUnavailableException>()
+            .WithMessage("*vector of length 3*expected 8*");
+    }
+
+    [Fact]
+    public async Task EmbedBatch_Empty_ShortCircuits_NoHttpCall()
+    {
+        (ApimEmbeddingClient client, CapturingHandler handler, _) = CreateClient(
+            respondJson: BuildSuccessJson(dim: 8, inputs: 1, promptTokens: 42));
+
+        IReadOnlyList<ReadOnlyMemory<float>> result = await client.EmbedBatchAsync([], CancellationToken.None);
+
+        result.Should().BeEmpty();
+        handler.LastRequest.Should().BeNull(
+            "an empty batch must not consume APIM tokens or hit the wire");
+    }
+
+    private static string BuildSuccessJson(int dim, int inputs, int promptTokens)
+    {
+        var items = Enumerable.Range(0, inputs).Select(i => new
+        {
+            index = i,
+            embedding = Enumerable.Range(0, dim).Select(v => (float)(((i + 1) * 0.01f) + (v * 0.001f))).ToArray(),
+        });
+        var payload = new
+        {
+            data = items,
+            usage = new { prompt_tokens = promptTokens, total_tokens = promptTokens },
+        };
+        return JsonSerializer.Serialize(payload);
+    }
+
+    private static (ApimEmbeddingClient client, CapturingHandler handler, InMemoryCostTracker tracker) CreateClient(
+        string respondJson,
+        HttpStatusCode respondStatus = HttpStatusCode.OK,
+        int deploymentReplyMs = 0,
+        int dimensions = 8)
+    {
+        var options = new AzureAISearchOptions
+        {
+            Endpoint = "https://mysearch.search.windows.net",
+        };
+        options.Embeddings.Endpoint = "https://apim.example.com/inference";
+        options.Embeddings.Deployment = "text-embedding-3-small";
+        options.Embeddings.Dimensions = dimensions;
+        options.Embeddings.UseManagedIdentity = false;
+        options.Embeddings.ApimSubscriptionKey = "test-key";
+
+        var handler = new CapturingHandler(respondStatus, respondJson, deploymentReplyMs);
+        var http = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://apim.example.com/inference/", UriKind.Absolute),
+        };
+
+        var tracker = new InMemoryCostTracker(
+            Options.Create(new ObservabilityOptions
+            {
+                MaxCostEvents = 100,
+                CostEventTtlHours = 24,
+            }),
+            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build());
+
+        var client = new ApimEmbeddingClient(
+            http,
+            options,
+            tracker,
+            NullLoggerFactory.Instance.CreateLogger<ApimEmbeddingClient>());
+
+        return (client, handler, tracker);
+    }
+
+    private sealed class CapturingHandler(HttpStatusCode status, string body, int delayMs) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            if (delayMs > 0)
+            {
+                await Task.Delay(delayMs, cancellationToken);
+            }
+            return new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/ApimEmbeddingClientTests.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/ApimEmbeddingClientTests.cs
@@ -50,7 +50,7 @@ public class ApimEmbeddingClientTests
     {
         // Return the response with items in reversed order — the client must
         // reorder by the index field so caller-order is preserved.
-        string body = """
+        string body = /*lang=json,strict*/ """
         {
           "data": [
             { "index": 1, "embedding": [0.1, 0.2, 0.3, 0.4] },
@@ -72,7 +72,7 @@ public class ApimEmbeddingClientTests
     {
         (ApimEmbeddingClient client, CapturingHandler handler, _) = CreateClient(
             respondStatus: HttpStatusCode.ServiceUnavailable,
-            respondJson: "{\"error\":\"backend unreachable\"}");
+            respondJson: /*lang=json,strict*/ "{\"error\":\"backend unreachable\"}");
 
         Func<Task> act = () => client.EmbedAsync("hi", CancellationToken.None);
 

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchDefaultDisabledStartupTests.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchDefaultDisabledStartupTests.cs
@@ -1,0 +1,140 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Rag;
+using RetailPulse.Api.Rag.AzureAISearch;
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Tests.Rag.AzureAISearch;
+
+/// <summary>
+/// Optional-default proof. Mirrors the Program.cs wiring for the Knowledge
+/// section without any cloud resource, then verifies that:
+///
+/// 1. The provider selector resolves <see cref="KnowledgeProviderMode.InMemory"/>.
+/// 2. The provider registry contains ONLY the InMemory factory.
+/// 3. No Azure AI Search DI type is materialized.
+/// 4. Calling <see cref="IKnowledgeBase.ProbeAsync"/> completes without
+///    contacting any external resource.
+///
+/// This is the executable proof of the issue #103 non-negotiable requirement
+/// that the provider is fully optional.
+/// </summary>
+public class AzureAISearchDefaultDisabledStartupTests
+{
+    [Fact]
+    public void DefaultConfiguration_ResolvesInMemoryAndOmitsAzureAISearch()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection([])
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(config);
+        services.Configure<KnowledgeOptions>(config.GetSection(KnowledgeOptions.SectionName));
+        services.Configure<KnowledgeProviderOptions>(config.GetSection(KnowledgeProviderOptions.SectionName));
+        services.AddSingleton<InMemoryKnowledgeBase>();
+        services.AddSingleton(sp =>
+        {
+            var registry = new KnowledgeProviderRegistry();
+            registry.Register(
+                KnowledgeProviderMode.InMemory,
+                s => s.GetRequiredService<InMemoryKnowledgeBase>());
+            foreach (IKnowledgeProviderContribution c in sp.GetServices<IKnowledgeProviderContribution>())
+            {
+                c.Register(registry);
+            }
+            return registry;
+        });
+        services.AddSingleton<KnowledgeProviderSelector>();
+
+        // This is the target line under test — extension must be a no-op on
+        // blank config, leaving InMemory as the only registered provider.
+        services.AddAzureAISearchKnowledgeProvider(config);
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        KnowledgeProviderSelector selector = sp.GetRequiredService<KnowledgeProviderSelector>();
+        selector.ResolveMode().Should().Be(KnowledgeProviderMode.InMemory);
+        selector.ResolveDegradation().Should().Be(KnowledgeDegradationMode.FailLoud);
+
+        KnowledgeProviderRegistry registry = sp.GetRequiredService<KnowledgeProviderRegistry>();
+        registry.RegisteredModes.Should().ContainSingle().Which
+            .Should().Be(KnowledgeProviderMode.InMemory);
+        registry.IsRegistered(KnowledgeProviderMode.AzureAISearch).Should().BeFalse(
+            "the default demo config MUST NOT register a cloud provider factory");
+
+        sp.GetService<AzureAISearchKnowledgeBase>().Should().BeNull(
+            "the KB itself must not be resolvable when the endpoint is blank");
+        sp.GetService<AzureAISearchOptions>().Should().BeNull(
+            "the strongly-typed options singleton is only registered on the enabled path");
+
+        // Materialize the primary and probe — no exception, no external call.
+        IKnowledgeBase primary = selector.CreatePrimary(sp);
+        primary.GetCapabilities().ProviderName.Should().Be(InMemoryKnowledgeBase.ProviderName);
+        Func<Task> probe = () => primary.ProbeAsync();
+        probe.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public void DefaultConfiguration_SelectingAzureAISearch_FailsLoudlyWithActionableMessage()
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                // Mode selected but the provider extension was never wired.
+                ["Knowledge:Provider:Mode"] = "AzureAISearch",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(config);
+        services.Configure<KnowledgeOptions>(config.GetSection(KnowledgeOptions.SectionName));
+        services.Configure<KnowledgeProviderOptions>(config.GetSection(KnowledgeProviderOptions.SectionName));
+        services.AddSingleton<InMemoryKnowledgeBase>();
+        services.AddSingleton(sp =>
+        {
+            var registry = new KnowledgeProviderRegistry();
+            registry.Register(
+                KnowledgeProviderMode.InMemory,
+                s => s.GetRequiredService<InMemoryKnowledgeBase>());
+            foreach (IKnowledgeProviderContribution c in sp.GetServices<IKnowledgeProviderContribution>())
+            {
+                c.Register(registry);
+            }
+            return registry;
+        });
+        services.AddSingleton<KnowledgeProviderSelector>();
+        services.AddAzureAISearchKnowledgeProvider(config);
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        KnowledgeProviderSelector selector = sp.GetRequiredService<KnowledgeProviderSelector>();
+        Action act = () => selector.CreatePrimary(sp);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not registered*")
+            .WithMessage("*AzureAISearch*");
+    }
+
+    /// <summary>
+    /// Guard so a future change to the extension can't silently re-materialize
+    /// clients on the disabled path — the DI graph shape is the source of truth.
+    /// </summary>
+    [Fact]
+    public void InMemoryKnowledgeBase_ProbeAsync_DoesNotHitNetwork()
+    {
+        InMemoryKnowledgeBase kb = new(
+            NullLoggerFactory.Instance.CreateLogger<InMemoryKnowledgeBase>(),
+            Options.Create(new KnowledgeOptions()));
+
+        Func<Task> probe = () => kb.ProbeAsync();
+        probe.Should().NotThrowAsync();
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchIndexSchemaTests.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchIndexSchemaTests.cs
@@ -1,0 +1,162 @@
+using Azure.Search.Documents.Indexes.Models;
+using FluentAssertions;
+using RetailPulse.Api.Rag.AzureAISearch;
+
+namespace RetailPulse.Tests.Rag.AzureAISearch;
+
+/// <summary>
+/// Index schema contract. Every field the provider reads must exist with the
+/// right type; the vector dimension must match the configured Embeddings
+/// dimensions. A drifted schema is detected explicitly so operators can run
+/// the documented reindex procedure rather than silently corrupt a live index.
+/// </summary>
+public class AzureAISearchIndexSchemaTests
+{
+    [Fact]
+    public void Build_IncludesEveryConsumedField()
+    {
+        var opts = new AzureAISearchOptions
+        {
+            Endpoint = "https://x.search.windows.net",
+            IndexName = "test",
+        };
+        opts.Embeddings.Dimensions = 128;
+
+        SearchIndex index = AzureAISearchIndexSchema.Build(opts);
+
+        var fieldNames = index.Fields.Select(f => f.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        fieldNames.Should().Contain([
+            AzureAISearchIndexSchema.ChunkIdField,
+            AzureAISearchIndexSchema.DocumentIdField,
+            AzureAISearchIndexSchema.ChunkIndexField,
+            AzureAISearchIndexSchema.TitleField,
+            AzureAISearchIndexSchema.ContentField,
+            AzureAISearchIndexSchema.SourceField,
+            AzureAISearchIndexSchema.SectionHeaderField,
+            AzureAISearchIndexSchema.IngestedAtField,
+            AzureAISearchIndexSchema.SchemaVersionField,
+            AzureAISearchIndexSchema.AgentScopeField,
+            AzureAISearchIndexSchema.VectorField,
+        ]);
+
+        SearchField vector = index.Fields.Single(f => f.Name == AzureAISearchIndexSchema.VectorField);
+        vector.VectorSearchDimensions.Should().Be(128);
+    }
+
+    [Fact]
+    public void Build_KeyFieldIsChunkId()
+    {
+        SearchIndex index = AzureAISearchIndexSchema.Build(new AzureAISearchOptions
+        {
+            Endpoint = "https://x.search.windows.net",
+            IndexName = "test",
+        });
+
+        SearchField key = index.Fields.Single(f => f.IsKey == true);
+        key.Name.Should().Be(AzureAISearchIndexSchema.ChunkIdField,
+            "the chunk id is the durable identity of each document");
+    }
+
+    [Fact]
+    public void Build_IncludesHnswVectorProfile()
+    {
+        SearchIndex index = AzureAISearchIndexSchema.Build(new AzureAISearchOptions
+        {
+            Endpoint = "https://x.search.windows.net",
+            IndexName = "test",
+            VectorProfileName = "vec-p",
+            HnswAlgorithmName = "hnsw-a",
+        });
+
+        index.VectorSearch.Should().NotBeNull();
+        index.VectorSearch.Algorithms.Should().ContainSingle(a => a.Name == "hnsw-a");
+        index.VectorSearch.Profiles.Should().ContainSingle(p => p.Name == "vec-p");
+    }
+
+    [Fact]
+    public void Build_SemanticEnabled_IncludesSemanticConfiguration()
+    {
+        var opts = new AzureAISearchOptions
+        {
+            Endpoint = "https://x.search.windows.net",
+            IndexName = "test",
+            SemanticRankingEnabled = true,
+            SemanticConfigurationName = "sem-c",
+        };
+
+        SearchIndex index = AzureAISearchIndexSchema.Build(opts);
+
+        index.SemanticSearch.Should().NotBeNull();
+        index.SemanticSearch.Configurations
+            .Should().ContainSingle(c => c.Name == "sem-c");
+    }
+
+    [Fact]
+    public void Build_SemanticDisabled_OmitsSemanticConfiguration()
+    {
+        SearchIndex index = AzureAISearchIndexSchema.Build(new AzureAISearchOptions
+        {
+            Endpoint = "https://x.search.windows.net",
+            IndexName = "test",
+            SemanticRankingEnabled = false,
+        });
+
+        index.SemanticSearch.Should().BeNull(
+            "the demo default keeps the free semantic feature off unless explicitly opted into");
+    }
+
+    [Fact]
+    public void DetectMismatch_HappyPath_ReturnsNull()
+    {
+        var opts = new AzureAISearchOptions
+        {
+            Endpoint = "https://x.search.windows.net",
+            IndexName = "test",
+        };
+        SearchIndex live = AzureAISearchIndexSchema.Build(opts);
+
+        string? diff = AzureAISearchIndexSchema.DetectMismatch(live, opts);
+
+        diff.Should().BeNull();
+    }
+
+    [Fact]
+    public void DetectMismatch_ReportsMissingField()
+    {
+        var opts = new AzureAISearchOptions
+        {
+            Endpoint = "https://x.search.windows.net",
+            IndexName = "test",
+        };
+        SearchIndex live = AzureAISearchIndexSchema.Build(opts);
+        SearchField missing = live.Fields.Single(f => f.Name == AzureAISearchIndexSchema.SourceField);
+        live.Fields.Remove(missing);
+
+        string? diff = AzureAISearchIndexSchema.DetectMismatch(live, opts);
+
+        diff.Should().NotBeNull().And.Contain(AzureAISearchIndexSchema.SourceField);
+    }
+
+    [Fact]
+    public void DetectMismatch_ReportsVectorDimensionDrift()
+    {
+        var opts = new AzureAISearchOptions
+        {
+            Endpoint = "https://x.search.windows.net",
+            IndexName = "test",
+        };
+        opts.Embeddings.Dimensions = 1536;
+        SearchIndex live = AzureAISearchIndexSchema.Build(opts);
+
+        var drifted = new AzureAISearchOptions
+        {
+            Endpoint = opts.Endpoint,
+            IndexName = opts.IndexName,
+        };
+        drifted.Embeddings.Dimensions = 768;
+
+        string? diff = AzureAISearchIndexSchema.DetectMismatch(live, drifted);
+
+        diff.Should().NotBeNull().And.Contain("dimension");
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchLiveConformanceTests.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchLiveConformanceTests.cs
@@ -1,0 +1,139 @@
+using Azure.Identity;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Rag.AzureAISearch;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Rag;
+
+namespace RetailPulse.Tests.Rag.AzureAISearch;
+
+/// <summary>
+/// Live conformance for the Azure AI Search provider. Mirrors the invariants
+/// codified in <see cref="KnowledgeBaseConformanceTests"/> but decorates each
+/// case with <see cref="LiveAzureAISearchFactAttribute"/> so xunit skips
+/// cleanly (with an explicit reason string) when the environment variables
+/// documented on <see cref="AzureAISearchLiveTestConfig"/> are not set.
+///
+/// A companion always-run test asserts the skip is explicit — the CI output
+/// distinguishes "unconfigured, skipped" from "configured but silently no-op".
+///
+/// The suite provisions a per-run index name so concurrent CI runs cannot
+/// clobber each other, and does not delete the index at teardown so operators
+/// can inspect state. Follow <c>docs/rag/azure-ai-search-index.md</c> to
+/// reset a live index.
+/// </summary>
+public sealed class AzureAISearchLiveConformanceTests
+{
+    private static async Task<AzureAISearchKnowledgeBase> CreateAsync()
+    {
+        string indexName = ("rp-" + Guid.NewGuid().ToString("N"))[..24];
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Knowledge:AzureAISearch:Endpoint"] = AzureAISearchLiveTestConfig.ResolveEndpoint(),
+                ["Knowledge:AzureAISearch:IndexName"] = indexName,
+                ["Knowledge:AzureAISearch:Embeddings:Endpoint"] = AzureAISearchLiveTestConfig.ResolveEmbeddingsEndpoint(),
+                ["Knowledge:AzureAISearch:Embeddings:Deployment"] = AzureAISearchLiveTestConfig.ResolveEmbeddingsDeployment(),
+                ["Knowledge:AzureAISearch:Embeddings:ApimSubscriptionKey"] = AzureAISearchLiveTestConfig.ResolveEmbeddingsApimKey(),
+                ["Knowledge:AzureAISearch:SemanticRankingEnabled"] = AzureAISearchLiveTestConfig.ResolveSemantic() ? "true" : "false",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(config);
+        services.Configure<KnowledgeOptions>(_ => { });
+        services.AddSingleton<Azure.Core.TokenCredential>(new DefaultAzureCredential());
+        services.AddSingleton<ICostTracker>(new InMemoryCostTracker(
+            Options.Create(new ObservabilityOptions { MaxCostEvents = 100, CostEventTtlHours = 24 }),
+            config));
+        services.AddAzureAISearchKnowledgeProvider(config);
+
+        ServiceProvider sp = services.BuildServiceProvider();
+        AzureAISearchKnowledgeBase kb = sp.GetRequiredService<AzureAISearchKnowledgeBase>();
+        await kb.ProbeAsync();
+        return kb;
+    }
+
+    [LiveAzureAISearchFact]
+    public async Task ProbeAsync_HealthyProvider_Completes()
+    {
+        AzureAISearchKnowledgeBase kb = await CreateAsync();
+        Func<Task> probe = () => kb.ProbeAsync();
+        await probe.Should().NotThrowAsync();
+    }
+
+    [LiveAzureAISearchFact]
+    public async Task GetCapabilities_ReportsHybridAndPersistent()
+    {
+        AzureAISearchKnowledgeBase kb = await CreateAsync();
+        KnowledgeBaseCapabilities caps = kb.GetCapabilities();
+
+        caps.ProviderName.Should().Be(AzureAISearchKnowledgeBase.ProviderName);
+        caps.Persistent.Should().BeTrue();
+        caps.RequiresCloud.Should().BeTrue();
+        caps.Relevance.Should().Be(KnowledgeRelevanceKind.Hybrid);
+        caps.ScoreSemantics.Should().Contain("not comparable");
+    }
+
+    [LiveAzureAISearchFact]
+    public async Task Ingest_ThenSearch_FindsRelevantContent()
+    {
+        AzureAISearchKnowledgeBase kb = await CreateAsync();
+        await kb.IngestDocumentAsync(
+            "Holiday Planning",
+            "Holiday displays should go up in early October for maximum impact. " +
+            "Themed holiday displays outperform generic seasonal displays.",
+            "conformance-live");
+
+        // Give the index a moment for near-real-time indexing.
+        await Task.Delay(TimeSpan.FromSeconds(3));
+
+        IReadOnlyList<SearchResult> results = await kb.SearchAsync("holiday");
+        results.Should().NotBeEmpty();
+        results.Should().OnlyContain(r => r.Score >= 0);
+    }
+
+    [LiveAzureAISearchFact]
+    public async Task DeleteDocument_RemovesFromListAndSearch()
+    {
+        AzureAISearchKnowledgeBase kb = await CreateAsync();
+        string id = await kb.IngestDocumentAsync(
+            "Live-Deletable",
+            "Uniquetermxyzzy content that is only in this document.",
+            "conformance-live");
+
+        await Task.Delay(TimeSpan.FromSeconds(2));
+        await kb.DeleteDocumentAsync(id);
+        await Task.Delay(TimeSpan.FromSeconds(3));
+
+        IReadOnlyList<SearchResult> hits = await kb.SearchAsync("uniquetermxyzzy");
+        hits.Should().NotContain(r => r.DocumentId == id);
+    }
+
+    /// <summary>
+    /// Explicit skip assertion. Always runs. Asserts the environment either
+    /// exposes a real endpoint (so the [LiveAzureAISearchFact] cases above
+    /// executed) or that the skip reason string is the documented one — a
+    /// silent no-op is never a valid outcome.
+    /// </summary>
+    [Fact]
+    public void LiveConformance_ExplicitlyAssertsSkipReason_WhenUnconfigured()
+    {
+        bool configured = AzureAISearchLiveTestConfig.IsConfigured(out string? reason);
+
+        if (configured)
+        {
+            reason.Should().BeNull();
+            return;
+        }
+
+        reason.Should().Be(AzureAISearchLiveTestConfig.SkipReason,
+            "live conformance must record an explicit skip reason so operators distinguish an outage from an unconfigured environment");
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchLiveConformanceTests.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchLiveConformanceTests.cs
@@ -32,7 +32,7 @@ public sealed class AzureAISearchLiveConformanceTests
     {
         string indexName = ("rp-" + Guid.NewGuid().ToString("N"))[..24];
 
-        var config = new ConfigurationBuilder()
+        IConfigurationRoot config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Knowledge:AzureAISearch:Endpoint"] = AzureAISearchLiveTestConfig.ResolveEndpoint(),

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchLiveTestConfig.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchLiveTestConfig.cs
@@ -1,0 +1,76 @@
+namespace RetailPulse.Tests.Rag.AzureAISearch;
+
+/// <summary>
+/// Reads live Azure AI Search integration test configuration from environment
+/// variables. When any required value is missing, tests using this helper
+/// skip cleanly with an explicit reason recorded on the xunit output.
+///
+/// Required env vars:
+/// <list type="bullet">
+///   <item><c>RETAIL_PULSE_AI_SEARCH_ENDPOINT</c> — Search service endpoint (https://...search.windows.net)</item>
+///   <item><c>RETAIL_PULSE_AI_SEARCH_EMBEDDINGS_ENDPOINT</c> — APIM inference base URL</item>
+/// </list>
+/// Optional env vars:
+/// <list type="bullet">
+///   <item><c>RETAIL_PULSE_AI_SEARCH_INDEX</c> (default: retail-pulse-live-tests)</item>
+///   <item><c>RETAIL_PULSE_AI_SEARCH_EMBEDDINGS_DEPLOYMENT</c> (default: text-embedding-3-small)</item>
+///   <item><c>RETAIL_PULSE_AI_SEARCH_EMBEDDINGS_APIM_KEY</c> (bypasses MI when set)</item>
+///   <item><c>RETAIL_PULSE_AI_SEARCH_SEMANTIC</c> (true/false, default: false)</item>
+/// </list>
+/// </summary>
+public static class AzureAISearchLiveTestConfig
+{
+    public const string SkipReason =
+        "Live Azure AI Search integration test skipped — set RETAIL_PULSE_AI_SEARCH_ENDPOINT and RETAIL_PULSE_AI_SEARCH_EMBEDDINGS_ENDPOINT to run.";
+
+    public static bool IsConfigured(out string? reason)
+    {
+        string? endpoint = Environment.GetEnvironmentVariable("RETAIL_PULSE_AI_SEARCH_ENDPOINT");
+        string? embeddings = Environment.GetEnvironmentVariable("RETAIL_PULSE_AI_SEARCH_EMBEDDINGS_ENDPOINT");
+        if (string.IsNullOrWhiteSpace(endpoint) || string.IsNullOrWhiteSpace(embeddings))
+        {
+            reason = SkipReason;
+            return false;
+        }
+        reason = null;
+        return true;
+    }
+
+    public static string ResolveIndex() =>
+        Environment.GetEnvironmentVariable("RETAIL_PULSE_AI_SEARCH_INDEX") ?? "retail-pulse-live-tests";
+
+    public static string ResolveEmbeddingsDeployment() =>
+        Environment.GetEnvironmentVariable("RETAIL_PULSE_AI_SEARCH_EMBEDDINGS_DEPLOYMENT") ?? "text-embedding-3-small";
+
+    public static string? ResolveEmbeddingsApimKey() =>
+        Environment.GetEnvironmentVariable("RETAIL_PULSE_AI_SEARCH_EMBEDDINGS_APIM_KEY");
+
+    public static bool ResolveSemantic() =>
+        string.Equals(
+            Environment.GetEnvironmentVariable("RETAIL_PULSE_AI_SEARCH_SEMANTIC")?.Trim(),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+
+    public static string ResolveEndpoint() =>
+        Environment.GetEnvironmentVariable("RETAIL_PULSE_AI_SEARCH_ENDPOINT")!;
+
+    public static string ResolveEmbeddingsEndpoint() =>
+        Environment.GetEnvironmentVariable("RETAIL_PULSE_AI_SEARCH_EMBEDDINGS_ENDPOINT")!;
+}
+
+/// <summary>
+/// xUnit <see cref="FactAttribute"/> that skips at test-discovery time when the
+/// live Azure AI Search integration environment is not configured. The skip
+/// reason is set from <see cref="AzureAISearchLiveTestConfig.SkipReason"/> so
+/// operators reading the CI output see explicitly why the test did not run.
+/// </summary>
+public sealed class LiveAzureAISearchFactAttribute : FactAttribute
+{
+    public LiveAzureAISearchFactAttribute()
+    {
+        if (!AzureAISearchLiveTestConfig.IsConfigured(out string? reason))
+        {
+            Skip = reason;
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchOptionsTests.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchOptionsTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using RetailPulse.Api.Rag.AzureAISearch;
+
+namespace RetailPulse.Tests.Rag.AzureAISearch;
+
+/// <summary>
+/// Options-shape tests. The provider is fully optional — a blank endpoint
+/// must resolve to IsConfigured=false and never throw, and every enabled-path
+/// validation must produce an actionable message naming the offending field.
+/// </summary>
+public class AzureAISearchOptionsTests
+{
+    [Fact]
+    public void Default_IsNotConfigured()
+    {
+        var opts = new AzureAISearchOptions();
+        opts.IsConfigured.Should().BeFalse(
+            "blank endpoint means the provider is fully disabled and no client is materialized");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void BlankEndpoint_IsNotConfigured(string? endpoint)
+    {
+        var opts = new AzureAISearchOptions { Endpoint = endpoint };
+        opts.IsConfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateEnabled_RejectsBlankEndpoint()
+    {
+        var opts = new AzureAISearchOptions();
+        opts.Embeddings.Endpoint = "https://apim.example.com/inference";
+        Action act = opts.ValidateEnabled;
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Endpoint is required*");
+    }
+
+    [Fact]
+    public void ValidateEnabled_RejectsNonAbsoluteEndpoint()
+    {
+        var opts = new AzureAISearchOptions
+        {
+            Endpoint = "not-a-url",
+        };
+        opts.Embeddings.Endpoint = "https://apim.example.com/inference";
+        Action act = opts.ValidateEnabled;
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*absolute http(s) URL*");
+    }
+
+    [Fact]
+    public void ValidateEnabled_RequiresEmbeddingsEndpoint()
+    {
+        var opts = new AzureAISearchOptions
+        {
+            Endpoint = "https://mysearch.search.windows.net",
+        };
+        Action act = opts.ValidateEnabled;
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Embeddings*Endpoint*APIM*");
+    }
+
+    [Fact]
+    public void ValidateEnabled_HappyPath_DoesNotThrow()
+    {
+        var opts = new AzureAISearchOptions
+        {
+            Endpoint = "https://mysearch.search.windows.net",
+            IndexName = "retail-pulse",
+        };
+        opts.Embeddings.Endpoint = "https://apim.example.com/inference";
+        opts.Embeddings.Deployment = "text-embedding-3-small";
+
+        Action act = opts.ValidateEnabled;
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ResolveModelId_DefaultsToDeployment_WhenModelIdBlank()
+    {
+        var e = new AzureAISearchEmbeddingsOptions { Deployment = "custom-embed" };
+        e.ResolveModelId().Should().Be("custom-embed");
+    }
+
+    [Fact]
+    public void ResolveModelId_HonorsExplicitModelId()
+    {
+        var e = new AzureAISearchEmbeddingsOptions
+        {
+            Deployment = "custom-embed",
+            ModelId = "text-embedding-3-small",
+        };
+        e.ResolveModelId().Should().Be("text-embedding-3-small");
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchRetrievalQualityComparisonTests.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchRetrievalQualityComparisonTests.cs
@@ -165,7 +165,7 @@ public sealed class AzureAISearchRetrievalQualityComparisonTests
     {
         string indexName = ("rp-cmp-" + Guid.NewGuid().ToString("N"))[..24];
 
-        var config = new ConfigurationBuilder()
+        IConfigurationRoot config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Knowledge:AzureAISearch:Endpoint"] = AzureAISearchLiveTestConfig.ResolveEndpoint(),

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchRetrievalQualityComparisonTests.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchRetrievalQualityComparisonTests.cs
@@ -1,0 +1,195 @@
+using Azure.Identity;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Rag;
+using RetailPulse.Api.Rag.AzureAISearch;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Rag;
+using Xunit.Abstractions;
+
+namespace RetailPulse.Tests.Rag.AzureAISearch;
+
+/// <summary>
+/// Runs a fixed query set against BOTH the in-memory BM25 provider and the
+/// live Azure AI Search provider (when configured) and records the top-k
+/// recall for each. Semantic retrieval should beat lexical on paraphrased
+/// queries; if it doesn't, the harness surfaces the number honestly to the
+/// test output so the PR body can record the finding.
+///
+/// Skipped cleanly with an explicit reason when the live environment is not
+/// configured. Never fails on quality — it captures the number and lets the
+/// human reviewer interpret it.
+/// </summary>
+public sealed class AzureAISearchRetrievalQualityComparisonTests
+{
+    private static readonly (string Title, string Content, string Source)[] _corpus =
+    [
+        ("Category Management Playbook",
+         "Category management defines the role, strategy, and metrics for every merchandising category. " +
+         "Category captains coordinate with suppliers on planograms, promotional cadence, and assortment. " +
+         "The end goal is category-level growth measured against a defined benchmark.",
+         "playbook"),
+        ("Holiday Planning Guide",
+         "Holiday displays should be set in early October to maximize impact. " +
+         "Themed holiday displays outperform generic seasonal displays year over year. " +
+         "Ensure holiday-specific SKUs are protected from stockouts through the peak weeks.",
+         "guide"),
+        ("Supplier Terms Standards",
+         "Supplier terms must include on-time delivery penalties, quality inspection windows, and returns policy. " +
+         "Terms are renegotiated annually and reviewed against category benchmarks.",
+         "standards"),
+        ("Planogram Compliance Standard",
+         "Planogram compliance is measured weekly by store-level audit teams. " +
+         "Non-compliant fixtures must be corrected within 48 hours. " +
+         "Repeat non-compliance triggers a category review.",
+         "standard"),
+        ("Assortment Optimization Notes",
+         "Assortment optimization balances SKU productivity, category coverage, and shelf space efficiency. " +
+         "Slow movers below a defined velocity threshold are candidates for deletion each quarter.",
+         "notes"),
+    ];
+
+    // Paraphrased queries — lexical BM25 usually MISSES these because they
+    // avoid the exact keywords in the corpus while preserving semantic intent.
+    private static readonly (string Query, string ExpectedTitle)[] _paraphrasedQueries =
+    [
+        ("How do I coordinate with vendors on shelf layouts?", "Category Management Playbook"),
+        ("When should Christmas fixtures be installed?", "Holiday Planning Guide"),
+        ("What penalties apply to vendors who miss shipment windows?", "Supplier Terms Standards"),
+        ("How often do audit teams check display compliance?", "Planogram Compliance Standard"),
+        ("Which slow items should we drop from the shelf?", "Assortment Optimization Notes"),
+    ];
+
+    private readonly ITestOutputHelper _output;
+
+    public AzureAISearchRetrievalQualityComparisonTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task BaselineInMemory_RunsAgainstFixedQuerySet()
+    {
+        InMemoryKnowledgeBase kb = new(
+            NullLoggerFactory.Instance.CreateLogger<InMemoryKnowledgeBase>(),
+            Options.Create(new KnowledgeOptions()));
+
+        foreach ((string title, string content, string source) in _corpus)
+        {
+            await kb.IngestDocumentAsync(title, content, source);
+        }
+
+        int hits = 0;
+        _output.WriteLine("=== InMemory BM25 baseline (paraphrased query set) ===");
+        foreach ((string query, string expectedTitle) in _paraphrasedQueries)
+        {
+            IReadOnlyList<SearchResult> results = await kb.SearchAsync(query, topK: 3);
+            bool matched = results.Any(r => r.Title == expectedTitle);
+            if (matched) hits++;
+            _output.WriteLine($"query='{query}' expected='{expectedTitle}' top3=[{string.Join(", ", results.Select(r => r.Title))}] matched={matched}");
+        }
+        _output.WriteLine($"BaselineInMemory Recall@3: {hits}/{_paraphrasedQueries.Length}");
+
+        // The baseline is expected to underperform on paraphrase — this is
+        // the executable "why we need semantic" documentation. We record it
+        // but do not fail on quality.
+        hits.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [LiveAzureAISearchFact]
+    public async Task SemanticProvider_MeetsOrExceedsInMemoryOnParaphrasedQueries()
+    {
+        // Live comparison — ingest the same corpus into a fresh per-run
+        // Azure AI Search index and compare Recall@3 to the in-memory baseline
+        // on the same paraphrased queries.
+        InMemoryKnowledgeBase baseline = new(
+            NullLoggerFactory.Instance.CreateLogger<InMemoryKnowledgeBase>(),
+            Options.Create(new KnowledgeOptions()));
+        foreach ((string title, string content, string source) in _corpus)
+        {
+            await baseline.IngestDocumentAsync(title, content, source);
+        }
+
+        AzureAISearchKnowledgeBase semantic = await CreateLiveProviderAsync();
+        foreach ((string title, string content, string source) in _corpus)
+        {
+            await semantic.IngestDocumentAsync(title, content, source);
+        }
+        // Let Azure AI Search near-real-time indexing settle before querying.
+        await Task.Delay(TimeSpan.FromSeconds(5));
+
+        int lexicalHits = 0, semanticHits = 0;
+        _output.WriteLine("=== Retrieval quality comparison: InMemory (BM25) vs AzureAISearch (Hybrid) ===");
+        foreach ((string query, string expectedTitle) in _paraphrasedQueries)
+        {
+            IReadOnlyList<SearchResult> lex = await baseline.SearchAsync(query, topK: 3);
+            IReadOnlyList<SearchResult> sem = await semantic.SearchAsync(query, topK: 3);
+            bool lexHit = lex.Any(r => r.Title == expectedTitle);
+            bool semHit = sem.Any(r => r.Title == expectedTitle);
+            if (lexHit) lexicalHits++;
+            if (semHit) semanticHits++;
+
+            _output.WriteLine(
+                $"query='{query}' expected='{expectedTitle}' lex=[{string.Join(", ", lex.Select(r => r.Title))}] sem=[{string.Join(", ", sem.Select(r => r.Title))}] lexHit={lexHit} semHit={semHit}");
+        }
+
+        _output.WriteLine($"Recall@3 InMemory (BM25): {lexicalHits}/{_paraphrasedQueries.Length}");
+        _output.WriteLine($"Recall@3 AzureAISearch (Hybrid): {semanticHits}/{_paraphrasedQueries.Length}");
+
+        // Report honestly — we do NOT enforce semantic > lexical because live
+        // model quality varies. The harness surfaces the numbers to the PR
+        // and CI output; humans interpret them.
+        semanticHits.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public void RetrievalQuality_ExplicitlyAssertsSkipReason_WhenUnconfigured()
+    {
+        bool configured = AzureAISearchLiveTestConfig.IsConfigured(out string? reason);
+        if (configured)
+        {
+            reason.Should().BeNull();
+            return;
+        }
+        reason.Should().Be(AzureAISearchLiveTestConfig.SkipReason,
+            "the comparison harness must record an explicit skip reason so operators can distinguish an outage from an unconfigured environment");
+    }
+
+    private static async Task<AzureAISearchKnowledgeBase> CreateLiveProviderAsync()
+    {
+        string indexName = ("rp-cmp-" + Guid.NewGuid().ToString("N"))[..24];
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Knowledge:AzureAISearch:Endpoint"] = AzureAISearchLiveTestConfig.ResolveEndpoint(),
+                ["Knowledge:AzureAISearch:IndexName"] = indexName,
+                ["Knowledge:AzureAISearch:Embeddings:Endpoint"] = AzureAISearchLiveTestConfig.ResolveEmbeddingsEndpoint(),
+                ["Knowledge:AzureAISearch:Embeddings:Deployment"] = AzureAISearchLiveTestConfig.ResolveEmbeddingsDeployment(),
+                ["Knowledge:AzureAISearch:Embeddings:ApimSubscriptionKey"] = AzureAISearchLiveTestConfig.ResolveEmbeddingsApimKey(),
+                ["Knowledge:AzureAISearch:SemanticRankingEnabled"] = AzureAISearchLiveTestConfig.ResolveSemantic() ? "true" : "false",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(config);
+        services.Configure<KnowledgeOptions>(_ => { });
+        services.AddSingleton<Azure.Core.TokenCredential>(new DefaultAzureCredential());
+        services.AddSingleton<ICostTracker>(new InMemoryCostTracker(
+            Options.Create(new ObservabilityOptions { MaxCostEvents = 100, CostEventTtlHours = 24 }),
+            config));
+        services.AddAzureAISearchKnowledgeProvider(config);
+
+        ServiceProvider sp = services.BuildServiceProvider();
+        AzureAISearchKnowledgeBase kb = sp.GetRequiredService<AzureAISearchKnowledgeBase>();
+        await kb.ProbeAsync();
+        return kb;
+    }
+}

--- a/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchServiceCollectionExtensionsTests.cs
+++ b/tests/RetailPulse.Tests/Rag/AzureAISearch/AzureAISearchServiceCollectionExtensionsTests.cs
@@ -1,0 +1,149 @@
+using Azure.Core;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Rag;
+using RetailPulse.Api.Rag.AzureAISearch;
+using RetailPulse.Contracts.Observability;
+
+namespace RetailPulse.Tests.Rag.AzureAISearch;
+
+/// <summary>
+/// DI-shape contract. When Knowledge:AzureAISearch:Endpoint is blank the
+/// extension MUST be a no-op — no Search SDK client, no HTTP client, no
+/// contribution to the provider registry — so the default demo path is byte-
+/// for-byte identical to the InMemory-only baseline. When the endpoint is
+/// configured the extension registers the provider and contributes an
+/// AzureAISearch factory to the registry.
+/// </summary>
+public class AzureAISearchServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddAzureAISearchKnowledgeProvider_BlankEndpoint_NoRegistrations()
+    {
+        ServiceCollection services = BuildBaselineServices();
+        int before = services.Count;
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection([])
+            .Build();
+
+        services.AddAzureAISearchKnowledgeProvider(config);
+
+        services.Count.Should().Be(before,
+            "blank endpoint means the provider is disabled — no service should be registered");
+        services.Should().NotContain(sd => sd.ServiceType == typeof(SearchClient));
+        services.Should().NotContain(sd => sd.ServiceType == typeof(SearchIndexClient));
+        services.Should().NotContain(sd => sd.ServiceType == typeof(AzureAISearchKnowledgeBase));
+        services.Should().NotContain(sd => sd.ServiceType == typeof(IKnowledgeProviderContribution));
+    }
+
+    [Fact]
+    public void AddAzureAISearchKnowledgeProvider_BlankEndpoint_DoesNotRegisterEmbeddingsHttpClient()
+    {
+        ServiceCollection services = BuildBaselineServices();
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection([])
+            .Build();
+
+        services.AddAzureAISearchKnowledgeProvider(config);
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        // The named HttpClient is only registered on the enabled path.
+        // Requesting it should NOT resolve into a client that has our base
+        // address / handler pipeline; verify by asserting the extension left
+        // the DI graph exactly as our baseline (no IHttpClientFactory added).
+        sp.GetService<IHttpClientFactory>().Should().BeNull(
+            "no HTTP factory should be materialized on the disabled path");
+    }
+
+    [Fact]
+    public void AddAzureAISearchKnowledgeProvider_Configured_RegistersProviderAndContribution()
+    {
+        ServiceCollection services = BuildBaselineServices();
+        // Substitute the token credential BEFORE the extension so tests do
+        // not need a real Azure identity — the extension uses TryAddSingleton.
+        services.AddSingleton<TokenCredential>(new FakeTokenCredential());
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Knowledge:AzureAISearch:Endpoint"] = "https://mysearch.search.windows.net",
+                ["Knowledge:AzureAISearch:IndexName"] = "retail-pulse-test",
+                ["Knowledge:AzureAISearch:Embeddings:Endpoint"] = "https://apim.example.com/inference",
+                ["Knowledge:AzureAISearch:Embeddings:Deployment"] = "text-embedding-3-small",
+                ["Knowledge:AzureAISearch:Embeddings:Dimensions"] = "8",
+            })
+            .Build();
+
+        services.AddAzureAISearchKnowledgeProvider(config);
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        AzureAISearchKnowledgeBase kb = sp.GetRequiredService<AzureAISearchKnowledgeBase>();
+        kb.GetCapabilities().ProviderName.Should().Be(AzureAISearchKnowledgeBase.ProviderName);
+        kb.GetCapabilities().Persistent.Should().BeTrue();
+        kb.GetCapabilities().RequiresCloud.Should().BeTrue();
+
+        IEnumerable<IKnowledgeProviderContribution> contributions =
+            sp.GetServices<IKnowledgeProviderContribution>();
+        contributions.Should().ContainSingle();
+
+        var registry = new KnowledgeProviderRegistry();
+        registry.Register(KnowledgeProviderMode.InMemory, _ =>
+            throw new InvalidOperationException("in-memory factory should not be invoked here"));
+        foreach (IKnowledgeProviderContribution c in contributions)
+        {
+            c.Register(registry);
+        }
+        registry.IsRegistered(KnowledgeProviderMode.AzureAISearch).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddAzureAISearchKnowledgeProvider_ConfiguredButInvalid_FailsFast()
+    {
+        ServiceCollection services = BuildBaselineServices();
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Knowledge:AzureAISearch:Endpoint"] = "https://mysearch.search.windows.net",
+                // No Embeddings:Endpoint on purpose — must fail fast.
+            })
+            .Build();
+
+        Action act = () => services.AddAzureAISearchKnowledgeProvider(config);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Embeddings*Endpoint*");
+    }
+
+    private static ServiceCollection BuildBaselineServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.Configure<KnowledgeOptions>(_ => { });
+        services.Configure<ObservabilityOptions>(_ => { });
+        services.AddSingleton<ICostTracker>(new InMemoryCostTracker(
+            Options.Create(new ObservabilityOptions
+            {
+                MaxCostEvents = 100,
+                CostEventTtlHours = 24,
+                MaxSessions = 10,
+                MaxMessagesPerSession = 10,
+            }),
+            new ConfigurationBuilder().Build()));
+        return services;
+    }
+
+    private sealed class FakeTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken) =>
+            new("fake-token", DateTimeOffset.UtcNow.AddHours(1));
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken) =>
+            new(GetToken(requestContext, cancellationToken));
+    }
+}


### PR DESCRIPTION
# Closes #103

Optional, fully-opt-in Azure AI Search knowledge provider that plugs into the
`IKnowledgeBase` seam from #102. The default demo path is byte-for-byte
unchanged: no Search SDK, no HTTP handler, no credential, no Bicep resource,
no cost. Selecting `Knowledge:Provider:Mode=AzureAISearch` without wiring the
extension fails startup with an actionable message via `KnowledgeProviderRegistry`.

## Architecture

- **Retrieval** — Hybrid vector + BM25 through Azure AI Search, with optional
  semantic reranker (`SemanticRankingEnabled=false` by default). Query
  embedding via `ApimEmbeddingClient` → APIM AI Gateway; hybrid RRF at the
  index; semantic rerank when configured. Scores are provider-local — the
  contract exposes this in `GetCapabilities().ScoreSemantics` and refuses
  cross-provider ranking.
- **Index schema** — `AzureAISearchIndexSchema.Build` is the single source of
  truth. Fields cover `id`, `documentId`, `chunkIndex`, `title` (searchable +
  filterable + sortable, en.lucene), `content` (searchable, en.lucene),
  `source`, `sectionHeader`, `ingestedAt`, `schemaVersion`, `agentScope`
  (reserved for #105), and `contentVector` (HNSW, cosine). Semantic
  configuration is included conditionally.
- **Drift detection** — `AzureAISearchIndexSchema.DetectMismatch` runs on
  every probe; the provider surfaces a drifted live index as
  `KnowledgeProviderUnavailableException` with the offending difference so
  operators follow the documented reindex procedure, not a silent mutation.
- **Ingestion** — Uses the existing `DocumentChunker` so chunk boundaries stay
  portable across providers. Chunks are embedded in a single batched call,
  then uploaded via `MergeOrUpload`; partial failures surface with the first
  backend error.
- **Embedding through APIM** — `ApimEmbeddingClient` uses the Azure OpenAI
  embeddings shape with a managed-identity bearer token (optional `api-key`
  header for local dev). Every successful call raises a `UsageEvent` on the
  shared `ICostTracker` — embedding tokens are metered/rate-limited/audited
  under the same policy as chat completions. `TokenPricing` ships two default
  rows (`text-embedding-3-small`, `text-embedding-3-large`).
- **Resilience** — Search SDK uses its built-in retry with bounded network
  timeout. Embeddings HTTP path uses `AddKnowledgeEmbeddingsResilienceHandler`
  (timeout + retry inside circuit breaker); breaker state surfaces on
  `CircuitBreakerHealthCheck` under `knowledgeCircuitState`.
- **DI seam** — New `IKnowledgeProviderContribution` interface lets opt-in
  modules register their factory on `KnowledgeProviderRegistry` without
  editing `Program.cs`. `AddAzureAISearchKnowledgeProvider` is a no-op when
  `Knowledge:AzureAISearch:Endpoint` is blank — no client, credential, or
  contribution is registered.
- **Bicep** — `infra/modules/ai-search.bicep` provisions a Basic-SKU Search
  service with `SystemAssigned` identity, `disableLocalAuth=true`, and
  `semanticSearch='free'`. `main.bicep` gates behind `aiSearchEnabled=false`.
  Postprovision hooks (`postprovision.ps1` / `.sh`) grant `Search Service
  Contributor` + `Search Index Data Contributor` idempotently to each
  container app system identity when enabled.

## Index lifecycle

Full procedure in `docs/rag/azure-ai-search-index.md`:

- **Create.** `AutoCreateIndex=true` (default) creates the index at first probe.
- **Migrate.** Schema changes require a new index name; the provider surfaces
  drift and never mutates in place. Docs describe the side-by-side swap.
- **Reindex.** Documented step-by-step; new index → deploy new name → ingest →
  drop old index.

## Optional-default proof (non-negotiable)

Verified by executable tests:

- `AzureAISearchDefaultDisabledStartupTests.DefaultConfiguration_ResolvesInMemoryAndOmitsAzureAISearch`
  mirrors the Program.cs wiring with a blank config, resolves
  `KnowledgeProviderSelector.ResolveMode()`, and asserts:
  - `RegisteredModes` is exactly `[InMemory]`.
  - `AzureAISearchKnowledgeBase` is not resolvable.
  - `AzureAISearchOptions` singleton is not registered.
  - `ProbeAsync` on the primary completes without any external call.
- `AzureAISearchDefaultDisabledStartupTests.DefaultConfiguration_SelectingAzureAISearch_FailsLoudlyWithActionableMessage`
  proves the "silent degradation prevention" contract: selecting the mode
  without wiring throws a clear message naming the missing registration.
- `AzureAISearchServiceCollectionExtensionsTests.AddAzureAISearchKnowledgeProvider_BlankEndpoint_NoRegistrations`
  asserts the extension is byte-for-byte a no-op on the disabled path — no
  `SearchClient`, `SearchIndexClient`, `IKnowledgeProviderContribution`, or
  `IHttpClientFactory` is added to the DI graph.
- `AzureAISearchDeploymentContractTests.MainBicep_GatesAiSearchBehindDisabledDefault`
  asserts `main.bicep` ships `param aiSearchEnabled bool = false` and gates
  the module on the flag. Confirmed by `az bicep build` locally.

## Testing

**Local `dotnet test RetailPulse.slnx`:** 2964 passed, 5 skipped (live-only),
0 failed.

**Skipped tests are explicit.** All 5 live tests are decorated with
`[LiveAzureAISearchFact]`, which sets an explicit `Skip = "Live Azure AI
Search integration test skipped — set RETAIL_PULSE_AI_SEARCH_ENDPOINT and
RETAIL_PULSE_AI_SEARCH_EMBEDDINGS_ENDPOINT to run."` when the env vars are
missing. Two companion `[Fact]` tests
(`LiveConformance_ExplicitlyAssertsSkipReason_WhenUnconfigured`,
`RetrievalQuality_ExplicitlyAssertsSkipReason_WhenUnconfigured`) ALWAYS run
and assert either that the live env is configured or that the skip reason is
the documented one — no silent no-op is a valid outcome.

**dotnet format:** `dotnet format RetailPulse.slnx --verify-no-changes`
completes with exit 0.

**Bicep:** `az bicep build --file infra/main.bicep` succeeds with no errors.

**Test breakdown (feature-scoped):**

- `AzureAISearchOptionsTests` — options binding, validation, model-id
  resolution.
- `AzureAISearchIndexSchemaTests` — schema build, key field, HNSW profile,
  semantic on/off, drift detection (missing field, dimension mismatch).
- `ApimEmbeddingClientTests` — path shape, cost recording on success, order
  preservation by index, transport failure → `KnowledgeProviderUnavailableException`,
  dimension mismatch fails loud, empty batch short-circuits with no HTTP call.
- `AzureAISearchServiceCollectionExtensionsTests` — DI shape on disabled and
  enabled paths, provider + contribution registration, fail-fast on missing
  embeddings endpoint.
- `AzureAISearchDefaultDisabledStartupTests` — Program.cs default-path proof.
- `AzureAISearchLiveConformanceTests` — happy-path conformance against the
  real backend when configured; skips explicitly otherwise.
- `AzureAISearchRetrievalQualityComparisonTests` — fixed paraphrased query
  set run against both InMemory (BM25) and Azure AI Search (Hybrid);
  Recall@3 recorded to test output.
- `AzureAISearchDeploymentContractTests` — module + main.bicep + main.bicepparam
  + postprovision hook contract.

## Retrieval-quality comparison

**Local run (unconfigured — semantic side skipped):**

`BaselineInMemory_RunsAgainstFixedQuerySet` runs against the fixed paraphrased
query set encoded in the harness and reports Recall@3 for the InMemory BM25
baseline. The paraphrased queries are chosen so the exact keywords in the
corpus don't overlap the query terms — Recall@3 for BM25 is expected to be
low; that is the executable "why we need semantic" documentation.

**Live comparison (requires cloud config):** When `RETAIL_PULSE_AI_SEARCH_*`
env vars are set, `SemanticProvider_MeetsOrExceedsInMemoryOnParaphrasedQueries`
runs the same query set against a fresh per-run Azure AI Search index and
writes both Recall@3 numbers to the xunit test output. The harness does NOT
enforce semantic > lexical — it reports the numbers honestly so a human
reviewer can interpret them. Baseline expectation: semantic beats lexical on
paraphrase; if it doesn't, the test surface makes it visible immediately.

Because this PR was authored without a live Azure AI Search subscription
attached to the session, the semantic side of the comparison is reported as
"skipped: `RETAIL_PULSE_AI_SEARCH_ENDPOINT` unset". Operators running the
suite against a live tenant will see the full comparison printed to the
xunit output.

## Known limitations

- Semantic reranker relies on the Search service's Semantic Search feature.
  Basic-SKU includes the free tier; higher-volume workloads should upgrade to
  the paid semantic ranker.
- Deletion is a two-step operation (filter → collect chunk ids → delete).
  Azure AI Search does not accept a bare filter as a delete predicate.
- `agentScope` is written as an empty array on every ingest and is reserved
  for the per-agent knowledge binding in #105.

## Wave 5 & squad context

Working as Kroger (Lead). Squad member spawn prompt confirms explicit user
override to target `main` and the exact branch `squad/103-azure-ai-search-provider`.
Existing `.squad` working-tree changes are pre-existing user/session state and
were not touched.

Prerequisites merged in this branch's base:
#88, #89, #90, #91, #98, #99, #100, #102, #110, #116.

## Commits

- `d068e27` — feat(rag): Azure AI Search knowledge provider (core implementation)
- `cea9db7` — docs(rag): ADR-012, architecture.md, deployment-azd.md, reindex procedure

Both commits carry the required `Co-authored-by: Copilot` trailer.
