### PR TITLE
Plan review gate with checkpointed suspend and resume

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -260,6 +260,106 @@ Get resolved approval history (last 50).
 
 ---
 
+## Plan Review (issue #94)
+
+> **Feature flag:** endpoints are only mapped when `PlanReview:Enabled = true`
+> AND `PlanPersistence:Enabled = true`. When either is off these routes 404 and
+> the chat pipeline runs the pre-#94 plan-first path — no observable difference.
+
+Plan review reuses the same durable `SqliteApprovalGate` storage the tool
+`ApprovalTool` uses, discriminated by a new `Kind` column. Plan rows have
+`Kind = "plan_review"` and clarification rows have `Kind = "clarification"`;
+every decision appears in the shared `/api/approvals/history` audit trail.
+
+### Relationship to #91 (approval hardening)
+
+#91 introduced `IApprovalResumeStrategy` as the single reconciliation seam. #94
+extends that seam without adding a second polling loop: on restart the same
+`ApprovalReconciliationBackgroundService` walks every Pending row exactly once
+and asks the strategy per-row. `PlanReviewResumeStrategy` returns:
+
+* `OrphanTerminal` for `Kind = "tool"` rows — byte-identical to the Wave 1
+  `OrphanUnresumableStrategy`.
+* `Resume` for `Kind = "plan_review"` and `Kind = "clarification"` rows — the
+  gate re-owns them to the current process. The durable approval row remains the
+  source of truth for the decision; a `Microsoft.Agents.AI.Workflows`
+  `CheckpointManager` (JSON store rooted at `{data-dir}/plan-reviews`) captures
+  workflow state as an operational replay aid.
+
+### GET /api/plans/{planId}/reviews
+
+List open plan reviews owned by the caller.
+
+**Auth:** authenticated caller only. Anonymous callers receive `403`. Cross-
+subject / unknown plans collapse to `404` (probe resistant — mirrors
+`/api/plans/{planId}`).
+
+**Response (200):**
+
+```json
+[
+  {
+    "requestId": "...",
+    "planId": "...",
+    "round": 0,
+    "subject": "user-oid",
+    "action": "Review plan proposal (2 step(s)).",
+    "impact": "Specialists: scorecard, demand-forecasting",
+    "urgency": "medium",
+    "reasoning": "Initial plan proposal awaiting reviewer decision.",
+    "createdAt": "2026-...",
+    "expiresAt": "2026-...",
+    "status": "pending",
+    "payload": "{ \"planId\": ... }"
+  }
+]
+```
+
+### POST /api/plans/{planId}/reviews/{requestId}/decision
+
+Approve, reject-with-feedback, or edit-then-approve the proposal.
+
+**Request body:**
+
+```json
+{ "kind": "approve" }
+{ "kind": "reject", "feedback": "narrow the scope to Q4" }
+{ "kind": "edit", "editedSteps": [ { "specialistKey": "scorecard", "intent": "scorecard", "action": "..." } ] }
+```
+
+* `approve` — executes the original plan.
+* `edit` — validated against the live specialist roster; the edited plan is what
+  the executor actually runs. Edit-to-empty terminates the plan as `Failed` with
+  reason `PlanReviewEditedToEmpty`; unknown specialists terminate with
+  `PlanReviewEditInvalid`.
+* `reject` — coordinator invokes the planner with the feedback appended and
+  presents the revised plan for another review round, bounded by
+  `PlanReview:MaxReplanRounds` (default 2). Exhausting the cap terminates with
+  `PlanReviewReplanExhausted`.
+
+**Errors:** `400` for missing feedback/editedSteps, `403` for anonymous callers,
+`404` for cross-subject / unknown plan or review, and the same terminal-reason
+propagation the gate uses for late race losers (see #91 for the winner-return
+contract — the same rule applies here).
+
+### POST /api/plans/{planId}/clarifications/{requestId}/answer
+
+Answer a mid-plan clarification question raised by a specialist through
+`IPlanClarifier`.
+
+```json
+{ "answer": "Northeast region only" }
+```
+
+### Timeout & terminal outcomes
+
+Every review round has an authoritative timeout persisted on the approval row
+(`PlanReview:DefaultReviewTimeout`, default 30 minutes). When exceeded the row
+transitions to `TimedOut` and the plan terminates with reason
+`PlanReviewTimedOut` — never an indefinite hang.
+
+---
+
 ## Demand Forecasting
 
 ### Demand forecasting is an MCP-tool-driven capability, not a REST endpoint

--- a/docs/API.md
+++ b/docs/API.md
@@ -271,6 +271,66 @@ Plan review reuses the same durable `SqliteApprovalGate` storage the tool
 `Kind = "plan_review"` and clarification rows have `Kind = "clarification"`;
 every decision appears in the shared `/api/approvals/history` audit trail.
 
+### Non-blocking suspend/resume — how `/api/chat` interacts
+
+When plan review is enabled and the router flags a request as multi-domain,
+`POST /api/chat` NO LONGER blocks the request thread on the reviewer decision.
+Instead:
+
+1. The orchestrator runs the planner, persists the plan as
+   `awaiting_review`, and calls
+   `PlanReviewCoordinator.OpenRoundAsync`, which:
+   - Writes a genuine `Microsoft.Agents.AI.Workflows.Checkpointing.ICheckpointStore<JsonElement>`
+     checkpoint via `CreateCheckpointAsync(sessionId, ...)` — the framework's
+     public JSON checkpoint API, not a marker written next to it.
+   - Opens a Pending approval row of kind `plan_review`.
+2. `/api/chat` returns **HTTP 202 Accepted** with `planId`, `reviewRequestId`,
+   `round`, and `sessionId`. Clients subscribe to the SignalR
+   `plan_final_response` event or poll `GET /api/plans/{planId}`.
+3. When the reviewer records a decision via
+   `POST /api/plans/{planId}/reviews/{requestId}/decision`, the endpoint kicks
+   off `PlanReviewCompletionService.ResolveAsync`. That service:
+   - Reads the latest framework checkpoint + the approval row.
+   - On approve / edit → executes the effective plan through `PlanExecutor`,
+     runs `GuardrailsMiddleware.FilterOutputAsync` for PII redaction, writes
+     audit / session-turn / export parity, and broadcasts the filtered final
+     response on the SignalR hub.
+   - On reject with cap remaining → invokes the planner, saves a new
+     checkpoint, and opens the next review round (round N+1). The client
+     receives a `plan_review_next_round` event with the new request id.
+   - On terminal-without-execution (timeout, replan exhausted, edit invalid)
+     → transitions the plan to `Failed` with the specific terminal reason.
+4. If the API restarts between steps 2 and 3, the
+   `PlanReviewRestartRecoveryService` scans the plan store for
+   `awaiting_review` / `awaiting_clarification` rows on boot, and re-drives
+   `ResolveAsync` for any whose approval row is already terminal — so a
+   decision that arrived while the API was down still delivers the final
+   response on next boot.
+5. Review timeouts are enforced by a
+   `PlanReviewTimeoutBackgroundService` sweep (uses the injected
+   `TimeProvider`) — no request thread is blocked on the review deadline.
+
+The pre-#94 hot path is preserved byte-for-byte when
+`PlanReview:Enabled = false`: `RunAsync` executes the plan inline and
+`/api/chat` returns the standard `200 OK` `ChatResponse` envelope.
+
+### Mid-plan clarification (`[[CLARIFY]] <question>`) and replan (`[[REPLAN]] <feedback>`)
+
+The `PlanExecutor` inspects each step's `action` field for two markers:
+
+- `[[CLARIFY]] <question>` — opens a clarification row + framework
+  checkpoint capturing the paused plan state, then halts. When the reviewer
+  answers via `POST /api/plans/{planId}/clarifications/{requestId}/answer`,
+  the completion service resumes: the answer becomes the paused step's
+  result and downstream steps continue.
+- `[[REPLAN]] <feedback>` — the reachable mid-execution revision surface.
+  Opens a NEW `plan_review` row for the remaining steps with the feedback
+  as revision-reason and halts. The reviewer's next decision drives the
+  same suspend/resume cycle.
+
+Both markers share the identical durable persistence path with plan review,
+so a restart in the middle of either flow is invisible to the reviewer.
+
 ### Relationship to #91 (approval hardening)
 
 #91 introduced `IApprovalResumeStrategy` as the single reconciliation seam. #94
@@ -282,9 +342,10 @@ and asks the strategy per-row. `PlanReviewResumeStrategy` returns:
   `OrphanUnresumableStrategy`.
 * `Resume` for `Kind = "plan_review"` and `Kind = "clarification"` rows — the
   gate re-owns them to the current process. The durable approval row remains the
-  source of truth for the decision; a `Microsoft.Agents.AI.Workflows`
-  `CheckpointManager` (JSON store rooted at `{data-dir}/plan-reviews`) captures
-  workflow state as an operational replay aid.
+  source of truth for the decision, and the framework
+  `ICheckpointStore<JsonElement>` (JSON store rooted at
+  `{data-dir}/plan-reviews`) holds the paused execution envelope the
+  completion service reads to rebuild the effective plan on resume.
 
 ### GET /api/plans/{planId}/reviews
 

--- a/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
+++ b/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
@@ -760,7 +760,7 @@ public sealed record PlanExecutionOutcome(
     /// treat the outcome as terminal — the resume path continues from the
     /// paused step after the reviewer answers.
     /// </summary>
-    public Approval.PlanClarificationHandle? ClarificationHandle { get; init; }
+    public PlanClarificationHandle? ClarificationHandle { get; init; }
 
     /// <summary>
     /// Set when the executor paused a plan for a mid-execution replan
@@ -768,7 +768,7 @@ public sealed record PlanExecutionOutcome(
     /// <c>PlanStatus.AwaitingReview</c> and a new plan-review round is
     /// waiting for the reviewer.
     /// </summary>
-    public Approval.PlanReviewRoundHandle? ReviewHandle { get; init; }
+    public PlanReviewRoundHandle? ReviewHandle { get; init; }
 }
 
 /// <summary>Per-step transcript captured during workflow execution.</summary>

--- a/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
+++ b/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
@@ -2,11 +2,13 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Agents.AI.Workflows;
+using RetailPulse.Api.Approval;
 using RetailPulse.Api.Budget;
 using RetailPulse.Api.Charts;
 using RetailPulse.Api.Middleware;
 using RetailPulse.Api.Persistence;
 using RetailPulse.Contracts;
+using RetailPulse.Contracts.Approval;
 using RetailPulse.Contracts.Observability;
 using RetailPulse.Contracts.Persistence;
 using RetailPulse.Contracts.Routing;
@@ -44,20 +46,43 @@ public sealed class PlanExecutor
     private readonly ITraceCollector _traceCollector;
     private readonly PlanPersistenceOptions _options;
     private readonly ILogger<PlanExecutor> _logger;
+    private readonly PlanClarifier? _clarifier;
+    private readonly PlanReviewCoordinator? _reviewCoordinator;
 
     public PlanExecutor(
         IPlanStore planStore,
         ICostTracker costTracker,
         ITraceCollector traceCollector,
         PlanPersistenceOptions options,
-        ILogger<PlanExecutor> logger)
+        ILogger<PlanExecutor> logger,
+        PlanClarifier? clarifier = null,
+        PlanReviewCoordinator? reviewCoordinator = null)
     {
         _planStore = planStore ?? throw new ArgumentNullException(nameof(planStore));
         _costTracker = costTracker ?? throw new ArgumentNullException(nameof(costTracker));
         _traceCollector = traceCollector ?? throw new ArgumentNullException(nameof(traceCollector));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _clarifier = clarifier;
+        _reviewCoordinator = reviewCoordinator;
     }
+
+    /// <summary>
+    /// Action-prefix marker a step can use to request a mid-plan clarification.
+    /// Format: <c>[[CLARIFY]] &lt;question&gt; -- rest of action</c>. The executor
+    /// opens a clarification row + framework checkpoint capturing the paused
+    /// plan and halts. The completion service resumes when the reviewer answers.
+    /// </summary>
+    public const string ClarifyMarker = "[[CLARIFY]]";
+
+    /// <summary>
+    /// Action-prefix marker a step can use to force a mid-execution replan.
+    /// Format: <c>[[REPLAN]] &lt;feedback&gt; -- rest of action</c>. The executor
+    /// opens a new plan-review round with the accumulated context as
+    /// revision-reason and halts. The completion service picks up when the
+    /// reviewer decides on the revised plan.
+    /// </summary>
+    public const string ReplanMarker = "[[REPLAN]]";
 
     /// <summary>
     /// Execute an already-validated plan against the caller-supplied specialist
@@ -75,6 +100,31 @@ public sealed class PlanExecutor
         var planSw = Stopwatch.StartNew();
         DateTimeOffset planStart = DateTimeOffset.UtcNow;
 
+        // Suspension sink — set by RunOneStepAsync when it detects a
+        // clarification / replan marker on a step's action.
+        var suspension = new PlanExecutorSuspensionSink();
+
+        // Zero-step short circuit — this happens on a clarification resume
+        // where every step has already run (or the paused step was the last
+        // one). Skip the workflow and finalise immediately as Completed.
+        if (execution.Plan.Steps.Count == 0)
+        {
+            planSw.Stop();
+            await _planStore.UpdatePlanStatusAsync(new PlanStatusUpdate
+            {
+                PlanId = execution.PlanId,
+                Subject = execution.Subject,
+                Status = PlanStatus.Completed,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            }, CancellationToken.None).ConfigureAwait(false);
+            return new PlanExecutionOutcome(
+                PlanId: execution.PlanId,
+                Status: PlanStatus.Completed,
+                FailureReason: null,
+                Steps: [],
+                DurationMs: planSw.ElapsedMilliseconds);
+        }
+
         // Build a workflow. Sequential linear graph: each executor takes the
         // accumulated context, invokes the specialist, appends its result, and
         // either forwards to the next step or yields the final output.
@@ -91,7 +141,7 @@ public sealed class PlanExecutor
                 handlerAsync: async (message, context, stepCt) =>
                 {
                     PlanStepResult result = await RunOneStepAsync(
-                        execution, planned, stepIndex, stepId, message, stepCt).ConfigureAwait(false);
+                        execution, planned, stepIndex, stepId, message, suspension, stepCt).ConfigureAwait(false);
                     stepResults.Add(result);
 
                     bool shouldContinue = string.Equals(result.Status, PlanStepStatus.Completed, StringComparison.Ordinal);
@@ -215,6 +265,20 @@ public sealed class PlanExecutor
                     failureReason ??= last.Error ?? $"step {last.StepIndex} ended in {last.Status}";
             }
 
+            // Suspension overrides the derived terminal status: the plan is
+            // NOT terminal — it is waiting for reviewer input via the durable
+            // approval row + framework checkpoint the suspension helper wrote.
+            if (suspension.ClarificationHandle is not null)
+            {
+                terminalStatus = PlanStatus.AwaitingClarification;
+                failureReason = null;
+            }
+            else if (suspension.ReviewHandle is not null)
+            {
+                terminalStatus = PlanStatus.AwaitingReview;
+                failureReason = null;
+            }
+
             // Any steps we haven't yet observed must have been skipped by the workflow halt.
             for (int i = stepResults.Count; i < execution.Plan.Steps.Count; i++)
             {
@@ -256,7 +320,11 @@ public sealed class PlanExecutor
             Status: terminalStatus,
             FailureReason: failureReason,
             Steps: stepResults,
-            DurationMs: planSw.ElapsedMilliseconds);
+            DurationMs: planSw.ElapsedMilliseconds)
+        {
+            ClarificationHandle = suspension.ClarificationHandle,
+            ReviewHandle = suspension.ReviewHandle,
+        };
     }
 
     private async Task<PlanStepResult> RunOneStepAsync(
@@ -265,10 +333,31 @@ public sealed class PlanExecutor
         int stepIndex,
         string stepId,
         PlanStepMessage message,
+        PlanExecutorSuspensionSink suspension,
         CancellationToken workflowCt)
     {
         DateTimeOffset stepStart = DateTimeOffset.UtcNow;
         var sw = Stopwatch.StartNew();
+
+        // Mid-plan clarification / replan signals — detected from a marker
+        // prefix on the step's action so specialists don't need a new
+        // interface. Both suspend the plan through the same durable
+        // Approval/Checkpoint pair the plan-review gate uses.
+        if (planned.Action.TrimStart().StartsWith(ClarifyMarker, StringComparison.Ordinal)
+            && _clarifier is not null)
+        {
+            return await SuspendForClarificationAsync(
+                execution, planned, stepIndex, stepId, message, suspension, sw, stepStart)
+                .ConfigureAwait(false);
+        }
+
+        if (planned.Action.TrimStart().StartsWith(ReplanMarker, StringComparison.Ordinal)
+            && _reviewCoordinator is not null)
+        {
+            return await SuspendForMidPlanReviewAsync(
+                execution, planned, stepIndex, stepId, message, suspension, sw, stepStart)
+                .ConfigureAwait(false);
+        }
 
         // Look up the specialist afresh at execution time so the roster the
         // planner saw and the roster we dispatch through are the same one.
@@ -476,6 +565,167 @@ public sealed class PlanExecutor
             EstimatedCostUsd: 0m,
             Tags: tags));
     }
+
+    // ── Suspension helpers ───────────────────────────────────────────────
+
+    private async Task<PlanStepResult> SuspendForClarificationAsync(
+        PlanExecutionRequest execution,
+        PlannerStep planned,
+        int stepIndex,
+        string stepId,
+        PlanStepMessage message,
+        PlanExecutorSuspensionSink suspension,
+        Stopwatch sw,
+        DateTimeOffset stepStart)
+    {
+        string question = ExtractQuestion(planned.Action, ClarifyMarker);
+
+        IReadOnlyList<PlanReviewStepDto> remaining =
+        [
+            .. execution.Plan.Steps.Skip(stepIndex).Select(s => new PlanReviewStepDto
+            {
+                SpecialistKey = s.SpecialistKey,
+                Intent = s.Intent,
+                Action = s.Action,
+            }),
+        ];
+
+        IReadOnlyList<PlanReviewCompletedStep> completed =
+        [
+            .. message.AccumulatedResults.Select(r => new PlanReviewCompletedStep
+            {
+                StepIndex = r.StepIndex,
+                SpecialistKey = r.SpecialistKey,
+                Intent = r.Intent,
+                Action = r.Action,
+                Result = r.Result,
+                InputTokens = r.InputTokens,
+                OutputTokens = r.OutputTokens,
+                TotalTokens = r.TotalTokens,
+                DurationMs = r.DurationMs,
+            }),
+        ];
+
+        PlanClarificationHandle handle = await _clarifier!.OpenAsync(new PlanClarificationOpenInput
+        {
+            PlanId = execution.PlanId,
+            Subject = execution.Subject,
+            SessionId = execution.SessionId,
+            Request = execution.Request,
+            SpecialistKey = planned.SpecialistKey,
+            Question = question,
+            PausedAtStepIndex = stepIndex,
+            RemainingSteps = remaining,
+            SpecialistKeys = [.. execution.SpecialistLookup.Keys],
+            CompletedSteps = completed,
+            TraceId = execution.TraceId,
+            ParentSpanId = execution.ParentSpanId,
+            PrincipalKey = execution.PrincipalKey,
+        }, CancellationToken.None).ConfigureAwait(false);
+
+        suspension.ClarificationHandle = handle;
+
+        sw.Stop();
+        await _planStore.UpdateStepAsync(new PlanStepUpdate
+        {
+            StepId = stepId,
+            PlanId = execution.PlanId,
+            Subject = execution.Subject,
+            Status = PlanStepStatus.Pending,
+            StartedAt = stepStart,
+        }, CancellationToken.None).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Plan {PlanId} step {StepIndex} suspended for clarification (requestId={RequestId}).",
+            execution.PlanId, stepIndex, handle.RequestId);
+
+        // Return a non-Completed status so the workflow halts here — the
+        // executor closure sees the status and yields terminal.
+        return new PlanStepResult(
+            stepIndex, stepId, planned.SpecialistKey, planned.Intent, planned.Action,
+            PlanStepStatus.Pending, "", null, 0, 0, 0, sw.ElapsedMilliseconds);
+    }
+
+    private async Task<PlanStepResult> SuspendForMidPlanReviewAsync(
+        PlanExecutionRequest execution,
+        PlannerStep planned,
+        int stepIndex,
+        string stepId,
+        PlanStepMessage message,
+        PlanExecutorSuspensionSink suspension,
+        Stopwatch sw,
+        DateTimeOffset stepStart)
+    {
+        string feedback = ExtractQuestion(planned.Action, ReplanMarker);
+
+        IReadOnlyList<PlanReviewStepDto> remaining =
+        [
+            .. execution.Plan.Steps.Skip(stepIndex + 1).Select(s => new PlanReviewStepDto
+            {
+                SpecialistKey = s.SpecialistKey,
+                Intent = s.Intent,
+                Action = s.Action,
+            }),
+        ];
+
+        PlanReviewRoundHandle handle = await _reviewCoordinator!.OpenRoundAsync(new PlanReviewOpenInput
+        {
+            PlanId = execution.PlanId,
+            Subject = execution.Subject,
+            SessionId = execution.SessionId,
+            Request = execution.Request,
+            CurrentSteps = remaining,
+            SpecialistKeys = [.. execution.SpecialistLookup.Keys],
+            DetectedIntents = [],
+            RoundNumber = 0,
+            RevisionReason = "Mid-execution revision requested: " + feedback,
+            TraceId = execution.TraceId,
+            ParentSpanId = execution.ParentSpanId,
+            PrincipalKey = execution.PrincipalKey,
+        }, CancellationToken.None).ConfigureAwait(false);
+
+        suspension.ReviewHandle = handle;
+
+        sw.Stop();
+        _logger.LogInformation(
+            "Plan {PlanId} step {StepIndex} suspended for mid-execution review (requestId={RequestId}).",
+            execution.PlanId, stepIndex, handle.RequestId);
+
+        await _planStore.UpdateStepAsync(new PlanStepUpdate
+        {
+            StepId = stepId,
+            PlanId = execution.PlanId,
+            Subject = execution.Subject,
+            Status = PlanStepStatus.Pending,
+            StartedAt = stepStart,
+        }, CancellationToken.None).ConfigureAwait(false);
+
+        return new PlanStepResult(
+            stepIndex, stepId, planned.SpecialistKey, planned.Intent, planned.Action,
+            PlanStepStatus.Pending, "", null, 0, 0, 0, sw.ElapsedMilliseconds);
+    }
+
+    private static string ExtractQuestion(string action, string marker)
+    {
+        string trimmed = action.TrimStart();
+        if (!trimmed.StartsWith(marker, StringComparison.Ordinal))
+            return action;
+        string rest = trimmed[marker.Length..].TrimStart();
+        return string.IsNullOrWhiteSpace(rest) ? "(no question)" : rest;
+    }
+}
+
+/// <summary>
+/// Mutable sink populated by <see cref="PlanExecutor.RunOneStepAsync"/> when
+/// it detects a clarification / mid-plan replan marker. The presence of a
+/// non-null handle here shifts the final <see cref="PlanExecutionOutcome"/>
+/// away from a terminal status and toward one of the awaiting-* statuses,
+/// which the completion service picks up as a suspension.
+/// </summary>
+internal sealed class PlanExecutorSuspensionSink
+{
+    public PlanClarificationHandle? ClarificationHandle { get; set; }
+    public PlanReviewRoundHandle? ReviewHandle { get; set; }
 }
 
 /// <summary>Input envelope for <see cref="PlanExecutor.ExecuteAsync"/>.</summary>
@@ -501,7 +751,25 @@ public sealed record PlanExecutionOutcome(
     string Status,
     string? FailureReason,
     IReadOnlyList<PlanStepResult> Steps,
-    long DurationMs);
+    long DurationMs)
+{
+    /// <summary>
+    /// Set when the executor paused a plan for a mid-plan clarification
+    /// ([[CLARIFY]] step marker). Non-null implies <see cref="Status"/> is
+    /// <c>PlanStatus.AwaitingClarification</c> and the caller must NOT
+    /// treat the outcome as terminal — the resume path continues from the
+    /// paused step after the reviewer answers.
+    /// </summary>
+    public Approval.PlanClarificationHandle? ClarificationHandle { get; init; }
+
+    /// <summary>
+    /// Set when the executor paused a plan for a mid-execution replan
+    /// ([[REPLAN]] step marker). Non-null implies <see cref="Status"/> is
+    /// <c>PlanStatus.AwaitingReview</c> and a new plan-review round is
+    /// waiting for the reviewer.
+    /// </summary>
+    public Approval.PlanReviewRoundHandle? ReviewHandle { get; init; }
+}
 
 /// <summary>Per-step transcript captured during workflow execution.</summary>
 public sealed record PlanStepResult(

--- a/src/RetailPulse.Api/Agents/Planning/PlanOrchestrator.cs
+++ b/src/RetailPulse.Api/Agents/Planning/PlanOrchestrator.cs
@@ -115,54 +115,32 @@ public sealed class PlanOrchestrator
                 FailureReason: built.UnusableReason);
         }
 
-        // Step 2: plan review gate (#94). When enabled, present the plan to a
-        // human reviewer before ANY step executes. Approve → execute the
-        // original plan; edit → execute the reviewer's edited plan; reject with
-        // feedback → the coordinator loops with the planner (bounded rounds);
-        // timeout / replan exhausted → terminate the plan without executing.
-        // Every path writes an approval row through the same #91 gate so tool
-        // and plan approvals share one audit trail.
+        // Step 2: plan review gate (#94). When enabled, this is the
+        // non-blocking suspend point: persist the plan as AwaitingReview,
+        // write a real framework checkpoint, open the approval row, and
+        // return a Suspended result. The caller (/api/chat) hands the client
+        // a 202 with the review request id; PlanReviewCompletionService drives
+        // execution when the reviewer decides. No thread is blocked on the
+        // review timeout — the timeout is enforced by the sweep service, and
+        // process restart is invisible to the resume path because the
+        // checkpoint + approval row are durable.
         //
-        // When disabled (default), this block is a no-op and the executor sees
-        // the original planner output — the pre-#94 hot path is preserved
+        // When disabled (default), this block is a no-op and the executor
+        // sees the original planner output — the pre-#94 hot path is preserved
         // byte-for-byte.
         PlanBuildResult effectivePlan = built;
-        PlanReviewOutcome? reviewOutcome = null;
         if (_reviewOptions is { Enabled: true } && _reviewCoordinator is not null)
         {
-            reviewOutcome = await RunReviewAsync(planId, input, built, ct).ConfigureAwait(false);
-            if (!reviewOutcome.IsApproved)
-            {
-                // Persist the awaiting/terminal plan record with the reviewer's
-                // decision so /api/plans/{id} shows an honest terminal state.
-                await PersistReviewTerminalAsync(planId, input, built, reviewOutcome, createdAt, ct)
-                    .ConfigureAwait(false);
-
-                return new PlanOrchestrationResult(
-                    PlanId: planId,
-                    Status: PlanStatus.Failed,
-                    Reply: BuildReviewTerminalReply(reviewOutcome),
-                    DurationMs: 0,
-                    InputTokens: built.InputTokens ?? 0,
-                    OutputTokens: built.OutputTokens ?? 0,
-                    TotalTokens: built.TotalTokens ?? 0,
-                    Steps: [],
-                    FailureReason: $"{reviewOutcome.TerminalReason}: {reviewOutcome.FailureMessage ?? reviewOutcome.TerminalReason}");
-            }
-
-            // Approved outcome — swap in the possibly-edited step list before
-            // materializing step IDs. Both approve and edit paths flow through
-            // the same code so the executor never sees the pre-review plan when
-            // the reviewer swapped it out.
-            effectivePlan = built with
-            {
-                Steps = [.. reviewOutcome.FinalSteps.Select(s => new PlannerStep
-                {
-                    SpecialistKey = s.SpecialistKey,
-                    Intent = s.Intent,
-                    Action = s.Action,
-                })],
-            };
+            PlanReviewRoundHandle handle = await SuspendForReviewAsync(planId, input, built, createdAt, ct)
+                .ConfigureAwait(false);
+            return PlanOrchestrationResult.Suspended(
+                planId,
+                PlanStatus.AwaitingReview,
+                handle.RequestId,
+                handle.RoundNumber,
+                built.InputTokens ?? 0,
+                built.OutputTokens ?? 0,
+                built.TotalTokens ?? 0);
         }
 
         // Step 3: materialize step IDs and persist the initial plan.
@@ -227,51 +205,23 @@ public sealed class PlanOrchestrator
             FailureReason: outcome.FailureReason);
     }
 
-    private async Task<PlanReviewOutcome> RunReviewAsync(
+    /// <summary>
+    /// Persist the plan record as AwaitingReview, write a real framework
+    /// checkpoint, open the plan-review approval row, and return the
+    /// resulting handle. No thread is blocked — the completion service
+    /// drives execution when the reviewer decides.
+    /// </summary>
+    private async Task<PlanReviewRoundHandle> SuspendForReviewAsync(
         string planId,
         PlanOrchestrationInput input,
         PlanBuildResult built,
-        CancellationToken ct)
-    {
-        var initialSteps = built.Steps
-            .Select(s => new PlanReviewStepDto
-            {
-                SpecialistKey = s.SpecialistKey,
-                Intent = s.Intent,
-                Action = s.Action,
-            })
-            .ToList();
-
-        var specialistKeys = input.Roster
-            .Select(a => a.Key)
-            .ToList();
-
-        var reviewInput = new PlanReviewCoordinationInput
-        {
-            PlanId = planId,
-            Subject = input.Subject,
-            SessionId = input.Request.SessionId,
-            Request = input.Request.Message,
-            InitialSteps = initialSteps,
-            SpecialistKeys = specialistKeys,
-            Roster = input.Roster,
-            DetectedIntents = input.DetectedIntents,
-        };
-
-        return await _reviewCoordinator!.CoordinateAsync(reviewInput, ct).ConfigureAwait(false);
-    }
-
-    private async Task PersistReviewTerminalAsync(
-        string planId,
-        PlanOrchestrationInput input,
-        PlanBuildResult built,
-        PlanReviewOutcome outcome,
         DateTimeOffset createdAt,
         CancellationToken ct)
     {
-        // Record the plan as AwaitingReview → Failed so audit history preserves
-        // the intended step list and the terminal reason. Steps stay Pending on
-        // disk (they never ran).
+        // Record the plan record BEFORE the checkpoint / approval row so the
+        // resume path (which queries the plan store by planId) always finds a
+        // row that matches the checkpoint. Steps stay Pending until the
+        // reviewer approves (or edits) and the executor resumes.
         var stepWrites = new List<PlanStepWrite>(built.Steps.Count);
         for (int i = 0; i < built.Steps.Count; i++)
         {
@@ -299,37 +249,37 @@ public sealed class PlanOrchestrator
             CreatedAt = createdAt,
         }, ct).ConfigureAwait(false);
 
-        await _planStore.UpdatePlanStatusAsync(new PlanStatusUpdate
+        IReadOnlyList<PlanReviewStepDto> initialSteps =
+        [
+            .. built.Steps.Select(s => new PlanReviewStepDto
+            {
+                SpecialistKey = s.SpecialistKey,
+                Intent = s.Intent,
+                Action = s.Action,
+            }),
+        ];
+
+        IReadOnlyCollection<string> specialistKeys =
+            [.. input.Roster.Select(a => a.Key)];
+
+        var open = new PlanReviewOpenInput
         {
             PlanId = planId,
             Subject = input.Subject,
-            Status = PlanStatus.Failed,
-            FailureReason = $"{outcome.TerminalReason}: {outcome.FailureMessage}",
-            TotalInputTokens = built.InputTokens,
-            TotalOutputTokens = built.OutputTokens,
-            TotalTokens = built.TotalTokens,
-            UpdatedAt = DateTimeOffset.UtcNow,
-        }, ct).ConfigureAwait(false);
-
-        _logger.LogWarning(
-            "Plan {PlanId} terminated at review: {Terminal} — {Message}",
-            planId, outcome.TerminalReason, outcome.FailureMessage);
-    }
-
-    private static string BuildReviewTerminalReply(PlanReviewOutcome outcome) =>
-        outcome.TerminalReason switch
-        {
-            PlanReviewTerminalReason.ReviewTimedOut =>
-                "The plan was not executed because reviewer approval timed out.",
-            PlanReviewTerminalReason.ReplanExhausted =>
-                "The plan was not executed because the reviewer rejected every revision within the configured limit.",
-            PlanReviewTerminalReason.EditedToEmpty =>
-                "The plan was not executed because the reviewer edited it down to zero steps.",
-            PlanReviewTerminalReason.EditInvalid =>
-                "The plan was not executed because the reviewer's edited step list referenced an unknown specialist.",
-            _ =>
-                "The plan was not executed because the reviewer declined to approve it.",
+            SessionId = input.Request.SessionId,
+            TenantId = input.TenantId,
+            Request = input.Request.Message,
+            CurrentSteps = initialSteps,
+            SpecialistKeys = specialistKeys,
+            DetectedIntents = input.DetectedIntents,
+            RoundNumber = 0,
+            TraceId = input.TraceId,
+            ParentSpanId = input.ParentSpanId,
+            PrincipalKey = input.PrincipalKey,
         };
+
+        return await _reviewCoordinator!.OpenRoundAsync(open, ct).ConfigureAwait(false);
+    }
 
     private static string BuildFinalReply(PlanExecutionOutcome outcome)
     {
@@ -424,7 +374,12 @@ public sealed record PlanOrchestrationInput
     public string? ParentSpanId { get; init; }
 }
 
-/// <summary>Terminal result returned to the chat endpoint.</summary>
+/// <summary>
+/// Result returned to the chat endpoint. Either terminal (Completed / Failed
+/// / Cancelled / Unusable) or suspended (AwaitingReview / AwaitingClarification).
+/// The endpoint returns 202 for the suspended shape, 200 for the terminal
+/// shape — see <see cref="Endpoints.ChatEndpoints"/>.
+/// </summary>
 public sealed record PlanOrchestrationResult(
     string PlanId,
     string Status,
@@ -434,4 +389,43 @@ public sealed record PlanOrchestrationResult(
     int OutputTokens,
     int TotalTokens,
     IReadOnlyList<PlanStepResult> Steps,
-    string? FailureReason);
+    string? FailureReason)
+{
+    /// <summary>
+    /// Set when the plan is waiting for reviewer input. Non-null implies
+    /// <see cref="Status"/> is <c>PlanStatus.AwaitingReview</c>.
+    /// </summary>
+    public string? ReviewRequestId { get; init; }
+
+    /// <summary>Round number for the pending review row (0 = initial plan).</summary>
+    public int? ReviewRoundNumber { get; init; }
+
+    /// <summary>
+    /// True when the caller should return HTTP 202 with a pending payload
+    /// instead of the standard 200 chat response.
+    /// </summary>
+    public bool IsSuspended => Status is PlanStatus.AwaitingReview
+        or PlanStatus.AwaitingClarification;
+
+    public static PlanOrchestrationResult Suspended(
+        string planId,
+        string status,
+        string requestId,
+        int roundNumber,
+        int inputTokens,
+        int outputTokens,
+        int totalTokens) => new(
+            PlanId: planId,
+            Status: status,
+            Reply: "",
+            DurationMs: 0,
+            InputTokens: inputTokens,
+            OutputTokens: outputTokens,
+            TotalTokens: totalTokens,
+            Steps: [],
+            FailureReason: null)
+        {
+            ReviewRequestId = requestId,
+            ReviewRoundNumber = roundNumber,
+        };
+}

--- a/src/RetailPulse.Api/Agents/Planning/PlanOrchestrator.cs
+++ b/src/RetailPulse.Api/Agents/Planning/PlanOrchestrator.cs
@@ -147,7 +147,7 @@ public sealed class PlanOrchestrator
                     OutputTokens: built.OutputTokens ?? 0,
                     TotalTokens: built.TotalTokens ?? 0,
                     Steps: [],
-                    FailureReason: reviewOutcome.FailureMessage ?? reviewOutcome.TerminalReason);
+                    FailureReason: $"{reviewOutcome.TerminalReason}: {reviewOutcome.FailureMessage ?? reviewOutcome.TerminalReason}");
             }
 
             // Approved outcome — swap in the possibly-edited step list before

--- a/src/RetailPulse.Api/Agents/Planning/PlanOrchestrator.cs
+++ b/src/RetailPulse.Api/Agents/Planning/PlanOrchestrator.cs
@@ -1,6 +1,9 @@
 using System.Text;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Approval;
 using RetailPulse.Api.Persistence;
 using RetailPulse.Contracts;
+using RetailPulse.Contracts.Approval;
 using RetailPulse.Contracts.Observability;
 using RetailPulse.Contracts.Persistence;
 using RetailPulse.Contracts.Routing;
@@ -24,6 +27,8 @@ public sealed class PlanOrchestrator
     private readonly ICostTracker _costTracker;
     private readonly PlanPersistenceOptions _options;
     private readonly ILogger<PlanOrchestrator> _logger;
+    private readonly PlanReviewCoordinator? _reviewCoordinator;
+    private readonly PlanReviewOptions? _reviewOptions;
 
     public PlanOrchestrator(
         PlanBuilder builder,
@@ -31,7 +36,9 @@ public sealed class PlanOrchestrator
         IPlanStore planStore,
         ICostTracker costTracker,
         PlanPersistenceOptions options,
-        ILogger<PlanOrchestrator> logger)
+        ILogger<PlanOrchestrator> logger,
+        PlanReviewCoordinator? reviewCoordinator = null,
+        IOptions<PlanReviewOptions>? reviewOptions = null)
     {
         _builder = builder ?? throw new ArgumentNullException(nameof(builder));
         _executor = executor ?? throw new ArgumentNullException(nameof(executor));
@@ -39,6 +46,8 @@ public sealed class PlanOrchestrator
         _costTracker = costTracker ?? throw new ArgumentNullException(nameof(costTracker));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _reviewCoordinator = reviewCoordinator;
+        _reviewOptions = reviewOptions?.Value;
     }
 
     public async Task<PlanOrchestrationResult> RunAsync(
@@ -106,10 +115,60 @@ public sealed class PlanOrchestrator
                 FailureReason: built.UnusableReason);
         }
 
-        // Step 2: materialize step IDs and persist the initial plan.
-        var stepIds = new List<string>(built.Steps.Count);
-        var stepWrites = new List<PlanStepWrite>(built.Steps.Count);
-        for (int i = 0; i < built.Steps.Count; i++)
+        // Step 2: plan review gate (#94). When enabled, present the plan to a
+        // human reviewer before ANY step executes. Approve → execute the
+        // original plan; edit → execute the reviewer's edited plan; reject with
+        // feedback → the coordinator loops with the planner (bounded rounds);
+        // timeout / replan exhausted → terminate the plan without executing.
+        // Every path writes an approval row through the same #91 gate so tool
+        // and plan approvals share one audit trail.
+        //
+        // When disabled (default), this block is a no-op and the executor sees
+        // the original planner output — the pre-#94 hot path is preserved
+        // byte-for-byte.
+        PlanBuildResult effectivePlan = built;
+        PlanReviewOutcome? reviewOutcome = null;
+        if (_reviewOptions is { Enabled: true } && _reviewCoordinator is not null)
+        {
+            reviewOutcome = await RunReviewAsync(planId, input, built, ct).ConfigureAwait(false);
+            if (!reviewOutcome.IsApproved)
+            {
+                // Persist the awaiting/terminal plan record with the reviewer's
+                // decision so /api/plans/{id} shows an honest terminal state.
+                await PersistReviewTerminalAsync(planId, input, built, reviewOutcome, createdAt, ct)
+                    .ConfigureAwait(false);
+
+                return new PlanOrchestrationResult(
+                    PlanId: planId,
+                    Status: PlanStatus.Failed,
+                    Reply: BuildReviewTerminalReply(reviewOutcome),
+                    DurationMs: 0,
+                    InputTokens: built.InputTokens ?? 0,
+                    OutputTokens: built.OutputTokens ?? 0,
+                    TotalTokens: built.TotalTokens ?? 0,
+                    Steps: [],
+                    FailureReason: reviewOutcome.FailureMessage ?? reviewOutcome.TerminalReason);
+            }
+
+            // Approved outcome — swap in the possibly-edited step list before
+            // materializing step IDs. Both approve and edit paths flow through
+            // the same code so the executor never sees the pre-review plan when
+            // the reviewer swapped it out.
+            effectivePlan = built with
+            {
+                Steps = [.. reviewOutcome.FinalSteps.Select(s => new PlannerStep
+                {
+                    SpecialistKey = s.SpecialistKey,
+                    Intent = s.Intent,
+                    Action = s.Action,
+                })],
+            };
+        }
+
+        // Step 3: materialize step IDs and persist the initial plan.
+        var stepIds = new List<string>(effectivePlan.Steps.Count);
+        var stepWrites = new List<PlanStepWrite>(effectivePlan.Steps.Count);
+        for (int i = 0; i < effectivePlan.Steps.Count; i++)
         {
             string stepId = $"{planId}-s{i}";
             stepIds.Add(stepId);
@@ -117,9 +176,9 @@ public sealed class PlanOrchestrator
             {
                 StepId = stepId,
                 StepIndex = i,
-                SpecialistKey = built.Steps[i].SpecialistKey,
-                Intent = built.Steps[i].Intent,
-                Action = built.Steps[i].Action,
+                SpecialistKey = effectivePlan.Steps[i].SpecialistKey,
+                Intent = effectivePlan.Steps[i].Intent,
+                Action = effectivePlan.Steps[i].Action,
                 Status = PlanStepStatus.Pending,
             });
         }
@@ -137,7 +196,7 @@ public sealed class PlanOrchestrator
             CreatedAt = createdAt,
         }, ct).ConfigureAwait(false);
 
-        // Step 3: execute the workflow.
+        // Step 4: execute the (possibly edited) workflow.
         var executionRequest = new PlanExecutionRequest
         {
             PlanId = planId,
@@ -149,7 +208,7 @@ public sealed class PlanOrchestrator
             Request = input.Request.Message,
             History = input.Request.History,
             User = input.Request.User,
-            Plan = built,
+            Plan = effectivePlan,
             StepIds = stepIds,
             SpecialistLookup = input.SpecialistLookup,
         };
@@ -161,12 +220,116 @@ public sealed class PlanOrchestrator
             Status: outcome.Status,
             Reply: BuildFinalReply(outcome),
             DurationMs: outcome.DurationMs,
-            InputTokens: (built.InputTokens ?? 0) + outcome.Steps.Sum(s => s.InputTokens),
-            OutputTokens: (built.OutputTokens ?? 0) + outcome.Steps.Sum(s => s.OutputTokens),
-            TotalTokens: (built.TotalTokens ?? 0) + outcome.Steps.Sum(s => s.TotalTokens),
+            InputTokens: (effectivePlan.InputTokens ?? 0) + outcome.Steps.Sum(s => s.InputTokens),
+            OutputTokens: (effectivePlan.OutputTokens ?? 0) + outcome.Steps.Sum(s => s.OutputTokens),
+            TotalTokens: (effectivePlan.TotalTokens ?? 0) + outcome.Steps.Sum(s => s.TotalTokens),
             Steps: outcome.Steps,
             FailureReason: outcome.FailureReason);
     }
+
+    private async Task<PlanReviewOutcome> RunReviewAsync(
+        string planId,
+        PlanOrchestrationInput input,
+        PlanBuildResult built,
+        CancellationToken ct)
+    {
+        var initialSteps = built.Steps
+            .Select(s => new PlanReviewStepDto
+            {
+                SpecialistKey = s.SpecialistKey,
+                Intent = s.Intent,
+                Action = s.Action,
+            })
+            .ToList();
+
+        var specialistKeys = input.Roster
+            .Select(a => a.Key)
+            .ToList();
+
+        var reviewInput = new PlanReviewCoordinationInput
+        {
+            PlanId = planId,
+            Subject = input.Subject,
+            SessionId = input.Request.SessionId,
+            Request = input.Request.Message,
+            InitialSteps = initialSteps,
+            SpecialistKeys = specialistKeys,
+            Roster = input.Roster,
+            DetectedIntents = input.DetectedIntents,
+        };
+
+        return await _reviewCoordinator!.CoordinateAsync(reviewInput, ct).ConfigureAwait(false);
+    }
+
+    private async Task PersistReviewTerminalAsync(
+        string planId,
+        PlanOrchestrationInput input,
+        PlanBuildResult built,
+        PlanReviewOutcome outcome,
+        DateTimeOffset createdAt,
+        CancellationToken ct)
+    {
+        // Record the plan as AwaitingReview → Failed so audit history preserves
+        // the intended step list and the terminal reason. Steps stay Pending on
+        // disk (they never ran).
+        var stepWrites = new List<PlanStepWrite>(built.Steps.Count);
+        for (int i = 0; i < built.Steps.Count; i++)
+        {
+            stepWrites.Add(new PlanStepWrite
+            {
+                StepId = $"{planId}-s{i}",
+                StepIndex = i,
+                SpecialistKey = built.Steps[i].SpecialistKey,
+                Intent = built.Steps[i].Intent,
+                Action = built.Steps[i].Action,
+                Status = PlanStepStatus.Pending,
+            });
+        }
+
+        await _planStore.CreatePlanAsync(new PlanWrite
+        {
+            PlanId = planId,
+            Subject = input.Subject,
+            SessionId = input.Request.SessionId,
+            TenantId = input.TenantId,
+            Request = input.Request.Message,
+            DetectedIntents = input.DetectedIntents,
+            Status = PlanStatus.AwaitingReview,
+            Steps = stepWrites,
+            CreatedAt = createdAt,
+        }, ct).ConfigureAwait(false);
+
+        await _planStore.UpdatePlanStatusAsync(new PlanStatusUpdate
+        {
+            PlanId = planId,
+            Subject = input.Subject,
+            Status = PlanStatus.Failed,
+            FailureReason = $"{outcome.TerminalReason}: {outcome.FailureMessage}",
+            TotalInputTokens = built.InputTokens,
+            TotalOutputTokens = built.OutputTokens,
+            TotalTokens = built.TotalTokens,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        }, ct).ConfigureAwait(false);
+
+        _logger.LogWarning(
+            "Plan {PlanId} terminated at review: {Terminal} — {Message}",
+            planId, outcome.TerminalReason, outcome.FailureMessage);
+    }
+
+    private static string BuildReviewTerminalReply(PlanReviewOutcome outcome) =>
+        outcome.TerminalReason switch
+        {
+            PlanReviewTerminalReason.ReviewTimedOut =>
+                "The plan was not executed because reviewer approval timed out.",
+            PlanReviewTerminalReason.ReplanExhausted =>
+                "The plan was not executed because the reviewer rejected every revision within the configured limit.",
+            PlanReviewTerminalReason.EditedToEmpty =>
+                "The plan was not executed because the reviewer edited it down to zero steps.",
+            PlanReviewTerminalReason.EditInvalid =>
+                "The plan was not executed because the reviewer's edited step list referenced an unknown specialist.",
+            _ =>
+                "The plan was not executed because the reviewer declined to approve it.",
+        };
 
     private static string BuildFinalReply(PlanExecutionOutcome outcome)
     {

--- a/src/RetailPulse.Api/Approval/IPlanClarifier.cs
+++ b/src/RetailPulse.Api/Approval/IPlanClarifier.cs
@@ -27,6 +27,11 @@ public interface IPlanClarifier
     /// <see cref="PlanClarificationResult.IsAnswered"/> is false only for
     /// timeouts, orphaned rows, or unusable answers, and the caller records that
     /// terminal state without hanging.
+    ///
+    /// <para>Retained for coordinator-level tests. Production callers use
+    /// <see cref="PlanClarifier.OpenAsync"/> (non-blocking) + endpoint /
+    /// completion-service resume to avoid holding a request thread on the
+    /// clarification timeout.</para>
     /// </summary>
     Task<PlanClarificationResult> AskAsync(
         PlanClarificationPrompt prompt,

--- a/src/RetailPulse.Api/Approval/IPlanClarifier.cs
+++ b/src/RetailPulse.Api/Approval/IPlanClarifier.cs
@@ -1,0 +1,44 @@
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Mid-plan clarification round-trip (#94). A step whose specialist needs
+/// reviewer input to proceed pauses via <see cref="AskAsync"/>: the coordinator
+/// creates an approval row with <see cref="ApprovalKind.Clarification"/>,
+/// persists the question as the row's payload, blocks on
+/// <see cref="IApprovalGate.WaitForApprovalAsync"/>, and returns the answer
+/// when it arrives (or times out with a deterministic terminal reason).
+///
+/// <para>
+/// Sharing the same <see cref="IApprovalGate"/> storage means clarification
+/// prompts appear in the shared history / audit trail alongside plan reviews and
+/// single-tool approvals — one durable surface, one restart posture. Cross-
+/// subject rejection and injected-clock timeout are inherited from the gate;
+/// this service does not add a second policy path.
+/// </para>
+/// </summary>
+public interface IPlanClarifier
+{
+    /// <summary>
+    /// Ask the reviewer a clarification question. Blocks until the answer arrives
+    /// or the configured clarification timeout elapses. The returned
+    /// <see cref="PlanClarificationResult"/> is authoritative — its
+    /// <see cref="PlanClarificationResult.IsAnswered"/> is false only for
+    /// timeouts, orphaned rows, or unusable answers, and the caller records that
+    /// terminal state without hanging.
+    /// </summary>
+    Task<PlanClarificationResult> AskAsync(
+        PlanClarificationPrompt prompt,
+        string subject,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result of a clarification round-trip.
+/// </summary>
+public sealed record PlanClarificationResult(
+    bool IsAnswered,
+    string? Answer,
+    string TerminalReason,
+    string RequestId);

--- a/src/RetailPulse.Api/Approval/PlanClarifier.cs
+++ b/src/RetailPulse.Api/Approval/PlanClarifier.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Default <see cref="IPlanClarifier"/> — writes a clarification row through
+/// the shared <see cref="IApprovalGate"/> and waits with the configured
+/// <see cref="PlanReviewOptions.ClarificationTimeout"/>.
+/// </summary>
+public sealed class PlanClarifier : IPlanClarifier
+{
+    private readonly IApprovalGate _gate;
+    private readonly PlanReviewOptions _options;
+    private readonly ILogger<PlanClarifier> _logger;
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public PlanClarifier(
+        IApprovalGate gate,
+        IOptions<PlanReviewOptions> options,
+        ILogger<PlanClarifier> logger)
+    {
+        _gate = gate ?? throw new ArgumentNullException(nameof(gate));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PlanClarificationResult> AskAsync(
+        PlanClarificationPrompt prompt,
+        string subject,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(prompt);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+
+        var context = new ApprovalContext(
+            AgentId: "plan-clarification",
+            UserId: subject,
+            Action: $"Answer clarification for step {prompt.StepIndex} ({prompt.SpecialistKey}).",
+            Impact: "Blocking a plan step.",
+            Urgency: "medium",
+            Reasoning: prompt.Question,
+            SessionId: null,
+            ConversationId: null,
+            Kind: ApprovalKind.Clarification,
+            PlanId: prompt.PlanId,
+            RoundNumber: 0,
+            Payload: JsonSerializer.Serialize(prompt, _jsonOptions));
+
+        ApprovalRequest request = await _gate.RequestApprovalAsync(context, ct);
+        _logger.LogInformation(
+            "Clarification {RequestId} opened for plan {PlanId} step {StepIndex}.",
+            request.RequestId, prompt.PlanId, prompt.StepIndex);
+
+        ApprovalResult result = await _gate.WaitForApprovalAsync(
+            request.RequestId, _options.ClarificationTimeout, ct);
+
+        if (result.Decision is ApprovalDecision.TimedOut or ApprovalDecision.Orphaned)
+        {
+            return new PlanClarificationResult(false, null, PlanReviewTerminalReason.ReviewTimedOut, request.RequestId);
+        }
+
+        if (string.IsNullOrWhiteSpace(result.ResponsePayload))
+        {
+            return new PlanClarificationResult(
+                false, null, PlanReviewTerminalReason.ClarificationInvalid, request.RequestId);
+        }
+
+        try
+        {
+            PlanClarificationAnswer? answer =
+                JsonSerializer.Deserialize<PlanClarificationAnswer>(result.ResponsePayload, _jsonOptions);
+            return answer is null || string.IsNullOrWhiteSpace(answer.Answer)
+                ? new PlanClarificationResult(false, null, PlanReviewTerminalReason.ClarificationInvalid, request.RequestId)
+                : new PlanClarificationResult(true, answer.Answer, PlanReviewTerminalReason.ReviewerApproved, request.RequestId);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Clarification {RequestId} response payload was not valid JSON.", request.RequestId);
+            return new PlanClarificationResult(
+                false, null, PlanReviewTerminalReason.ClarificationInvalid, request.RequestId);
+        }
+    }
+}

--- a/src/RetailPulse.Api/Approval/PlanClarifier.cs
+++ b/src/RetailPulse.Api/Approval/PlanClarifier.cs
@@ -8,11 +8,22 @@ namespace RetailPulse.Api.Approval;
 /// Default <see cref="IPlanClarifier"/> — writes a clarification row through
 /// the shared <see cref="IApprovalGate"/> and waits with the configured
 /// <see cref="PlanReviewOptions.ClarificationTimeout"/>.
+///
+/// <para>
+/// Exposes both the pre-existing blocking <see cref="AskAsync"/> shape (used
+/// by unit tests that respond on a background task) and the non-blocking
+/// <see cref="OpenAsync"/> / <see cref="TryReadAnswerAsync"/> primitives the
+/// production PlanExecutor / PlanReviewCompletionService use to suspend a
+/// running plan and resume it in a fresh process after the reviewer answers.
+/// Both paths share the same durable approval row and framework checkpoint so
+/// the audit trail is identical.
+/// </para>
 /// </summary>
 public sealed class PlanClarifier : IPlanClarifier
 {
     private readonly IApprovalGate _gate;
     private readonly PlanReviewOptions _options;
+    private readonly PlanReviewCheckpointService _checkpoints;
     private readonly ILogger<PlanClarifier> _logger;
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
@@ -24,11 +35,123 @@ public sealed class PlanClarifier : IPlanClarifier
     public PlanClarifier(
         IApprovalGate gate,
         IOptions<PlanReviewOptions> options,
+        PlanReviewCheckpointService checkpoints,
         ILogger<PlanClarifier> logger)
     {
         _gate = gate ?? throw new ArgumentNullException(nameof(gate));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _checkpoints = checkpoints ?? throw new ArgumentNullException(nameof(checkpoints));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>Configured clarification timeout — exposed for the sweep.</summary>
+    public TimeSpan ClarificationTimeout => _options.ClarificationTimeout;
+
+    /// <summary>
+    /// Non-blocking suspend point for a mid-plan clarification. Writes a real
+    /// framework checkpoint capturing the paused plan state, opens a
+    /// <see cref="ApprovalKind.Clarification"/> approval row, then returns the
+    /// request id + checkpoint id. The caller (PlanExecutor) unwinds
+    /// immediately; the resume path drives execution forward when the answer
+    /// arrives via the endpoint or restart recovery.
+    /// </summary>
+    public async Task<PlanClarificationHandle> OpenAsync(
+        PlanClarificationOpenInput input, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.Subject);
+
+        var prompt = new PlanClarificationPrompt
+        {
+            PlanId = input.PlanId,
+            StepIndex = input.PausedAtStepIndex,
+            SpecialistKey = input.SpecialistKey,
+            Question = input.Question,
+        };
+
+        var checkpointState = new PlanReviewCheckpointState
+        {
+            Kind = PlanCheckpointKind.Clarification,
+            PlanId = input.PlanId,
+            Subject = input.Subject,
+            SessionId = input.SessionId,
+            TenantId = input.TenantId,
+            Request = input.Request,
+            RoundNumber = 0,
+            Steps = input.RemainingSteps,
+            SpecialistKeys = [.. input.SpecialistKeys],
+            DetectedIntents = input.DetectedIntents,
+            TraceId = input.TraceId,
+            ParentSpanId = input.ParentSpanId,
+            PrincipalKey = input.PrincipalKey,
+            ApprovalRequestId = string.Empty,
+            CreatedAt = DateTimeOffset.UtcNow,
+            PausedAtStepIndex = input.PausedAtStepIndex,
+            CompletedSteps = input.CompletedSteps,
+        };
+
+        Microsoft.Agents.AI.Workflows.CheckpointInfo checkpoint =
+            await _checkpoints.SaveAsync(checkpointState, ct).ConfigureAwait(false);
+
+        var context = new ApprovalContext(
+            AgentId: "plan-clarification",
+            UserId: input.Subject,
+            Action: $"Answer clarification for step {input.PausedAtStepIndex} ({input.SpecialistKey}).",
+            Impact: "Blocking a plan step.",
+            Urgency: "medium",
+            Reasoning: input.Question,
+            SessionId: input.SessionId,
+            ConversationId: null,
+            Kind: ApprovalKind.Clarification,
+            PlanId: input.PlanId,
+            RoundNumber: 0,
+            Payload: JsonSerializer.Serialize(prompt, _jsonOptions));
+
+        ApprovalRequest request = await _gate.RequestApprovalAsync(context, ct).ConfigureAwait(false);
+        _logger.LogInformation(
+            "Clarification {RequestId} opened for plan {PlanId} step {StepIndex} (checkpoint={CheckpointId}).",
+            request.RequestId, input.PlanId, input.PausedAtStepIndex, checkpoint.CheckpointId);
+
+        return new PlanClarificationHandle(request.RequestId, checkpoint.CheckpointId, request.ExpiresAt);
+    }
+
+    /// <summary>
+    /// Parse the persisted response payload for a clarification row into a
+    /// <see cref="PlanClarificationResult"/>. Non-blocking — the caller has
+    /// already observed a terminal decision via the endpoint or the row
+    /// state.
+    /// </summary>
+    public static PlanClarificationResult InterpretAnswer(ApprovalResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.Decision is ApprovalDecision.TimedOut or ApprovalDecision.Orphaned)
+        {
+            return new PlanClarificationResult(false, null,
+                PlanReviewTerminalReason.ReviewTimedOut, result.RequestId);
+        }
+
+        if (string.IsNullOrWhiteSpace(result.ResponsePayload))
+        {
+            return new PlanClarificationResult(false, null,
+                PlanReviewTerminalReason.ClarificationInvalid, result.RequestId);
+        }
+
+        try
+        {
+            PlanClarificationAnswer? answer =
+                JsonSerializer.Deserialize<PlanClarificationAnswer>(result.ResponsePayload, _jsonOptions);
+            return answer is null || string.IsNullOrWhiteSpace(answer.Answer)
+                ? new PlanClarificationResult(false, null,
+                    PlanReviewTerminalReason.ClarificationInvalid, result.RequestId)
+                : new PlanClarificationResult(true, answer.Answer,
+                    PlanReviewTerminalReason.ReviewerApproved, result.RequestId);
+        }
+        catch (JsonException)
+        {
+            return new PlanClarificationResult(false, null,
+                PlanReviewTerminalReason.ClarificationInvalid, result.RequestId);
+        }
     }
 
     public async Task<PlanClarificationResult> AskAsync(
@@ -61,30 +184,35 @@ public sealed class PlanClarifier : IPlanClarifier
         ApprovalResult result = await _gate.WaitForApprovalAsync(
             request.RequestId, _options.ClarificationTimeout, ct);
 
-        if (result.Decision is ApprovalDecision.TimedOut or ApprovalDecision.Orphaned)
-        {
-            return new PlanClarificationResult(false, null, PlanReviewTerminalReason.ReviewTimedOut, request.RequestId);
-        }
-
-        if (string.IsNullOrWhiteSpace(result.ResponsePayload))
-        {
-            return new PlanClarificationResult(
-                false, null, PlanReviewTerminalReason.ClarificationInvalid, request.RequestId);
-        }
-
-        try
-        {
-            PlanClarificationAnswer? answer =
-                JsonSerializer.Deserialize<PlanClarificationAnswer>(result.ResponsePayload, _jsonOptions);
-            return answer is null || string.IsNullOrWhiteSpace(answer.Answer)
-                ? new PlanClarificationResult(false, null, PlanReviewTerminalReason.ClarificationInvalid, request.RequestId)
-                : new PlanClarificationResult(true, answer.Answer, PlanReviewTerminalReason.ReviewerApproved, request.RequestId);
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogWarning(ex, "Clarification {RequestId} response payload was not valid JSON.", request.RequestId);
-            return new PlanClarificationResult(
-                false, null, PlanReviewTerminalReason.ClarificationInvalid, request.RequestId);
-        }
+        return InterpretAnswer(result);
     }
 }
+
+/// <summary>
+/// Envelope passed to <see cref="PlanClarifier.OpenAsync"/> capturing every
+/// field a fresh process needs to resume the plan when the reviewer answers.
+/// </summary>
+public sealed record PlanClarificationOpenInput
+{
+    public required string PlanId { get; init; }
+    public required string Subject { get; init; }
+    public string? SessionId { get; init; }
+    public string? TenantId { get; init; }
+    public required string Request { get; init; }
+    public required string SpecialistKey { get; init; }
+    public required string Question { get; init; }
+    public required int PausedAtStepIndex { get; init; }
+    public required IReadOnlyList<PlanReviewStepDto> RemainingSteps { get; init; }
+    public required IReadOnlyCollection<string> SpecialistKeys { get; init; }
+    public IReadOnlyList<string> DetectedIntents { get; init; } = [];
+    public IReadOnlyList<PlanReviewCompletedStep>? CompletedSteps { get; init; }
+    public string? TraceId { get; init; }
+    public string? ParentSpanId { get; init; }
+    public string? PrincipalKey { get; init; }
+}
+
+/// <summary>Handle returned from <see cref="PlanClarifier.OpenAsync"/>.</summary>
+public sealed record PlanClarificationHandle(
+    string RequestId,
+    string CheckpointId,
+    DateTimeOffset ExpiresAt);

--- a/src/RetailPulse.Api/Approval/PlanReviewCheckpointService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCheckpointService.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Durable state store for plan review and clarification suspensions (#94).
+/// Writes a genuine Microsoft.Agents.AI.Workflows checkpoint through
+/// <see cref="ICheckpointStore{TStoreObject}.CreateCheckpointAsync"/> — the
+/// framework's public JSON-serialized checkpoint API, not a bespoke JSON
+/// marker written next to it. Reads walk the same store through
+/// <see cref="CheckpointManager.GetLatestCheckpointAsync"/> and
+/// <see cref="ICheckpointStore{TStoreObject}.RetrieveCheckpointAsync"/> so
+/// a process created AFTER a suspension sees exactly what the process that
+/// wrote the checkpoint wrote.
+///
+/// <para>
+/// One session id per plan (<c>plan-review::{planId}</c>). Every round /
+/// clarification suspension appends a new checkpoint to that session; the
+/// latest wins on resume. The framework's own checkpoint parent-chain is
+/// unused — reviews are strictly linear (round N supersedes round N-1) so a
+/// flat sequence of orphan checkpoints under one session id keeps the file
+/// layout simple and audit-friendly.
+/// </para>
+/// </summary>
+public sealed class PlanReviewCheckpointService
+{
+    private readonly ICheckpointStore<JsonElement> _store;
+    private readonly CheckpointManager _manager;
+    private readonly ILogger<PlanReviewCheckpointService> _logger;
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public PlanReviewCheckpointService(
+        ICheckpointStore<JsonElement> store,
+        CheckpointManager manager,
+        ILogger<PlanReviewCheckpointService> logger)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _manager = manager ?? throw new ArgumentNullException(nameof(manager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Deterministic session id used for every checkpoint tied to a single
+    /// plan. Exposed so tests can assert the same session id the coordinator
+    /// used to write the checkpoint is the one the resume path reads.
+    /// </summary>
+    public static string SessionIdFor(string planId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(planId);
+        return $"plan-review::{planId}";
+    }
+
+    /// <summary>
+    /// Save a new checkpoint through the framework store. Returns the
+    /// framework-issued <see cref="CheckpointInfo"/> so callers can persist
+    /// it into the approval row's audit record (round → checkpoint id).
+    /// </summary>
+    public async ValueTask<CheckpointInfo> SaveAsync(
+        PlanReviewCheckpointState state, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ct.ThrowIfCancellationRequested();
+
+        JsonElement value = JsonSerializer.SerializeToElement(state, _jsonOptions);
+        string sessionId = SessionIdFor(state.PlanId);
+        CheckpointInfo info = await _store
+            .CreateCheckpointAsync(sessionId, value, parent: null!)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Plan {PlanId} checkpoint saved (kind={Kind}, round={Round}, checkpointId={CheckpointId}).",
+            state.PlanId, state.Kind, state.RoundNumber, info.CheckpointId);
+
+        return info;
+    }
+
+    /// <summary>
+    /// Load the most recent checkpoint for a plan. Returns null when no
+    /// checkpoint exists (e.g., review is disabled, or the store lost the
+    /// data). The resume path treats null as a hard signal to terminate the
+    /// plan honestly instead of guessing at state.
+    /// </summary>
+    public async ValueTask<PlanReviewCheckpointState?> LoadLatestAsync(
+        string planId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(planId);
+        ct.ThrowIfCancellationRequested();
+
+        string sessionId = SessionIdFor(planId);
+        CheckpointInfo? latest = await _manager
+            .GetLatestCheckpointAsync(sessionId, ct)
+            .ConfigureAwait(false);
+        if (latest is null)
+        {
+            _logger.LogDebug(
+                "Plan {PlanId} checkpoint miss — no framework checkpoint present at session {SessionId}.",
+                planId, sessionId);
+            return null;
+        }
+
+        JsonElement value = await _store
+            .RetrieveCheckpointAsync(sessionId, latest)
+            .ConfigureAwait(false);
+
+        PlanReviewCheckpointState? state =
+            JsonSerializer.Deserialize<PlanReviewCheckpointState>(value.GetRawText(), _jsonOptions);
+        if (state is null)
+        {
+            _logger.LogWarning(
+                "Plan {PlanId} checkpoint at {SessionId} deserialised to null — treating as absent.",
+                planId, sessionId);
+        }
+        return state;
+    }
+}

--- a/src/RetailPulse.Api/Approval/PlanReviewCheckpointService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCheckpointService.cs
@@ -72,7 +72,7 @@ public sealed class PlanReviewCheckpointService
         JsonElement value = JsonSerializer.SerializeToElement(state, _jsonOptions);
         string sessionId = SessionIdFor(state.PlanId);
         CheckpointInfo info = await _store
-            .CreateCheckpointAsync(sessionId, value, parent: null!)
+            .CreateCheckpointAsync(sessionId, value, parent: null)
             .ConfigureAwait(false);
 
         _logger.LogInformation(

--- a/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
@@ -582,7 +582,7 @@ public sealed class PlanReviewCompletionService
             ITenantProvider tenantProvider = sp.GetRequiredService<ITenantProvider>();
 
             int totalTokens = outcome.Steps.Sum(s => s.TotalTokens);
-            TimeSpan duration = TimeSpan.FromMilliseconds(outcome.DurationMs);
+            var duration = TimeSpan.FromMilliseconds(outcome.DurationMs);
 
             await auditLog.LogAsync(new AuditEntry(
                 Guid.NewGuid().ToString("N"),

--- a/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
@@ -1,0 +1,737 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Agents.Planning;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Middleware;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Approval;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Persistence;
+using RetailPulse.Contracts.Routing;
+
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Owns the plan-review resume path. Called by the decision / clarification-
+/// answer endpoints after they record the reviewer response, and by
+/// <see cref="PlanReviewRestartRecoveryService"/> at boot for decisions that
+/// arrived while the API was down.
+///
+/// <para>
+/// Semantics on entry:
+/// </para>
+/// <list type="bullet">
+///   <item>The plan record is in <c>AwaitingReview</c> or
+///     <c>AwaitingClarification</c>.</item>
+///   <item>The latest approval row (kind = plan_review or clarification) for
+///     the plan carries a terminal <see cref="ApprovalDecision"/>.</item>
+///   <item>The framework checkpoint at <see cref="PlanReviewCheckpointService.SessionIdFor"/>
+///     holds a <see cref="PlanReviewCheckpointState"/> the coordinator wrote
+///     at suspension.</item>
+/// </list>
+///
+/// <para>
+/// Semantics on exit:
+/// </para>
+/// <list type="bullet">
+///   <item>Approve / edit → the effective plan is executed via
+///     <see cref="PlanExecutor"/>; the composed reply is filtered through
+///     <see cref="GuardrailsMiddleware.FilterOutputAsync"/>; audit,
+///     conversation-export, and session-turn writes fire; the final response
+///     is persisted onto the plan record's <c>FailureReason</c> column
+///     (which now doubles as <c>FinalReply</c> for review-driven turns) and
+///     broadcast over the SignalR hub as <c>plan_final_response</c>. Plan
+///     status transitions to <c>Completed</c> / <c>Failed</c>.</item>
+///   <item>Reject with cap remaining → the replanner produces a revised step
+///     list, a new plan-review row + checkpoint open for round N+1, and a
+///     <c>plan_review_next_round</c> hub event fires so the reviewer UI can
+///     surface the new request id.</item>
+///   <item>Terminal without execution → plan status transitions to
+///     <c>Failed</c> with the terminal reason; the failure reply is persisted
+///     and broadcast.</item>
+/// </list>
+///
+/// <para>
+/// The completion service is idempotent: if the plan is already Completed or
+/// Failed, ResolveAsync short-circuits. This lets the restart recovery
+/// service race the endpoint without duplicating work.
+/// </para>
+/// </summary>
+public sealed class PlanReviewCompletionService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<PlanReviewCompletionService> _logger;
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public PlanReviewCompletionService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<PlanReviewCompletionService> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Drive the plan through its next terminal or intermediate state after a
+    /// reviewer decision has been recorded on the approval row. Returns a
+    /// summary of the transition — Executed / SuspendedForNextRound /
+    /// SuspendedForClarification / TerminatedWithoutExecution / NoOp.
+    /// </summary>
+    public async Task<PlanReviewCompletionResult> ResolveAsync(
+        string planId, string subject, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(planId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+
+        await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
+        IServiceProvider sp = scope.ServiceProvider;
+
+        IPlanStore planStore = sp.GetRequiredService<IPlanStore>();
+        PlanDetailDto? plan = await planStore.GetPlanAsync(subject, planId, ct);
+        if (plan is null)
+        {
+            _logger.LogWarning("Resolve requested for missing plan {PlanId}/{Subject}.", planId, subject);
+            return PlanReviewCompletionResult.NoOp("plan not found");
+        }
+
+        // Idempotency guard: once we've moved to a terminal status, ignore
+        // subsequent resolve calls so the endpoint and restart recovery can
+        // race safely.
+        if (plan.Status is PlanStatus.Completed or PlanStatus.Failed
+            or PlanStatus.Cancelled or PlanStatus.Unusable)
+        {
+            return PlanReviewCompletionResult.NoOp("plan already terminal");
+        }
+
+        PlanReviewCheckpointService checkpoints = sp.GetRequiredService<PlanReviewCheckpointService>();
+        PlanReviewCheckpointState? state = await checkpoints.LoadLatestAsync(planId, ct);
+        if (state is null)
+        {
+            _logger.LogError(
+                "Plan {PlanId} has no framework checkpoint at resume time; terminating as failed.",
+                planId);
+            await FinaliseAsFailedAsync(planStore, plan, subject,
+                $"{PlanReviewTerminalReason.ReviewTimedOut}: no checkpoint present at resume time.",
+                sp, ct);
+            return PlanReviewCompletionResult.TerminatedWithoutExecution(
+                PlanReviewTerminalReason.ReviewTimedOut,
+                "no checkpoint present at resume time");
+        }
+
+        return state.Kind switch
+        {
+            PlanCheckpointKind.Review =>
+                await ResolveReviewAsync(sp, planStore, plan, state, ct),
+            PlanCheckpointKind.Clarification =>
+                await ResolveClarificationAsync(sp, planStore, plan, state, ct),
+            _ => PlanReviewCompletionResult.NoOp($"unknown checkpoint kind '{state.Kind}'"),
+        };
+    }
+
+    // ── Review branch ────────────────────────────────────────────────────
+
+    private async Task<PlanReviewCompletionResult> ResolveReviewAsync(
+        IServiceProvider sp,
+        IPlanStore planStore,
+        PlanDetailDto plan,
+        PlanReviewCheckpointState state,
+        CancellationToken ct)
+    {
+        IApprovalGate gate = sp.GetRequiredService<IApprovalGate>();
+        PlanReviewCoordinator coord = sp.GetRequiredService<PlanReviewCoordinator>();
+
+        ApprovalRequest? row = await FindLatestRowForPlanAsync(
+            gate, plan.PlanId, state.Subject, ApprovalKind.PlanReview, ct);
+        if (row is null)
+        {
+            return PlanReviewCompletionResult.NoOp("no plan-review row for plan yet");
+        }
+        if (row.Decision == ApprovalDecision.Pending)
+        {
+            // Row exists but has not decided yet — nothing to do; the sweep
+            // or the endpoint will call us back after the decision lands.
+            return PlanReviewCompletionResult.NoOp("review row still pending");
+        }
+
+        ApprovalResult result = new(
+            row.RequestId, row.Decision, row.Comment, row.RespondedAt,
+            row.TerminalReason, row.ResponsePayload);
+
+        PlanReviewContinuation continuation = coord.EvaluateDecision(new PlanReviewEvaluationInput
+        {
+            PlanId = state.PlanId,
+            RoundNumber = state.RoundNumber,
+            CurrentSteps = state.Steps,
+            SpecialistKeys = state.SpecialistKeys,
+        }, result);
+
+        switch (continuation.Kind)
+        {
+            case PlanReviewContinuationKind.Approved:
+                return await ExecuteApprovedPlanAsync(
+                    sp, planStore, plan, state,
+                    continuation.ApprovedSteps ?? state.Steps,
+                    continuation.TerminalReason, ct);
+
+            case PlanReviewContinuationKind.Terminal:
+                await FinaliseAsFailedAsync(planStore, plan, state.Subject,
+                    $"{continuation.TerminalReason}: {continuation.FailureMessage}", sp, ct);
+                await BroadcastFinalAsync(sp, plan.PlanId, state.Subject,
+                    BuildTerminalReply(continuation.TerminalReason), continuation.TerminalReason);
+                return PlanReviewCompletionResult.TerminatedWithoutExecution(
+                    continuation.TerminalReason,
+                    continuation.FailureMessage);
+
+            case PlanReviewContinuationKind.NeedsReplan:
+                {
+                    // Rehydrate the roster from the current process's DI so we
+                    // replan against the same specialists the executor will run.
+                    IReadOnlyList<ISpecialistAgent> roster =
+                        [.. sp.GetRequiredService<IEnumerable<ISpecialistAgent>>()];
+                    PlanBuildResult? replanned = await coord.ReplanAsync(
+                        state.Request, continuation.RejectionFeedback,
+                        roster, state.DetectedIntents, ct);
+                    if (replanned is null || replanned.IsUnusable)
+                    {
+                        string msg = replanned?.UnusableReason ?? "planner unavailable";
+                        await FinaliseAsFailedAsync(planStore, plan, state.Subject,
+                            $"{PlanReviewTerminalReason.ReplanExhausted}: {msg}", sp, ct);
+                        await BroadcastFinalAsync(sp, plan.PlanId, state.Subject,
+                            BuildTerminalReply(PlanReviewTerminalReason.ReplanExhausted),
+                            PlanReviewTerminalReason.ReplanExhausted);
+                        return PlanReviewCompletionResult.TerminatedWithoutExecution(
+                            PlanReviewTerminalReason.ReplanExhausted, msg);
+                    }
+
+                    var nextSteps = replanned.Steps
+                        .Select(s => new PlanReviewStepDto
+                        {
+                            SpecialistKey = s.SpecialistKey,
+                            Intent = s.Intent,
+                            Action = s.Action,
+                        })
+                        .ToList();
+
+                    PlanReviewRoundHandle nextHandle = await coord.OpenRoundAsync(new PlanReviewOpenInput
+                    {
+                        PlanId = state.PlanId,
+                        Subject = state.Subject,
+                        SessionId = state.SessionId,
+                        TenantId = state.TenantId,
+                        Request = state.Request,
+                        CurrentSteps = nextSteps,
+                        SpecialistKeys = state.SpecialistKeys,
+                        DetectedIntents = state.DetectedIntents,
+                        RoundNumber = state.RoundNumber + 1,
+                        RevisionReason = string.IsNullOrWhiteSpace(continuation.RejectionFeedback)
+                            ? "Reviewer rejected the previous plan."
+                            : "Reviewer feedback: " + continuation.RejectionFeedback,
+                        TraceId = state.TraceId,
+                        ParentSpanId = state.ParentSpanId,
+                        PrincipalKey = state.PrincipalKey,
+                    }, ct);
+
+                    // Broadcast that a new review round is waiting.
+                    IHubContext<TelemetryHub>? hub = sp.GetService<IHubContext<TelemetryHub>>();
+                    if (hub is not null)
+                    {
+                        await hub.Clients.All.SendAsync("plan_review_next_round", new
+                        {
+                            planId = state.PlanId,
+                            requestId = nextHandle.RequestId,
+                            round = nextHandle.RoundNumber,
+                        }, ct);
+                    }
+
+                    return PlanReviewCompletionResult.SuspendedForNextRound(
+                        nextHandle.RequestId, nextHandle.RoundNumber);
+                }
+
+            default:
+                return PlanReviewCompletionResult.NoOp($"unknown continuation kind {continuation.Kind}");
+        }
+    }
+
+    // ── Clarification branch ─────────────────────────────────────────────
+
+    private async Task<PlanReviewCompletionResult> ResolveClarificationAsync(
+        IServiceProvider sp,
+        IPlanStore planStore,
+        PlanDetailDto plan,
+        PlanReviewCheckpointState state,
+        CancellationToken ct)
+    {
+        IApprovalGate gate = sp.GetRequiredService<IApprovalGate>();
+        ApprovalRequest? row = await FindLatestRowForPlanAsync(
+            gate, plan.PlanId, state.Subject, ApprovalKind.Clarification, ct);
+        if (row is null)
+            return PlanReviewCompletionResult.NoOp("no clarification row for plan yet");
+        if (row.Decision == ApprovalDecision.Pending)
+            return PlanReviewCompletionResult.NoOp("clarification row still pending");
+
+        ApprovalResult result = new(
+            row.RequestId, row.Decision, row.Comment, row.RespondedAt,
+            row.TerminalReason, row.ResponsePayload);
+        PlanClarificationResult clarification = PlanClarifier.InterpretAnswer(result);
+
+        if (!clarification.IsAnswered)
+        {
+            await FinaliseAsFailedAsync(planStore, plan, state.Subject,
+                $"{clarification.TerminalReason}: reviewer did not provide a usable answer.",
+                sp, ct);
+            await BroadcastFinalAsync(sp, plan.PlanId, state.Subject,
+                BuildTerminalReply(clarification.TerminalReason), clarification.TerminalReason);
+            return PlanReviewCompletionResult.TerminatedWithoutExecution(
+                clarification.TerminalReason, "no usable clarification answer");
+        }
+
+        // Substitute the answer as the paused step's Result, then execute the
+        // remaining steps starting from PausedAtStepIndex + 1.
+        int pauseIndex = state.PausedAtStepIndex ?? 0;
+        List<PlanReviewCompletedStep> priorCompleted =
+            [.. state.CompletedSteps ?? []];
+
+        // The paused step itself becomes an "answer" step with the answer as
+        // its transcript so the accumulated context reads coherently.
+        PlanReviewStepDto paused = pauseIndex < state.Steps.Count
+            ? state.Steps[pauseIndex]
+            : new PlanReviewStepDto
+            {
+                SpecialistKey = "clarification",
+                Intent = "clarification",
+                Action = "clarification",
+            };
+        priorCompleted.Add(new PlanReviewCompletedStep
+        {
+            StepIndex = pauseIndex,
+            SpecialistKey = paused.SpecialistKey,
+            Intent = paused.Intent,
+            Action = paused.Action,
+            Result = clarification.Answer ?? string.Empty,
+            InputTokens = 0,
+            OutputTokens = 0,
+            TotalTokens = 0,
+            DurationMs = 0,
+        });
+
+        IReadOnlyList<PlanReviewStepDto> remaining =
+            [.. state.Steps.Skip(pauseIndex + 1)];
+        return await ExecuteApprovedPlanAsync(
+            sp, planStore, plan, state,
+            remaining,
+            PlanReviewTerminalReason.ReviewerApproved,
+            ct,
+            resumeCompletedSteps: priorCompleted);
+    }
+
+    // ── Shared execute path ──────────────────────────────────────────────
+
+    private async Task<PlanReviewCompletionResult> ExecuteApprovedPlanAsync(
+        IServiceProvider sp,
+        IPlanStore planStore,
+        PlanDetailDto plan,
+        PlanReviewCheckpointState state,
+        IReadOnlyList<PlanReviewStepDto> effectiveSteps,
+        string terminalReason,
+        CancellationToken ct,
+        IReadOnlyList<PlanReviewCompletedStep>? resumeCompletedSteps = null)
+    {
+        // Move plan to Running and materialise step ids so the executor and
+        // store agree on the same shape.
+        var effectivePlan = new PlanBuildResult
+        {
+            Steps = [.. effectiveSteps.Select(s => new PlannerStep
+            {
+                SpecialistKey = s.SpecialistKey,
+                Intent = s.Intent,
+                Action = s.Action,
+            })],
+        };
+
+        var stepIds = new List<string>(effectivePlan.Steps.Count);
+        var stepWrites = new List<PlanStepWrite>(effectivePlan.Steps.Count);
+        int offset = resumeCompletedSteps?.Count ?? 0;
+        for (int i = 0; i < effectivePlan.Steps.Count; i++)
+        {
+            string stepId = $"{plan.PlanId}-r{state.RoundNumber}-s{offset + i}";
+            stepIds.Add(stepId);
+            stepWrites.Add(new PlanStepWrite
+            {
+                StepId = stepId,
+                StepIndex = offset + i,
+                SpecialistKey = effectivePlan.Steps[i].SpecialistKey,
+                Intent = effectivePlan.Steps[i].Intent,
+                Action = effectivePlan.Steps[i].Action,
+                Status = PlanStepStatus.Pending,
+            });
+        }
+
+        // Persist the resolved (edited/approved) plan onto the same row.
+        await planStore.UpdatePlanStatusAsync(new PlanStatusUpdate
+        {
+            PlanId = plan.PlanId,
+            Subject = state.Subject,
+            Status = PlanStatus.Running,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        }, ct);
+
+        // Roster + lookup from the CURRENT process's DI so the resume is
+        // self-contained (no cross-process handle references).
+        IReadOnlyList<ISpecialistAgent> roster =
+            [.. sp.GetRequiredService<IEnumerable<ISpecialistAgent>>()];
+        var lookup = roster.ToDictionary(s => s.Key, s => s, StringComparer.OrdinalIgnoreCase);
+
+        var executionRequest = new PlanExecutionRequest
+        {
+            PlanId = plan.PlanId,
+            Subject = state.Subject,
+            PrincipalKey = state.PrincipalKey ?? state.Subject,
+            SessionId = state.SessionId,
+            TraceId = state.TraceId ?? Guid.NewGuid().ToString("N"),
+            ParentSpanId = state.ParentSpanId,
+            Request = state.Request,
+            History = null,
+            User = null,
+            Plan = effectivePlan,
+            StepIds = stepIds,
+            SpecialistLookup = lookup,
+        };
+
+        PlanExecutor executor = sp.GetRequiredService<PlanExecutor>();
+        PlanExecutionOutcome outcome = await executor.ExecuteAsync(executionRequest, ct);
+
+        // If the executor asks to pause for clarification / replan, hand off.
+        if (outcome.Status == PlanStatus.AwaitingClarification
+            && outcome.ClarificationHandle is { } clarHandle)
+        {
+            return PlanReviewCompletionResult.SuspendedForClarification(
+                clarHandle.RequestId, clarHandle.CheckpointId);
+        }
+
+        if (outcome.Status == PlanStatus.AwaitingReview
+            && outcome.ReviewHandle is { } reviewHandle)
+        {
+            return PlanReviewCompletionResult.SuspendedForNextRound(
+                reviewHandle.RequestId, reviewHandle.RoundNumber);
+        }
+
+        // Compose the final reply from step transcripts (approved-review path
+        // + any resumed clarification prefixes).
+        string composed = ComposeFinalReply(resumeCompletedSteps, outcome);
+
+        // Output guardrail + PII filter — parity with /api/chat single-
+        // specialist path.
+        GuardrailsMiddleware guardrails = sp.GetRequiredService<GuardrailsMiddleware>();
+        string filtered = await guardrails.FilterOutputAsync(composed, state.Subject, ct);
+
+        await FinaliseAsCompletedAsync(planStore, plan.PlanId, state.Subject,
+            filtered, terminalReason, outcome, ct);
+
+        // Chat-turn parity — mirror the trio the single-specialist branch fires.
+        await ApplyChatTurnParityAsync(sp, plan, state, filtered, outcome, ct);
+
+        await BroadcastFinalAsync(sp, plan.PlanId, state.Subject, filtered, terminalReason);
+
+        return PlanReviewCompletionResult.Executed(filtered, outcome);
+    }
+
+    private static string ComposeFinalReply(
+        IReadOnlyList<PlanReviewCompletedStep>? resumeCompletedSteps,
+        PlanExecutionOutcome outcome)
+    {
+        var sb = new StringBuilder();
+        if (resumeCompletedSteps is not null)
+        {
+            foreach (PlanReviewCompletedStep step in resumeCompletedSteps)
+            {
+                if (string.IsNullOrWhiteSpace(step.Result)) continue;
+                if (sb.Length > 0) sb.AppendLine().AppendLine("---").AppendLine();
+                sb.Append(step.Result);
+            }
+        }
+        foreach (PlanStepResult step in outcome.Steps)
+        {
+            if (string.IsNullOrWhiteSpace(step.Result)) continue;
+            if (sb.Length > 0) sb.AppendLine().AppendLine("---").AppendLine();
+            sb.Append(step.Result);
+        }
+        if (sb.Length == 0)
+        {
+            sb.Append(outcome.Status switch
+            {
+                PlanStatus.Failed => "The plan-first orchestrator was unable to produce a reply. " +
+                    (outcome.FailureReason ?? "One or more steps failed."),
+                PlanStatus.Cancelled => "The plan-first orchestrator was cancelled before producing a reply.",
+                _ => "The plan-first orchestrator produced no output.",
+            });
+        }
+        return sb.ToString();
+    }
+
+    private static string BuildTerminalReply(string terminalReason) => terminalReason switch
+    {
+        PlanReviewTerminalReason.ReviewTimedOut =>
+            "The plan was not executed because reviewer approval timed out.",
+        PlanReviewTerminalReason.ReplanExhausted =>
+            "The plan was not executed because the reviewer rejected every revision within the configured limit.",
+        PlanReviewTerminalReason.EditedToEmpty =>
+            "The plan was not executed because the reviewer edited it down to zero steps.",
+        PlanReviewTerminalReason.EditInvalid =>
+            "The plan was not executed because the reviewer's edited step list referenced an unknown specialist.",
+        PlanReviewTerminalReason.ClarificationInvalid =>
+            "The plan was not executed because the mid-plan clarification response was not usable.",
+        _ => "The plan was not executed because the reviewer declined to approve it.",
+    };
+
+    private static async Task<ApprovalRequest?> FindLatestRowForPlanAsync(
+        IApprovalGate gate, string planId, string subject, string kind, CancellationToken ct)
+    {
+        IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync(subject, ct);
+        ApprovalRequest? bestPending = pending
+            .Where(r => string.Equals(r.Context.PlanId, planId, StringComparison.Ordinal)
+                && string.Equals(r.Context.Kind, kind, StringComparison.Ordinal))
+            .OrderByDescending(r => r.Context.RoundNumber)
+            .ThenByDescending(r => r.CreatedAt)
+            .FirstOrDefault();
+        if (bestPending is not null) return bestPending;
+
+        IReadOnlyList<ApprovalRequest> history = await gate.GetHistoryAsync(500, ct);
+        return history
+            .Where(r => string.Equals(r.Context.PlanId, planId, StringComparison.Ordinal)
+                && string.Equals(r.Context.UserId, subject, StringComparison.Ordinal)
+                && string.Equals(r.Context.Kind, kind, StringComparison.Ordinal))
+            .OrderByDescending(r => r.Context.RoundNumber)
+            .ThenByDescending(r => r.RespondedAt ?? r.CreatedAt)
+            .FirstOrDefault();
+    }
+
+    private static async Task FinaliseAsFailedAsync(
+        IPlanStore planStore,
+        PlanDetailDto plan,
+        string subject,
+        string failureReason,
+        IServiceProvider sp,
+        CancellationToken ct)
+    {
+        await planStore.UpdatePlanStatusAsync(new PlanStatusUpdate
+        {
+            PlanId = plan.PlanId,
+            Subject = subject,
+            Status = PlanStatus.Failed,
+            FailureReason = failureReason,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        }, ct);
+    }
+
+    private static async Task FinaliseAsCompletedAsync(
+        IPlanStore planStore,
+        string planId,
+        string subject,
+        string finalReply,
+        string terminalReason,
+        PlanExecutionOutcome outcome,
+        CancellationToken ct)
+    {
+        // Preserve the reply on the plan record so a later GET /api/plans/{id}
+        // returns the same text the reviewer/subject saw on the SignalR
+        // broadcast. The FailureReason column doubles as the terminal transcript
+        // marker keyed by <c>PlanReviewFinalReply</c> prefix so downstream
+        // consumers don't need a schema change.
+        string payload = "PlanReviewFinalReply::" + terminalReason + "::" + finalReply;
+        await planStore.UpdatePlanStatusAsync(new PlanStatusUpdate
+        {
+            PlanId = planId,
+            Subject = subject,
+            Status = outcome.Status is PlanStatus.Completed
+                or PlanStatus.Failed or PlanStatus.Cancelled
+                    ? outcome.Status : PlanStatus.Completed,
+            FailureReason = payload,
+            TotalInputTokens = outcome.Steps.Sum(s => s.InputTokens),
+            TotalOutputTokens = outcome.Steps.Sum(s => s.OutputTokens),
+            TotalTokens = outcome.Steps.Sum(s => s.TotalTokens),
+            TotalDurationMs = outcome.DurationMs,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        }, ct);
+    }
+
+    private async Task ApplyChatTurnParityAsync(
+        IServiceProvider sp,
+        PlanDetailDto plan,
+        PlanReviewCheckpointState state,
+        string filteredReply,
+        PlanExecutionOutcome outcome,
+        CancellationToken ct)
+    {
+        try
+        {
+            IAuditLog auditLog = sp.GetRequiredService<IAuditLog>();
+            ConversationExporter exporter = sp.GetRequiredService<ConversationExporter>();
+            ISessionStore? sessionStore = sp.GetService<ISessionStore>();
+            IOptions<SessionPersistenceOptions>? sessionOpts =
+                sp.GetService<IOptions<SessionPersistenceOptions>>();
+            ITenantProvider tenantProvider = sp.GetRequiredService<ITenantProvider>();
+
+            int totalTokens = outcome.Steps.Sum(s => s.TotalTokens);
+            TimeSpan duration = TimeSpan.FromMilliseconds(outcome.DurationMs);
+
+            await auditLog.LogAsync(new AuditEntry(
+                Guid.NewGuid().ToString("N"),
+                DateTime.UtcNow, state.Subject, "planner",
+                $"chat.plan.review.resolve",
+                state.Request[..Math.Min(200, state.Request.Length)],
+                filteredReply[..Math.Min(200, filteredReply.Length)],
+                totalTokens, duration), ct);
+
+            string? sessionId = state.SessionId;
+            if (!string.IsNullOrWhiteSpace(sessionId))
+            {
+                await exporter.TrackMessageAsync(sessionId, new TrackedMessage
+                {
+                    Role = "user",
+                    Content = state.Request,
+                }, ct);
+                await exporter.TrackMessageAsync(sessionId, new TrackedMessage
+                {
+                    Role = "assistant",
+                    Content = filteredReply,
+                    AgentId = "planner",
+                    DurationMs = outcome.DurationMs,
+                    Tokens = totalTokens,
+                }, ct);
+
+                bool persistenceEnabled = sessionStore is not null
+                    && sessionOpts is not null
+                    && sessionOpts.Value.Enabled;
+                if (persistenceEnabled)
+                {
+                    string? tenantId = tenantProvider.GetTenant()?.Company;
+                    DateTimeOffset now = DateTimeOffset.UtcNow;
+                    await sessionStore!.PersistTurnAsync(new SessionTurnWrite
+                    {
+                        SessionId = sessionId,
+                        Subject = state.Subject,
+                        TenantId = tenantId,
+                        Role = "user",
+                        Content = state.Request,
+                        RoutingIntent = "plan",
+                        RoutingAgentKey = "planner",
+                        RoutingConfidence = 0,
+                        Timestamp = now,
+                    }, ct);
+                    await sessionStore.PersistTurnAsync(new SessionTurnWrite
+                    {
+                        SessionId = sessionId,
+                        Subject = state.Subject,
+                        TenantId = tenantId,
+                        Role = "assistant",
+                        Content = filteredReply,
+                        AgentId = "planner",
+                        RoutingIntent = "plan",
+                        RoutingAgentKey = "planner",
+                        RoutingConfidence = 0,
+                        InputTokens = outcome.Steps.Sum(s => s.InputTokens),
+                        OutputTokens = outcome.Steps.Sum(s => s.OutputTokens),
+                        TotalTokens = totalTokens,
+                        SpanSummary = JsonSerializer.Serialize(new
+                        {
+                            agent = "planner",
+                            planId = plan.PlanId,
+                            status = outcome.Status,
+                            steps = outcome.Steps.Count,
+                            durationMs = outcome.DurationMs,
+                        }),
+                        Timestamp = now,
+                    }, ct);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Chat-turn parity is best-effort by design (mirrors ChatEndpoints).
+            _logger.LogWarning(ex,
+                "Chat-turn parity write failed for plan {PlanId}; final response was still delivered.",
+                plan.PlanId);
+        }
+    }
+
+    private static async Task BroadcastFinalAsync(
+        IServiceProvider sp, string planId, string subject, string reply, string terminalReason)
+    {
+        IHubContext<TelemetryHub>? hub = sp.GetService<IHubContext<TelemetryHub>>();
+        if (hub is null) return;
+        await hub.Clients.All.SendAsync("plan_final_response", new
+        {
+            planId,
+            subject,
+            reply,
+            terminalReason,
+        });
+    }
+}
+
+/// <summary>Outcome of one call to <see cref="PlanReviewCompletionService.ResolveAsync"/>.</summary>
+public sealed record PlanReviewCompletionResult
+{
+    public required PlanReviewCompletionKind Kind { get; init; }
+    public string? Reply { get; init; }
+    public string? TerminalReason { get; init; }
+    public string? FailureMessage { get; init; }
+    public string? NextRequestId { get; init; }
+    public int? NextRoundNumber { get; init; }
+    public string? ClarificationRequestId { get; init; }
+    public string? ClarificationCheckpointId { get; init; }
+    public PlanExecutionOutcome? ExecutionOutcome { get; init; }
+
+    public static PlanReviewCompletionResult Executed(string reply, PlanExecutionOutcome outcome) => new()
+    {
+        Kind = PlanReviewCompletionKind.Executed,
+        Reply = reply,
+        ExecutionOutcome = outcome,
+    };
+
+    public static PlanReviewCompletionResult SuspendedForNextRound(string requestId, int round) => new()
+    {
+        Kind = PlanReviewCompletionKind.SuspendedForNextRound,
+        NextRequestId = requestId,
+        NextRoundNumber = round,
+    };
+
+    public static PlanReviewCompletionResult SuspendedForClarification(string requestId, string checkpointId) => new()
+    {
+        Kind = PlanReviewCompletionKind.SuspendedForClarification,
+        ClarificationRequestId = requestId,
+        ClarificationCheckpointId = checkpointId,
+    };
+
+    public static PlanReviewCompletionResult TerminatedWithoutExecution(string reason, string? failure) => new()
+    {
+        Kind = PlanReviewCompletionKind.TerminatedWithoutExecution,
+        TerminalReason = reason,
+        FailureMessage = failure,
+    };
+
+    public static PlanReviewCompletionResult NoOp(string reason) => new()
+    {
+        Kind = PlanReviewCompletionKind.NoOp,
+        FailureMessage = reason,
+    };
+}
+
+public enum PlanReviewCompletionKind
+{
+    Executed,
+    SuspendedForNextRound,
+    SuspendedForClarification,
+    TerminatedWithoutExecution,
+    NoOp,
+}

--- a/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
@@ -26,7 +26,11 @@ public interface IPlanReviewReplanner
 public sealed class PlanBuilderReplanner : IPlanReviewReplanner
 {
     private readonly PlanBuilder _builder;
-    public PlanBuilderReplanner(PlanBuilder builder) => _builder = builder;
+    public PlanBuilderReplanner(PlanBuilder builder)
+    {
+        _builder = builder;
+    }
+
     public Task<PlanBuildResult> ReplanAsync(
         string revisedRequest,
         IReadOnlyList<Contracts.Routing.ISpecialistAgent> roster,
@@ -436,7 +440,7 @@ public sealed class PlanReviewCoordinator
     {
         try
         {
-            var sessionId = SessionIdFor(planId, round);
+            string sessionId = SessionIdFor(planId, round);
             JsonElement element = JsonSerializer.SerializeToElement(proposal, _jsonOptions);
             // The default CheckpointManager exposes CreateCheckpointAsync via
             // its ICheckpointStore<JsonElement>. We rely on GetLatestCheckpointAsync
@@ -472,7 +476,7 @@ public sealed class PlanReviewCoordinator
     private static string BuildImpactLabel(IReadOnlyList<PlanReviewStepDto> steps)
     {
         if (steps.Count == 0) return "No steps planned.";
-        var top = steps.Take(3).Select(s => s.SpecialistKey);
+        IEnumerable<string> top = steps.Take(3).Select(s => s.SpecialistKey);
         string more = steps.Count > 3 ? $" (+{steps.Count - 3} more)" : "";
         return "Specialists: " + string.Join(", ", top) + more;
     }

--- a/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
@@ -41,39 +41,33 @@ public sealed class PlanBuilderReplanner : IPlanReviewReplanner
 /// <summary>
 /// Runs the durable plan review gate (#94). Owns the single resume mechanism the
 /// design review pinned: a Microsoft.Agents.AI.Workflows checkpoint captured by
-/// <see cref="CheckpointManager"/> during the review pause, integrated through
+/// <see cref="ICheckpointStore{TStoreObject}"/> during the review pause, integrated through
 /// the #91 <see cref="IApprovalGate"/> so plan and tool approvals share one
 /// audit trail and one restart posture.
 ///
 /// <para>
-/// Flow per plan:
+/// The coordinator exposes two shapes:
 /// </para>
-/// <list type="number">
-///   <item>Serialize the current proposal (round N) into an
-///     <see cref="ApprovalContext.Payload"/> and open a durable approval row
-///     with <see cref="ApprovalKind.PlanReview"/> and <see cref="ApprovalContext.RoundNumber"/> = N.</item>
-///   <item>Persist a workflow checkpoint via <see cref="CheckpointManager"/> using
-///     session id = <c>planId</c>. The checkpoint captures the workflow's paused
-///     state; the durable source of truth for the reviewer decision is the
-///     approval row.</item>
-///   <item>Block on <see cref="IApprovalGate.WaitForApprovalAsync"/> with the
-///     configured review timeout. A restart during this wait leaves the row
-///     Pending; reconciliation adopts it via
-///     <see cref="PlanReviewResumeStrategy"/> and the new-instance endpoint
-///     receives the decision and resumes execution directly.</item>
-///   <item>Interpret the decision:
-///     <list type="bullet">
-///       <item><c>Approve</c> → return the current steps as the final plan.</item>
-///       <item><c>Edit</c> → validate the edited steps against the live roster
-///         and return them as the final plan.</item>
-///       <item><c>Reject</c> with feedback → if round N &lt; MaxReplanRounds,
-///         invoke the planner with the feedback appended and loop to step 1
-///         with N+1. Otherwise terminate with
-///         <see cref="PlanReviewTerminalReason.ReplanExhausted"/>.</item>
-///       <item><c>Timeout</c> → terminate with
-///         <see cref="PlanReviewTerminalReason.ReviewTimedOut"/>.</item>
-///     </list>
-///   </item>
+/// <list type="bullet">
+///   <item><see cref="OpenRoundAsync"/> — non-blocking primitive. Opens the
+///     approval row and writes a real framework checkpoint at the same time,
+///     then returns immediately. This is the production path: no thread
+///     is blocked while the reviewer thinks, and a process restart between
+///     open and decide is invisible to the resume path because the durable
+///     approval row + checkpoint together are enough to continue.</item>
+///   <item><see cref="EvaluateDecisionAsync"/> — non-blocking primitive.
+///     Consumes a persisted <see cref="ApprovalResult"/> and returns either
+///     an approved outcome (with the effective step list), a terminal
+///     failure, or a request to replan and re-open the next round. Called
+///     by <see cref="PlanReviewCompletionService"/> after the decision
+///     endpoint records the reviewer response, and by the boot-time
+///     recovery service for decisions that arrived while the API was down.</item>
+///   <item><see cref="CoordinateAsync"/> — the pre-existing looping wrapper.
+///     Kept because coordinator-level tests exercise the review loop with an
+///     immediate-response gate; it now delegates to the non-blocking
+///     primitives so the production semantics (real checkpoint written,
+///     replan cap enforced, reject/approve/edit shape) are the same in both
+///     paths.</item>
 /// </list>
 /// </summary>
 public sealed class PlanReviewCoordinator
@@ -81,7 +75,7 @@ public sealed class PlanReviewCoordinator
     private readonly IApprovalGate _gate;
     private readonly IPlanReviewReplanner? _replanner;
     private readonly PlanReviewOptions _options;
-    private readonly CheckpointManager _checkpointManager;
+    private readonly PlanReviewCheckpointService _checkpoints;
     private readonly ILogger<PlanReviewCoordinator> _logger;
     private readonly TimeProvider _timeProvider;
 
@@ -94,23 +88,241 @@ public sealed class PlanReviewCoordinator
     public PlanReviewCoordinator(
         IApprovalGate gate,
         IOptions<PlanReviewOptions> options,
-        CheckpointManager checkpointManager,
+        PlanReviewCheckpointService checkpoints,
         ILogger<PlanReviewCoordinator> logger,
         IPlanReviewReplanner? replanner = null,
         TimeProvider? timeProvider = null)
     {
         _gate = gate ?? throw new ArgumentNullException(nameof(gate));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
-        _checkpointManager = checkpointManager ?? throw new ArgumentNullException(nameof(checkpointManager));
+        _checkpoints = checkpoints ?? throw new ArgumentNullException(nameof(checkpoints));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _replanner = replanner;
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
+    /// <summary>Configured maximum replan rounds — exposed so the completion service can enforce the same cap.</summary>
+    public int MaxReplanRounds => _options.MaxReplanRounds;
+
+    /// <summary>Configured review round timeout — exposed so the sweep and completion services agree on the same deadline.</summary>
+    public TimeSpan DefaultReviewTimeout => _options.DefaultReviewTimeout;
+
+    // ── Non-blocking primitives ────────────────────────────────────────────
+
+    /// <summary>
+    /// Open one review round: persist a real Microsoft.Agents.AI.Workflows
+    /// checkpoint capturing everything needed to resume in a new host, then
+    /// open the durable approval row that carries the reviewer decision. The
+    /// caller receives the request id + checkpoint id and immediately returns
+    /// — no thread is blocked while the reviewer decides.
+    ///
+    /// <para>
+    /// Ordering is deliberate: the checkpoint is written BEFORE the approval
+    /// row so a crash between the two leaves the checkpoint orphaned (safe),
+    /// but a decision endpoint never sees an approval row that does not have
+    /// a checkpoint behind it. The resume path treats a missing checkpoint as
+    /// a hard fault instead of guessing.
+    /// </para>
+    /// </summary>
+    public async Task<PlanReviewRoundHandle> OpenRoundAsync(
+        PlanReviewOpenInput input, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.PlanId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.Subject);
+        ArgumentNullException.ThrowIfNull(input.CurrentSteps);
+        ArgumentNullException.ThrowIfNull(input.SpecialistKeys);
+
+        var proposal = new PlanReviewProposal
+        {
+            PlanId = input.PlanId,
+            RoundNumber = input.RoundNumber,
+            Request = input.Request,
+            Steps = input.CurrentSteps,
+            RevisionReason = input.RevisionReason,
+        };
+
+        // Framework checkpoint first — genuine ICheckpointStore.CreateCheckpointAsync
+        // call, not a JSON marker written next to it. If this throws the row
+        // is never opened and the caller receives the error verbatim.
+        var checkpointState = new PlanReviewCheckpointState
+        {
+            Kind = PlanCheckpointKind.Review,
+            PlanId = input.PlanId,
+            Subject = input.Subject,
+            SessionId = input.SessionId,
+            TenantId = input.TenantId,
+            Request = input.Request,
+            RoundNumber = input.RoundNumber,
+            Steps = input.CurrentSteps,
+            SpecialistKeys = [.. input.SpecialistKeys],
+            DetectedIntents = input.DetectedIntents,
+            TraceId = input.TraceId,
+            ParentSpanId = input.ParentSpanId,
+            PrincipalKey = input.PrincipalKey,
+            ApprovalRequestId = string.Empty,
+            CreatedAt = _timeProvider.GetUtcNow(),
+            RevisionReason = input.RevisionReason,
+        };
+
+        CheckpointInfo checkpoint = await _checkpoints.SaveAsync(checkpointState, ct).ConfigureAwait(false);
+
+        var context = new ApprovalContext(
+            AgentId: "plan-review",
+            UserId: input.Subject,
+            Action: BuildActionLabel(input.RoundNumber, input.CurrentSteps.Count),
+            Impact: BuildImpactLabel(input.CurrentSteps),
+            Urgency: "medium",
+            Reasoning: input.RevisionReason ?? "Initial plan proposal awaiting reviewer decision.",
+            SessionId: input.SessionId,
+            ConversationId: null,
+            Kind: ApprovalKind.PlanReview,
+            PlanId: input.PlanId,
+            RoundNumber: input.RoundNumber,
+            Payload: JsonSerializer.Serialize(proposal, _jsonOptions));
+
+        ApprovalRequest request = await _gate.RequestApprovalAsync(context, ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Plan {PlanId} review round {Round} opened (requestId={RequestId}, subject={Subject}, checkpoint={CheckpointId}).",
+            input.PlanId, input.RoundNumber, request.RequestId, input.Subject, checkpoint.CheckpointId);
+
+        return new PlanReviewRoundHandle(
+            RequestId: request.RequestId,
+            CheckpointId: checkpoint.CheckpointId,
+            RoundNumber: input.RoundNumber,
+            CreatedAt: request.CreatedAt,
+            ExpiresAt: request.ExpiresAt);
+    }
+
+    /// <summary>
+    /// Non-blocking decision interpreter. Consumes a persisted
+    /// <see cref="ApprovalResult"/> for a round and returns:
+    /// <list type="bullet">
+    ///   <item><c>Approved(steps)</c> — reviewer approved (possibly with edits) and
+    ///     the effective plan is ready to execute.</item>
+    ///   <item><c>Terminal(reason, msg)</c> — final decision that does NOT execute
+    ///     (timeout, replan exhausted, edit invalid, edited to empty).</item>
+    ///   <item><c>NeedsReplan(feedback)</c> — reviewer rejected and the cap has
+    ///     not been reached. The caller invokes the replanner and calls
+    ///     <see cref="OpenRoundAsync"/> for round N+1.</item>
+    /// </list>
+    /// </summary>
+    public PlanReviewContinuation EvaluateDecision(
+        PlanReviewEvaluationInput input,
+        ApprovalResult result)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.Decision == ApprovalDecision.TimedOut)
+        {
+            return PlanReviewContinuation.Terminal(
+                PlanReviewTerminalReason.ReviewTimedOut,
+                "Review timed out — no reviewer decision received.",
+                input.RoundNumber);
+        }
+
+        if (result.Decision == ApprovalDecision.Orphaned)
+        {
+            return PlanReviewContinuation.Terminal(
+                PlanReviewTerminalReason.ReviewTimedOut,
+                "Review orphaned by reconciliation before adoption completed.",
+                input.RoundNumber);
+        }
+
+        PlanReviewResponsePayload payload = ParseResponsePayload(result.ResponsePayload, result.Decision);
+
+        switch (payload.Kind)
+        {
+            case PlanReviewKinds.Approve:
+                return PlanReviewContinuation.Approved(
+                    input.CurrentSteps,
+                    PlanReviewTerminalReason.ReviewerApproved,
+                    input.RoundNumber);
+
+            case PlanReviewKinds.Edit:
+                {
+                    IReadOnlyList<PlanReviewStepDto> edited =
+                        payload.EditedSteps ?? input.CurrentSteps;
+                    string? invalid = ValidateEditedSteps(edited, input.SpecialistKeys);
+                    if (invalid is not null)
+                    {
+                        return PlanReviewContinuation.Terminal(
+                            invalid,
+                            invalid == PlanReviewTerminalReason.EditedToEmpty
+                                ? "Reviewer dropped every step."
+                                : "Reviewer edit referenced an unknown specialist or missing action.",
+                            input.RoundNumber);
+                    }
+                    return PlanReviewContinuation.Approved(
+                        edited,
+                        PlanReviewTerminalReason.ReviewerEdited,
+                        input.RoundNumber);
+                }
+
+            case PlanReviewKinds.Reject:
+                if (input.RoundNumber >= _options.MaxReplanRounds)
+                {
+                    return PlanReviewContinuation.Terminal(
+                        PlanReviewTerminalReason.ReplanExhausted,
+                        $"Replan budget exhausted after round {input.RoundNumber + 1}.",
+                        input.RoundNumber);
+                }
+                return PlanReviewContinuation.NeedsReplan(payload.Feedback, input.RoundNumber);
+
+            default:
+                _logger.LogWarning(
+                    "Plan {PlanId} received unknown response kind '{Kind}' at round {Round}; treating as reject.",
+                    input.PlanId, payload.Kind, input.RoundNumber);
+                if (input.RoundNumber >= _options.MaxReplanRounds)
+                {
+                    return PlanReviewContinuation.Terminal(
+                        PlanReviewTerminalReason.ReplanExhausted,
+                        "Reviewer response was unrecognizable and replan budget is exhausted.",
+                        input.RoundNumber);
+                }
+                return PlanReviewContinuation.NeedsReplan(payload.Feedback, input.RoundNumber);
+        }
+    }
+
+    /// <summary>
+    /// Convenience wrapper the completion service uses: invokes the
+    /// replanner with the feedback appended to the original request. Returns
+    /// null when no replanner is registered so the caller can terminate with
+    /// <see cref="PlanReviewTerminalReason.ReplanExhausted"/> instead of
+    /// silently continuing.
+    /// </summary>
+    public async Task<PlanBuildResult?> ReplanAsync(
+        string originalRequest,
+        string? feedback,
+        IReadOnlyList<Contracts.Routing.ISpecialistAgent>? roster,
+        IReadOnlyList<string> detectedIntents,
+        CancellationToken ct)
+    {
+        if (_replanner is null || roster is null || roster.Count == 0)
+        {
+            _logger.LogWarning(
+                "Replan requested but planner/roster missing — coordinator cannot revise the plan.");
+            return null;
+        }
+
+        string revised = BuildRevisedRequest(originalRequest, feedback ?? string.Empty);
+        return await _replanner.ReplanAsync(revised, roster, detectedIntents, ct).ConfigureAwait(false);
+    }
+
+    // ── Existing loop wrapper (kept for coordinator-level tests) ──────────
+
     /// <summary>
     /// Drive the review loop for a plan. Returns a terminal outcome describing
     /// whether the plan is approved to execute (with the possibly-edited steps),
     /// or terminated with a reason the caller records into the plan store.
+    /// This method BLOCKS on <see cref="IApprovalGate.WaitForApprovalAsync"/>
+    /// — it is retained for coordinator-level tests that respond immediately
+    /// on a background task. The production suspend/resume path uses
+    /// <see cref="OpenRoundAsync"/> + <see cref="EvaluateDecision"/> through
+    /// <see cref="PlanReviewCompletionService"/> and never blocks a thread on
+    /// the review timeout.
     /// </summary>
     public async Task<PlanReviewOutcome> CoordinateAsync(
         PlanReviewCoordinationInput input,
@@ -129,163 +341,88 @@ public sealed class PlanReviewCoordinator
 
         while (round <= _options.MaxReplanRounds)
         {
-            var proposal = new PlanReviewProposal
+            PlanReviewRoundHandle handle = await OpenRoundAsync(new PlanReviewOpenInput
             {
                 PlanId = input.PlanId,
-                RoundNumber = round,
+                Subject = input.Subject,
+                SessionId = input.SessionId,
                 Request = input.Request,
-                Steps = currentSteps,
+                CurrentSteps = currentSteps,
+                SpecialistKeys = input.SpecialistKeys,
+                DetectedIntents = input.DetectedIntents,
+                RoundNumber = round,
                 RevisionReason = revisionReason,
-            };
+                TenantId = input.TenantId,
+                TraceId = input.TraceId,
+                ParentSpanId = input.ParentSpanId,
+                PrincipalKey = input.PrincipalKey,
+            }, ct).ConfigureAwait(false);
 
-            // Persist a checkpoint of the paused workflow so restart can inspect
-            // the same state a resume-in-process would see. The durable approval
-            // row remains the source of truth for the decision.
-            CheckpointInfo? checkpoint = await TryWriteCheckpointAsync(input.PlanId, round, proposal, ct);
-
-            var context = new ApprovalContext(
-                AgentId: "plan-review",
-                UserId: input.Subject,
-                Action: BuildActionLabel(round, currentSteps.Count),
-                Impact: BuildImpactLabel(currentSteps),
-                Urgency: "medium",
-                Reasoning: revisionReason ?? "Initial plan proposal awaiting reviewer decision.",
-                SessionId: input.SessionId,
-                ConversationId: null,
-                Kind: ApprovalKind.PlanReview,
-                PlanId: input.PlanId,
-                RoundNumber: round,
-                Payload: JsonSerializer.Serialize(proposal, _jsonOptions));
-
-            ApprovalRequest request = await _gate.RequestApprovalAsync(context, ct);
-            rounds.Add(new PlanReviewRoundRecord(round, request.RequestId, checkpoint?.CheckpointId));
-
-            _logger.LogInformation(
-                "Plan {PlanId} review round {Round} pending (requestId={RequestId}, subject={Subject}, checkpoint={CheckpointId}).",
-                input.PlanId, round, request.RequestId, input.Subject, checkpoint?.CheckpointId);
+            rounds.Add(new PlanReviewRoundRecord(round, handle.RequestId, handle.CheckpointId));
 
             ApprovalResult result;
             try
             {
-                result = await _gate.WaitForApprovalAsync(request.RequestId, _options.DefaultReviewTimeout, ct);
+                result = await _gate.WaitForApprovalAsync(handle.RequestId, _options.DefaultReviewTimeout, ct);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
                 throw;
             }
 
-            if (result.Decision == ApprovalDecision.TimedOut)
+            PlanReviewContinuation continuation = EvaluateDecision(new PlanReviewEvaluationInput
             {
-                _logger.LogWarning(
-                    "Plan {PlanId} review round {Round} timed out (requestId={RequestId}, subject={Subject}).",
-                    input.PlanId, round, request.RequestId, input.Subject);
-                return PlanReviewOutcome.Terminated(
-                    PlanReviewTerminalReason.ReviewTimedOut,
-                    "Review timed out — no reviewer decision received.",
+                PlanId = input.PlanId,
+                RoundNumber = round,
+                CurrentSteps = currentSteps,
+                SpecialistKeys = input.SpecialistKeys,
+            }, result);
+
+            if (continuation.Kind == PlanReviewContinuationKind.Approved)
+            {
+                return PlanReviewOutcome.Approved(
+                    continuation.ApprovedSteps ?? [],
+                    continuation.TerminalReason,
                     round,
                     rounds);
             }
 
-            if (result.Decision == ApprovalDecision.Orphaned)
+            if (continuation.Kind == PlanReviewContinuationKind.Terminal)
             {
                 return PlanReviewOutcome.Terminated(
-                    PlanReviewTerminalReason.ReviewTimedOut,
-                    "Review orphaned by reconciliation before adoption completed.",
+                    continuation.TerminalReason,
+                    continuation.FailureMessage ?? continuation.TerminalReason,
                     round,
                     rounds);
             }
 
-            PlanReviewResponsePayload responsePayload = ParseResponsePayload(result.ResponsePayload, result.Decision);
-            PlanReviewOutcome? terminal = HandleDecision(
-                input,
-                currentSteps,
-                responsePayload,
-                result,
-                round,
-                rounds);
+            // NeedsReplan — invoke the replanner via the shared helper, then loop.
+            PlanBuildResult? replanned = await ReplanAsync(
+                input.Request,
+                continuation.RejectionFeedback,
+                input.Roster,
+                input.DetectedIntents,
+                ct).ConfigureAwait(false);
 
-            if (terminal is { } outcome && outcome.IsTerminalWithoutFurtherRounds())
+            if (replanned is null || replanned.IsUnusable)
             {
-                return outcome;
+                return PlanReviewOutcome.Terminated(
+                    PlanReviewTerminalReason.ReplanExhausted,
+                    "Replan produced no usable plan: " + (replanned?.UnusableReason ?? "planner unavailable"),
+                    round,
+                    rounds);
             }
 
-            // Reject-with-feedback path: replan if budget remains.
-            if (responsePayload.Kind == PlanReviewKinds.Reject)
+            currentSteps = [.. replanned.Steps.Select(s => new PlanReviewStepDto
             {
-                if (round >= _options.MaxReplanRounds)
-                {
-                    _logger.LogWarning(
-                        "Plan {PlanId} exhausted replan budget after round {Round} (max={Max}).",
-                        input.PlanId, round, _options.MaxReplanRounds);
-                    return PlanReviewOutcome.Terminated(
-                        PlanReviewTerminalReason.ReplanExhausted,
-                        $"Replan budget exhausted after round {round + 1}.",
-                        round,
-                        rounds);
-                }
-
-                if (_replanner is null || input.Roster is null)
-                {
-                    _logger.LogWarning(
-                        "Plan {PlanId} reject-with-feedback cannot replan — planner or roster missing.",
-                        input.PlanId);
-                    return PlanReviewOutcome.Terminated(
-                        PlanReviewTerminalReason.ReplanExhausted,
-                        "Replan requested but no planner is registered for this coordinator.",
-                        round,
-                        rounds);
-                }
-
-                string feedback = responsePayload.Feedback ?? "";
-                string revisedRequest = BuildRevisedRequest(input.Request, feedback);
-
-                PlanBuildResult replanned;
-                try
-                {
-                    replanned = await _replanner.ReplanAsync(
-                        revisedRequest,
-                        input.Roster,
-                        input.DetectedIntents,
-                        ct);
-                }
-                catch (OperationCanceledException) when (ct.IsCancellationRequested)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Plan {PlanId} replan failed at round {Round}.", input.PlanId, round);
-                    return PlanReviewOutcome.Terminated(
-                        PlanReviewTerminalReason.ReplanExhausted,
-                        "Replan invocation failed: " + ex.Message,
-                        round,
-                        rounds);
-                }
-
-                if (replanned.IsUnusable)
-                {
-                    return PlanReviewOutcome.Terminated(
-                        PlanReviewTerminalReason.ReplanExhausted,
-                        "Replan produced no usable plan: " + (replanned.UnusableReason ?? "unknown"),
-                        round,
-                        rounds);
-                }
-
-                currentSteps = [.. replanned.Steps.Select(s => new PlanReviewStepDto
-                {
-                    SpecialistKey = s.SpecialistKey,
-                    Intent = s.Intent,
-                    Action = s.Action,
-                })];
-                revisionReason = string.IsNullOrWhiteSpace(feedback)
-                    ? "Reviewer rejected the previous plan."
-                    : "Reviewer feedback: " + feedback;
-                round++;
-                continue;
-            }
-
-            // Approve / Edit path — terminal with the decided steps.
-            return terminal!;
+                SpecialistKey = s.SpecialistKey,
+                Intent = s.Intent,
+                Action = s.Action,
+            })];
+            revisionReason = string.IsNullOrWhiteSpace(continuation.RejectionFeedback)
+                ? "Reviewer rejected the previous plan."
+                : "Reviewer feedback: " + continuation.RejectionFeedback;
+            round++;
         }
 
         // Loop exit — replan cap reached without a terminal decision. Return a
@@ -327,76 +464,6 @@ public sealed class PlanReviewCoordinator
         return null;
     }
 
-    private PlanReviewOutcome? HandleDecision(
-        PlanReviewCoordinationInput input,
-        IReadOnlyList<PlanReviewStepDto> currentSteps,
-        PlanReviewResponsePayload responsePayload,
-        ApprovalResult result,
-        int round,
-        List<PlanReviewRoundRecord> rounds)
-    {
-        switch (responsePayload.Kind)
-        {
-            case PlanReviewKinds.Approve:
-                _logger.LogInformation(
-                    "Plan {PlanId} approved at round {Round} (requestId={RequestId}).",
-                    input.PlanId, round, result.RequestId);
-                return PlanReviewOutcome.Approved(
-                    currentSteps,
-                    PlanReviewTerminalReason.ReviewerApproved,
-                    round,
-                    rounds);
-
-            case PlanReviewKinds.Edit:
-                {
-                    IReadOnlyList<PlanReviewStepDto> edited =
-                        responsePayload.EditedSteps ?? currentSteps;
-                    string? invalid = ValidateEditedSteps(edited, input.SpecialistKeys);
-                    if (invalid is not null)
-                    {
-                        _logger.LogWarning(
-                            "Plan {PlanId} edit rejected at round {Round}: {Reason}.",
-                            input.PlanId, round, invalid);
-                        return PlanReviewOutcome.Terminated(
-                            invalid,
-                            invalid == PlanReviewTerminalReason.EditedToEmpty
-                                ? "Reviewer dropped every step."
-                                : "Reviewer edit referenced an unknown specialist or missing action.",
-                            round,
-                            rounds);
-                    }
-
-                    _logger.LogInformation(
-                        "Plan {PlanId} approved with edits at round {Round} (steps={Steps}).",
-                        input.PlanId, round, edited.Count);
-                    return PlanReviewOutcome.Approved(
-                        edited,
-                        PlanReviewTerminalReason.ReviewerEdited,
-                        round,
-                        rounds);
-                }
-
-            case PlanReviewKinds.Reject:
-                // Signal a rejection (non-terminal until the replan cap is hit;
-                // the coordinator handles that transition itself).
-                return PlanReviewOutcome.Rejected(
-                    responsePayload.Feedback,
-                    PlanReviewTerminalReason.ReviewerRejected,
-                    round,
-                    rounds);
-
-            default:
-                _logger.LogWarning(
-                    "Plan {PlanId} received unknown response kind '{Kind}' at round {Round}; treating as reject.",
-                    input.PlanId, responsePayload.Kind, round);
-                return PlanReviewOutcome.Rejected(
-                    responsePayload.Feedback,
-                    PlanReviewTerminalReason.ReviewerRejected,
-                    round,
-                    rounds);
-        }
-    }
-
     private PlanReviewResponsePayload ParseResponsePayload(string? persistedPayload, ApprovalDecision decision)
     {
         // Derive from ApprovalDecision when no payload was persisted so a
@@ -431,42 +498,6 @@ public sealed class PlanReviewCoordinator
             return new PlanReviewResponsePayload { Kind = PlanReviewKinds.Reject };
         }
     }
-
-    private async Task<CheckpointInfo?> TryWriteCheckpointAsync(
-        string planId,
-        int round,
-        PlanReviewProposal proposal,
-        CancellationToken ct)
-    {
-        try
-        {
-            string sessionId = SessionIdFor(planId, round);
-            JsonElement element = JsonSerializer.SerializeToElement(proposal, _jsonOptions);
-            // The default CheckpointManager exposes CreateCheckpointAsync via
-            // its ICheckpointStore<JsonElement>. We rely on GetLatestCheckpointAsync
-            // to expose the persisted metadata for the review row; older versions
-            // simply return null so the coordinator still functions without it.
-            _ = element;
-            CheckpointInfo? latest = await _checkpointManager
-                .GetLatestCheckpointAsync(sessionId, ct)
-                .ConfigureAwait(false);
-            return latest;
-        }
-        catch (Exception ex)
-        {
-            // Checkpoint persistence is an operational aid — never fail the
-            // review because the framework's checkpoint store was momentarily
-            // unavailable. The durable approval row still carries the
-            // authoritative state.
-            _logger.LogWarning(
-                ex,
-                "Plan {PlanId} round {Round} checkpoint write skipped (non-fatal).",
-                planId, round);
-            return null;
-        }
-    }
-
-    private static string SessionIdFor(string planId, int round) => $"plan-review::{planId}::r{round}";
 
     private static string BuildActionLabel(int round, int stepCount) =>
         round == 0
@@ -506,6 +537,114 @@ public sealed record PlanReviewCoordinationInput
     public IReadOnlyList<Contracts.Routing.ISpecialistAgent>? Roster { get; init; }
 
     public IReadOnlyList<string> DetectedIntents { get; init; } = [];
+
+    // Optional metadata forwarded into the checkpoint so a fresh process can
+    // reconstruct the execution envelope on resume without re-reading DI.
+    public string? TenantId { get; init; }
+    public string? TraceId { get; init; }
+    public string? ParentSpanId { get; init; }
+    public string? PrincipalKey { get; init; }
+}
+
+/// <summary>
+/// Input for <see cref="PlanReviewCoordinator.OpenRoundAsync"/>. Non-blocking
+/// suspend point: opens the durable approval row and writes a real framework
+/// checkpoint capturing every field a fresh process needs to resume.
+/// </summary>
+public sealed record PlanReviewOpenInput
+{
+    public required string PlanId { get; init; }
+    public required string Subject { get; init; }
+    public string? SessionId { get; init; }
+    public required string Request { get; init; }
+    public required IReadOnlyList<PlanReviewStepDto> CurrentSteps { get; init; }
+    public required IReadOnlyCollection<string> SpecialistKeys { get; init; }
+    public IReadOnlyList<string> DetectedIntents { get; init; } = [];
+    public required int RoundNumber { get; init; }
+    public string? RevisionReason { get; init; }
+    public string? TenantId { get; init; }
+    public string? TraceId { get; init; }
+    public string? ParentSpanId { get; init; }
+    public string? PrincipalKey { get; init; }
+}
+
+/// <summary>
+/// Input for <see cref="PlanReviewCoordinator.EvaluateDecision"/>. Pure
+/// synchronous accessor — no side effects.
+/// </summary>
+public sealed record PlanReviewEvaluationInput
+{
+    public required string PlanId { get; init; }
+    public required int RoundNumber { get; init; }
+    public required IReadOnlyList<PlanReviewStepDto> CurrentSteps { get; init; }
+    public required IReadOnlyCollection<string> SpecialistKeys { get; init; }
+}
+
+/// <summary>
+/// Handle returned from <see cref="PlanReviewCoordinator.OpenRoundAsync"/>.
+/// Every field is durable: the request id points at the approval row on disk,
+/// the checkpoint id points at the framework-issued checkpoint JSON on disk.
+/// </summary>
+public sealed record PlanReviewRoundHandle(
+    string RequestId,
+    string CheckpointId,
+    int RoundNumber,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset ExpiresAt);
+
+/// <summary>Kind discriminator for <see cref="PlanReviewContinuation"/>.</summary>
+public enum PlanReviewContinuationKind
+{
+    /// <summary>Reviewer approved — <see cref="PlanReviewContinuation.ApprovedSteps"/> is set.</summary>
+    Approved,
+    /// <summary>Terminal without execution (timeout, replan exhausted, edit invalid, etc.).</summary>
+    Terminal,
+    /// <summary>Reviewer rejected with feedback and the replan cap has not been reached.</summary>
+    NeedsReplan,
+}
+
+/// <summary>
+/// Result of <see cref="PlanReviewCoordinator.EvaluateDecision"/>. Immutable
+/// value the completion service acts on: approve → execute; terminal →
+/// finalize plan as failed; replan → invoke planner and open round N+1.
+/// </summary>
+public sealed record PlanReviewContinuation
+{
+    public required PlanReviewContinuationKind Kind { get; init; }
+    public required int RoundNumber { get; init; }
+    public string TerminalReason { get; init; } = "";
+    public string? FailureMessage { get; init; }
+    public IReadOnlyList<PlanReviewStepDto>? ApprovedSteps { get; init; }
+    public string? RejectionFeedback { get; init; }
+
+    public static PlanReviewContinuation Approved(
+        IReadOnlyList<PlanReviewStepDto> steps, string terminalReason, int round) =>
+        new()
+        {
+            Kind = PlanReviewContinuationKind.Approved,
+            RoundNumber = round,
+            ApprovedSteps = steps,
+            TerminalReason = terminalReason,
+        };
+
+    public static PlanReviewContinuation Terminal(
+        string terminalReason, string failureMessage, int round) =>
+        new()
+        {
+            Kind = PlanReviewContinuationKind.Terminal,
+            RoundNumber = round,
+            TerminalReason = terminalReason,
+            FailureMessage = failureMessage,
+        };
+
+    public static PlanReviewContinuation NeedsReplan(string? feedback, int round) =>
+        new()
+        {
+            Kind = PlanReviewContinuationKind.NeedsReplan,
+            RoundNumber = round,
+            RejectionFeedback = feedback,
+            TerminalReason = PlanReviewTerminalReason.ReviewerRejected,
+        };
 }
 
 /// <summary>Round-level audit record surfaced back to the caller and history endpoint.</summary>
@@ -568,12 +707,4 @@ public sealed record PlanReviewOutcome
             RejectionFeedback = feedback,
         };
 
-    /// <summary>
-    /// True for approve/edit outcomes and for terminals the loop treats as final
-    /// (timeout, exhausted). Rejection outcomes are intentionally NOT terminal
-    /// here because the coordinator's replan branch takes over.
-    /// </summary>
-    internal bool IsTerminalWithoutFurtherRounds() =>
-        IsApproved || (
-            TerminalReason != PlanReviewTerminalReason.ReviewerRejected);
 }

--- a/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
@@ -8,6 +8,33 @@ using RetailPulse.Contracts.Approval;
 namespace RetailPulse.Api.Approval;
 
 /// <summary>
+/// Seam the coordinator uses to obtain a revised plan after a reject-with-
+/// feedback outcome. The production implementation wraps
+/// <see cref="PlanBuilder.BuildAsync"/>; tests can substitute a stub without
+/// standing up a full <see cref="Microsoft.Extensions.AI.IChatClient"/>.
+/// </summary>
+public interface IPlanReviewReplanner
+{
+    Task<PlanBuildResult> ReplanAsync(
+        string revisedRequest,
+        IReadOnlyList<Contracts.Routing.ISpecialistAgent> roster,
+        IReadOnlyList<string> detectedIntents,
+        CancellationToken ct);
+}
+
+/// <summary>Default replanner — delegates to the tenant planner via <see cref="PlanBuilder"/>.</summary>
+public sealed class PlanBuilderReplanner : IPlanReviewReplanner
+{
+    private readonly PlanBuilder _builder;
+    public PlanBuilderReplanner(PlanBuilder builder) => _builder = builder;
+    public Task<PlanBuildResult> ReplanAsync(
+        string revisedRequest,
+        IReadOnlyList<Contracts.Routing.ISpecialistAgent> roster,
+        IReadOnlyList<string> detectedIntents,
+        CancellationToken ct) => _builder.BuildAsync(revisedRequest, roster, detectedIntents, ct);
+}
+
+/// <summary>
 /// Runs the durable plan review gate (#94). Owns the single resume mechanism the
 /// design review pinned: a Microsoft.Agents.AI.Workflows checkpoint captured by
 /// <see cref="CheckpointManager"/> during the review pause, integrated through
@@ -48,7 +75,7 @@ namespace RetailPulse.Api.Approval;
 public sealed class PlanReviewCoordinator
 {
     private readonly IApprovalGate _gate;
-    private readonly PlanBuilder? _planner;
+    private readonly IPlanReviewReplanner? _replanner;
     private readonly PlanReviewOptions _options;
     private readonly CheckpointManager _checkpointManager;
     private readonly ILogger<PlanReviewCoordinator> _logger;
@@ -65,14 +92,14 @@ public sealed class PlanReviewCoordinator
         IOptions<PlanReviewOptions> options,
         CheckpointManager checkpointManager,
         ILogger<PlanReviewCoordinator> logger,
-        PlanBuilder? planner = null,
+        IPlanReviewReplanner? replanner = null,
         TimeProvider? timeProvider = null)
     {
         _gate = gate ?? throw new ArgumentNullException(nameof(gate));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         _checkpointManager = checkpointManager ?? throw new ArgumentNullException(nameof(checkpointManager));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _planner = planner;
+        _replanner = replanner;
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
@@ -193,7 +220,7 @@ public sealed class PlanReviewCoordinator
                         rounds);
                 }
 
-                if (_planner is null || input.Roster is null)
+                if (_replanner is null || input.Roster is null)
                 {
                     _logger.LogWarning(
                         "Plan {PlanId} reject-with-feedback cannot replan — planner or roster missing.",
@@ -211,7 +238,7 @@ public sealed class PlanReviewCoordinator
                 PlanBuildResult replanned;
                 try
                 {
-                    replanned = await _planner.BuildAsync(
+                    replanned = await _replanner.ReplanAsync(
                         revisedRequest,
                         input.Roster,
                         input.DetectedIntents,

--- a/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
@@ -1,0 +1,548 @@
+using System.Text.Json;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Agents.Planning;
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Runs the durable plan review gate (#94). Owns the single resume mechanism the
+/// design review pinned: a Microsoft.Agents.AI.Workflows checkpoint captured by
+/// <see cref="CheckpointManager"/> during the review pause, integrated through
+/// the #91 <see cref="IApprovalGate"/> so plan and tool approvals share one
+/// audit trail and one restart posture.
+///
+/// <para>
+/// Flow per plan:
+/// </para>
+/// <list type="number">
+///   <item>Serialize the current proposal (round N) into an
+///     <see cref="ApprovalContext.Payload"/> and open a durable approval row
+///     with <see cref="ApprovalKind.PlanReview"/> and <see cref="ApprovalContext.RoundNumber"/> = N.</item>
+///   <item>Persist a workflow checkpoint via <see cref="CheckpointManager"/> using
+///     session id = <c>planId</c>. The checkpoint captures the workflow's paused
+///     state; the durable source of truth for the reviewer decision is the
+///     approval row.</item>
+///   <item>Block on <see cref="IApprovalGate.WaitForApprovalAsync"/> with the
+///     configured review timeout. A restart during this wait leaves the row
+///     Pending; reconciliation adopts it via
+///     <see cref="PlanReviewResumeStrategy"/> and the new-instance endpoint
+///     receives the decision and resumes execution directly.</item>
+///   <item>Interpret the decision:
+///     <list type="bullet">
+///       <item><c>Approve</c> → return the current steps as the final plan.</item>
+///       <item><c>Edit</c> → validate the edited steps against the live roster
+///         and return them as the final plan.</item>
+///       <item><c>Reject</c> with feedback → if round N &lt; MaxReplanRounds,
+///         invoke the planner with the feedback appended and loop to step 1
+///         with N+1. Otherwise terminate with
+///         <see cref="PlanReviewTerminalReason.ReplanExhausted"/>.</item>
+///       <item><c>Timeout</c> → terminate with
+///         <see cref="PlanReviewTerminalReason.ReviewTimedOut"/>.</item>
+///     </list>
+///   </item>
+/// </list>
+/// </summary>
+public sealed class PlanReviewCoordinator
+{
+    private readonly IApprovalGate _gate;
+    private readonly PlanBuilder? _planner;
+    private readonly PlanReviewOptions _options;
+    private readonly CheckpointManager _checkpointManager;
+    private readonly ILogger<PlanReviewCoordinator> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public PlanReviewCoordinator(
+        IApprovalGate gate,
+        IOptions<PlanReviewOptions> options,
+        CheckpointManager checkpointManager,
+        ILogger<PlanReviewCoordinator> logger,
+        PlanBuilder? planner = null,
+        TimeProvider? timeProvider = null)
+    {
+        _gate = gate ?? throw new ArgumentNullException(nameof(gate));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _checkpointManager = checkpointManager ?? throw new ArgumentNullException(nameof(checkpointManager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _planner = planner;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Drive the review loop for a plan. Returns a terminal outcome describing
+    /// whether the plan is approved to execute (with the possibly-edited steps),
+    /// or terminated with a reason the caller records into the plan store.
+    /// </summary>
+    public async Task<PlanReviewOutcome> CoordinateAsync(
+        PlanReviewCoordinationInput input,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.PlanId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.Subject);
+        ArgumentNullException.ThrowIfNull(input.InitialSteps);
+        ArgumentNullException.ThrowIfNull(input.SpecialistKeys);
+
+        IReadOnlyList<PlanReviewStepDto> currentSteps = input.InitialSteps;
+        string? revisionReason = null;
+        int round = 0;
+        List<PlanReviewRoundRecord> rounds = [];
+
+        while (round <= _options.MaxReplanRounds)
+        {
+            var proposal = new PlanReviewProposal
+            {
+                PlanId = input.PlanId,
+                RoundNumber = round,
+                Request = input.Request,
+                Steps = currentSteps,
+                RevisionReason = revisionReason,
+            };
+
+            // Persist a checkpoint of the paused workflow so restart can inspect
+            // the same state a resume-in-process would see. The durable approval
+            // row remains the source of truth for the decision.
+            CheckpointInfo? checkpoint = await TryWriteCheckpointAsync(input.PlanId, round, proposal, ct);
+
+            var context = new ApprovalContext(
+                AgentId: "plan-review",
+                UserId: input.Subject,
+                Action: BuildActionLabel(round, currentSteps.Count),
+                Impact: BuildImpactLabel(currentSteps),
+                Urgency: "medium",
+                Reasoning: revisionReason ?? "Initial plan proposal awaiting reviewer decision.",
+                SessionId: input.SessionId,
+                ConversationId: null,
+                Kind: ApprovalKind.PlanReview,
+                PlanId: input.PlanId,
+                RoundNumber: round,
+                Payload: JsonSerializer.Serialize(proposal, _jsonOptions));
+
+            ApprovalRequest request = await _gate.RequestApprovalAsync(context, ct);
+            rounds.Add(new PlanReviewRoundRecord(round, request.RequestId, checkpoint?.CheckpointId));
+
+            _logger.LogInformation(
+                "Plan {PlanId} review round {Round} pending (requestId={RequestId}, subject={Subject}, checkpoint={CheckpointId}).",
+                input.PlanId, round, request.RequestId, input.Subject, checkpoint?.CheckpointId);
+
+            ApprovalResult result;
+            try
+            {
+                result = await _gate.WaitForApprovalAsync(request.RequestId, _options.DefaultReviewTimeout, ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+
+            if (result.Decision == ApprovalDecision.TimedOut)
+            {
+                _logger.LogWarning(
+                    "Plan {PlanId} review round {Round} timed out (requestId={RequestId}, subject={Subject}).",
+                    input.PlanId, round, request.RequestId, input.Subject);
+                return PlanReviewOutcome.Terminated(
+                    PlanReviewTerminalReason.ReviewTimedOut,
+                    "Review timed out — no reviewer decision received.",
+                    round,
+                    rounds);
+            }
+
+            if (result.Decision == ApprovalDecision.Orphaned)
+            {
+                return PlanReviewOutcome.Terminated(
+                    PlanReviewTerminalReason.ReviewTimedOut,
+                    "Review orphaned by reconciliation before adoption completed.",
+                    round,
+                    rounds);
+            }
+
+            PlanReviewResponsePayload responsePayload = ParseResponsePayload(result.ResponsePayload, result.Decision);
+            PlanReviewOutcome? terminal = HandleDecision(
+                input,
+                currentSteps,
+                responsePayload,
+                result,
+                round,
+                rounds);
+
+            if (terminal is { } outcome && outcome.IsTerminalWithoutFurtherRounds())
+            {
+                return outcome;
+            }
+
+            // Reject-with-feedback path: replan if budget remains.
+            if (responsePayload.Kind == PlanReviewKinds.Reject)
+            {
+                if (round >= _options.MaxReplanRounds)
+                {
+                    _logger.LogWarning(
+                        "Plan {PlanId} exhausted replan budget after round {Round} (max={Max}).",
+                        input.PlanId, round, _options.MaxReplanRounds);
+                    return PlanReviewOutcome.Terminated(
+                        PlanReviewTerminalReason.ReplanExhausted,
+                        $"Replan budget exhausted after round {round + 1}.",
+                        round,
+                        rounds);
+                }
+
+                if (_planner is null || input.Roster is null)
+                {
+                    _logger.LogWarning(
+                        "Plan {PlanId} reject-with-feedback cannot replan — planner or roster missing.",
+                        input.PlanId);
+                    return PlanReviewOutcome.Terminated(
+                        PlanReviewTerminalReason.ReplanExhausted,
+                        "Replan requested but no planner is registered for this coordinator.",
+                        round,
+                        rounds);
+                }
+
+                string feedback = responsePayload.Feedback ?? "";
+                string revisedRequest = BuildRevisedRequest(input.Request, feedback);
+
+                PlanBuildResult replanned;
+                try
+                {
+                    replanned = await _planner.BuildAsync(
+                        revisedRequest,
+                        input.Roster,
+                        input.DetectedIntents,
+                        ct);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Plan {PlanId} replan failed at round {Round}.", input.PlanId, round);
+                    return PlanReviewOutcome.Terminated(
+                        PlanReviewTerminalReason.ReplanExhausted,
+                        "Replan invocation failed: " + ex.Message,
+                        round,
+                        rounds);
+                }
+
+                if (replanned.IsUnusable)
+                {
+                    return PlanReviewOutcome.Terminated(
+                        PlanReviewTerminalReason.ReplanExhausted,
+                        "Replan produced no usable plan: " + (replanned.UnusableReason ?? "unknown"),
+                        round,
+                        rounds);
+                }
+
+                currentSteps = [.. replanned.Steps.Select(s => new PlanReviewStepDto
+                {
+                    SpecialistKey = s.SpecialistKey,
+                    Intent = s.Intent,
+                    Action = s.Action,
+                })];
+                revisionReason = string.IsNullOrWhiteSpace(feedback)
+                    ? "Reviewer rejected the previous plan."
+                    : "Reviewer feedback: " + feedback;
+                round++;
+                continue;
+            }
+
+            // Approve / Edit path — terminal with the decided steps.
+            return terminal!;
+        }
+
+        // Loop exit — replan cap reached without a terminal decision. Return a
+        // terminal outcome so callers never see an ambiguous "no result" state.
+        return PlanReviewOutcome.Terminated(
+            PlanReviewTerminalReason.ReplanExhausted,
+            "Replan cap reached without a reviewer decision.",
+            round,
+            rounds);
+    }
+
+    /// <summary>
+    /// Validate that an edited plan references only specialists in the live
+    /// roster. Returns the terminal reason string when invalid; null when valid.
+    /// Split out so tests can pin the exact validation surface without needing
+    /// to drive the full coordinator loop.
+    /// </summary>
+    public static string? ValidateEditedSteps(
+        IReadOnlyList<PlanReviewStepDto> editedSteps,
+        IReadOnlyCollection<string> specialistKeys)
+    {
+        ArgumentNullException.ThrowIfNull(editedSteps);
+        ArgumentNullException.ThrowIfNull(specialistKeys);
+
+        if (editedSteps.Count == 0)
+            return PlanReviewTerminalReason.EditedToEmpty;
+
+        var validKeys = new HashSet<string>(specialistKeys, StringComparer.OrdinalIgnoreCase);
+        foreach (PlanReviewStepDto step in editedSteps)
+        {
+            if (string.IsNullOrWhiteSpace(step.SpecialistKey))
+                return PlanReviewTerminalReason.EditInvalid;
+            if (!validKeys.Contains(step.SpecialistKey))
+                return PlanReviewTerminalReason.EditInvalid;
+            if (string.IsNullOrWhiteSpace(step.Action))
+                return PlanReviewTerminalReason.EditInvalid;
+        }
+
+        return null;
+    }
+
+    private PlanReviewOutcome? HandleDecision(
+        PlanReviewCoordinationInput input,
+        IReadOnlyList<PlanReviewStepDto> currentSteps,
+        PlanReviewResponsePayload responsePayload,
+        ApprovalResult result,
+        int round,
+        List<PlanReviewRoundRecord> rounds)
+    {
+        switch (responsePayload.Kind)
+        {
+            case PlanReviewKinds.Approve:
+                _logger.LogInformation(
+                    "Plan {PlanId} approved at round {Round} (requestId={RequestId}).",
+                    input.PlanId, round, result.RequestId);
+                return PlanReviewOutcome.Approved(
+                    currentSteps,
+                    PlanReviewTerminalReason.ReviewerApproved,
+                    round,
+                    rounds);
+
+            case PlanReviewKinds.Edit:
+                {
+                    IReadOnlyList<PlanReviewStepDto> edited =
+                        responsePayload.EditedSteps ?? currentSteps;
+                    string? invalid = ValidateEditedSteps(edited, input.SpecialistKeys);
+                    if (invalid is not null)
+                    {
+                        _logger.LogWarning(
+                            "Plan {PlanId} edit rejected at round {Round}: {Reason}.",
+                            input.PlanId, round, invalid);
+                        return PlanReviewOutcome.Terminated(
+                            invalid,
+                            invalid == PlanReviewTerminalReason.EditedToEmpty
+                                ? "Reviewer dropped every step."
+                                : "Reviewer edit referenced an unknown specialist or missing action.",
+                            round,
+                            rounds);
+                    }
+
+                    _logger.LogInformation(
+                        "Plan {PlanId} approved with edits at round {Round} (steps={Steps}).",
+                        input.PlanId, round, edited.Count);
+                    return PlanReviewOutcome.Approved(
+                        edited,
+                        PlanReviewTerminalReason.ReviewerEdited,
+                        round,
+                        rounds);
+                }
+
+            case PlanReviewKinds.Reject:
+                // Signal a rejection (non-terminal until the replan cap is hit;
+                // the coordinator handles that transition itself).
+                return PlanReviewOutcome.Rejected(
+                    responsePayload.Feedback,
+                    PlanReviewTerminalReason.ReviewerRejected,
+                    round,
+                    rounds);
+
+            default:
+                _logger.LogWarning(
+                    "Plan {PlanId} received unknown response kind '{Kind}' at round {Round}; treating as reject.",
+                    input.PlanId, responsePayload.Kind, round);
+                return PlanReviewOutcome.Rejected(
+                    responsePayload.Feedback,
+                    PlanReviewTerminalReason.ReviewerRejected,
+                    round,
+                    rounds);
+        }
+    }
+
+    private PlanReviewResponsePayload ParseResponsePayload(string? persistedPayload, ApprovalDecision decision)
+    {
+        // Derive from ApprovalDecision when no payload was persisted so a
+        // legacy endpoint that only records approve/reject (no ResponsePayload)
+        // still produces a coherent shape the coordinator can act on.
+        if (string.IsNullOrWhiteSpace(persistedPayload))
+        {
+            string derivedKind = decision switch
+            {
+                ApprovalDecision.Approved => PlanReviewKinds.Approve,
+                ApprovalDecision.Modified => PlanReviewKinds.Edit,
+                ApprovalDecision.Rejected => PlanReviewKinds.Reject,
+                ApprovalDecision.TimedOut => PlanReviewKinds.Reject,
+                ApprovalDecision.Orphaned => PlanReviewKinds.Reject,
+                ApprovalDecision.Pending => PlanReviewKinds.Reject,
+                _ => PlanReviewKinds.Reject,
+            };
+            return new PlanReviewResponsePayload { Kind = derivedKind };
+        }
+
+        try
+        {
+            PlanReviewResponsePayload? parsed =
+                JsonSerializer.Deserialize<PlanReviewResponsePayload>(persistedPayload, _jsonOptions);
+            return parsed is null || string.IsNullOrWhiteSpace(parsed.Kind)
+                ? new PlanReviewResponsePayload { Kind = PlanReviewKinds.Reject }
+                : parsed;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to deserialize plan review response payload; treating as reject.");
+            return new PlanReviewResponsePayload { Kind = PlanReviewKinds.Reject };
+        }
+    }
+
+    private async Task<CheckpointInfo?> TryWriteCheckpointAsync(
+        string planId,
+        int round,
+        PlanReviewProposal proposal,
+        CancellationToken ct)
+    {
+        try
+        {
+            var sessionId = SessionIdFor(planId, round);
+            JsonElement element = JsonSerializer.SerializeToElement(proposal, _jsonOptions);
+            // The default CheckpointManager exposes CreateCheckpointAsync via
+            // its ICheckpointStore<JsonElement>. We rely on GetLatestCheckpointAsync
+            // to expose the persisted metadata for the review row; older versions
+            // simply return null so the coordinator still functions without it.
+            _ = element;
+            CheckpointInfo? latest = await _checkpointManager
+                .GetLatestCheckpointAsync(sessionId, ct)
+                .ConfigureAwait(false);
+            return latest;
+        }
+        catch (Exception ex)
+        {
+            // Checkpoint persistence is an operational aid — never fail the
+            // review because the framework's checkpoint store was momentarily
+            // unavailable. The durable approval row still carries the
+            // authoritative state.
+            _logger.LogWarning(
+                ex,
+                "Plan {PlanId} round {Round} checkpoint write skipped (non-fatal).",
+                planId, round);
+            return null;
+        }
+    }
+
+    private static string SessionIdFor(string planId, int round) => $"plan-review::{planId}::r{round}";
+
+    private static string BuildActionLabel(int round, int stepCount) =>
+        round == 0
+            ? $"Review plan proposal ({stepCount} step(s))."
+            : $"Review revised plan proposal — round {round + 1} ({stepCount} step(s)).";
+
+    private static string BuildImpactLabel(IReadOnlyList<PlanReviewStepDto> steps)
+    {
+        if (steps.Count == 0) return "No steps planned.";
+        var top = steps.Take(3).Select(s => s.SpecialistKey);
+        string more = steps.Count > 3 ? $" (+{steps.Count - 3} more)" : "";
+        return "Specialists: " + string.Join(", ", top) + more;
+    }
+
+    private static string BuildRevisedRequest(string original, string feedback) =>
+        string.IsNullOrWhiteSpace(feedback)
+            ? original
+            : $"{original}\n\n[Reviewer feedback for revised plan]: {feedback}";
+
+    // Reserved for round-timestamp features; keep the injected TimeProvider referenced.
+    internal DateTimeOffset UtcNow() => _timeProvider.GetUtcNow();
+}
+
+/// <summary>Input for <see cref="PlanReviewCoordinator.CoordinateAsync"/>.</summary>
+public sealed record PlanReviewCoordinationInput
+{
+    public required string PlanId { get; init; }
+    public required string Subject { get; init; }
+    public string? SessionId { get; init; }
+    public required string Request { get; init; }
+    public required IReadOnlyList<PlanReviewStepDto> InitialSteps { get; init; }
+
+    /// <summary>Every specialist key the planner saw. Edits must reference one of these.</summary>
+    public required IReadOnlyCollection<string> SpecialistKeys { get; init; }
+
+    /// <summary>Roster reference for replan — optional so tests can skip replan.</summary>
+    public IReadOnlyList<Contracts.Routing.ISpecialistAgent>? Roster { get; init; }
+
+    public IReadOnlyList<string> DetectedIntents { get; init; } = [];
+}
+
+/// <summary>Round-level audit record surfaced back to the caller and history endpoint.</summary>
+public sealed record PlanReviewRoundRecord(int RoundNumber, string RequestId, string? CheckpointId);
+
+/// <summary>Terminal outcome of the review loop.</summary>
+public sealed record PlanReviewOutcome
+{
+    public required bool IsApproved { get; init; }
+    public required IReadOnlyList<PlanReviewStepDto> FinalSteps { get; init; }
+    public required string TerminalReason { get; init; }
+    public required string? FailureMessage { get; init; }
+    public required int FinalRound { get; init; }
+    public required IReadOnlyList<PlanReviewRoundRecord> Rounds { get; init; }
+    public string? RejectionFeedback { get; init; }
+
+    public static PlanReviewOutcome Approved(
+        IReadOnlyList<PlanReviewStepDto> steps,
+        string terminalReason,
+        int round,
+        IReadOnlyList<PlanReviewRoundRecord> rounds) =>
+        new()
+        {
+            IsApproved = true,
+            FinalSteps = steps,
+            TerminalReason = terminalReason,
+            FailureMessage = null,
+            FinalRound = round,
+            Rounds = rounds,
+        };
+
+    public static PlanReviewOutcome Terminated(
+        string terminalReason,
+        string failureMessage,
+        int round,
+        IReadOnlyList<PlanReviewRoundRecord> rounds) =>
+        new()
+        {
+            IsApproved = false,
+            FinalSteps = [],
+            TerminalReason = terminalReason,
+            FailureMessage = failureMessage,
+            FinalRound = round,
+            Rounds = rounds,
+        };
+
+    public static PlanReviewOutcome Rejected(
+        string? feedback,
+        string terminalReason,
+        int round,
+        IReadOnlyList<PlanReviewRoundRecord> rounds) =>
+        new()
+        {
+            IsApproved = false,
+            FinalSteps = [],
+            TerminalReason = terminalReason,
+            FailureMessage = feedback,
+            FinalRound = round,
+            Rounds = rounds,
+            RejectionFeedback = feedback,
+        };
+
+    /// <summary>
+    /// True for approve/edit outcomes and for terminals the loop treats as final
+    /// (timeout, exhausted). Rejection outcomes are intentionally NOT terminal
+    /// here because the coordinator's replan branch takes over.
+    /// </summary>
+    internal bool IsTerminalWithoutFurtherRounds() =>
+        IsApproved || (
+            TerminalReason != PlanReviewTerminalReason.ReviewerRejected);
+}

--- a/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
@@ -246,16 +246,14 @@ public sealed class PlanReviewCoordinator
                     IReadOnlyList<PlanReviewStepDto> edited =
                         payload.EditedSteps ?? input.CurrentSteps;
                     string? invalid = ValidateEditedSteps(edited, input.SpecialistKeys);
-                    if (invalid is not null)
-                    {
-                        return PlanReviewContinuation.Terminal(
+                    return invalid is not null
+                        ? PlanReviewContinuation.Terminal(
                             invalid,
                             invalid == PlanReviewTerminalReason.EditedToEmpty
                                 ? "Reviewer dropped every step."
                                 : "Reviewer edit referenced an unknown specialist or missing action.",
-                            input.RoundNumber);
-                    }
-                    return PlanReviewContinuation.Approved(
+                            input.RoundNumber)
+                        : PlanReviewContinuation.Approved(
                         edited,
                         PlanReviewTerminalReason.ReviewerEdited,
                         input.RoundNumber);

--- a/src/RetailPulse.Api/Approval/PlanReviewOptions.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewOptions.cs
@@ -1,0 +1,59 @@
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Configuration for the plan review gate (#94). Behavior-safe by default: the
+/// feature is OFF unless <see cref="Enabled"/> is explicitly true, so #93's hot
+/// path (plan generation → execution without a human pause) keeps its exact
+/// pre-#94 shape. Every timeout is bounded and every replan cap is finite —
+/// the coordinator is architecturally incapable of hanging on human input.
+/// </summary>
+public sealed class PlanReviewOptions
+{
+    public const string SectionName = "PlanReview";
+
+    /// <summary>
+    /// Master switch. False (default) skips the plan review gate entirely — the
+    /// planner produces a plan and the executor runs it immediately, matching
+    /// #93's default posture. Setting this to true wires the coordinator into
+    /// <see cref="Agents.Planning.PlanOrchestrator"/> and swaps the reconciliation
+    /// resume strategy for one that adopts plan-review rows across restarts.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Authoritative timeout for a plan review round. Persisted on the approval
+    /// row so a waiter created before a restart still honours the same timeout
+    /// after adoption by the new instance. When exceeded, the row transitions to
+    /// <see cref="Contracts.Approval.ApprovalDecision.TimedOut"/> and the plan
+    /// terminates with terminal reason
+    /// <see cref="Contracts.Approval.PlanReviewTerminalReason.ReviewTimedOut"/> —
+    /// never an indefinite hang. Default: 30 minutes.
+    /// </summary>
+    public TimeSpan DefaultReviewTimeout { get; set; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Maximum reject-with-feedback rounds. Round 0 is the initial plan; a
+    /// rejection at round R produces round R+1 if R+1 &lt;= MaxReplanRounds.
+    /// Beyond that the coordinator terminates with
+    /// <see cref="Contracts.Approval.PlanReviewTerminalReason.ReplanExhausted"/>.
+    /// Default: 2 (initial + up to two revised plans).
+    /// </summary>
+    public int MaxReplanRounds { get; set; } = 2;
+
+    /// <summary>
+    /// Timeout for a mid-plan clarification round-trip. Distinct from the review
+    /// timeout because a clarification interrupts mid-execution and typically
+    /// wants a shorter deadline. Default: 15 minutes.
+    /// </summary>
+    public TimeSpan ClarificationTimeout { get; set; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Sub-directory under the data directory where the framework
+    /// <c>Microsoft.Agents.AI.Workflows.CheckpointManager</c> stores its JSON
+    /// checkpoints for the plan review workflow. One JSON file per session id
+    /// (plan id + round). Kept relative so the resolved data directory (which
+    /// itself may be ephemeral on this deployment — see DataDirectoryResolver)
+    /// remains the single source of truth.
+    /// </summary>
+    public string CheckpointSubdirectory { get; set; } = "plan-reviews";
+}

--- a/src/RetailPulse.Api/Approval/PlanReviewRestartRecoveryService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewRestartRecoveryService.cs
@@ -56,7 +56,7 @@ public sealed class PlanReviewRestartRecoveryService : IHostedService
                 if (string.IsNullOrWhiteSpace(r.Context.PlanId))
                     continue;
 
-                (string PlanId, string Subject) key = (r.Context.PlanId!, r.Context.UserId);
+                (string PlanId, string Subject) key = (r.Context.PlanId, r.Context.UserId);
                 if (candidates.TryGetValue(key, out ApprovalRequest? existing))
                 {
                     if ((r.RespondedAt ?? r.CreatedAt) > (existing.RespondedAt ?? existing.CreatedAt))

--- a/src/RetailPulse.Api/Approval/PlanReviewRestartRecoveryService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewRestartRecoveryService.cs
@@ -1,0 +1,102 @@
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts.Approval;
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Restart-time recovery: scan every subject's approval history for plan-
+/// review / clarification rows that reached a terminal decision while the
+/// API was down (or during process startup) and drive them through
+/// <see cref="PlanReviewCompletionService.ResolveAsync"/> so the final
+/// response is delivered / persisted. Idempotent: the completion service
+/// short-circuits when the plan is already terminal.
+///
+/// <para>
+/// Runs AFTER <see cref="ApprovalReconciliationBackgroundService"/> so any
+/// row still Pending under a previous instance has already been re-adopted
+/// by the current process. That means every terminal row we see here is
+/// legitimately owned by the reviewer's response, not by an orphan sweep.
+/// </para>
+/// </summary>
+public sealed class PlanReviewRestartRecoveryService : IHostedService
+{
+    private readonly IServiceProvider _sp;
+    private readonly ILogger<PlanReviewRestartRecoveryService> _logger;
+
+    public PlanReviewRestartRecoveryService(
+        IServiceProvider sp,
+        ILogger<PlanReviewRestartRecoveryService> logger)
+    {
+        _sp = sp;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using AsyncServiceScope scope = _sp.CreateAsyncScope();
+            IServiceProvider sp = scope.ServiceProvider;
+            IApprovalGate gate = sp.GetRequiredService<IApprovalGate>();
+            IPlanStore planStore = sp.GetRequiredService<IPlanStore>();
+            PlanReviewCompletionService completion =
+                sp.GetRequiredService<PlanReviewCompletionService>();
+
+            // Walk history — decisions may arrive at any point; we look for
+            // rows whose plan is still stuck in an awaiting-* state.
+            IReadOnlyList<ApprovalRequest> history = await gate.GetHistoryAsync(1000, cancellationToken);
+            var candidates = new Dictionary<(string PlanId, string Subject), ApprovalRequest>();
+            foreach (ApprovalRequest r in history)
+            {
+                if (r.Context.Kind is not (ApprovalKind.PlanReview or ApprovalKind.Clarification))
+                    continue;
+                if (r.Decision == ApprovalDecision.Pending)
+                    continue;
+                if (string.IsNullOrWhiteSpace(r.Context.PlanId))
+                    continue;
+
+                (string PlanId, string Subject) key = (r.Context.PlanId!, r.Context.UserId);
+                if (candidates.TryGetValue(key, out ApprovalRequest? existing))
+                {
+                    if ((r.RespondedAt ?? r.CreatedAt) > (existing.RespondedAt ?? existing.CreatedAt))
+                        candidates[key] = r;
+                }
+                else
+                {
+                    candidates[key] = r;
+                }
+            }
+
+            int resolved = 0;
+            foreach ((string planId, string subject) in candidates.Keys)
+            {
+                PlanDetailDto? plan = await planStore.GetPlanAsync(subject, planId, cancellationToken);
+                if (plan is null) continue;
+                if (plan.Status is not (PlanStatus.AwaitingReview or PlanStatus.AwaitingClarification))
+                    continue;
+
+                PlanReviewCompletionResult result = await completion.ResolveAsync(planId, subject, cancellationToken);
+                _logger.LogInformation(
+                    "Plan {PlanId} restart-recovered via {Kind}.",
+                    planId, result.Kind);
+                resolved++;
+            }
+
+            _logger.LogInformation(
+                "PlanReviewRestartRecoveryService completed: {Count} plan(s) resumed.",
+                resolved);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "PlanReviewRestartRecoveryService failed. Traffic may proceed; the next boot will retry.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/RetailPulse.Api/Approval/PlanReviewResumeStrategy.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewResumeStrategy.cs
@@ -1,0 +1,49 @@
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Wave 2 resume strategy for plan review (#94). Extends the #91 seam without
+/// introducing a second reconciliation mechanism: reconciliation still walks
+/// every Pending row exactly once, and the strategy branches on
+/// <see cref="ApprovalContext.Kind"/> to decide the per-row action.
+///
+/// <para>
+/// Tool rows (<see cref="ApprovalKind.Tool"/> — the ApprovalTool default) keep
+/// their #91 behavior: no execution checkpoint exists for a single blocked-tool
+/// call, so the row is terminated with <see cref="ApprovalResumeAction.OrphanTerminal"/>.
+/// This is byte-for-byte identical to <see cref="OrphanUnresumableStrategy"/> for
+/// tool rows, so registering this strategy is a strict superset — never a change
+/// in existing behavior for the ApprovalTool.
+/// </para>
+///
+/// <para>
+/// Plan review and clarification rows (<see cref="ApprovalKind.PlanReview"/> /
+/// <see cref="ApprovalKind.Clarification"/>) return
+/// <see cref="ApprovalResumeAction.Resume"/>. The gate re-owns the row to the
+/// current process and refreshes its heartbeat, so the next reconciliation pass
+/// leaves it alone. When the human decision later arrives via the plan-review
+/// endpoint, that endpoint executes the persisted plan directly through the
+/// same coordinator seam — the row's <see cref="ApprovalRequest.ResponsePayload"/>
+/// (edited plan or feedback) is the authoritative source of truth. The framework
+/// checkpoint written by <see cref="PlanReviewCoordinator"/> is available as an
+/// operational replay aid, but the coordinator does not require it to make
+/// progress after restart.
+/// </para>
+/// </summary>
+public sealed class PlanReviewResumeStrategy : IApprovalResumeStrategy
+{
+    public Task<ApprovalResumeAction> DecideAsync(ApprovalRequest orphaned, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(orphaned);
+
+        string kind = orphaned.Context?.Kind ?? ApprovalKind.Tool;
+        ApprovalResumeAction action = kind switch
+        {
+            ApprovalKind.PlanReview => ApprovalResumeAction.Resume,
+            ApprovalKind.Clarification => ApprovalResumeAction.Resume,
+            _ => ApprovalResumeAction.OrphanTerminal,
+        };
+        return Task.FromResult(action);
+    }
+}

--- a/src/RetailPulse.Api/Approval/PlanReviewTimeoutBackgroundService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewTimeoutBackgroundService.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Options;
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Api.Approval;
+
+/// <summary>
+/// Periodic sweep that enforces
+/// <see cref="PlanReviewOptions.DefaultReviewTimeout"/> and
+/// <see cref="PlanReviewOptions.ClarificationTimeout"/> against Pending plan-
+/// review and clarification rows. Replaces the pre-#94 blocked-thread wait
+/// in <see cref="IApprovalGate.WaitForApprovalAsync"/> — the timeout is now a
+/// terminal transition on the row, driven by an injected <see cref="TimeProvider"/>
+/// (so a fake clock advances the sweep deterministically in tests).
+///
+/// <para>
+/// On every tick, expired rows transition to
+/// <see cref="ApprovalDecision.TimedOut"/> through
+/// <see cref="IApprovalGate.RespondAsync"/> (race-safe conditional UPDATE), and
+/// the completion service is invoked so the plan finalises with reason
+/// <see cref="PlanReviewTerminalReason.ReviewTimedOut"/>.
+/// </para>
+/// </summary>
+public sealed class PlanReviewTimeoutBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _sp;
+    private readonly TimeProvider _clock;
+    private readonly IOptions<PlanReviewOptions> _options;
+    private readonly ILogger<PlanReviewTimeoutBackgroundService> _logger;
+
+    public PlanReviewTimeoutBackgroundService(
+        IServiceProvider sp,
+        TimeProvider clock,
+        IOptions<PlanReviewOptions> options,
+        ILogger<PlanReviewTimeoutBackgroundService> logger)
+    {
+        _sp = sp;
+        _clock = clock;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        TimeSpan tick = TimeSpan.FromSeconds(15);
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await SweepAsync(stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "PlanReviewTimeoutBackgroundService tick failed; retrying next cycle.");
+                }
+                try
+                {
+                    await Task.Delay(tick, _clock, stoppingToken);
+                }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private async Task SweepAsync(CancellationToken ct)
+    {
+        await using AsyncServiceScope scope = _sp.CreateAsyncScope();
+        IServiceProvider sp = scope.ServiceProvider;
+        IApprovalGate gate = sp.GetRequiredService<IApprovalGate>();
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+
+        // We do not have a per-subject-scanning helper on IApprovalGate, so we
+        // scope the sweep to rows visible via GetHistoryAsync + a subject scan
+        // gathered from the recent history. This bounds memory to the number
+        // of distinct recent subjects, which is small in this deployment.
+        IReadOnlyList<ApprovalRequest> recent = await gate.GetHistoryAsync(500, ct);
+        var subjects = recent.Select(r => r.Context.UserId).Distinct(StringComparer.Ordinal).ToList();
+
+        DateTimeOffset now = _clock.GetUtcNow();
+        foreach (string subject in subjects)
+        {
+            IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync(subject, ct);
+            foreach (ApprovalRequest row in pending)
+            {
+                bool expired = row.Context.Kind switch
+                {
+                    ApprovalKind.PlanReview =>
+                        now - row.CreatedAt >= _options.Value.DefaultReviewTimeout,
+                    ApprovalKind.Clarification =>
+                        now - row.CreatedAt >= _options.Value.ClarificationTimeout,
+                    _ => false,
+                };
+                if (!expired) continue;
+
+                await gate.RespondAsync(
+                    row.RequestId, ApprovalDecision.TimedOut,
+                    comment: "Plan review sweep observed deadline elapse.",
+                    responsePayload: null, ct: ct);
+
+                if (!string.IsNullOrWhiteSpace(row.Context.PlanId))
+                {
+                    await completion.ResolveAsync(row.Context.PlanId!, subject, ct);
+                }
+            }
+        }
+    }
+}

--- a/src/RetailPulse.Api/Approval/PlanReviewTimeoutBackgroundService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewTimeoutBackgroundService.cs
@@ -41,7 +41,7 @@ public sealed class PlanReviewTimeoutBackgroundService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        TimeSpan tick = TimeSpan.FromSeconds(15);
+        var tick = TimeSpan.FromSeconds(15);
         try
         {
             while (!stoppingToken.IsCancellationRequested)
@@ -101,7 +101,7 @@ public sealed class PlanReviewTimeoutBackgroundService : BackgroundService
 
                 if (!string.IsNullOrWhiteSpace(row.Context.PlanId))
                 {
-                    await completion.ResolveAsync(row.Context.PlanId!, subject, ct);
+                    await completion.ResolveAsync(row.Context.PlanId, subject, ct);
                 }
             }
         }

--- a/src/RetailPulse.Api/Approval/SqliteApprovalGate.cs
+++ b/src/RetailPulse.Api/Approval/SqliteApprovalGate.cs
@@ -118,7 +118,12 @@ public sealed class SqliteApprovalGate : IApprovalGate
                     Comment          TEXT,
                     CreatedAt        TEXT NOT NULL,
                     ExpiresAt        TEXT NOT NULL,
-                    RespondedAt      TEXT
+                    RespondedAt      TEXT,
+                    Kind             TEXT NOT NULL DEFAULT 'tool',
+                    PlanId           TEXT,
+                    RoundNumber      INTEGER NOT NULL DEFAULT 0,
+                    Payload          TEXT,
+                    ResponsePayload  TEXT
                 );
 
                 CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_UserId_Decision
@@ -129,6 +134,12 @@ public sealed class SqliteApprovalGate : IApprovalGate
 
                 CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_Decision_Instance
                     ON ApprovalRequests (Decision, AgentInstanceId);
+
+                CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_PlanId_Decision
+                    ON ApprovalRequests (PlanId, Decision);
+
+                CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_UserId_Kind_Decision
+                    ON ApprovalRequests (UserId, Kind, Decision);
                 """;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -146,6 +157,11 @@ public sealed class SqliteApprovalGate : IApprovalGate
             ("HeartbeatAt",     "ALTER TABLE ApprovalRequests ADD COLUMN HeartbeatAt TEXT"),
             ("TimeoutSeconds",  "ALTER TABLE ApprovalRequests ADD COLUMN TimeoutSeconds INTEGER NOT NULL DEFAULT 300"),
             ("TerminalReason",  "ALTER TABLE ApprovalRequests ADD COLUMN TerminalReason TEXT"),
+            ("Kind",            "ALTER TABLE ApprovalRequests ADD COLUMN Kind TEXT NOT NULL DEFAULT 'tool'"),
+            ("PlanId",          "ALTER TABLE ApprovalRequests ADD COLUMN PlanId TEXT"),
+            ("RoundNumber",     "ALTER TABLE ApprovalRequests ADD COLUMN RoundNumber INTEGER NOT NULL DEFAULT 0"),
+            ("Payload",         "ALTER TABLE ApprovalRequests ADD COLUMN Payload TEXT"),
+            ("ResponsePayload", "ALTER TABLE ApprovalRequests ADD COLUMN ResponsePayload TEXT"),
         ];
         foreach ((string name, string ddl) in additions)
         {
@@ -154,6 +170,20 @@ public sealed class SqliteApprovalGate : IApprovalGate
             await using SqliteCommand alter = conn.CreateCommand();
             alter.CommandText = ddl;
             await alter.ExecuteNonQueryAsync();
+        }
+
+        // Create the plan-review helper indexes AFTER any additive column
+        // migration completes so older databases that predate the Kind/PlanId
+        // columns still gain the same indexes on next boot.
+        await using (SqliteCommand idx = conn.CreateCommand())
+        {
+            idx.CommandText = """
+                CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_PlanId_Decision
+                    ON ApprovalRequests (PlanId, Decision);
+                CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_UserId_Kind_Decision
+                    ON ApprovalRequests (UserId, Kind, Decision);
+                """;
+            await idx.ExecuteNonQueryAsync();
         }
     }
 
@@ -183,11 +213,13 @@ public sealed class SqliteApprovalGate : IApprovalGate
             INSERT INTO ApprovalRequests (
                 RequestId, AgentId, UserId, Action, Impact, Urgency, Reasoning,
                 SessionId, ConversationId, AgentInstanceId, HeartbeatAt, TimeoutSeconds,
-                Decision, CreatedAt, ExpiresAt)
+                Decision, CreatedAt, ExpiresAt,
+                Kind, PlanId, RoundNumber, Payload)
             VALUES (
                 @id, @agentId, @userId, @action, @impact, @urgency, @reasoning,
                 @sessionId, @conversationId, @instanceId, @heartbeatAt, @timeoutSeconds,
-                'Pending', @createdAt, @expiresAt)
+                'Pending', @createdAt, @expiresAt,
+                @kind, @planId, @roundNumber, @payload)
             """;
         cmd.Parameters.AddWithValue("@id", requestId);
         cmd.Parameters.AddWithValue("@agentId", context.AgentId);
@@ -203,11 +235,22 @@ public sealed class SqliteApprovalGate : IApprovalGate
         cmd.Parameters.AddWithValue("@timeoutSeconds", (long)_defaultTimeout.TotalSeconds);
         cmd.Parameters.AddWithValue("@createdAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
         cmd.Parameters.AddWithValue("@expiresAt", expiresAt.ToString(_iso8601, CultureInfo.InvariantCulture));
+        // Kind defaults to the tool tag so any pre-#94 producer (ApprovalTool)
+        // that still builds ApprovalContext without setting Kind lands with the
+        // exact same value the schema default would have used — no behavior
+        // change for tool approvals.
+        cmd.Parameters.AddWithValue(
+            "@kind",
+            string.IsNullOrWhiteSpace(context.Kind) ? ApprovalKind.Tool : context.Kind);
+        cmd.Parameters.AddWithValue("@planId", (object?)context.PlanId ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@roundNumber", context.RoundNumber);
+        cmd.Parameters.AddWithValue("@payload", (object?)context.Payload ?? DBNull.Value);
         await cmd.ExecuteNonQueryAsync(ct);
 
         _logger.LogInformation(
-            "Approval request {RequestId} created for agent {AgentId}, user {UserId}, urgency {Urgency}, instance {InstanceId}, timeout {TimeoutSeconds}s",
-            requestId, context.AgentId, context.UserId, context.Urgency, InstanceId, (long)_defaultTimeout.TotalSeconds);
+            "Approval request {RequestId} created (kind={Kind}, planId={PlanId}, round={Round}) for agent {AgentId}, user {UserId}, urgency {Urgency}, instance {InstanceId}, timeout {TimeoutSeconds}s",
+            requestId, context.Kind, context.PlanId, context.RoundNumber,
+            context.AgentId, context.UserId, context.Urgency, InstanceId, (long)_defaultTimeout.TotalSeconds);
 
         return new ApprovalRequest(requestId, context, now, expiresAt);
     }
@@ -224,7 +267,8 @@ public sealed class SqliteApprovalGate : IApprovalGate
             row.Decision,
             row.Comment,
             row.RespondedAt,
-            row.TerminalReason);
+            row.TerminalReason,
+            row.ResponsePayload);
     }
 
     public async Task<ApprovalResult> WaitForApprovalAsync(string requestId, TimeSpan? timeout = null, CancellationToken ct = default)
@@ -246,7 +290,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
 
             if (row.Decision != ApprovalDecision.Pending)
             {
-                return new ApprovalResult(row.RequestId, row.Decision, row.Comment, row.RespondedAt, row.TerminalReason);
+                return new ApprovalResult(row.RequestId, row.Decision, row.Comment, row.RespondedAt, row.TerminalReason, row.ResponsePayload);
             }
 
             // Heartbeat the row so operators can observe that this waiter is alive.
@@ -263,6 +307,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
                     ApprovalDecision.TimedOut,
                     ReasonTimeout,
                     comment: "Approval timed out — no response received.",
+                    responsePayload: null,
                     ct);
             }
 
@@ -274,7 +319,12 @@ public sealed class SqliteApprovalGate : IApprovalGate
         throw new OperationCanceledException(ct);
     }
 
-    public async Task<ApprovalResult> RespondAsync(string requestId, ApprovalDecision decision, string? comment = null, CancellationToken ct = default)
+    public async Task<ApprovalResult> RespondAsync(
+        string requestId,
+        ApprovalDecision decision,
+        string? comment = null,
+        string? responsePayload = null,
+        CancellationToken ct = default)
     {
         string reason = decision switch
         {
@@ -287,7 +337,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
             _ => throw new ArgumentOutOfRangeException(nameof(decision), decision, "Cannot record Pending as a terminal decision.")
         };
 
-        (bool won, ApprovalRequest? current) = await TryConditionalTransitionAsync(requestId, decision, reason, comment, ct);
+        (bool won, ApprovalRequest? current) = await TryConditionalTransitionAsync(requestId, decision, reason, comment, responsePayload, ct);
         if (current is null)
         {
             _logger.LogWarning("Approval {RequestId} was not updated — the request does not exist.", requestId);
@@ -316,7 +366,8 @@ public sealed class SqliteApprovalGate : IApprovalGate
             current.Decision,
             current.Comment,
             current.RespondedAt,
-            current.TerminalReason);
+            current.TerminalReason,
+            current.ResponsePayload);
     }
 
     /// <summary>
@@ -359,6 +410,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
                         ApprovalDecision.Orphaned,
                         ReasonOrphanedOnRestart,
                         comment: "Approval closed by restart reconciliation — no in-process waiter survived.",
+                        responsePayload: null,
                         ct);
                     if (won)
                     {
@@ -423,12 +475,13 @@ public sealed class SqliteApprovalGate : IApprovalGate
         ApprovalDecision decision,
         string reason,
         string? comment,
+        string? responsePayload,
         CancellationToken ct)
     {
-        (bool _, ApprovalRequest? current) = await TryConditionalTransitionAsync(requestId, decision, reason, comment, ct);
+        (bool _, ApprovalRequest? current) = await TryConditionalTransitionAsync(requestId, decision, reason, comment, responsePayload, ct);
         return current is null
             ? throw new KeyNotFoundException($"Approval request '{requestId}' not found.")
-            : new ApprovalResult(current.RequestId, current.Decision, current.Comment, current.RespondedAt, current.TerminalReason);
+            : new ApprovalResult(current.RequestId, current.Decision, current.Comment, current.RespondedAt, current.TerminalReason, current.ResponsePayload);
     }
 
     private async Task<(bool won, ApprovalRequest? current)> TryConditionalTransitionAsync(
@@ -436,6 +489,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
         ApprovalDecision decision,
         string reason,
         string? comment,
+        string? responsePayload,
         CancellationToken ct)
     {
         DateTimeOffset now = _timeProvider.GetUtcNow();
@@ -450,7 +504,8 @@ public sealed class SqliteApprovalGate : IApprovalGate
                 SET Decision = @decision,
                     TerminalReason = @reason,
                     Comment = @comment,
-                    RespondedAt = @respondedAt
+                    RespondedAt = @respondedAt,
+                    ResponsePayload = @responsePayload
                 WHERE RequestId = @id AND Decision = 'Pending'
                 """;
             update.Parameters.AddWithValue("@id", requestId);
@@ -458,6 +513,7 @@ public sealed class SqliteApprovalGate : IApprovalGate
             update.Parameters.AddWithValue("@reason", reason);
             update.Parameters.AddWithValue("@comment", (object?)comment ?? DBNull.Value);
             update.Parameters.AddWithValue("@respondedAt", now.ToString(_iso8601, CultureInfo.InvariantCulture));
+            update.Parameters.AddWithValue("@responsePayload", (object?)responsePayload ?? DBNull.Value);
             affected = await update.ExecuteNonQueryAsync(ct);
         }
 
@@ -546,6 +602,11 @@ public sealed class SqliteApprovalGate : IApprovalGate
         string requestId = reader.GetString(reader.GetOrdinal("RequestId"));
         string? sessionId = TryGetString(reader, "SessionId");
         string? conversationId = TryGetString(reader, "ConversationId");
+        string kind = TryGetString(reader, "Kind") ?? ApprovalKind.Tool;
+        string? planId = TryGetString(reader, "PlanId");
+        int roundNumber = TryGetInt(reader, "RoundNumber") ?? 0;
+        string? payload = TryGetString(reader, "Payload");
+        string? responsePayload = TryGetString(reader, "ResponsePayload");
         var context = new ApprovalContext(
             AgentId: reader.GetString(reader.GetOrdinal("AgentId")),
             UserId: reader.GetString(reader.GetOrdinal("UserId")),
@@ -554,7 +615,11 @@ public sealed class SqliteApprovalGate : IApprovalGate
             Urgency: reader.IsDBNull(reader.GetOrdinal("Urgency")) ? "medium" : reader.GetString(reader.GetOrdinal("Urgency")),
             Reasoning: reader.IsDBNull(reader.GetOrdinal("Reasoning")) ? "" : reader.GetString(reader.GetOrdinal("Reasoning")),
             SessionId: sessionId,
-            ConversationId: conversationId
+            ConversationId: conversationId,
+            Kind: kind,
+            PlanId: planId,
+            RoundNumber: roundNumber,
+            Payload: payload
         );
 
         string decisionStr = reader.GetString(reader.GetOrdinal("Decision"));
@@ -568,7 +633,8 @@ public sealed class SqliteApprovalGate : IApprovalGate
             : DateTimeOffset.Parse(reader.GetString(reader.GetOrdinal("RespondedAt")), CultureInfo.InvariantCulture);
         string? terminalReason = TryGetString(reader, "TerminalReason");
 
-        return new ApprovalRequest(requestId, context, createdAt, expiresAt, decision, comment, respondedAt, terminalReason);
+        return new ApprovalRequest(
+            requestId, context, createdAt, expiresAt, decision, comment, respondedAt, terminalReason, responsePayload);
     }
 
     private static string? TryGetString(SqliteDataReader reader, string columnName)
@@ -577,5 +643,13 @@ public sealed class SqliteApprovalGate : IApprovalGate
         try { ordinal = reader.GetOrdinal(columnName); }
         catch (IndexOutOfRangeException) { return null; }
         return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+    }
+
+    private static int? TryGetInt(SqliteDataReader reader, string columnName)
+    {
+        int ordinal;
+        try { ordinal = reader.GetOrdinal(columnName); }
+        catch (IndexOutOfRangeException) { return null; }
+        return reader.IsDBNull(ordinal) ? null : reader.GetInt32(ordinal);
     }
 }

--- a/src/RetailPulse.Api/Approval/SqliteApprovalGate.cs
+++ b/src/RetailPulse.Api/Approval/SqliteApprovalGate.cs
@@ -175,16 +175,14 @@ public sealed class SqliteApprovalGate : IApprovalGate
         // Create the plan-review helper indexes AFTER any additive column
         // migration completes so older databases that predate the Kind/PlanId
         // columns still gain the same indexes on next boot.
-        await using (SqliteCommand idx = conn.CreateCommand())
-        {
-            idx.CommandText = """
+        await using SqliteCommand idx = conn.CreateCommand();
+        idx.CommandText = """
                 CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_PlanId_Decision
                     ON ApprovalRequests (PlanId, Decision);
                 CREATE INDEX IF NOT EXISTS IX_ApprovalRequests_UserId_Kind_Decision
                     ON ApprovalRequests (UserId, Kind, Decision);
                 """;
-            await idx.ExecuteNonQueryAsync();
-        }
+        await idx.ExecuteNonQueryAsync();
     }
 
     private static async Task<HashSet<string>> ReadColumnsAsync(SqliteConnection conn)

--- a/src/RetailPulse.Api/Endpoints/ApprovalEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ApprovalEndpoints.cs
@@ -72,7 +72,7 @@ public static class ApprovalEndpoints
                 // another human response, we must NOT echo the caller-requested decision
                 // — the HTTP response and the SignalR broadcast both report the actual
                 // stored outcome so exactly one user-visible resolution is observable.
-                ApprovalResult result = await gate.RespondAsync(requestId, decision, body.Comment, ct);
+                ApprovalResult result = await gate.RespondAsync(requestId, decision, body.Comment, ct: ct);
 
                 var payload = new
                 {

--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -501,6 +501,30 @@ public static class ChatEndpoints
                                 ParentSpanId = chatActivity?.SpanId.ToString(),
                             }, ct);
 
+                        // Plan review (#94) may suspend the plan for reviewer
+                        // input. The endpoint MUST NOT block on the review
+                        // timeout: instead, return 202 Accepted with the plan
+                        // and review request identifiers so the client (a) knows
+                        // its request was accepted and (b) can poll or subscribe
+                        // for the final response. When review is disabled or the
+                        // plan completed without suspension, the shape below
+                        // still returns 200 with the existing ChatResponse
+                        // envelope — no behavior change on that path.
+                        if (planResult.IsSuspended)
+                        {
+                            return Results.Accepted(
+                                uri: $"/api/plans/{planResult.PlanId}",
+                                value: new
+                                {
+                                    planId = planResult.PlanId,
+                                    status = planResult.Status,
+                                    reviewRequestId = planResult.ReviewRequestId,
+                                    round = planResult.ReviewRoundNumber,
+                                    sessionId,
+                                    message = "Plan is awaiting reviewer input. Subscribe to the telemetry hub for 'plan_final_response' or poll GET /api/plans/{planId}.",
+                                });
+                        }
+
                         // Output guardrail parity — the single-specialist path filters the
                         // reply through the shared PII/content-safety seam BEFORE returning
                         // (see FilterOutputAsync call below). The plan-first reply is a

--- a/src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
+using RetailPulse.Api.Approval;
 using RetailPulse.Api.Auth;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Persistence;
@@ -69,6 +70,7 @@ public static class PlanReviewEndpoints
             IPlanStore planStore,
             IHubContext<TelemetryHub> hubContext,
             HttpContext http,
+            [FromServices] PlanReviewCompletionService? completion,
             CancellationToken ct) =>
         {
             if (RefuseAnonymous(http, out IResult? refusal))
@@ -100,8 +102,10 @@ public static class PlanReviewEndpoints
                 !string.Equals(row.Context.PlanId, planId, StringComparison.Ordinal) ||
                 !string.Equals(row.Context.Kind, ApprovalKind.PlanReview, StringComparison.Ordinal))
             {
-                // Cross-subject probe or wrong plan — return 404 shape so the
-                // endpoint cannot be used to enumerate someone else's plans.
+                // Cross-subject probe, wrong plan, or wrong kind — return 404
+                // so the endpoint cannot be used to probe another subject's
+                // plans. Row is left untouched: we never invoke RespondAsync
+                // on a row the caller does not own.
                 return Results.NotFound(new { error = "Plan review not found." });
             }
 
@@ -139,6 +143,16 @@ public static class PlanReviewEndpoints
             };
 
             await hubContext.Clients.All.SendAsync("plan_review_resolved", responseDto, ct);
+
+            // Drive the plan through the resume path so the reviewer's
+            // decision produces a real final response (execute the effective
+            // plan, filter, persist, broadcast). ResolveAsync is idempotent
+            // and short-circuits when the plan is already terminal.
+            if (completion is not null)
+            {
+                _ = KickoffCompletionAsync(completion, planId, subject);
+            }
+
             return Results.Ok(responseDto);
         })
         .WithName("DecidePlanReview")
@@ -156,6 +170,7 @@ public static class PlanReviewEndpoints
             IApprovalGate gate,
             IPlanStore planStore,
             HttpContext http,
+            [FromServices] PlanReviewCompletionService? completion,
             CancellationToken ct) =>
         {
             if (RefuseAnonymous(http, out IResult? refusal))
@@ -185,6 +200,11 @@ public static class PlanReviewEndpoints
                 responsePayload: payloadJson,
                 ct: ct);
 
+            if (completion is not null)
+            {
+                _ = KickoffCompletionAsync(completion, planId, subject);
+            }
+
             return Results.Ok(new
             {
                 requestId = result.RequestId,
@@ -203,6 +223,26 @@ public static class PlanReviewEndpoints
         .RequireRateLimiting("moderate");
 
         return app;
+    }
+
+    /// <summary>
+    /// Fire-and-forget resume driver used from the decision / answer endpoints.
+    /// Swallowed exceptions are logged inside the completion service — a
+    /// failure MUST NOT surface as a 5xx to the reviewer because the
+    /// authoritative row is already terminal at this point.
+    /// </summary>
+    private static async Task KickoffCompletionAsync(
+        PlanReviewCompletionService completion, string planId, string subject)
+    {
+        try
+        {
+            await completion.ResolveAsync(planId, subject);
+        }
+        catch
+        {
+            // Errors are captured by the completion service's own logger; the
+            // restart recovery service will pick up the plan on next boot.
+        }
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────

--- a/src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs
@@ -1,0 +1,298 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Api.Security.Anonymous;
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Api.Endpoints;
+
+/// <summary>
+/// HTTP endpoints for plan review (#94). Mirrors the plan-endpoint auth
+/// posture: anonymous callers cannot decide plan reviews, and cross-subject
+/// decisions collapse into a 404 so the endpoint cannot be used to probe or
+/// influence another subject's plan. Every decision is persisted through the
+/// shared <see cref="IApprovalGate"/> so plan and tool approvals share one
+/// audit trail (#91).
+/// </summary>
+public static class PlanReviewEndpoints
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public static WebApplication MapPlanReviewEndpoints(this WebApplication app)
+    {
+        RouteGroupBuilder group = app.MapGroup("/api/plans/{planId}/reviews")
+            .WithTags("Plan Review")
+            .RequireAuthorization();
+
+        // GET /api/plans/{planId}/reviews — list open reviews owned by the caller.
+        group.MapGet("/", async (
+            string planId,
+            IApprovalGate gate,
+            IPlanStore planStore,
+            HttpContext http,
+            CancellationToken ct) =>
+        {
+            if (RefuseAnonymous(http, out IResult? refusal))
+                return refusal;
+
+            string subject = UserIdentity.Resolve(http.User);
+            if (!await OwnsPlanAsync(planStore, subject, planId, ct))
+                return NotFound(planId);
+
+            IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync(subject, ct);
+            return Results.Ok(
+                pending
+                    .Where(r => string.Equals(r.Context.PlanId, planId, StringComparison.Ordinal)
+                                && string.Equals(r.Context.Kind, ApprovalKind.PlanReview, StringComparison.Ordinal))
+                    .Select(ToListDto)
+                    .ToArray());
+        })
+        .WithName("ListPlanReviews")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .RequireRateLimiting("relaxed");
+
+        // POST /api/plans/{planId}/reviews/{requestId}/decision — approve/reject/edit.
+        group.MapPost("/{requestId}/decision", async (
+            string planId,
+            string requestId,
+            [FromBody] PlanReviewDecisionRequest body,
+            IApprovalGate gate,
+            IPlanStore planStore,
+            IHubContext<TelemetryHub> hubContext,
+            HttpContext http,
+            CancellationToken ct) =>
+        {
+            if (RefuseAnonymous(http, out IResult? refusal))
+                return refusal;
+
+            if (body is null || string.IsNullOrWhiteSpace(body.Kind))
+                return Results.BadRequest(new { error = "Decision kind is required." });
+
+            string subject = UserIdentity.Resolve(http.User);
+            if (!await OwnsPlanAsync(planStore, subject, planId, ct))
+                return NotFound(planId);
+
+            // Look up the row before deciding so we can enforce subject ownership.
+            ApprovalRequest? row;
+            try
+            {
+                ApprovalResult existing = await gate.GetResultAsync(requestId, ct);
+                // Fetch full history/pending metadata to obtain subject & plan id
+                // (RespondAsync's result does not include the context).
+                row = await FindRowAsync(gate, subject, requestId, ct);
+            }
+            catch (KeyNotFoundException)
+            {
+                return Results.NotFound(new { error = "Plan review not found." });
+            }
+
+            if (row is null ||
+                !string.Equals(row.Context.UserId, subject, StringComparison.Ordinal) ||
+                !string.Equals(row.Context.PlanId, planId, StringComparison.Ordinal) ||
+                !string.Equals(row.Context.Kind, ApprovalKind.PlanReview, StringComparison.Ordinal))
+            {
+                // Cross-subject probe or wrong plan — return 404 shape so the
+                // endpoint cannot be used to enumerate someone else's plans.
+                return Results.NotFound(new { error = "Plan review not found." });
+            }
+
+            (ApprovalDecision decision, string kind, IReadOnlyList<PlanReviewStepDto>? editedSteps, string? feedback, string? invalid)
+                = ClassifyDecision(body);
+            if (invalid is not null)
+                return Results.BadRequest(new { error = invalid });
+
+            var payload = new PlanReviewResponsePayload
+            {
+                Kind = kind,
+                EditedSteps = editedSteps,
+                Feedback = feedback,
+            };
+
+            string payloadJson = JsonSerializer.Serialize(payload, _jsonOptions);
+
+            ApprovalResult result = await gate.RespondAsync(
+                requestId,
+                decision,
+                comment: string.IsNullOrWhiteSpace(feedback) ? body.Comment : feedback,
+                responsePayload: payloadJson,
+                ct: ct);
+
+            var responseDto = new
+            {
+                requestId = result.RequestId,
+                planId,
+                decision = result.Decision.ToString().ToLowerInvariant(),
+                kind,
+                comment = result.Comment,
+                respondedAt = result.RespondedAt,
+                terminalReason = result.TerminalReason,
+                round = row.Context.RoundNumber,
+            };
+
+            await hubContext.Clients.All.SendAsync("plan_review_resolved", responseDto, ct);
+            return Results.Ok(responseDto);
+        })
+        .WithName("DecidePlanReview")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .RequireRateLimiting("moderate");
+
+        // POST /api/plans/{planId}/clarifications/{requestId}/answer — reviewer answers a clarification.
+        app.MapPost("/api/plans/{planId}/clarifications/{requestId}/answer", async (
+            string planId,
+            string requestId,
+            [FromBody] PlanClarificationAnswerRequest body,
+            IApprovalGate gate,
+            IPlanStore planStore,
+            HttpContext http,
+            CancellationToken ct) =>
+        {
+            if (RefuseAnonymous(http, out IResult? refusal))
+                return refusal;
+            if (body is null || string.IsNullOrWhiteSpace(body.Answer))
+                return Results.BadRequest(new { error = "Answer is required." });
+
+            string subject = UserIdentity.Resolve(http.User);
+            if (!await OwnsPlanAsync(planStore, subject, planId, ct))
+                return NotFound(planId);
+
+            ApprovalRequest? row = await FindRowAsync(gate, subject, requestId, ct);
+            if (row is null ||
+                !string.Equals(row.Context.UserId, subject, StringComparison.Ordinal) ||
+                !string.Equals(row.Context.PlanId, planId, StringComparison.Ordinal) ||
+                !string.Equals(row.Context.Kind, ApprovalKind.Clarification, StringComparison.Ordinal))
+            {
+                return Results.NotFound(new { error = "Clarification not found." });
+            }
+
+            var answer = new PlanClarificationAnswer { Answer = body.Answer };
+            string payloadJson = JsonSerializer.Serialize(answer, _jsonOptions);
+            ApprovalResult result = await gate.RespondAsync(
+                requestId,
+                ApprovalDecision.Approved,
+                comment: body.Answer,
+                responsePayload: payloadJson,
+                ct: ct);
+
+            return Results.Ok(new
+            {
+                requestId = result.RequestId,
+                planId,
+                decision = result.Decision.ToString().ToLowerInvariant(),
+                respondedAt = result.RespondedAt,
+                terminalReason = result.TerminalReason,
+            });
+        })
+        .WithName("AnswerPlanClarification")
+        .RequireAuthorization()
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .RequireRateLimiting("moderate");
+
+        return app;
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private static (ApprovalDecision decision, string kind, IReadOnlyList<PlanReviewStepDto>? editedSteps, string? feedback, string? invalid)
+        ClassifyDecision(PlanReviewDecisionRequest body)
+    {
+        string kind = body.Kind.Trim().ToLowerInvariant();
+        switch (kind)
+        {
+            case PlanReviewKinds.Approve:
+                return (ApprovalDecision.Approved, PlanReviewKinds.Approve, null, null, null);
+            case PlanReviewKinds.Reject:
+                if (string.IsNullOrWhiteSpace(body.Feedback))
+                    return (default, kind, null, null, "Reject decisions must include feedback.");
+                return (ApprovalDecision.Rejected, PlanReviewKinds.Reject, null, body.Feedback, null);
+            case PlanReviewKinds.Edit:
+                if (body.EditedSteps is null)
+                    return (default, kind, null, null, "Edit decisions must include editedSteps.");
+                return (ApprovalDecision.Modified, PlanReviewKinds.Edit, body.EditedSteps, null, null);
+            default:
+                return (default, kind, null, null, $"Unknown decision kind '{kind}'. Expected approve, reject, or edit.");
+        }
+    }
+
+    private static async Task<ApprovalRequest?> FindRowAsync(
+        IApprovalGate gate, string subject, string requestId, CancellationToken ct)
+    {
+        // The gate exposes GetPendingAsync (per user) and GetHistoryAsync; search
+        // both so we can look up rows regardless of whether they're still open.
+        IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync(subject, ct);
+        ApprovalRequest? hit = pending.FirstOrDefault(r => r.RequestId == requestId);
+        if (hit is not null) return hit;
+
+        IReadOnlyList<ApprovalRequest> history = await gate.GetHistoryAsync(200, ct);
+        return history.FirstOrDefault(r => r.RequestId == requestId
+            && string.Equals(r.Context.UserId, subject, StringComparison.Ordinal));
+    }
+
+    private static async Task<bool> OwnsPlanAsync(
+        IPlanStore store, string subject, string planId, CancellationToken ct)
+    {
+        Contracts.Persistence.PlanDetailDto? detail = await store.GetPlanAsync(subject, planId, ct);
+        return detail is not null;
+    }
+
+    private static IResult NotFound(string planId) =>
+        Results.NotFound(new { error = $"Plan '{planId}' not found." });
+
+    private static bool RefuseAnonymous(HttpContext http, out IResult? refusal)
+    {
+        if (AnonymousCapabilityPolicy.IsAnonymousPrincipal(http.User))
+        {
+            refusal = Results.Json(
+                new { error = "Anonymous callers do not own plan reviews.", code = "plan_review_unavailable" },
+                statusCode: StatusCodes.Status403Forbidden);
+            return true;
+        }
+        refusal = null;
+        return false;
+    }
+
+    private static object ToListDto(ApprovalRequest r) => new
+    {
+        requestId = r.RequestId,
+        planId = r.Context.PlanId,
+        round = r.Context.RoundNumber,
+        subject = r.Context.UserId,
+        action = r.Context.Action,
+        impact = r.Context.Impact,
+        urgency = r.Context.Urgency,
+        reasoning = r.Context.Reasoning,
+        createdAt = r.CreatedAt,
+        expiresAt = r.ExpiresAt,
+        status = r.Decision.ToString().ToLowerInvariant(),
+        payload = r.Context.Payload,
+    };
+}
+
+/// <summary>Request body for POST /api/plans/{planId}/reviews/{requestId}/decision.</summary>
+public sealed record PlanReviewDecisionRequest
+{
+    public required string Kind { get; init; }
+    public string? Comment { get; init; }
+    public string? Feedback { get; init; }
+    public IReadOnlyList<PlanReviewStepDto>? EditedSteps { get; init; }
+}
+
+/// <summary>Request body for the clarification-answer endpoint.</summary>
+public sealed record PlanClarificationAnswerRequest
+{
+    public required string Answer { get; init; }
+}

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -1143,8 +1143,61 @@ if (plannerDef is not null && planPersistenceOptsAtRegistration.Enabled)
             sp.GetRequiredService<IPlanStore>(),
             sp.GetRequiredService<ICostTracker>(),
             opts.Value,
-            sp.GetRequiredService<ILogger<PlanOrchestrator>>());
+            sp.GetRequiredService<ILogger<PlanOrchestrator>>(),
+            sp.GetService<PlanReviewCoordinator>(),
+            sp.GetService<IOptions<PlanReviewOptions>>());
     });
+}
+
+// Plan review gate (#94). Off by default. When PlanReview:Enabled = true, wires
+// the coordinator that inserts a human review pause before plan execution,
+// swaps in the plan-aware resume strategy (adopts plan-review rows across
+// restarts instead of orphaning), and registers the clarification service
+// specialists can use for mid-plan round-trips.
+//
+// Registered independently of PlanPersistence.Enabled so an operator can
+// enable review only when plans persist — the coordinator itself refuses to
+// run without the persistence path via the PlanOrchestrator constructor gate.
+builder.Services.Configure<PlanReviewOptions>(
+    builder.Configuration.GetSection(PlanReviewOptions.SectionName));
+PlanReviewOptions planReviewOptsAtRegistration = builder.Configuration
+    .GetSection(PlanReviewOptions.SectionName)
+    .Get<PlanReviewOptions>() ?? new PlanReviewOptions();
+if (planReviewOptsAtRegistration.Enabled)
+{
+    string reviewCheckpointDir = Path.Combine(
+        dataDirectory,
+        string.IsNullOrWhiteSpace(planReviewOptsAtRegistration.CheckpointSubdirectory)
+            ? "plan-reviews"
+            : planReviewOptsAtRegistration.CheckpointSubdirectory);
+    Directory.CreateDirectory(reviewCheckpointDir);
+    // Framework checkpoint store lives on the same durable data directory as
+    // every other SQLite store the API writes. One JSON file per session id.
+    builder.Services.AddSingleton<Microsoft.Agents.AI.Workflows.CheckpointManager>(_ =>
+    {
+        var store = new Microsoft.Agents.AI.Workflows.Checkpointing.FileSystemJsonCheckpointStore(
+            new DirectoryInfo(reviewCheckpointDir));
+        return Microsoft.Agents.AI.Workflows.CheckpointManager.CreateJson(store, customOptions: null);
+    });
+
+    builder.Services.AddScoped<PlanReviewCoordinator>(sp =>
+    {
+        return new PlanReviewCoordinator(
+            sp.GetRequiredService<IApprovalGate>(),
+            sp.GetRequiredService<IOptions<PlanReviewOptions>>(),
+            sp.GetRequiredService<Microsoft.Agents.AI.Workflows.CheckpointManager>(),
+            sp.GetRequiredService<ILogger<PlanReviewCoordinator>>(),
+            sp.GetService<PlanBuilder>(),
+            sp.GetRequiredService<TimeProvider>());
+    });
+
+    builder.Services.AddSingleton<IPlanClarifier, PlanClarifier>();
+
+    // Swap the reconciliation resume strategy for the plan-aware one. Tool rows
+    // still orphan terminally; plan-review / clarification rows are adopted so
+    // the human decision arriving after a restart proceeds normally.
+    builder.Services.RemoveAll<IApprovalResumeStrategy>();
+    builder.Services.AddSingleton<IApprovalResumeStrategy, PlanReviewResumeStrategy>();
 }
 
 // Register ExplainabilityService (singleton for cross-request trace storage)
@@ -1269,6 +1322,12 @@ if (app.Services.GetService<ISessionStore>() is not null)
 if (app.Services.GetService<IPlanStore>() is not null)
 {
     app.MapPlanEndpoints();
+    // Plan review endpoints (#94) — mapped only when the plan store is available
+    // AND PlanReview is enabled. Cross-subject decisions collapse to 404.
+    if (planReviewOptsAtRegistration.Enabled)
+    {
+        app.MapPlanReviewEndpoints();
+    }
 }
 
 // Anonymous mode: map the single unauthenticated bootstrap endpoint that mints short-lived

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -1173,23 +1173,20 @@ if (planReviewOptsAtRegistration.Enabled)
     Directory.CreateDirectory(reviewCheckpointDir);
     // Framework checkpoint store lives on the same durable data directory as
     // every other SQLite store the API writes. One JSON file per session id.
-    builder.Services.AddSingleton<Microsoft.Agents.AI.Workflows.CheckpointManager>(_ =>
+    builder.Services.AddSingleton(_ =>
     {
         var store = new Microsoft.Agents.AI.Workflows.Checkpointing.FileSystemJsonCheckpointStore(
             new DirectoryInfo(reviewCheckpointDir));
         return Microsoft.Agents.AI.Workflows.CheckpointManager.CreateJson(store, customOptions: null);
     });
 
-    builder.Services.AddScoped<PlanReviewCoordinator>(sp =>
-    {
-        return new PlanReviewCoordinator(
+    builder.Services.AddScoped(sp => new PlanReviewCoordinator(
             sp.GetRequiredService<IApprovalGate>(),
             sp.GetRequiredService<IOptions<PlanReviewOptions>>(),
             sp.GetRequiredService<Microsoft.Agents.AI.Workflows.CheckpointManager>(),
             sp.GetRequiredService<ILogger<PlanReviewCoordinator>>(),
             sp.GetService<IPlanReviewReplanner>(),
-            sp.GetRequiredService<TimeProvider>());
-    });
+            sp.GetRequiredService<TimeProvider>()));
 
     // Default replanner delegates to the tenant PlanBuilder — only registered
     // when a planner definition exists. If it is absent the coordinator

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -1187,9 +1187,18 @@ if (planReviewOptsAtRegistration.Enabled)
             sp.GetRequiredService<IOptions<PlanReviewOptions>>(),
             sp.GetRequiredService<Microsoft.Agents.AI.Workflows.CheckpointManager>(),
             sp.GetRequiredService<ILogger<PlanReviewCoordinator>>(),
-            sp.GetService<PlanBuilder>(),
+            sp.GetService<IPlanReviewReplanner>(),
             sp.GetRequiredService<TimeProvider>());
     });
+
+    // Default replanner delegates to the tenant PlanBuilder — only registered
+    // when a planner definition exists. If it is absent the coordinator
+    // terminates reject-with-feedback deterministically with ReplanExhausted;
+    // never a silent no-op.
+    if (plannerDef is not null && planPersistenceOptsAtRegistration.Enabled)
+    {
+        builder.Services.AddScoped<IPlanReviewReplanner, PlanBuilderReplanner>();
+    }
 
     builder.Services.AddSingleton<IPlanClarifier, PlanClarifier>();
 

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -1131,7 +1131,9 @@ if (plannerDef is not null && planPersistenceOptsAtRegistration.Enabled)
             sp.GetRequiredService<ICostTracker>(),
             sp.GetRequiredService<ITraceCollector>(),
             opts.Value,
-            sp.GetRequiredService<ILogger<PlanExecutor>>());
+            sp.GetRequiredService<ILogger<PlanExecutor>>(),
+            sp.GetService<PlanClarifier>(),
+            sp.GetService<PlanReviewCoordinator>());
     });
     builder.Services.AddScoped(sp =>
     {
@@ -1173,17 +1175,25 @@ if (planReviewOptsAtRegistration.Enabled)
     Directory.CreateDirectory(reviewCheckpointDir);
     // Framework checkpoint store lives on the same durable data directory as
     // every other SQLite store the API writes. One JSON file per session id.
-    builder.Services.AddSingleton(_ =>
+    // Register the store itself + the CheckpointManager wrapper — both are
+    // needed because our PlanReviewCheckpointService calls
+    // ICheckpointStore.CreateCheckpointAsync (real write path) and
+    // CheckpointManager.GetLatestCheckpointAsync (read helper).
+    builder.Services.AddSingleton<Microsoft.Agents.AI.Workflows.Checkpointing.ICheckpointStore<System.Text.Json.JsonElement>>(_ =>
+        new Microsoft.Agents.AI.Workflows.Checkpointing.FileSystemJsonCheckpointStore(
+            new DirectoryInfo(reviewCheckpointDir)));
+    builder.Services.AddSingleton(sp =>
     {
-        var store = new Microsoft.Agents.AI.Workflows.Checkpointing.FileSystemJsonCheckpointStore(
-            new DirectoryInfo(reviewCheckpointDir));
+        var store = sp.GetRequiredService<
+            Microsoft.Agents.AI.Workflows.Checkpointing.ICheckpointStore<System.Text.Json.JsonElement>>();
         return Microsoft.Agents.AI.Workflows.CheckpointManager.CreateJson(store, customOptions: null);
     });
+    builder.Services.AddSingleton<PlanReviewCheckpointService>();
 
     builder.Services.AddScoped(sp => new PlanReviewCoordinator(
             sp.GetRequiredService<IApprovalGate>(),
             sp.GetRequiredService<IOptions<PlanReviewOptions>>(),
-            sp.GetRequiredService<Microsoft.Agents.AI.Workflows.CheckpointManager>(),
+            sp.GetRequiredService<PlanReviewCheckpointService>(),
             sp.GetRequiredService<ILogger<PlanReviewCoordinator>>(),
             sp.GetService<IPlanReviewReplanner>(),
             sp.GetRequiredService<TimeProvider>()));
@@ -1197,13 +1207,23 @@ if (planReviewOptsAtRegistration.Enabled)
         builder.Services.AddScoped<IPlanReviewReplanner, PlanBuilderReplanner>();
     }
 
-    builder.Services.AddSingleton<IPlanClarifier, PlanClarifier>();
+    // Register the concrete first so the completion service can inject the
+    // real class (it needs OpenAsync/InterpretAnswer which live on the
+    // implementation, not the interface). The interface points at the same
+    // singleton.
+    builder.Services.AddSingleton<PlanClarifier>();
+    builder.Services.AddSingleton<IPlanClarifier>(sp => sp.GetRequiredService<PlanClarifier>());
 
     // Swap the reconciliation resume strategy for the plan-aware one. Tool rows
     // still orphan terminally; plan-review / clarification rows are adopted so
     // the human decision arriving after a restart proceeds normally.
     builder.Services.RemoveAll<IApprovalResumeStrategy>();
     builder.Services.AddSingleton<IApprovalResumeStrategy, PlanReviewResumeStrategy>();
+
+    // Wave 2: durable completion service + restart recovery + timeout sweep.
+    builder.Services.AddSingleton<PlanReviewCompletionService>();
+    builder.Services.AddHostedService<PlanReviewRestartRecoveryService>();
+    builder.Services.AddHostedService<PlanReviewTimeoutBackgroundService>();
 }
 
 // Register ExplainabilityService (singleton for cross-request trace storage)

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using System.Threading.RateLimiting;
 using Asp.Versioning;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -105,7 +107,7 @@ builder.Services.AddOpenTelemetry()
 
 // SignalR for real-time telemetry
 builder.Services.AddSignalR()
-    .AddJsonProtocol(options => options.PayloadSerializerOptions.PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase);
+    .AddJsonProtocol(options => options.PayloadSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase);
 
 // Session-ownership registry — binds a chat sessionId to its owning subject so the hubs can refuse
 // a caller that tries to join another subject's session group (Finding 6). Consulted only for
@@ -1179,13 +1181,13 @@ if (planReviewOptsAtRegistration.Enabled)
     // needed because our PlanReviewCheckpointService calls
     // ICheckpointStore.CreateCheckpointAsync (real write path) and
     // CheckpointManager.GetLatestCheckpointAsync (read helper).
-    builder.Services.AddSingleton<Microsoft.Agents.AI.Workflows.Checkpointing.ICheckpointStore<System.Text.Json.JsonElement>>(_ =>
-        new Microsoft.Agents.AI.Workflows.Checkpointing.FileSystemJsonCheckpointStore(
+    builder.Services.AddSingleton<ICheckpointStore<JsonElement>>(_ =>
+        new FileSystemJsonCheckpointStore(
             new DirectoryInfo(reviewCheckpointDir)));
     builder.Services.AddSingleton(sp =>
     {
-        var store = sp.GetRequiredService<
-            Microsoft.Agents.AI.Workflows.Checkpointing.ICheckpointStore<System.Text.Json.JsonElement>>();
+        ICheckpointStore<JsonElement> store = sp.GetRequiredService<
+            ICheckpointStore<JsonElement>>();
         return Microsoft.Agents.AI.Workflows.CheckpointManager.CreateJson(store, customOptions: null);
     });
     builder.Services.AddSingleton<PlanReviewCheckpointService>();

--- a/src/RetailPulse.Contracts/Approval/IApprovalGate.cs
+++ b/src/RetailPulse.Contracts/Approval/IApprovalGate.cs
@@ -44,8 +44,22 @@ public interface IApprovalGate
     /// report the returned <see cref="ApprovalResult"/>, not the caller-requested
     /// decision, so exactly one user-visible outcome is observable end-to-end.
     /// </para>
+    ///
+    /// <para>
+    /// Plan review (#94) reuses this same storage and code path so plan and
+    /// tool approvals share one audit trail. Callers pass an optional
+    /// <paramref name="responsePayload"/> to persist edited plan JSON,
+    /// rejection feedback, or a clarification answer alongside the decision;
+    /// the payload is opaque to the gate and read back through
+    /// <see cref="ApprovalResult.ResponsePayload"/>.
+    /// </para>
     /// </summary>
-    Task<ApprovalResult> RespondAsync(string requestId, ApprovalDecision decision, string? comment = null, CancellationToken ct = default);
+    Task<ApprovalResult> RespondAsync(
+        string requestId,
+        ApprovalDecision decision,
+        string? comment = null,
+        string? responsePayload = null,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Lists all pending approval requests for a given user.
@@ -72,7 +86,25 @@ public record ApprovalContext(
     // producers may leave both null; Wave 2 populates them so the resume strategy can
     // rehydrate a checkpointed execution instead of orphaning on restart.
     string? SessionId = null,
-    string? ConversationId = null
+    string? ConversationId = null,
+    // Category tag persisted verbatim so plan review (#94) rows can be distinguished
+    // from single-tool ApprovalTool rows without changing the base contract. Defaults
+    // to <see cref="ApprovalKind.Tool"/> so every existing producer keeps its exact
+    // stored shape and existing history/pending queries continue to observe the
+    // same rows they always did.
+    string Kind = ApprovalKind.Tool,
+    // Optional correlation back to a plan (#93/#94). Populated for plan review and
+    // clarification rows so the endpoint layer can list decisions per plan and the
+    // resume strategy can look up the workflow checkpoint for the same plan id.
+    string? PlanId = null,
+    // Zero-based replan round for plan review rows. Every reject-with-feedback
+    // increments the round; the coordinator enforces a bounded cap so replan can
+    // never loop forever.
+    int RoundNumber = 0,
+    // Opaque JSON payload the coordinator/endpoint stores alongside the request
+    // (e.g. the plan proposal or clarification question). Never inspected by the
+    // gate itself.
+    string? Payload = null
 );
 
 /// <summary>
@@ -90,7 +122,11 @@ public record ApprovalRequest(
     // "HumanRejected", "HumanModified", "Timeout", "OrphanedOnRestart"). Null while
     // the request is still <see cref="ApprovalDecision.Pending"/>. Additive with a
     // default so existing constructors continue to compile.
-    string? TerminalReason = null
+    string? TerminalReason = null,
+    // Opaque JSON payload written by the human responder (e.g. the edited plan or
+    // the clarification answer). Additive; existing callers ignore it. See
+    // <see cref="ApprovalResult.ResponsePayload"/>.
+    string? ResponsePayload = null
 );
 
 /// <summary>
@@ -104,7 +140,11 @@ public record ApprovalResult(
     // Distinguishable terminal reason (see <see cref="ApprovalRequest.TerminalReason"/>).
     // Additive with a default so the existing surface remains binary-compatible for
     // callers that only care about <see cref="Decision"/>.
-    string? TerminalReason = null
+    string? TerminalReason = null,
+    // Opaque JSON payload written by the human responder. Additive default so
+    // existing tool-approval callers stay identical. Plan review (#94) reads this
+    // to obtain edited plans, rejection feedback, and clarification answers.
+    string? ResponsePayload = null
 );
 
 public enum ApprovalDecision
@@ -118,4 +158,23 @@ public enum ApprovalDecision
     // survive a restart and could not be resumed from a checkpoint. See
     // <see cref="IApprovalResumeStrategy"/> for how Wave 2 replaces this default.
     Orphaned
+}
+
+/// <summary>
+/// Category tag stored on every approval row so plan review (#94), plan
+/// clarification (#94), and the pre-existing single-tool ApprovalTool path can
+/// share one durable table without cross-contaminating their surfaces. The gate
+/// itself does not interpret these values; the coordinator and endpoint layers
+/// route on them.
+/// </summary>
+public static class ApprovalKind
+{
+    /// <summary>Default — a single-tool ApprovalTool request (#91 behavior).</summary>
+    public const string Tool = "tool";
+
+    /// <summary>Plan-level review before execution (#94).</summary>
+    public const string PlanReview = "plan_review";
+
+    /// <summary>Mid-plan clarification round-trip (#94).</summary>
+    public const string Clarification = "clarification";
 }

--- a/src/RetailPulse.Contracts/Approval/PlanReview.cs
+++ b/src/RetailPulse.Contracts/Approval/PlanReview.cs
@@ -94,6 +94,71 @@ public sealed record PlanClarificationAnswer
 }
 
 /// <summary>
+/// Durable snapshot the plan review coordinator writes into the
+/// Microsoft.Agents.AI.Workflows checkpoint store at every suspension point.
+/// Captures everything a fresh process needs to resume execution when the
+/// human decision arrives — the proposed step list for this round, the
+/// caller identity, the request text, the roster keys the planner saw, and
+/// the current round number. Serialized as JSON so
+/// <c>ICheckpointStore&lt;JsonElement&gt;.CreateCheckpointAsync</c> can persist
+/// it verbatim.
+/// </summary>
+public sealed record PlanReviewCheckpointState
+{
+    /// <summary>Discriminator: <c>review</c> or <c>clarification</c>.</summary>
+    public required string Kind { get; init; }
+    public required string PlanId { get; init; }
+    public required string Subject { get; init; }
+    public string? SessionId { get; init; }
+    public string? TenantId { get; init; }
+    public required string Request { get; init; }
+    public required int RoundNumber { get; init; }
+    public required IReadOnlyList<PlanReviewStepDto> Steps { get; init; }
+    public required IReadOnlyList<string> SpecialistKeys { get; init; }
+    public IReadOnlyList<string> DetectedIntents { get; init; } = [];
+    public string? TraceId { get; init; }
+    public string? ParentSpanId { get; init; }
+    public string? PrincipalKey { get; init; }
+    public required string ApprovalRequestId { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public string? RevisionReason { get; init; }
+
+    // Clarification-only fields, null on plain plan-review checkpoints.
+    public int? PausedAtStepIndex { get; init; }
+    public IReadOnlyList<PlanReviewCompletedStep>? CompletedSteps { get; init; }
+}
+
+/// <summary>
+/// Snapshot of a plan step that already ran (Completed / Failed / Skipped)
+/// before the plan suspended for clarification. Persisted inside
+/// <see cref="PlanReviewCheckpointState.CompletedSteps"/> so the resume path
+/// can rebuild the accumulated context without re-running earlier specialists.
+/// </summary>
+public sealed record PlanReviewCompletedStep
+{
+    public required int StepIndex { get; init; }
+    public required string SpecialistKey { get; init; }
+    public required string Intent { get; init; }
+    public required string Action { get; init; }
+    public required string Result { get; init; }
+    public int InputTokens { get; init; }
+    public int OutputTokens { get; init; }
+    public int TotalTokens { get; init; }
+    public long DurationMs { get; init; }
+}
+
+/// <summary>
+/// Kinds recorded on <see cref="PlanReviewCheckpointState.Kind"/> so the
+/// resume path can dispatch to the right handler without re-reading the
+/// approval row.
+/// </summary>
+public static class PlanCheckpointKind
+{
+    public const string Review = "review";
+    public const string Clarification = "clarification";
+}
+
+/// <summary>
 /// Terminal reason strings written into
 /// <see cref="ApprovalResult.TerminalReason"/> and mirrored into the plan store's
 /// <c>FailureReason</c> column so the endpoint layer can render a specific

--- a/src/RetailPulse.Contracts/Approval/PlanReview.cs
+++ b/src/RetailPulse.Contracts/Approval/PlanReview.cs
@@ -1,0 +1,128 @@
+namespace RetailPulse.Contracts.Approval;
+
+/// <summary>
+/// Contract types for plan review (#94). Live in the shared contracts project so
+/// endpoints, background services, and tests can round-trip payloads without
+/// depending on the API's internal orchestration types. Every DTO is JSON-shape
+/// stable — the coordinator serializes proposals into
+/// <see cref="ApprovalContext.Payload"/> and reviewer responses into
+/// <see cref="ApprovalRequest.ResponsePayload"/> using these exact records.
+/// </summary>
+public static class PlanReviewKinds
+{
+    /// <summary>Response payload discriminator for an approve decision.</summary>
+    public const string Approve = "approve";
+
+    /// <summary>Response payload discriminator for a reject-with-feedback decision.</summary>
+    public const string Reject = "reject";
+
+    /// <summary>Response payload discriminator for an edit-then-approve decision.</summary>
+    public const string Edit = "edit";
+}
+
+/// <summary>
+/// One step in a plan proposal. Deliberately mirrors
+/// <c>PlannerStep</c> so the payload the reviewer sees is the same shape the
+/// planner produced, and edits arrive in the same shape the executor consumes.
+/// </summary>
+public sealed record PlanReviewStepDto
+{
+    public required string SpecialistKey { get; init; }
+    public required string Intent { get; init; }
+    public required string Action { get; init; }
+}
+
+/// <summary>
+/// Proposal presented to the human reviewer, persisted as JSON on the
+/// <see cref="ApprovalRequest"/> row.
+/// </summary>
+public sealed record PlanReviewProposal
+{
+    public required string PlanId { get; init; }
+    public required int RoundNumber { get; init; }
+    public required string Request { get; init; }
+    public required IReadOnlyList<PlanReviewStepDto> Steps { get; init; }
+
+    /// <summary>
+    /// Populated on rounds > 0 to explain to the reviewer why the plan was revised
+    /// (echoed back from the earlier rejection feedback). Null on the initial round.
+    /// </summary>
+    public string? RevisionReason { get; init; }
+}
+
+/// <summary>
+/// Human response payload. Discriminated by <see cref="Kind"/>:
+/// <list type="bullet">
+///   <item><c>approve</c>: <see cref="EditedSteps"/> is null; original plan runs.</item>
+///   <item><c>reject</c>: <see cref="Feedback"/> carries the free-text critique the
+///     planner will consume for the next round. When the replan cap is exhausted,
+///     the coordinator terminates the plan with reason
+///     <c>ReplanExhausted</c> — never an indefinite loop.</item>
+///   <item><c>edit</c>: <see cref="EditedSteps"/> replaces the original plan in
+///     the executor. Every step must reference a specialist in the same live
+///     roster the planner saw. An empty <see cref="EditedSteps"/> is treated as
+///     "drop the plan" and terminates it with reason <c>EditedToEmpty</c>.</item>
+/// </list>
+/// </summary>
+public sealed record PlanReviewResponsePayload
+{
+    public required string Kind { get; init; }
+    public IReadOnlyList<PlanReviewStepDto>? EditedSteps { get; init; }
+    public string? Feedback { get; init; }
+}
+
+/// <summary>
+/// Mid-plan clarification question the specialist raises through
+/// <see cref="Api.Approval.IPlanClarifier"/>. Persisted as JSON on the
+/// approval row's <see cref="ApprovalContext.Payload"/>.
+/// </summary>
+public sealed record PlanClarificationPrompt
+{
+    public required string PlanId { get; init; }
+    public required int StepIndex { get; init; }
+    public required string SpecialistKey { get; init; }
+    public required string Question { get; init; }
+}
+
+/// <summary>
+/// Reviewer's response to a clarification prompt. Written into the row's
+/// <see cref="ApprovalRequest.ResponsePayload"/>.
+/// </summary>
+public sealed record PlanClarificationAnswer
+{
+    public required string Answer { get; init; }
+}
+
+/// <summary>
+/// Terminal reason strings written into
+/// <see cref="ApprovalResult.TerminalReason"/> and mirrored into the plan store's
+/// <c>FailureReason</c> column so the endpoint layer can render a specific
+/// user-visible outcome. New reasons are additive; the existing single-tool
+/// approval terminal reasons remain unchanged.
+/// </summary>
+public static class PlanReviewTerminalReason
+{
+    /// <summary>Reviewer approved the current proposal.</summary>
+    public const string ReviewerApproved = "PlanReviewApproved";
+
+    /// <summary>Reviewer approved after amending the step list.</summary>
+    public const string ReviewerEdited = "PlanReviewEdited";
+
+    /// <summary>Reviewer rejected with feedback and replan is proceeding.</summary>
+    public const string ReviewerRejected = "PlanReviewRejected";
+
+    /// <summary>Replan round cap exhausted; plan terminated without executing.</summary>
+    public const string ReplanExhausted = "PlanReviewReplanExhausted";
+
+    /// <summary>Reviewer edited the plan down to zero steps.</summary>
+    public const string EditedToEmpty = "PlanReviewEditedToEmpty";
+
+    /// <summary>Reviewer's edited step list referenced an unknown specialist.</summary>
+    public const string EditInvalid = "PlanReviewEditInvalid";
+
+    /// <summary>Configured review timeout elapsed with no reviewer decision.</summary>
+    public const string ReviewTimedOut = "PlanReviewTimedOut";
+
+    /// <summary>Clarification response contract violated (unparseable, empty).</summary>
+    public const string ClarificationInvalid = "PlanClarificationInvalid";
+}

--- a/src/RetailPulse.Contracts/Persistence/PlanDtos.cs
+++ b/src/RetailPulse.Contracts/Persistence/PlanDtos.cs
@@ -14,6 +14,9 @@ public static class PlanStatus
     /// <summary>Planner returned a plan awaiting explicit human review (#94 hook).</summary>
     public const string AwaitingReview = "awaiting_review";
 
+    /// <summary>Plan execution paused mid-step for a clarification / mid-plan replan (#94).</summary>
+    public const string AwaitingClarification = "awaiting_clarification";
+
     /// <summary>At least one step is executing; the plan has not reached a terminal state.</summary>
     public const string Running = "running";
 

--- a/tests/RetailPulse.Tests/Approval/PlanClarifierTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanClarifierTests.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Approval;
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Tests.Approval;
+
+/// <summary>
+/// Mid-plan clarification round-trip (#94). Exercises the shared-gate storage
+/// path so the same audit history holds both plan review and clarification.
+/// </summary>
+public sealed class PlanClarifierTests : IDisposable
+{
+    private readonly string _dbPath;
+
+    public PlanClarifierTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"plan_clarify_{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { }
+        try { File.Delete(_dbPath + "-wal"); } catch { }
+        try { File.Delete(_dbPath + "-shm"); } catch { }
+    }
+
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private SqliteApprovalGate CreateGate() =>
+        new(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(),
+            TimeSpan.FromSeconds(30), TimeProvider.System);
+
+    private PlanClarifier CreateClarifier(SqliteApprovalGate gate, PlanReviewOptions options) =>
+        new(gate, Options.Create(options), Mock.Of<ILogger<PlanClarifier>>());
+
+    [Fact]
+    public async Task Clarification_round_trip_returns_reviewer_answer()
+    {
+        SqliteApprovalGate gate = CreateGate();
+        var options = new PlanReviewOptions { ClarificationTimeout = TimeSpan.FromSeconds(30) };
+        PlanClarifier clarifier = CreateClarifier(gate, options);
+
+        var prompt = new PlanClarificationPrompt
+        {
+            PlanId = "p-1",
+            StepIndex = 1,
+            SpecialistKey = "demand-forecasting",
+            Question = "Which region should we forecast?",
+        };
+
+        // Fire the clarification and wait for the row to appear.
+        Task<PlanClarificationResult> task = clarifier.AskAsync(prompt, "user-1");
+        ApprovalRequest row = await WaitForPending(gate, "user-1");
+
+        row.Context.Kind.Should().Be(ApprovalKind.Clarification);
+        row.Context.PlanId.Should().Be("p-1");
+
+        var answer = new PlanClarificationAnswer { Answer = "Northeast" };
+        await gate.RespondAsync(row.RequestId, ApprovalDecision.Approved, "Northeast",
+            responsePayload: JsonSerializer.Serialize(answer, _json));
+
+        PlanClarificationResult result = await task;
+        result.IsAnswered.Should().BeTrue();
+        result.Answer.Should().Be("Northeast");
+    }
+
+    [Fact]
+    public async Task Clarification_without_response_payload_returns_ClarificationInvalid()
+    {
+        SqliteApprovalGate gate = CreateGate();
+        var options = new PlanReviewOptions();
+        PlanClarifier clarifier = CreateClarifier(gate, options);
+
+        var prompt = new PlanClarificationPrompt
+        {
+            PlanId = "p-1",
+            StepIndex = 0,
+            SpecialistKey = "scorecard",
+            Question = "Which brand?",
+        };
+
+        Task<PlanClarificationResult> task = clarifier.AskAsync(prompt, "user-1");
+        ApprovalRequest row = await WaitForPending(gate, "user-1");
+
+        // Respond WITHOUT a payload — should surface as an invalid clarification.
+        await gate.RespondAsync(row.RequestId, ApprovalDecision.Approved, "answered");
+
+        PlanClarificationResult result = await task;
+        result.IsAnswered.Should().BeFalse();
+        result.TerminalReason.Should().Be(PlanReviewTerminalReason.ClarificationInvalid);
+    }
+
+    private static async Task<ApprovalRequest> WaitForPending(SqliteApprovalGate gate, string subject)
+    {
+        for (int i = 0; i < 400; i++)
+        {
+            IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync(subject);
+            if (pending.Count > 0) return pending[^1];
+            await Task.Delay(10);
+        }
+        throw new InvalidOperationException("Timed out waiting for pending row.");
+    }
+}

--- a/tests/RetailPulse.Tests/Approval/PlanClarifierTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanClarifierTests.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -15,10 +17,13 @@ namespace RetailPulse.Tests.Approval;
 public sealed class PlanClarifierTests : IDisposable
 {
     private readonly string _dbPath;
+    private readonly string _checkpointDir;
 
     public PlanClarifierTests()
     {
         _dbPath = Path.Combine(Path.GetTempPath(), $"plan_clarify_{Guid.NewGuid():N}.db");
+        _checkpointDir = Path.Combine(Path.GetTempPath(), $"plan_clarify_ckpt_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_checkpointDir);
     }
 
     public void Dispose()
@@ -26,6 +31,7 @@ public sealed class PlanClarifierTests : IDisposable
         try { File.Delete(_dbPath); } catch { }
         try { File.Delete(_dbPath + "-wal"); } catch { }
         try { File.Delete(_dbPath + "-shm"); } catch { }
+        try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
     }
 
     private static readonly JsonSerializerOptions _json = new()
@@ -38,8 +44,16 @@ public sealed class PlanClarifierTests : IDisposable
         new(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(),
             TimeSpan.FromSeconds(30), TimeProvider.System);
 
+    private PlanReviewCheckpointService CreateCheckpointService()
+    {
+        FileSystemJsonCheckpointStore store =
+            new(new DirectoryInfo(_checkpointDir));
+        CheckpointManager manager = CheckpointManager.CreateJson(store, customOptions: null);
+        return new PlanReviewCheckpointService(store, manager, Mock.Of<ILogger<PlanReviewCheckpointService>>());
+    }
+
     private PlanClarifier CreateClarifier(SqliteApprovalGate gate, PlanReviewOptions options) =>
-        new(gate, Options.Create(options), Mock.Of<ILogger<PlanClarifier>>());
+        new(gate, Options.Create(options), CreateCheckpointService(), Mock.Of<ILogger<PlanClarifier>>());
 
     [Fact]
     public async Task Clarification_round_trip_returns_reviewer_answer()

--- a/tests/RetailPulse.Tests/Approval/PlanClarifierTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanClarifierTests.cs
@@ -48,7 +48,7 @@ public sealed class PlanClarifierTests : IDisposable
     {
         FileSystemJsonCheckpointStore store =
             new(new DirectoryInfo(_checkpointDir));
-        CheckpointManager manager = CheckpointManager.CreateJson(store, customOptions: null);
+        var manager = CheckpointManager.CreateJson(store, customOptions: null);
         return new PlanReviewCheckpointService(store, manager, Mock.Of<ILogger<PlanReviewCheckpointService>>());
     }
 

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,7 +38,7 @@ namespace RetailPulse.Tests.Approval;
 ///   <item><c>PlanReviewCompletionService.ResolveAsync</c> — the resume driver.</item>
 /// </list>
 /// Every test uses a real <see cref="SqliteApprovalGate"/> and a real
-/// <see cref="Microsoft.Agents.AI.Workflows.Checkpointing.FileSystemJsonCheckpointStore"/>
+/// <see cref="FileSystemJsonCheckpointStore"/>
 /// so the persistence + framework-checkpoint surfaces are exercised end-to-end.
 /// </summary>
 public sealed class PlanReviewCompletionServiceTests : IDisposable
@@ -116,7 +117,7 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
 
         PlanDetailDto? plan = await plans2.GetPlanAsync("user-1", suspend.PlanId, default);
         plan.Should().NotBeNull();
-        plan!.Status.Should().Be(PlanStatus.Completed);
+        plan.Status.Should().Be(PlanStatus.Completed);
         plan.FailureReason.Should().StartWith("PlanReviewFinalReply::",
             "the resumed final reply is persisted onto the plan record so a later GET returns it.");
 
@@ -164,7 +165,7 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
 
         PlanDetailDto? plan = await plans.GetPlanAsync("user-1", suspend.PlanId, default);
         plan.Should().NotBeNull();
-        plan!.Status.Should().Be(PlanStatus.Completed);
+        plan.Status.Should().Be(PlanStatus.Completed);
 
         await sp.DisposeAsync();
     }
@@ -174,8 +175,8 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
     [Fact]
     public async Task Disabled_review_returns_terminal_result_and_writes_no_approval_row()
     {
-        (ServiceProvider sp, PlanOrchestrator orch, InMemoryPlanStore plans,
-            SqliteApprovalGate gate, ConcurrentQueue<string> _) = BuildHost(reviewEnabled: false);
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, _) = BuildHost(reviewEnabled: false);
 
         PlanOrchestrationResult r = await orch.RunAsync(SampleInput(), default);
         r.IsSuspended.Should().BeFalse();
@@ -183,6 +184,89 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
         (await gate.GetPendingAsync("user-1")).Should().BeEmpty();
         (await gate.GetHistoryAsync(50)).Should().BeEmpty(
             "disabled review never touches the approval gate.");
+
+        await sp.DisposeAsync();
+    }
+
+    // ── Mid-execution replan surface ([[REPLAN]] marker) ────────────────
+
+    [Fact]
+    public async Task Replan_marker_suspends_plan_for_a_new_review_round()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch, InMemoryPlanStore plans,
+            SqliteApprovalGate gate, ConcurrentQueue<string> _) =
+            BuildHost(plannerJson: PlannerJsonWithReplan());
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        // Reviewer approves the initial plan so execution starts and hits [[REPLAN]].
+        ApprovalRequest firstReview = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.PlanId == suspend.PlanId
+                      && r.Context.Kind == ApprovalKind.PlanReview);
+        await gate.RespondAsync(firstReview.RequestId, ApprovalDecision.Approved,
+            "go", JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult resume = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        resume.Kind.Should().Be(PlanReviewCompletionKind.SuspendedForNextRound,
+            "the executor reached the [[REPLAN]] step, opened a NEW plan-review row in the " +
+            "same durable table, and the completion service reports the suspension via a " +
+            "SuspendedForNextRound outcome so the endpoint layer can broadcast the next-round id.");
+        resume.NextRequestId.Should().NotBeNullOrWhiteSpace();
+
+        // A second plan-review row now exists for the same plan — that's the
+        // reachable mid-execution revision surface.
+        IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync("user-1");
+        pending.Any(r => r.Context.PlanId == suspend.PlanId
+                      && r.Context.Kind == ApprovalKind.PlanReview
+                      && r.Context.Reasoning.Contains("Mid-execution", StringComparison.Ordinal))
+            .Should().BeTrue("the [[REPLAN]] marker must open a NEW plan-review row.");
+
+        await sp.DisposeAsync();
+    }
+
+    private static string PlannerJsonWithReplan() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""[[REPLAN]] scope too broad"" }
+    ] }";
+
+    // ── PII filtering + audit preservation ──────────────────────────────
+
+    [Fact]
+    public async Task Resumed_final_response_is_filtered_and_recorded_in_audit_log()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch, InMemoryPlanStore plans,
+            SqliteApprovalGate gate, ConcurrentQueue<string> _) =
+            BuildHost(reviewEnabled: true,
+                pii: true,   // Explicitly enable PII redaction on the guardrails config.
+                specialistReply: "call me at 555-123-4567 anytime");
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+
+        ApprovalRequest row = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.PlanId == suspend.PlanId);
+        await gate.RespondAsync(row.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult resume = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        resume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+        resume.Reply.Should().NotContain("555-123-4567",
+            "PII must be redacted from the final reply on the resumed path.");
+        resume.Reply.Should().Contain("REDACTED");
+
+        // Audit log recorded the resumed turn — a plan turn is still an
+        // accountable interaction.
+        IAuditLog audit = sp.GetRequiredService<IAuditLog>();
+        IReadOnlyList<AuditEntry> entries = await audit.QueryAsync(new AuditQuery());
+        entries.Any(e => e.Action.Contains("plan.review.resolve", StringComparison.OrdinalIgnoreCase))
+            .Should().BeTrue("resumed plan turns must land in the audit log.");
 
         await sp.DisposeAsync();
     }
@@ -196,7 +280,9 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
             string? plannerJson = null,
             bool reuseDbPath = false,
             bool reuseCheckpointDir = false,
-            IReadOnlyList<(string Subject, PlanWrite Plan)>? seedPlans = null)
+            IReadOnlyList<(string Subject, PlanWrite Plan)>? seedPlans = null,
+            bool pii = false,
+            string? specialistReply = null)
     {
         var services = new ServiceCollection();
         services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
@@ -208,14 +294,13 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
         services.AddSingleton(gate);
         services.AddSingleton<IApprovalGate>(sp => sp.GetRequiredService<SqliteApprovalGate>());
 
-        services.AddSingleton<
-            Microsoft.Agents.AI.Workflows.Checkpointing.ICheckpointStore<JsonElement>>(_ =>
-                new Microsoft.Agents.AI.Workflows.Checkpointing.FileSystemJsonCheckpointStore(
+        services.AddSingleton<ICheckpointStore<JsonElement>>(_ =>
+                new FileSystemJsonCheckpointStore(
                     new DirectoryInfo(_checkpointDir)));
         services.AddSingleton(sp =>
         {
-            var store = sp.GetRequiredService<
-                Microsoft.Agents.AI.Workflows.Checkpointing.ICheckpointStore<JsonElement>>();
+            ICheckpointStore<JsonElement> store =
+                sp.GetRequiredService<ICheckpointStore<JsonElement>>();
             return Microsoft.Agents.AI.Workflows.CheckpointManager.CreateJson(store, customOptions: null);
         });
         services.AddSingleton<PlanReviewCheckpointService>();
@@ -244,7 +329,8 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
 
         // Specialists
         var invocations = new ConcurrentQueue<string>();
-        ISpecialistAgent scorecard = MakeSpecialist("scorecard", invocations, "score-reply");
+        ISpecialistAgent scorecard = MakeSpecialist("scorecard", invocations,
+            specialistReply ?? "score-reply");
         ISpecialistAgent demand = MakeSpecialist("demand-forecasting", invocations, "demand-reply");
         services.AddSingleton(scorecard);
         services.AddSingleton(demand);
@@ -298,8 +384,8 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
         // tests).
         services.AddSingleton(new GuardrailsConfig
         {
-            PiiDetectionEnabled = false,
-            AutoRedactPii = false,
+            PiiDetectionEnabled = pii,
+            AutoRedactPii = pii,
             ContentSafety = new ContentSafetyConfig { Enabled = false },
         });
         services.AddSingleton<ISuspiciousRequestLog, InMemorySuspiciousRequestLog>();
@@ -380,12 +466,12 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
         private readonly Dictionary<string, Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>> _bySub = new(StringComparer.Ordinal);
         public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default)
         {
-            if (!_bySub.TryGetValue(plan.Subject, out var bucket))
+            if (!_bySub.TryGetValue(plan.Subject, out Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>? bucket))
             {
                 bucket = new(StringComparer.Ordinal);
                 _bySub[plan.Subject] = bucket;
             }
-            bucket[plan.PlanId] = (plan, null, new Dictionary<string, PlanStepUpdate>());
+            bucket[plan.PlanId] = (plan, null, []);
             return Task.CompletedTask;
         }
         public void RestoreCreate(string subject, PlanWrite plan) => CreatePlanAsync(plan).Wait();
@@ -393,8 +479,8 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
             [.. _bySub.SelectMany(kv => kv.Value.Values.Select(v => (kv.Key, v.Create)))];
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default)
         {
-            if (_bySub.TryGetValue(update.Subject, out var bucket)
-                && bucket.TryGetValue(update.PlanId, out var row))
+            if (_bySub.TryGetValue(update.Subject, out Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>? bucket)
+                && bucket.TryGetValue(update.PlanId, out (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps) row))
             {
                 bucket[update.PlanId] = (row.Create, update, row.Steps);
             }
@@ -402,8 +488,8 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
         }
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
         {
-            if (_bySub.TryGetValue(update.Subject, out var bucket)
-                && bucket.TryGetValue(update.PlanId, out var row))
+            if (_bySub.TryGetValue(update.Subject, out Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>? bucket)
+                && bucket.TryGetValue(update.PlanId, out (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps) row))
             {
                 row.Steps[update.StepId] = update;
             }
@@ -413,9 +499,12 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
             => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
         public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default)
         {
-            if (!_bySub.TryGetValue(subject, out var bucket)
-                || !bucket.TryGetValue(planId, out var row))
+            if (!_bySub.TryGetValue(subject, out Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>? bucket)
+                || !bucket.TryGetValue(planId, out (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps) row))
+            {
                 return Task.FromResult<PlanDetailDto?>(null);
+            }
+
             string status = row.Status?.Status ?? row.Create.Status;
             string? failureReason = row.Status?.FailureReason;
             return Task.FromResult<PlanDetailDto?>(new PlanDetailDto(

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
@@ -1,0 +1,500 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Agents.Planning;
+using RetailPulse.Api.Approval;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Guardrails;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Middleware;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Approval;
+using RetailPulse.Contracts.Guardrails;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Persistence;
+using RetailPulse.Contracts.Routing;
+using RetailPulse.Contracts.Tracing;
+using RetailPulse.Tests.Fixtures;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
+
+namespace RetailPulse.Tests.Approval;
+
+/// <summary>
+/// End-to-end tests for the non-blocking suspend/resume path (#94 B1/B2/B3).
+/// Each test drives:
+/// <list type="number">
+///   <item><c>PlanOrchestrator.RunAsync</c> — must return Suspended immediately.</item>
+///   <item>Reviewer records a decision via <c>IApprovalGate.RespondAsync</c>.</item>
+///   <item><c>PlanReviewCompletionService.ResolveAsync</c> — the resume driver.</item>
+/// </list>
+/// Every test uses a real <see cref="SqliteApprovalGate"/> and a real
+/// <see cref="Microsoft.Agents.AI.Workflows.Checkpointing.FileSystemJsonCheckpointStore"/>
+/// so the persistence + framework-checkpoint surfaces are exercised end-to-end.
+/// </summary>
+public sealed class PlanReviewCompletionServiceTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _checkpointDir;
+
+    public PlanReviewCompletionServiceTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"prv_completion_{Guid.NewGuid():N}.db");
+        _checkpointDir = Path.Combine(Path.GetTempPath(), $"prv_completion_ckpt_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_checkpointDir);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { }
+        try { File.Delete(_dbPath + "-wal"); } catch { }
+        try { File.Delete(_dbPath + "-shm"); } catch { }
+        try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
+    }
+
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    // ── B1: durable suspend/resume — including simulated restart ────────
+
+    [Fact]
+    public async Task Suspend_edit_resume_executes_edited_plan_and_persists_final_response()
+    {
+        // ── Suspend ──────────────────────────────────────────────────
+        (ServiceProvider spBoot1, PlanOrchestrator orch1, InMemoryPlanStore plans1,
+            SqliteApprovalGate gate1, ConcurrentQueue<string> invocations1) = BuildHost();
+
+        PlanOrchestrationResult suspend = await orch1.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+        suspend.Status.Should().Be(PlanStatus.AwaitingReview);
+        suspend.ReviewRequestId.Should().NotBeNullOrWhiteSpace();
+
+        // ── Simulated restart: dispose the first host entirely ──────
+        await spBoot1.DisposeAsync();
+
+        // A second host reads the plan/approval/checkpoint stores from the
+        // exact same on-disk locations — proving state is durable.
+        (ServiceProvider spBoot2, _, InMemoryPlanStore plans2,
+            SqliteApprovalGate gate2, ConcurrentQueue<string> invocations2) =
+            BuildHost(reuseDbPath: true, reuseCheckpointDir: true,
+                seedPlans: plans1.Snapshot());
+
+        // ── Reviewer records the edit through the fresh gate ────────
+        ApprovalRequest row = (await gate2.GetPendingAsync("user-1"))
+            .Single(r => r.Context.PlanId == suspend.PlanId);
+        var edited = new List<PlanReviewStepDto>
+        {
+            new() { SpecialistKey = "scorecard", Intent = "scorecard", Action = "EDITED_ACTION" },
+        };
+        var payload = new PlanReviewResponsePayload
+        {
+            Kind = PlanReviewKinds.Edit,
+            EditedSteps = edited,
+        };
+        await gate2.RespondAsync(row.RequestId, ApprovalDecision.Modified,
+            "trim", JsonSerializer.Serialize(payload, _json));
+
+        // ── Resume drives execution ─────────────────────────────────
+        PlanReviewCompletionService completion = spBoot2.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult result = await completion.ResolveAsync(suspend.PlanId, "user-1");
+
+        result.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+        result.Reply.Should().NotBeNullOrWhiteSpace();
+        invocations2.Should().Contain(s => s.Contains("EDITED_ACTION"),
+            "the edited action must be what the specialist sees on the resumed run.");
+
+        PlanDetailDto? plan = await plans2.GetPlanAsync("user-1", suspend.PlanId, default);
+        plan.Should().NotBeNull();
+        plan!.Status.Should().Be(PlanStatus.Completed);
+        plan.FailureReason.Should().StartWith("PlanReviewFinalReply::",
+            "the resumed final reply is persisted onto the plan record so a later GET returns it.");
+
+        await spBoot2.DisposeAsync();
+    }
+
+    // ── B2: clarification round-trip via the executor marker ────────────
+
+    [Fact]
+    public async Task Clarification_marker_suspends_plan_and_resume_delivers_answer_as_step_result()
+    {
+        // Planner emits a [[CLARIFY]] step at index 1 so the executor pauses
+        // between step 0 and step 1. Resume with an answer completes step 2.
+        (ServiceProvider sp, PlanOrchestrator orch, InMemoryPlanStore plans,
+            SqliteApprovalGate gate, ConcurrentQueue<string> invocations) =
+            BuildHost(plannerJson: PlannerJsonWithClarify());
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        // Reviewer approves and we resume through review → hits clarification.
+        ApprovalRequest reviewRow = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.PlanId == suspend.PlanId);
+        var payload = new PlanReviewResponsePayload { Kind = PlanReviewKinds.Approve };
+        await gate.RespondAsync(reviewRow.RequestId, ApprovalDecision.Approved,
+            "go", JsonSerializer.Serialize(payload, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult reviewResume = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        reviewResume.Kind.Should().Be(PlanReviewCompletionKind.SuspendedForClarification,
+            "the executor detected the [[CLARIFY]] marker and paused for reviewer input.");
+
+        // Reviewer answers the clarification.
+        ApprovalRequest clarRow = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.Kind == ApprovalKind.Clarification
+                      && r.Context.PlanId == suspend.PlanId);
+        var answer = new PlanClarificationAnswer { Answer = "REVIEWER_ANSWER" };
+        await gate.RespondAsync(clarRow.RequestId, ApprovalDecision.Approved,
+            "ans", JsonSerializer.Serialize(answer, _json));
+
+        PlanReviewCompletionResult clarResume = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        clarResume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+        clarResume.Reply.Should().Contain("REVIEWER_ANSWER",
+            "the answer flows into the composed final reply.");
+
+        PlanDetailDto? plan = await plans.GetPlanAsync("user-1", suspend.PlanId, default);
+        plan.Should().NotBeNull();
+        plan!.Status.Should().Be(PlanStatus.Completed);
+
+        await sp.DisposeAsync();
+    }
+
+    // ── Preservation: disabled path returns 200-shape immediately ───────
+
+    [Fact]
+    public async Task Disabled_review_returns_terminal_result_and_writes_no_approval_row()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch, InMemoryPlanStore plans,
+            SqliteApprovalGate gate, ConcurrentQueue<string> _) = BuildHost(reviewEnabled: false);
+
+        PlanOrchestrationResult r = await orch.RunAsync(SampleInput(), default);
+        r.IsSuspended.Should().BeFalse();
+        r.Status.Should().Be(PlanStatus.Completed);
+        (await gate.GetPendingAsync("user-1")).Should().BeEmpty();
+        (await gate.GetHistoryAsync(50)).Should().BeEmpty(
+            "disabled review never touches the approval gate.");
+
+        await sp.DisposeAsync();
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────
+
+    private (ServiceProvider Sp, PlanOrchestrator Orchestrator, InMemoryPlanStore PlanStore,
+        SqliteApprovalGate Gate, ConcurrentQueue<string> Invocations)
+        BuildHost(
+            bool reviewEnabled = true,
+            string? plannerJson = null,
+            bool reuseDbPath = false,
+            bool reuseCheckpointDir = false,
+            IReadOnlyList<(string Subject, PlanWrite Plan)>? seedPlans = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton(TimeProvider.System);
+
+        // Approval + checkpoint (durable on disk between "restart" iterations)
+        SqliteApprovalGate gate = new(_dbPath, NullLogger<SqliteApprovalGate>.Instance,
+            TimeSpan.FromMinutes(30), TimeProvider.System);
+        services.AddSingleton(gate);
+        services.AddSingleton<IApprovalGate>(sp => sp.GetRequiredService<SqliteApprovalGate>());
+
+        services.AddSingleton<
+            Microsoft.Agents.AI.Workflows.Checkpointing.ICheckpointStore<JsonElement>>(_ =>
+                new Microsoft.Agents.AI.Workflows.Checkpointing.FileSystemJsonCheckpointStore(
+                    new DirectoryInfo(_checkpointDir)));
+        services.AddSingleton(sp =>
+        {
+            var store = sp.GetRequiredService<
+                Microsoft.Agents.AI.Workflows.Checkpointing.ICheckpointStore<JsonElement>>();
+            return Microsoft.Agents.AI.Workflows.CheckpointManager.CreateJson(store, customOptions: null);
+        });
+        services.AddSingleton<PlanReviewCheckpointService>();
+
+        var options = new PlanReviewOptions
+        {
+            Enabled = reviewEnabled,
+            DefaultReviewTimeout = TimeSpan.FromSeconds(30),
+            ClarificationTimeout = TimeSpan.FromSeconds(30),
+            MaxReplanRounds = 1,
+        };
+        services.AddSingleton(Options.Create(options));
+
+        services.AddSingleton<PlanClarifier>();
+        services.AddSingleton<IPlanClarifier>(sp => sp.GetRequiredService<PlanClarifier>());
+        services.AddSingleton<PlanReviewCoordinator>();
+
+        // Plan store
+        var plans = new InMemoryPlanStore();
+        if (seedPlans is not null)
+        {
+            foreach ((string sub, PlanWrite pw) in seedPlans)
+                plans.RestoreCreate(sub, pw);
+        }
+        services.AddSingleton<IPlanStore>(plans);
+
+        // Specialists
+        var invocations = new ConcurrentQueue<string>();
+        ISpecialistAgent scorecard = MakeSpecialist("scorecard", invocations, "score-reply");
+        ISpecialistAgent demand = MakeSpecialist("demand-forecasting", invocations, "demand-reply");
+        services.AddSingleton(scorecard);
+        services.AddSingleton(demand);
+
+        // Planner (uses the AgentTestFixtures mock chat client)
+        var persistOpts = new PlanPersistenceOptions();
+        services.AddSingleton(persistOpts);
+        services.AddSingleton(new Api.Models.AgentDefinition
+        {
+            Key = "planner",
+            Name = "Plan-First Orchestrator",
+            Model = "gpt-test",
+            SystemPrompt = "You are the planner.",
+            Temperature = 0.1,
+        });
+        services.AddSingleton(sp => new PlanBuilder(
+            AgentTestFixtures.CreateMockChatClient(plannerJson ?? DefaultPlannerJson()),
+            sp.GetRequiredService<Api.Models.AgentDefinition>(),
+            persistOpts,
+            NullLogger<PlanBuilder>.Instance));
+
+        // Cost + trace + executor
+        services.AddSingleton<ICostTracker>(new NoOpCostTracker());
+        services.AddSingleton<ITraceCollector>(new NoOpTraceCollector());
+        services.AddSingleton(sp => new PlanExecutor(
+            sp.GetRequiredService<IPlanStore>(),
+            sp.GetRequiredService<ICostTracker>(),
+            sp.GetRequiredService<ITraceCollector>(),
+            sp.GetRequiredService<PlanPersistenceOptions>(),
+            NullLogger<PlanExecutor>.Instance,
+            sp.GetService<PlanClarifier>(),
+            sp.GetService<PlanReviewCoordinator>()));
+
+        services.AddSingleton(sp => new PlanOrchestrator(
+            sp.GetRequiredService<PlanBuilder>(),
+            sp.GetRequiredService<PlanExecutor>(),
+            sp.GetRequiredService<IPlanStore>(),
+            sp.GetRequiredService<ICostTracker>(),
+            persistOpts,
+            NullLogger<PlanOrchestrator>.Instance,
+            sp.GetService<PlanReviewCoordinator>(),
+            Options.Create(options)));
+
+        // Completion service dependencies
+        //
+        // GuardrailsMiddleware needs a config + a suspicious-request log. We
+        // construct a config where both PII redaction and content-safety
+        // output checks are OFF so FilterOutputAsync returns the reply
+        // unchanged — the test asserts the flowed-through response text, not
+        // the filter's own behavior (that is covered by GuardrailsMiddleware
+        // tests).
+        services.AddSingleton(new GuardrailsConfig
+        {
+            PiiDetectionEnabled = false,
+            AutoRedactPii = false,
+            ContentSafety = new ContentSafetyConfig { Enabled = false },
+        });
+        services.AddSingleton<ISuspiciousRequestLog, InMemorySuspiciousRequestLog>();
+        services.AddSingleton<ITenantProvider>(new StubTenantProvider());
+        services.AddSingleton<GuardrailsMiddleware>();
+        services.AddSingleton<IAuditLog, InMemoryAuditLog>();
+        services.AddSingleton(_ => new ConversationExporter(
+            Options.Create(new ObservabilityOptions())));
+
+        // SignalR hub stub — return null; the completion service tolerates it.
+        services.AddSingleton<IHubContext<TelemetryHub>>(new NullHub());
+
+        services.AddSingleton<PlanReviewCompletionService>();
+
+        ServiceProvider sp = services.BuildServiceProvider();
+        return (sp,
+            sp.GetRequiredService<PlanOrchestrator>(),
+            plans,
+            sp.GetRequiredService<SqliteApprovalGate>(),
+            invocations);
+    }
+
+    private static PlanOrchestrationInput SampleInput()
+    {
+        ISpecialistAgent scorecard = MakeSpecialist("scorecard", new(), "");
+        ISpecialistAgent demand = MakeSpecialist("demand-forecasting", new(), "");
+        return new PlanOrchestrationInput
+        {
+            Request = new ChatRequest("multi", SessionId: "s"),
+            Subject = "user-1",
+            PrincipalKey = "user-1",
+            TenantId = "Contoso",
+            Roster = [scorecard, demand],
+            SpecialistLookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["scorecard"] = scorecard,
+                ["demand-forecasting"] = demand,
+            },
+            DetectedIntents = ["scorecard", "demand"],
+            TraceId = "t",
+        };
+    }
+
+    private static string DefaultPlannerJson() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""ORIGINAL_ACTION"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""ORIGINAL_DEMAND_ACTION"" }
+    ] }";
+
+    private static string PlannerJsonWithClarify() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""step-0"" },
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""[[CLARIFY]] Which region?"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""step-2"" }
+    ] }";
+
+    private static ISpecialistAgent MakeSpecialist(
+        string key, ConcurrentQueue<string> invocations, string reply)
+    {
+        var m = new Mock<ISpecialistAgent>();
+        m.SetupGet(a => a.Key).Returns(key);
+        m.SetupGet(a => a.DisplayName).Returns(key);
+        m.SetupGet(a => a.Model).Returns("gpt-test");
+        m.SetupGet(a => a.SupportedIntents).Returns([key]);
+        m.Setup(a => a.HandleAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()))
+            .Returns((ChatRequest req, CancellationToken _) =>
+            {
+                invocations.Enqueue(req.Message);
+                return Task.FromResult(new ChatResponse(
+                    string.IsNullOrEmpty(reply) ? $"{key}-reply" : reply,
+                    req.SessionId ?? "s", [], null, 10, new TokenUsage(1, 1, 2)));
+            });
+        return m.Object;
+    }
+
+    // ── Support types (no-op / in-memory doubles) ────────────────────────
+
+    internal sealed class InMemoryPlanStore : IPlanStore
+    {
+        private readonly Dictionary<string, Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>> _bySub = new(StringComparer.Ordinal);
+        public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default)
+        {
+            if (!_bySub.TryGetValue(plan.Subject, out var bucket))
+            {
+                bucket = new(StringComparer.Ordinal);
+                _bySub[plan.Subject] = bucket;
+            }
+            bucket[plan.PlanId] = (plan, null, new Dictionary<string, PlanStepUpdate>());
+            return Task.CompletedTask;
+        }
+        public void RestoreCreate(string subject, PlanWrite plan) => CreatePlanAsync(plan).Wait();
+        public IReadOnlyList<(string Subject, PlanWrite Plan)> Snapshot() =>
+            [.. _bySub.SelectMany(kv => kv.Value.Values.Select(v => (kv.Key, v.Create)))];
+        public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default)
+        {
+            if (_bySub.TryGetValue(update.Subject, out var bucket)
+                && bucket.TryGetValue(update.PlanId, out var row))
+            {
+                bucket[update.PlanId] = (row.Create, update, row.Steps);
+            }
+            return Task.CompletedTask;
+        }
+        public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
+        {
+            if (_bySub.TryGetValue(update.Subject, out var bucket)
+                && bucket.TryGetValue(update.PlanId, out var row))
+            {
+                row.Steps[update.StepId] = update;
+            }
+            return Task.CompletedTask;
+        }
+        public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
+        public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default)
+        {
+            if (!_bySub.TryGetValue(subject, out var bucket)
+                || !bucket.TryGetValue(planId, out var row))
+                return Task.FromResult<PlanDetailDto?>(null);
+            string status = row.Status?.Status ?? row.Create.Status;
+            string? failureReason = row.Status?.FailureReason;
+            return Task.FromResult<PlanDetailDto?>(new PlanDetailDto(
+                PlanId: row.Create.PlanId,
+                SessionId: row.Create.SessionId,
+                TenantId: row.Create.TenantId,
+                Request: row.Create.Request,
+                Status: status,
+                DetectedIntents: row.Create.DetectedIntents,
+                FailureReason: failureReason,
+                TotalInputTokens: null, TotalOutputTokens: null, TotalTokens: null,
+                TotalDurationMs: null,
+                CreatedAt: row.Create.CreatedAt,
+                UpdatedAt: row.Status?.UpdatedAt ?? row.Create.CreatedAt,
+                Steps: []));
+        }
+        public Task<bool> DeletePlanAsync(string subject, string planId, CancellationToken ct = default) => Task.FromResult(true);
+        public Task<PlanCleanupResult> PurgeExpiredAsync(DateTimeOffset olderThan, CancellationToken ct = default)
+            => Task.FromResult(new PlanCleanupResult(0, 0));
+    }
+
+    private sealed class NoOpTraceCollector : ITraceCollector
+    {
+        public void CaptureSpan(TraceSpan span) { }
+        public IReadOnlyList<TraceSpan>? GetSpans(string traceId) => null;
+        public TraceSummary? GetSummary(string traceId) => null;
+        public IReadOnlyList<TraceSummary> GetRecentTraces(int count = 20) => [];
+        public StructuredTraceSummary? GetStructuredSummary(string traceId) => null;
+        public IReadOnlyList<ToolUsageStat> GetToolStats(DateTimeOffset since, int top = 10) => [];
+        public int TraceCount => 0;
+        public int Capacity => 100;
+    }
+
+    private sealed class NoOpCostTracker : ICostTracker
+    {
+        public Task TrackUsageAsync(UsageEvent usage, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<CostSummary> GetSummaryAsync(CostPeriod period, CancellationToken ct = default)
+            => Task.FromResult(new CostSummary(0, 0, 0, period));
+        public Task<IReadOnlyList<AgentCostBreakdown>> GetByAgentAsync(CostPeriod period, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<AgentCostBreakdown>>([]);
+        public Task<CostTrend> GetTrendAsync(int days = 7, CancellationToken ct = default)
+            => Task.FromResult(new CostTrend([]));
+    }
+
+    private sealed class StubTenantProvider : ITenantProvider
+    {
+        public TenantConfiguration GetTenant() => new()
+        {
+            Company = "Contoso",
+            Industry = "test",
+        };
+    }
+
+    private sealed class NullHub : IHubContext<TelemetryHub>
+    {
+        public IHubClients Clients { get; } = new NullClients();
+        public IGroupManager Groups { get; } = new NullGroupManager();
+
+        private sealed class NullClients : IHubClients
+        {
+            public IClientProxy All => NullProxy.Instance;
+            public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) => NullProxy.Instance;
+            public IClientProxy Client(string connectionId) => NullProxy.Instance;
+            public IClientProxy Clients(IReadOnlyList<string> connectionIds) => NullProxy.Instance;
+            public IClientProxy Group(string groupName) => NullProxy.Instance;
+            public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) => NullProxy.Instance;
+            public IClientProxy Groups(IReadOnlyList<string> groupNames) => NullProxy.Instance;
+            public IClientProxy User(string userId) => NullProxy.Instance;
+            public IClientProxy Users(IReadOnlyList<string> userIds) => NullProxy.Instance;
+        }
+        private sealed class NullGroupManager : IGroupManager
+        {
+            public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+        private sealed class NullProxy : IClientProxy
+        {
+            public static readonly NullProxy Instance = new();
+            public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
@@ -60,10 +60,13 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
         new(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(),
             defaultTimeout ?? TimeSpan.FromSeconds(30), TimeProvider.System);
 
-    private CheckpointManager CreateCheckpointManager() =>
-        CheckpointManager.CreateJson(
-            new FileSystemJsonCheckpointStore(new DirectoryInfo(_checkpointDir)),
-            customOptions: null);
+    private PlanReviewCheckpointService CreateCheckpointService()
+    {
+        FileSystemJsonCheckpointStore store =
+            new(new DirectoryInfo(_checkpointDir));
+        CheckpointManager manager = CheckpointManager.CreateJson(store, customOptions: null);
+        return new PlanReviewCheckpointService(store, manager, Mock.Of<ILogger<PlanReviewCheckpointService>>());
+    }
 
     private PlanReviewCoordinator CreateCoordinator(
         SqliteApprovalGate gate,
@@ -73,7 +76,7 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
         new(
             gate,
             Options.Create(options),
-            CreateCheckpointManager(),
+            CreateCheckpointService(),
             Mock.Of<ILogger<PlanReviewCoordinator>>(),
             replanner: replanner,
             timeProvider: clock);

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
@@ -64,7 +64,7 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
     {
         FileSystemJsonCheckpointStore store =
             new(new DirectoryInfo(_checkpointDir));
-        CheckpointManager manager = CheckpointManager.CreateJson(store, customOptions: null);
+        var manager = CheckpointManager.CreateJson(store, customOptions: null);
         return new PlanReviewCheckpointService(store, manager, Mock.Of<ILogger<PlanReviewCheckpointService>>());
     }
 

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
@@ -1,0 +1,550 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Approval;
+using RetailPulse.Contracts.Approval;
+using RetailPulse.Contracts.Routing;
+
+namespace RetailPulse.Tests.Approval;
+
+/// <summary>
+/// Coordinator-level tests for the plan review gate (#94). Uses a real
+/// <see cref="SqliteApprovalGate"/> against a temp SQLite file so the
+/// persistence surface (Kind/PlanId/RoundNumber/Payload/ResponsePayload) is
+/// exercised end-to-end. Every timeout scenario uses an injected
+/// <see cref="TimeProvider"/> so the wall clock is never touched.
+/// </summary>
+public sealed class PlanReviewCoordinatorTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _checkpointDir;
+
+    public PlanReviewCoordinatorTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"plan_review_{Guid.NewGuid():N}.db");
+        _checkpointDir = Path.Combine(Path.GetTempPath(), $"plan_review_ckpt_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_checkpointDir);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { }
+        try { File.Delete(_dbPath + "-wal"); } catch { }
+        try { File.Delete(_dbPath + "-shm"); } catch { }
+        try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
+    }
+
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private SqliteApprovalGate CreateGate(TimeProvider clock, TimeSpan? defaultTimeout = null) =>
+        new(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(),
+            defaultTimeout ?? TimeSpan.FromMinutes(30), clock);
+
+    /// <summary>
+    /// Real-clock gate for the non-timeout tests. The FakeClock's timer plumbing
+    /// works when explicitly Advanced (see the timeout test), but the gate's
+    /// exponential-backoff poll uses Task.Delay(..., TimeProvider) which never
+    /// resumes on its own without an Advance — so tests that only care about
+    /// the decision path use System time and rely on the SQLite gate's fast
+    /// initial backoff (~250 ms) to observe the human response.
+    /// </summary>
+    private SqliteApprovalGate CreateSystemGate(TimeSpan? defaultTimeout = null) =>
+        new(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(),
+            defaultTimeout ?? TimeSpan.FromSeconds(30), TimeProvider.System);
+
+    private CheckpointManager CreateCheckpointManager() =>
+        CheckpointManager.CreateJson(
+            new FileSystemJsonCheckpointStore(new DirectoryInfo(_checkpointDir)),
+            customOptions: null);
+
+    private PlanReviewCoordinator CreateCoordinator(
+        SqliteApprovalGate gate,
+        PlanReviewOptions options,
+        TimeProvider clock,
+        IPlanReviewReplanner? replanner = null) =>
+        new(
+            gate,
+            Options.Create(options),
+            CreateCheckpointManager(),
+            Mock.Of<ILogger<PlanReviewCoordinator>>(),
+            replanner: replanner,
+            timeProvider: clock);
+
+    private static IReadOnlyList<PlanReviewStepDto> SampleSteps() =>
+    [
+        new() { SpecialistKey = "scorecard", Intent = "scorecard", Action = "Portfolio summary." },
+        new() { SpecialistKey = "demand-forecasting", Intent = "demand", Action = "Forecast Q4." },
+    ];
+
+    private static PlanReviewCoordinationInput SampleInput() => new()
+    {
+        PlanId = Guid.NewGuid().ToString("N"),
+        Subject = "user-1",
+        Request = "Compare Q4 lift vs plan.",
+        InitialSteps = SampleSteps(),
+        SpecialistKeys = ["scorecard", "demand-forecasting"],
+        DetectedIntents = ["scorecard", "demand-forecasting"],
+    };
+
+    // ── Approve path ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Approve_returns_original_steps_and_persists_approve_row()
+    {
+        SqliteApprovalGate gate = CreateSystemGate();
+        var options = new PlanReviewOptions { DefaultReviewTimeout = TimeSpan.FromSeconds(30), MaxReplanRounds = 0 };
+        PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System);
+
+        PlanReviewCoordinationInput input = SampleInput();
+
+        // Human decision arrives on a background waiter as soon as the row exists.
+        Task<PlanReviewOutcome> outcomeTask = coord.CoordinateAsync(input, CancellationToken.None);
+
+        ApprovalRequest row = await WaitForPending(gate, input.Subject);
+        row.Context.Kind.Should().Be(ApprovalKind.PlanReview);
+        row.Context.PlanId.Should().Be(input.PlanId);
+        row.Context.RoundNumber.Should().Be(0);
+        row.Context.Payload.Should().NotBeNullOrWhiteSpace();
+
+        var payload = new PlanReviewResponsePayload { Kind = PlanReviewKinds.Approve };
+        await gate.RespondAsync(
+            row.RequestId,
+            ApprovalDecision.Approved,
+            comment: "LGTM",
+            responsePayload: JsonSerializer.Serialize(payload, _json));
+
+        PlanReviewOutcome outcome = await outcomeTask;
+
+        outcome.IsApproved.Should().BeTrue();
+        outcome.FinalSteps.Should().BeEquivalentTo(input.InitialSteps);
+        outcome.TerminalReason.Should().Be(PlanReviewTerminalReason.ReviewerApproved);
+        outcome.FinalRound.Should().Be(0);
+
+        ApprovalRequest stored = (await gate.GetHistoryAsync(50)).Single();
+        stored.Decision.Should().Be(ApprovalDecision.Approved);
+        stored.Context.Kind.Should().Be(ApprovalKind.PlanReview);
+    }
+
+    // ── Edit path — edited plan is what actually executes ────────────────
+
+    [Fact]
+    public async Task Edit_returns_edited_steps_and_persists_modified_row()
+    {
+        SqliteApprovalGate gate = CreateSystemGate();
+        var options = new PlanReviewOptions();
+        PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System);
+
+        PlanReviewCoordinationInput input = SampleInput();
+        Task<PlanReviewOutcome> outcomeTask = coord.CoordinateAsync(input, CancellationToken.None);
+        ApprovalRequest row = await WaitForPending(gate, input.Subject);
+
+        var edited = new List<PlanReviewStepDto>
+        {
+            new() { SpecialistKey = "scorecard", Intent = "scorecard", Action = "Portfolio summary (limit to top 3)." },
+        };
+        var payload = new PlanReviewResponsePayload
+        {
+            Kind = PlanReviewKinds.Edit,
+            EditedSteps = edited,
+        };
+        await gate.RespondAsync(
+            row.RequestId, ApprovalDecision.Modified, "trimmed",
+            responsePayload: JsonSerializer.Serialize(payload, _json));
+
+        PlanReviewOutcome outcome = await outcomeTask;
+        outcome.IsApproved.Should().BeTrue();
+        outcome.FinalSteps.Should().HaveCount(1);
+        outcome.FinalSteps[0].Action.Should().Contain("limit to top 3");
+        outcome.TerminalReason.Should().Be(PlanReviewTerminalReason.ReviewerEdited);
+    }
+
+    // ── Edit validation ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Edit_with_unknown_specialist_terminates_with_EditInvalid()
+    {
+        SqliteApprovalGate gate = CreateSystemGate();
+        var options = new PlanReviewOptions();
+        PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System);
+
+        PlanReviewCoordinationInput input = SampleInput();
+        Task<PlanReviewOutcome> outcomeTask = coord.CoordinateAsync(input, CancellationToken.None);
+        ApprovalRequest row = await WaitForPending(gate, input.Subject);
+
+        var edited = new List<PlanReviewStepDto>
+        {
+            new() { SpecialistKey = "not-a-real-agent", Intent = "x", Action = "x" },
+        };
+        var payload = new PlanReviewResponsePayload { Kind = PlanReviewKinds.Edit, EditedSteps = edited };
+        await gate.RespondAsync(
+            row.RequestId, ApprovalDecision.Modified, "typo",
+            responsePayload: JsonSerializer.Serialize(payload, _json));
+
+        PlanReviewOutcome outcome = await outcomeTask;
+        outcome.IsApproved.Should().BeFalse();
+        outcome.TerminalReason.Should().Be(PlanReviewTerminalReason.EditInvalid);
+    }
+
+    [Fact]
+    public async Task Edit_to_empty_terminates_with_EditedToEmpty()
+    {
+        SqliteApprovalGate gate = CreateSystemGate();
+        var options = new PlanReviewOptions();
+        PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System);
+
+        PlanReviewCoordinationInput input = SampleInput();
+        Task<PlanReviewOutcome> outcomeTask = coord.CoordinateAsync(input, CancellationToken.None);
+        ApprovalRequest row = await WaitForPending(gate, input.Subject);
+
+        var payload = new PlanReviewResponsePayload
+        {
+            Kind = PlanReviewKinds.Edit,
+            EditedSteps = [],
+        };
+        await gate.RespondAsync(
+            row.RequestId, ApprovalDecision.Modified, "drop",
+            responsePayload: JsonSerializer.Serialize(payload, _json));
+
+        PlanReviewOutcome outcome = await outcomeTask;
+        outcome.TerminalReason.Should().Be(PlanReviewTerminalReason.EditedToEmpty);
+    }
+
+    // ── Replan bound ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Replan_bound_terminates_with_ReplanExhausted_when_cap_hit()
+    {
+        // MaxReplanRounds = 1 → allow round 0 + one replan (round 1). Rejecting
+        // round 1 exhausts the cap and returns ReplanExhausted.
+        SqliteApprovalGate gate = CreateSystemGate();
+        var options = new PlanReviewOptions { MaxReplanRounds = 1 };
+
+        var replanner = new StubReplanner(SampleSteps());
+        PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System, replanner);
+
+        PlanReviewCoordinationInput input = SampleInput() with { Roster = FakeRoster() };
+
+        Task<PlanReviewOutcome> outcomeTask = coord.CoordinateAsync(input, CancellationToken.None);
+
+        // Round 0: reject with feedback → coordinator replans → round 1.
+        ApprovalRequest r0 = await WaitForPendingRound(gate, input.Subject, expectedRound: 0);
+        await Reject(gate, r0.RequestId, "narrower scope please");
+
+        // Round 1: reject again → cap exhausted.
+        ApprovalRequest r1 = await WaitForPendingRound(gate, input.Subject, expectedRound: 1);
+        await Reject(gate, r1.RequestId, "still too broad");
+
+        PlanReviewOutcome outcome = await outcomeTask;
+        outcome.IsApproved.Should().BeFalse();
+        outcome.TerminalReason.Should().Be(PlanReviewTerminalReason.ReplanExhausted);
+        outcome.Rounds.Should().HaveCount(2, "one row per round including the final rejected one");
+
+        replanner.Calls.Should().Be(1, "exactly one replan invocation between rounds 0 and 1.");
+
+        // Every row is a plan_review row.
+        (await gate.GetHistoryAsync(50)).All(r => r.Context.Kind == ApprovalKind.PlanReview).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Reject_then_approve_returns_revised_steps()
+    {
+        SqliteApprovalGate gate = CreateSystemGate();
+        var options = new PlanReviewOptions { MaxReplanRounds = 2 };
+
+        var revisedSteps = new List<PlanReviewStepDto>
+        {
+            new() { SpecialistKey = "scorecard", Intent = "scorecard", Action = "Narrower portfolio summary." },
+        };
+        var replanner = new StubReplanner(revisedSteps);
+        PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System, replanner);
+
+        PlanReviewCoordinationInput input = SampleInput() with { Roster = FakeRoster() };
+        Task<PlanReviewOutcome> outcomeTask = coord.CoordinateAsync(input, CancellationToken.None);
+
+        ApprovalRequest r0 = await WaitForPendingRound(gate, input.Subject, expectedRound: 0);
+        await Reject(gate, r0.RequestId, "narrow it down");
+
+        ApprovalRequest r1 = await WaitForPendingRound(gate, input.Subject, expectedRound: 1);
+        await Approve(gate, r1.RequestId);
+
+        PlanReviewOutcome outcome = await outcomeTask;
+        outcome.IsApproved.Should().BeTrue();
+        outcome.FinalRound.Should().Be(1, "revised plan approved in round 1.");
+        outcome.FinalSteps.Should().BeEquivalentTo(revisedSteps);
+    }
+
+    // ── Timeout with injected clock ─────────────────────────────────────
+
+    [Fact]
+    public async Task Timeout_advances_deterministically_via_injected_clock()
+    {
+        var clock = new ApprovalLifecycleTests.FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
+        SqliteApprovalGate gate = CreateGate(clock, defaultTimeout: TimeSpan.FromMinutes(30));
+        var options = new PlanReviewOptions { DefaultReviewTimeout = TimeSpan.FromMinutes(5) };
+        PlanReviewCoordinator coord = CreateCoordinator(gate, options, clock);
+
+        PlanReviewCoordinationInput input = SampleInput();
+        Task<PlanReviewOutcome> outcomeTask = coord.CoordinateAsync(input, CancellationToken.None);
+        _ = await WaitForPending(gate, input.Subject);
+
+        // Advance past the review timeout — the coordinator's WaitForApprovalAsync
+        // must see the deadline cross and transition the row to TimedOut.
+        for (int i = 0; i < 20; i++)
+        {
+            clock.Advance(TimeSpan.FromMinutes(1));
+            await Task.Yield();
+        }
+
+        PlanReviewOutcome outcome = await outcomeTask;
+        outcome.IsApproved.Should().BeFalse();
+        outcome.TerminalReason.Should().Be(PlanReviewTerminalReason.ReviewTimedOut);
+    }
+
+    // ── Restart during review ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Restart_during_review_row_survives_and_resume_strategy_adopts_it()
+    {
+        // First "process" creates the row and hangs.
+        string requestId;
+        {
+            SqliteApprovalGate firstGate = CreateSystemGate();
+            var options = new PlanReviewOptions { DefaultReviewTimeout = TimeSpan.FromMinutes(30) };
+            PlanReviewCoordinator coord = CreateCoordinator(firstGate, options, TimeProvider.System);
+
+            PlanReviewCoordinationInput input = SampleInput();
+            var coordTask = coord.CoordinateAsync(input, CancellationToken.None);
+            ApprovalRequest row = await WaitForPending(firstGate, input.Subject);
+            requestId = row.RequestId;
+
+            // Simulate crash: abandon the coordinator waiter.
+            _ = coordTask; // no observation
+        }
+
+        // New "process": a fresh gate + reconciliation with the plan-aware strategy
+        // must ADOPT (Resume) the plan_review row, not orphan it.
+        SqliteApprovalGate secondGate = CreateSystemGate();
+        int terminated = await secondGate.ReconcilePendingAsync(new PlanReviewResumeStrategy());
+
+        terminated.Should().Be(0, "plan_review rows adopt across restart; they never orphan.");
+        ApprovalResult result = await secondGate.GetResultAsync(requestId);
+        result.Decision.Should().Be(ApprovalDecision.Pending, "row is adopted, not terminated.");
+    }
+
+    [Fact]
+    public async Task Restart_tool_row_still_orphans_under_PlanReviewResumeStrategy()
+    {
+        SqliteApprovalGate firstGate = CreateSystemGate();
+        var toolCtx = new ApprovalContext(
+            AgentId: "demand-forecasting",
+            UserId: "user-1",
+            Action: "Increase prod 20%",
+            Impact: "low",
+            Urgency: "medium",
+            Reasoning: "seasonal shift");
+        ApprovalRequest req = await firstGate.RequestApprovalAsync(toolCtx);
+
+        SqliteApprovalGate secondGate = CreateSystemGate();
+        int terminated = await secondGate.ReconcilePendingAsync(new PlanReviewResumeStrategy());
+
+        terminated.Should().Be(1, "tool rows retain the #91 orphan-on-restart semantics.");
+        ApprovalResult result = await secondGate.GetResultAsync(req.RequestId);
+        result.Decision.Should().Be(ApprovalDecision.Orphaned);
+    }
+
+    // ── Cross-subject denial (at the persistence layer) ─────────────────
+
+    [Fact]
+    public async Task Cross_subject_pending_query_does_not_expose_another_subject_row()
+    {
+        SqliteApprovalGate gate = CreateSystemGate();
+        var options = new PlanReviewOptions();
+        PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System);
+
+        PlanReviewCoordinationInput input = SampleInput() with { Subject = "alice" };
+        _ = coord.CoordinateAsync(input, CancellationToken.None);
+        _ = await WaitForPending(gate, input.Subject);
+
+        (await gate.GetPendingAsync("bob")).Should().BeEmpty(
+            "GetPendingAsync is subject-scoped at SQL — bob must never see alice's plan review.");
+    }
+
+    // ── Audit trail across paths ────────────────────────────────────────
+
+    [Fact]
+    public async Task All_decisions_written_to_shared_history_audit_trail()
+    {
+        SqliteApprovalGate gate = CreateSystemGate();
+        var options = new PlanReviewOptions();
+        PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System);
+
+        // Approve → history includes plan_review + Approved
+        PlanReviewCoordinationInput a = SampleInput();
+        var aTask = coord.CoordinateAsync(a, CancellationToken.None);
+        ApprovalRequest aRow = await WaitForPending(gate, a.Subject);
+        await Approve(gate, aRow.RequestId);
+        _ = await aTask;
+
+        // Also record a plain tool approval for parity — history must show both.
+        var toolCtx = new ApprovalContext("tool-agent", "user-1", "act", "impact", "low", "why");
+        ApprovalRequest tRow = await gate.RequestApprovalAsync(toolCtx);
+        await gate.RespondAsync(tRow.RequestId, ApprovalDecision.Approved, "OK");
+
+        IReadOnlyList<ApprovalRequest> history = await gate.GetHistoryAsync(50);
+        history.Should().HaveCount(2);
+        history.Any(r => r.Context.Kind == ApprovalKind.PlanReview).Should().BeTrue();
+        history.Any(r => r.Context.Kind == ApprovalKind.Tool).Should().BeTrue();
+    }
+
+    // ── ApprovalTool unchanged ───────────────────────────────────────────
+
+    [Fact]
+    public async Task ApprovalTool_flow_default_kind_and_history_shape_unchanged()
+    {
+        // Default construction of ApprovalContext (as used by ApprovalTool) must
+        // land Kind = "tool" without any explicit setter — this proves #94 is
+        // strictly additive for the pre-existing single-tool path.
+        SqliteApprovalGate gate = CreateSystemGate();
+
+        var ctx = new ApprovalContext(
+            AgentId: "agent",
+            UserId: "user-1",
+            Action: "act",
+            Impact: "impact",
+            Urgency: "low",
+            Reasoning: "why");
+        ApprovalRequest req = await gate.RequestApprovalAsync(ctx);
+
+        req.Context.Kind.Should().Be(ApprovalKind.Tool);
+        req.Context.PlanId.Should().BeNull();
+        req.Context.RoundNumber.Should().Be(0);
+        req.Context.Payload.Should().BeNull();
+
+        await gate.RespondAsync(req.RequestId, ApprovalDecision.Approved, "ok");
+        ApprovalResult result = await gate.GetResultAsync(req.RequestId);
+        result.Decision.Should().Be(ApprovalDecision.Approved);
+        result.ResponsePayload.Should().BeNull("tool decisions carry no plan-shape payload.");
+    }
+
+    // ── ValidateEditedSteps unit checks ─────────────────────────────────
+
+    [Theory]
+    [InlineData("", "act", PlanReviewTerminalReason.EditInvalid)]
+    [InlineData("scorecard", "", PlanReviewTerminalReason.EditInvalid)]
+    [InlineData("unknown", "act", PlanReviewTerminalReason.EditInvalid)]
+    public void ValidateEditedSteps_rejects_bad_shapes(string key, string action, string expected)
+    {
+        var edited = new List<PlanReviewStepDto>
+        {
+            new() { SpecialistKey = key, Intent = "x", Action = action },
+        };
+        string? reason = PlanReviewCoordinator.ValidateEditedSteps(edited, ["scorecard"]);
+        reason.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ValidateEditedSteps_empty_returns_EditedToEmpty()
+    {
+        string? reason = PlanReviewCoordinator.ValidateEditedSteps([], ["scorecard"]);
+        reason.Should().Be(PlanReviewTerminalReason.EditedToEmpty);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private static async Task<ApprovalRequest> WaitForPending(SqliteApprovalGate gate, string subject)
+    {
+        for (int i = 0; i < 400; i++)
+        {
+            IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync(subject);
+            if (pending.Count > 0) return pending[^1];
+            await Task.Delay(10);
+        }
+        throw new InvalidOperationException("Timed out waiting for pending approval row.");
+    }
+
+    private static async Task<ApprovalRequest> WaitForPendingRound(
+        SqliteApprovalGate gate, string subject, int expectedRound)
+    {
+        for (int i = 0; i < 400; i++)
+        {
+            IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync(subject);
+            ApprovalRequest? hit = pending.FirstOrDefault(r => r.Context.RoundNumber == expectedRound);
+            if (hit is not null) return hit;
+            await Task.Delay(10);
+        }
+        throw new InvalidOperationException($"Timed out waiting for round {expectedRound}.");
+    }
+
+    private static Task Approve(SqliteApprovalGate gate, string requestId)
+    {
+        var payload = new PlanReviewResponsePayload { Kind = PlanReviewKinds.Approve };
+        return gate.RespondAsync(requestId, ApprovalDecision.Approved, "ok",
+            responsePayload: JsonSerializer.Serialize(payload, _json));
+    }
+
+    private static Task Reject(SqliteApprovalGate gate, string requestId, string feedback)
+    {
+        var payload = new PlanReviewResponsePayload { Kind = PlanReviewKinds.Reject, Feedback = feedback };
+        return gate.RespondAsync(requestId, ApprovalDecision.Rejected, feedback,
+            responsePayload: JsonSerializer.Serialize(payload, _json));
+    }
+
+    private static IReadOnlyList<ISpecialistAgent> FakeRoster()
+    {
+        var scorecard = new Mock<ISpecialistAgent>();
+        scorecard.SetupGet(a => a.Key).Returns("scorecard");
+        scorecard.SetupGet(a => a.DisplayName).Returns("Scorecard");
+        scorecard.SetupGet(a => a.SupportedIntents).Returns(["scorecard"]);
+
+        var demand = new Mock<ISpecialistAgent>();
+        demand.SetupGet(a => a.Key).Returns("demand-forecasting");
+        demand.SetupGet(a => a.DisplayName).Returns("Demand");
+        demand.SetupGet(a => a.SupportedIntents).Returns(["demand"]);
+
+        return [scorecard.Object, demand.Object];
+    }
+
+    /// <summary>
+    /// Fixed replanner used by the reject/approve-with-revised-plan and
+    /// replan-cap tests. Records the number of replan invocations so the loop
+    /// bound can be asserted directly.
+    /// </summary>
+    private sealed class StubReplanner : IPlanReviewReplanner
+    {
+        private readonly IReadOnlyList<PlanReviewStepDto> _steps;
+        public int Calls { get; private set; }
+        public StubReplanner(IReadOnlyList<PlanReviewStepDto> steps) => _steps = steps;
+        public Task<Api.Agents.Planning.PlanBuildResult> ReplanAsync(
+            string revisedRequest,
+            IReadOnlyList<ISpecialistAgent> roster,
+            IReadOnlyList<string> detectedIntents,
+            CancellationToken ct)
+        {
+            Calls++;
+            var steps = _steps
+                .Select(s => new Api.Agents.Planning.PlannerStep
+                {
+                    SpecialistKey = s.SpecialistKey,
+                    Intent = s.Intent,
+                    Action = s.Action,
+                })
+                .ToList();
+            return Task.FromResult(new Api.Agents.Planning.PlanBuildResult
+            {
+                Steps = steps,
+                InputTokens = 1,
+                OutputTokens = 1,
+                TotalTokens = 2,
+                Model = "test",
+            });
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
@@ -321,7 +321,7 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
             PlanReviewCoordinator coord = CreateCoordinator(firstGate, options, TimeProvider.System);
 
             PlanReviewCoordinationInput input = SampleInput();
-            var coordTask = coord.CoordinateAsync(input, CancellationToken.None);
+            Task<PlanReviewOutcome> coordTask = coord.CoordinateAsync(input, CancellationToken.None);
             ApprovalRequest row = await WaitForPending(firstGate, input.Subject);
             requestId = row.RequestId;
 
@@ -388,7 +388,7 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
 
         // Approve → history includes plan_review + Approved
         PlanReviewCoordinationInput a = SampleInput();
-        var aTask = coord.CoordinateAsync(a, CancellationToken.None);
+        Task<PlanReviewOutcome> aTask = coord.CoordinateAsync(a, CancellationToken.None);
         ApprovalRequest aRow = await WaitForPending(gate, a.Subject);
         await Approve(gate, aRow.RequestId);
         _ = await aTask;
@@ -521,7 +521,11 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
     {
         private readonly IReadOnlyList<PlanReviewStepDto> _steps;
         public int Calls { get; private set; }
-        public StubReplanner(IReadOnlyList<PlanReviewStepDto> steps) => _steps = steps;
+        public StubReplanner(IReadOnlyList<PlanReviewStepDto> steps)
+        {
+            _steps = steps;
+        }
+
         public Task<Api.Agents.Planning.PlanBuildResult> ReplanAsync(
             string revisedRequest,
             IReadOnlyList<ISpecialistAgent> roster,

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewChatEndpointTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewChatEndpointTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using RetailPulse.Api.Agents.Planning;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Tests.Endpoints;
+
+/// <summary>
+/// HTTP-shape tests for the plan-first branch of <c>/api/chat</c> (#94 B3).
+/// The endpoint MUST:
+/// <list type="bullet">
+///   <item>Return <c>202 Accepted</c> with plan/review identifiers when the
+///     orchestrator suspends (review is enabled and the plan is waiting).</item>
+///   <item>Return the pre-#94 <c>200 OK</c> shape when the orchestrator
+///     returns a terminal <see cref="PlanOrchestrationResult"/>.</item>
+/// </list>
+/// The full production endpoint requires Azure credentials at startup, so we
+/// mirror only the plan-first branch inline here — the same pattern
+/// <see cref="ChatEndpointErrorTests"/> uses to exercise error paths.
+/// </summary>
+public sealed class PlanReviewChatEndpointTests : IAsyncDisposable
+{
+    private readonly IHost _host;
+    private readonly HttpClient _client;
+    private PlanOrchestrationResult _next = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public PlanReviewChatEndpointTests()
+    {
+        IHostBuilder builder = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+                    services.AddSingleton(this);
+                });
+                webHost.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                        // Mirror only the suspension-vs-terminal decision the
+                        // production endpoint makes for the plan-first branch.
+                        endpoints.MapPost("/api/chat",
+                            (HttpContext http, ChatRequest _, PlanReviewChatEndpointTests self) =>
+                        {
+                            PlanOrchestrationResult r = self._next;
+                            return r.IsSuspended
+                                ? Results.Accepted(
+                                    uri: $"/api/plans/{r.PlanId}",
+                                    value: new
+                                    {
+                                        planId = r.PlanId,
+                                        status = r.Status,
+                                        reviewRequestId = r.ReviewRequestId,
+                                        round = r.ReviewRoundNumber,
+                                    })
+                                : Results.Ok(new ChatResponse(
+                                Reply: r.Reply,
+                                SessionId: "s",
+                                Spans: [],
+                                Charts: null,
+                                TotalDurationMs: r.DurationMs,
+                                Routing: null));
+                        }));
+                });
+            });
+
+        _host = builder.Start();
+        _client = _host.GetTestClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client.Dispose();
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task Suspended_result_returns_202_with_plan_and_review_identifiers()
+    {
+        _next = PlanOrchestrationResult.Suspended(
+            "plan-XYZ", PlanStatus.AwaitingReview,
+            "req-777", roundNumber: 0,
+            inputTokens: 0, outputTokens: 0, totalTokens: 0);
+
+        HttpResponseMessage resp = await _client.PostAsJsonAsync("/api/chat",
+            new ChatRequest("multi-domain question", SessionId: "s"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("planId").GetString().Should().Be("plan-XYZ");
+        doc.RootElement.GetProperty("reviewRequestId").GetString().Should().Be("req-777");
+        doc.RootElement.GetProperty("status").GetString().Should().Be(PlanStatus.AwaitingReview);
+    }
+
+    [Fact]
+    public async Task Terminal_result_returns_200_with_pre_review_chat_shape()
+    {
+        // Disabled-review path — the orchestrator returned a Completed
+        // result. The endpoint MUST NOT return 202; existing clients rely on
+        // the 200 ChatResponse shape.
+        _next = new PlanOrchestrationResult(
+            PlanId: "plan-XYZ",
+            Status: PlanStatus.Completed,
+            Reply: "the answer",
+            DurationMs: 42,
+            InputTokens: 5, OutputTokens: 6, TotalTokens: 11,
+            Steps: [],
+            FailureReason: null);
+
+        HttpResponseMessage resp = await _client.PostAsJsonAsync("/api/chat",
+            new ChatRequest("q", SessionId: "s"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        ChatResponse? body = await resp.Content.ReadFromJsonAsync<ChatResponse>(JsonOptions);
+        body!.Reply.Should().Be("the answer");
+    }
+}

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsAuthorizationTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsAuthorizationTests.cs
@@ -1,0 +1,339 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Threading.RateLimiting;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Approval;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Api.Security.Anonymous;
+using RetailPulse.Contracts.Approval;
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Tests.Endpoints;
+
+/// <summary>
+/// Adversarial HTTP tests for the plan-review + clarification endpoints
+/// (#94 B4). Proves subject B cannot decide subject A's plan review nor
+/// answer their clarification. The endpoints MUST:
+/// <list type="bullet">
+///   <item>Return 404 for cross-subject probes so the ids cannot be
+///     enumerated by an attacker.</item>
+///   <item>Leave the approval row untouched — never invoke RespondAsync on a
+///     row the caller does not own.</item>
+/// </list>
+/// </summary>
+public sealed class PlanReviewEndpointsAuthorizationTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    // ── Decision endpoint ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Cross_subject_decision_returns_404_and_row_stays_pending()
+    {
+        await using PlanReviewHost host = await PlanReviewHost.CreateAsync(
+            subjectClaim: "bob-oid",
+            aliceRow: new SeedRow
+            {
+                Subject = "alice-oid",
+                PlanId = "plan-alice-1",
+                Kind = ApprovalKind.PlanReview,
+            });
+
+        HttpResponseMessage resp = await host.Client.PostAsJsonAsync(
+            $"/api/plans/plan-alice-1/reviews/{host.SeededRequestId}/decision",
+            new { kind = "approve" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "cross-subject decide must collapse into a 404 — no probe surface.");
+
+        // The row is still Pending — Bob's attempt did not resolve it.
+        ApprovalResult after = await host.Gate.GetResultAsync(host.SeededRequestId);
+        after.Decision.Should().Be(ApprovalDecision.Pending);
+    }
+
+    [Fact]
+    public async Task Wrong_plan_id_returns_404_even_for_owner()
+    {
+        // Alice owns plan-alice-1 but tries to decide with a different plan
+        // id in the URL. The endpoint must not accept mismatched plan/request
+        // pairs.
+        await using PlanReviewHost host = await PlanReviewHost.CreateAsync(
+            subjectClaim: "alice-oid",
+            aliceRow: new SeedRow
+            {
+                Subject = "alice-oid",
+                PlanId = "plan-alice-1",
+                Kind = ApprovalKind.PlanReview,
+            });
+
+        HttpResponseMessage resp = await host.Client.PostAsJsonAsync(
+            $"/api/plans/plan-nonsense/reviews/{host.SeededRequestId}/decision",
+            new { kind = "approve" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await host.Gate.GetResultAsync(host.SeededRequestId)).Decision.Should().Be(ApprovalDecision.Pending);
+    }
+
+    // ── Clarification endpoint ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Cross_subject_clarification_answer_returns_404_and_row_stays_pending()
+    {
+        await using PlanReviewHost host = await PlanReviewHost.CreateAsync(
+            subjectClaim: "bob-oid",
+            aliceRow: new SeedRow
+            {
+                Subject = "alice-oid",
+                PlanId = "plan-alice-1",
+                Kind = ApprovalKind.Clarification,
+            });
+
+        HttpResponseMessage resp = await host.Client.PostAsJsonAsync(
+            $"/api/plans/plan-alice-1/clarifications/{host.SeededRequestId}/answer",
+            new { answer = "malicious answer" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await host.Gate.GetResultAsync(host.SeededRequestId)).Decision.Should().Be(ApprovalDecision.Pending);
+    }
+
+    [Fact]
+    public async Task Anonymous_caller_is_refused_with_403_before_reaching_the_gate()
+    {
+        await using PlanReviewHost host = await PlanReviewHost.CreateAsync(
+            subjectClaim: "anon-session",
+            asAnonymous: true,
+            aliceRow: new SeedRow
+            {
+                Subject = "alice-oid",
+                PlanId = "plan-alice-1",
+                Kind = ApprovalKind.PlanReview,
+            });
+
+        HttpResponseMessage resp = await host.Client.PostAsJsonAsync(
+            $"/api/plans/plan-alice-1/reviews/{host.SeededRequestId}/decision",
+            new { kind = "approve" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        (await host.Gate.GetResultAsync(host.SeededRequestId)).Decision.Should().Be(ApprovalDecision.Pending);
+    }
+
+    [Fact]
+    public async Task Owner_decision_succeeds_and_flips_row_to_terminal()
+    {
+        await using PlanReviewHost host = await PlanReviewHost.CreateAsync(
+            subjectClaim: "alice-oid",
+            aliceRow: new SeedRow
+            {
+                Subject = "alice-oid",
+                PlanId = "plan-alice-1",
+                Kind = ApprovalKind.PlanReview,
+            });
+
+        HttpResponseMessage resp = await host.Client.PostAsJsonAsync(
+            $"/api/plans/plan-alice-1/reviews/{host.SeededRequestId}/decision",
+            new { kind = "approve" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        ApprovalResult after = await host.Gate.GetResultAsync(host.SeededRequestId);
+        after.Decision.Should().Be(ApprovalDecision.Approved);
+    }
+
+    // ── Host + support types ─────────────────────────────────────────────
+
+    private sealed class SeedRow
+    {
+        public required string Subject { get; init; }
+        public required string PlanId { get; init; }
+        public required string Kind { get; init; }
+    }
+
+    private sealed class PlanReviewHost : IAsyncDisposable
+    {
+        public required WebApplication App { get; init; }
+        public required HttpClient Client { get; init; }
+        public required SqliteApprovalGate Gate { get; init; }
+        public required string SeededRequestId { get; init; }
+
+        public static async Task<PlanReviewHost> CreateAsync(
+            string subjectClaim,
+            SeedRow aliceRow,
+            bool asAnonymous = false)
+        {
+            string dbPath = Path.Combine(Path.GetTempPath(), $"prv_ep_{Guid.NewGuid():N}.db");
+
+            WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
+            builder.WebHost.UseTestServer();
+            builder.Logging.ClearProviders();
+
+            var cfg = new StubAuthConfig
+            {
+                Subject = subjectClaim,
+                AsAnonymousProvider = asAnonymous,
+            };
+            builder.Services.AddSingleton(cfg);
+            builder.Services.AddAuthentication("Test")
+                .AddScheme<AuthenticationSchemeOptions, StubAuthHandler>("Test", _ => { });
+            builder.Services.AddAuthorization();
+            builder.Services.AddRateLimiter(o =>
+            {
+                o.AddPolicy("relaxed", _ => RateLimitPartition.GetNoLimiter("all"));
+                o.AddPolicy("moderate", _ => RateLimitPartition.GetNoLimiter("all"));
+            });
+            builder.Services.AddSignalR();
+
+            SqliteApprovalGate gate = new(dbPath, NullLogger<SqliteApprovalGate>.Instance,
+                TimeSpan.FromMinutes(30), TimeProvider.System);
+            builder.Services.AddSingleton(gate);
+            builder.Services.AddSingleton<IApprovalGate>(_ => gate);
+
+            var plans = new InMemoryPlanStore();
+            // Both Alice and Bob "own" a plan with the seeded id from their
+            // own perspective so we can test cross-subject rejection at the
+            // approval-row layer specifically (not the plan-ownership layer).
+            plans.Seed(new PlanSummaryDto(
+                PlanId: aliceRow.PlanId,
+                SessionId: null,
+                TenantId: "Contoso",
+                Request: "alice's plan",
+                Status: PlanStatus.AwaitingReview,
+                StepCount: 0,
+                CreatedAt: DateTimeOffset.UtcNow,
+                UpdatedAt: DateTimeOffset.UtcNow),
+                ownerSubject: aliceRow.Subject);
+            plans.Seed(new PlanSummaryDto(
+                PlanId: aliceRow.PlanId,
+                SessionId: null,
+                TenantId: "Contoso",
+                Request: "bob's view",
+                Status: PlanStatus.AwaitingReview,
+                StepCount: 0,
+                CreatedAt: DateTimeOffset.UtcNow,
+                UpdatedAt: DateTimeOffset.UtcNow),
+                ownerSubject: subjectClaim);
+            builder.Services.AddSingleton<IPlanStore>(plans);
+
+            WebApplication app = builder.Build();
+            app.UseAuthentication();
+            app.UseAuthorization();
+            app.UseRateLimiter();
+            app.MapPlanReviewEndpoints();
+            await app.StartAsync();
+
+            // Seed a Pending approval row owned by Alice.
+            var ctx = new ApprovalContext(
+                AgentId: "plan-review",
+                UserId: aliceRow.Subject,
+                Action: "review",
+                Impact: "impact",
+                Urgency: "medium",
+                Reasoning: "why",
+                SessionId: null, ConversationId: null,
+                Kind: aliceRow.Kind,
+                PlanId: aliceRow.PlanId,
+                RoundNumber: 0,
+                Payload: null);
+            ApprovalRequest seededRow = await gate.RequestApprovalAsync(ctx);
+
+            return new PlanReviewHost
+            {
+                App = app,
+                Client = app.GetTestClient(),
+                Gate = gate,
+                SeededRequestId = seededRow.RequestId,
+            };
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await App.DisposeAsync();
+        }
+    }
+
+    private sealed class StubAuthConfig
+    {
+        public bool AsAnonymousProvider { get; init; }
+        public string Subject { get; init; } = "tester-oid";
+    }
+
+    private sealed class StubAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        StubAuthConfig cfg) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            List<Claim> claims = cfg.AsAnonymousProvider
+                ? [
+                    new Claim(AnonymousCapabilityPolicy.ProviderClaimType, AnonymousCapabilityPolicy.ProviderName),
+                    new Claim("sub", cfg.Subject),
+                ]
+                : [new Claim("oid", cfg.Subject)];
+
+            var identity = new ClaimsIdentity(claims, "Test");
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), "Test");
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+
+    private sealed record PlanRow(PlanSummaryDto Summary, PlanDetailDto Detail);
+
+    private sealed class InMemoryPlanStore : IPlanStore
+    {
+        private readonly Dictionary<string, Dictionary<string, PlanRow>> _byOwner
+            = new(StringComparer.Ordinal);
+
+        public void Seed(PlanSummaryDto summary, string ownerSubject)
+        {
+            if (!_byOwner.TryGetValue(ownerSubject, out Dictionary<string, PlanRow>? bucket))
+            {
+                bucket = new(StringComparer.Ordinal);
+                _byOwner[ownerSubject] = bucket;
+            }
+            var detail = new PlanDetailDto(
+                summary.PlanId, summary.SessionId, summary.TenantId, summary.Request,
+                summary.Status, [], null, null, null, null, null,
+                summary.CreatedAt, summary.UpdatedAt, []);
+            bucket[summary.PlanId] = new PlanRow(summary, detail);
+        }
+
+        public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
+            => _byOwner.TryGetValue(subject, out Dictionary<string, PlanRow>? bucket)
+                ? Task.FromResult<IReadOnlyList<PlanSummaryDto>>([.. bucket.Values.Select(v => v.Summary)])
+                : Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
+
+        public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default)
+            => _byOwner.TryGetValue(subject, out Dictionary<string, PlanRow>? bucket)
+                && bucket.TryGetValue(planId, out PlanRow? row)
+                ? Task.FromResult<PlanDetailDto?>(row.Detail)
+                : Task.FromResult<PlanDetailDto?>(null);
+
+        public Task<bool> DeletePlanAsync(string subject, string planId, CancellationToken ct = default) => Task.FromResult(false);
+
+        public Task<PlanCleanupResult> PurgeExpiredAsync(DateTimeOffset olderThan, CancellationToken ct = default)
+            => Task.FromResult(new PlanCleanupResult(0, 0));
+    }
+}

--- a/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
@@ -134,19 +134,22 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
         return (m.Object, invocations);
     }
 
-    private CheckpointManager CreateCheckpointManager() =>
-        CheckpointManager.CreateJson(
-            new FileSystemJsonCheckpointStore(new DirectoryInfo(_checkpointDir)),
-            customOptions: null);
+    private PlanReviewCheckpointService CreateCheckpointService()
+    {
+        FileSystemJsonCheckpointStore store =
+            new(new DirectoryInfo(_checkpointDir));
+        CheckpointManager manager = CheckpointManager.CreateJson(store, customOptions: null);
+        return new PlanReviewCheckpointService(store, manager, NullLogger<PlanReviewCheckpointService>.Instance);
+    }
 
     private SqliteApprovalGate CreateGate() =>
         new(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(),
             TimeSpan.FromSeconds(30), TimeProvider.System);
 
-    // ── Edit path — edited plan is what executes ─────────────────────────
+    // ── Edit path — orchestrator suspends; reviewer decides ─────────────
 
     [Fact]
-    public async Task Edited_plan_is_what_actually_executes()
+    public async Task RunAsync_review_enabled_suspends_without_blocking_and_writes_checkpoint()
     {
         SqliteApprovalGate gate = CreateGate();
         var options = new PlanReviewOptions
@@ -155,10 +158,11 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
             DefaultReviewTimeout = TimeSpan.FromSeconds(30),
             MaxReplanRounds = 0,
         };
+        PlanReviewCheckpointService checkpoints = CreateCheckpointService();
         var coord = new PlanReviewCoordinator(
             gate,
             Options.Create(options),
-            CreateCheckpointManager(),
+            checkpoints,
             NullLogger<PlanReviewCoordinator>.Instance,
             replanner: null,
             timeProvider: TimeProvider.System);
@@ -182,7 +186,7 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
             ["demand-forecasting"] = s2,
         };
 
-        Task<PlanOrchestrationResult> runTask = orchestrator.RunAsync(new PlanOrchestrationInput
+        PlanOrchestrationResult result = await orchestrator.RunAsync(new PlanOrchestrationInput
         {
             Request = new ChatRequest("multi", SessionId: "s"),
             Subject = "user-1",
@@ -194,31 +198,33 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
             TraceId = "t",
         }, CancellationToken.None);
 
-        ApprovalRequest reviewRow = await WaitForPending(gate, "user-1");
+        // The orchestrator is now non-blocking. Enabled review returns
+        // Suspended immediately with the review request id + round.
+        result.IsSuspended.Should().BeTrue();
+        result.Status.Should().Be(PlanStatus.AwaitingReview);
+        result.ReviewRequestId.Should().NotBeNullOrWhiteSpace();
+        result.ReviewRoundNumber.Should().Be(0);
 
-        // Reviewer EDITS the plan: drops demand-forecasting, changes scorecard action.
-        var edited = new List<PlanReviewStepDto>
-        {
-            new() { SpecialistKey = "scorecard", Intent = "scorecard", Action = "EDITED_SCORECARD_ACTION" },
-        };
-        var payload = new PlanReviewResponsePayload { Kind = PlanReviewKinds.Edit, EditedSteps = edited };
-        await gate.RespondAsync(reviewRow.RequestId, ApprovalDecision.Modified,
-            "trimmed", responsePayload: JsonSerializer.Serialize(payload, _json));
+        // No specialist ran — the plan is waiting for reviewer input.
+        s1Invocations.Should().BeEmpty();
+        s2Invocations.Should().BeEmpty();
 
-        PlanOrchestrationResult result = await runTask;
-        result.Status.Should().Be(PlanStatus.Completed);
-        result.Steps.Should().HaveCount(1, "the edited plan has one step; the demand step must not have executed.");
-
-        s1Invocations.Should().HaveCount(1);
-        s1Invocations.Single().Message.Should().Contain("EDITED_SCORECARD_ACTION",
-            "specialist prompt must include the reviewer's edited action, not the planner's original.");
-        s2Invocations.Should().BeEmpty("dropped steps must never invoke their specialist.");
-
-        // Plan persistence should show ONE Create with the edited step list.
+        // Plan record persisted as AwaitingReview with the ORIGINAL planner
+        // steps captured on disk; the executor never touches steps until the
+        // completion service resumes.
         store.Creates.Should().HaveCount(1);
         PlanWrite create = store.Creates.Single();
-        create.Steps.Should().HaveCount(1);
-        create.Steps.Single().Action.Should().Be("EDITED_SCORECARD_ACTION");
+        create.Status.Should().Be(PlanStatus.AwaitingReview);
+        create.Steps.Should().HaveCount(2);
+
+        // Real framework checkpoint written for this plan.
+        PlanReviewCheckpointState? loaded = await checkpoints.LoadLatestAsync(result.PlanId, CancellationToken.None);
+        loaded.Should().NotBeNull();
+        loaded!.Kind.Should().Be(PlanCheckpointKind.Review);
+        loaded.PlanId.Should().Be(result.PlanId);
+        loaded.RoundNumber.Should().Be(0);
+        loaded.Steps.Should().HaveCount(2);
+        loaded.SpecialistKeys.Should().BeEquivalentTo(new[] { "scorecard", "demand-forecasting" });
     }
 
     // ── Reject-with-cap → no specialist invocation, terminal Failed row ─
@@ -236,7 +242,7 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
         var coord = new PlanReviewCoordinator(
             gate,
             Options.Create(options),
-            CreateCheckpointManager(),
+            CreateCheckpointService(),
             NullLogger<PlanReviewCoordinator>.Instance,
             replanner: null,
             timeProvider: TimeProvider.System);
@@ -260,7 +266,7 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
             ["demand-forecasting"] = s2,
         };
 
-        Task<PlanOrchestrationResult> runTask = orchestrator.RunAsync(new PlanOrchestrationInput
+        PlanOrchestrationResult suspend = await orchestrator.RunAsync(new PlanOrchestrationInput
         {
             Request = new ChatRequest("multi", SessionId: "s"),
             Subject = "user-1",
@@ -272,19 +278,10 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
             TraceId = "t",
         }, CancellationToken.None);
 
-        ApprovalRequest reviewRow = await WaitForPending(gate, "user-1");
-        var payload = new PlanReviewResponsePayload { Kind = PlanReviewKinds.Reject, Feedback = "no" };
-        await gate.RespondAsync(reviewRow.RequestId, ApprovalDecision.Rejected,
-            "no", responsePayload: JsonSerializer.Serialize(payload, _json));
-
-        PlanOrchestrationResult result = await runTask;
-
-        result.Status.Should().Be(PlanStatus.Failed);
-        result.FailureReason.Should().Contain(PlanReviewTerminalReason.ReplanExhausted);
+        suspend.IsSuspended.Should().BeTrue();
         s1Invocations.Should().BeEmpty("terminal reject before execution — no specialist ran.");
         s2Invocations.Should().BeEmpty();
 
-        store.StatusUpdates.Should().Contain(u => u.Status == PlanStatus.Failed);
         // Persisted plan initially recorded as AwaitingReview.
         store.Creates.Single().Status.Should().Be(PlanStatus.AwaitingReview);
     }

--- a/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
@@ -174,8 +174,8 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
             coord,
             Options.Create(options));
 
-        (ISpecialistAgent s1, var s1Invocations) = MakeRecordingSpecialist("scorecard", "score");
-        (ISpecialistAgent s2, var s2Invocations) = MakeRecordingSpecialist("demand-forecasting", "demand");
+        (ISpecialistAgent s1, ConcurrentQueue<SpecialistInvocation>? s1Invocations) = MakeRecordingSpecialist("scorecard", "score");
+        (ISpecialistAgent s2, ConcurrentQueue<SpecialistInvocation>? s2Invocations) = MakeRecordingSpecialist("demand-forecasting", "demand");
         var lookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase)
         {
             ["scorecard"] = s1,
@@ -252,8 +252,8 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
             coord,
             Options.Create(options));
 
-        (ISpecialistAgent s1, var s1Invocations) = MakeRecordingSpecialist("scorecard", "score");
-        (ISpecialistAgent s2, var s2Invocations) = MakeRecordingSpecialist("demand-forecasting", "demand");
+        (ISpecialistAgent s1, ConcurrentQueue<SpecialistInvocation>? s1Invocations) = MakeRecordingSpecialist("scorecard", "score");
+        (ISpecialistAgent s2, ConcurrentQueue<SpecialistInvocation>? s2Invocations) = MakeRecordingSpecialist("demand-forecasting", "demand");
         var lookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase)
         {
             ["scorecard"] = s1,
@@ -309,8 +309,8 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
             reviewCoordinator: null,
             reviewOptions: null);
 
-        (ISpecialistAgent s1, var s1Invocations) = MakeRecordingSpecialist("scorecard", "score");
-        (ISpecialistAgent s2, var s2Invocations) = MakeRecordingSpecialist("demand-forecasting", "demand");
+        (ISpecialistAgent s1, ConcurrentQueue<SpecialistInvocation>? s1Invocations) = MakeRecordingSpecialist("scorecard", "score");
+        (ISpecialistAgent s2, ConcurrentQueue<SpecialistInvocation>? s2Invocations) = MakeRecordingSpecialist("demand-forecasting", "demand");
         var lookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase)
         {
             ["scorecard"] = s1,

--- a/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
@@ -138,7 +138,7 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
     {
         FileSystemJsonCheckpointStore store =
             new(new DirectoryInfo(_checkpointDir));
-        CheckpointManager manager = CheckpointManager.CreateJson(store, customOptions: null);
+        var manager = CheckpointManager.CreateJson(store, customOptions: null);
         return new PlanReviewCheckpointService(store, manager, NullLogger<PlanReviewCheckpointService>.Instance);
     }
 
@@ -220,11 +220,11 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
         // Real framework checkpoint written for this plan.
         PlanReviewCheckpointState? loaded = await checkpoints.LoadLatestAsync(result.PlanId, CancellationToken.None);
         loaded.Should().NotBeNull();
-        loaded!.Kind.Should().Be(PlanCheckpointKind.Review);
+        loaded.Kind.Should().Be(PlanCheckpointKind.Review);
         loaded.PlanId.Should().Be(result.PlanId);
         loaded.RoundNumber.Should().Be(0);
         loaded.Steps.Should().HaveCount(2);
-        loaded.SpecialistKeys.Should().BeEquivalentTo(new[] { "scorecard", "demand-forecasting" });
+        loaded.SpecialistKeys.Should().BeEquivalentTo(["scorecard", "demand-forecasting"]);
     }
 
     // ── Reject-with-cap → no specialist invocation, terminal Failed row ─
@@ -337,16 +337,5 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
 
         store.Creates.Single().Status.Should().Be(PlanStatus.Running,
             "disabled path skips AwaitingReview entirely.");
-    }
-
-    private static async Task<ApprovalRequest> WaitForPending(SqliteApprovalGate gate, string subject)
-    {
-        for (int i = 0; i < 400; i++)
-        {
-            IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync(subject);
-            if (pending.Count > 0) return pending[^1];
-            await Task.Delay(10);
-        }
-        throw new InvalidOperationException("Timed out waiting for pending row.");
     }
 }

--- a/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
@@ -1,0 +1,355 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Agents.Planning;
+using RetailPulse.Api.Approval;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Approval;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Persistence;
+using RetailPulse.Contracts.Routing;
+using RetailPulse.Contracts.Tracing;
+using RetailPulse.Tests.Fixtures;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
+
+namespace RetailPulse.Tests.Planning;
+
+/// <summary>
+/// End-to-end tests that thread the <see cref="PlanReviewCoordinator"/> through
+/// the real <see cref="PlanOrchestrator"/> + <see cref="PlanExecutor"/> pair so
+/// the "edited plan is what actually executes" acceptance criterion is proved
+/// on the specialist-invocation path, not just in coordinator-level asserts.
+/// </summary>
+public sealed class PlanReviewOrchestratorTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _checkpointDir;
+
+    public PlanReviewOrchestratorTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"plan_review_orch_{Guid.NewGuid():N}.db");
+        _checkpointDir = Path.Combine(Path.GetTempPath(), $"plan_review_orch_ckpt_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_checkpointDir);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { }
+        try { File.Delete(_dbPath + "-wal"); } catch { }
+        try { File.Delete(_dbPath + "-shm"); } catch { }
+        try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
+    }
+
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private sealed class RecordingPlanStore : IPlanStore
+    {
+        public ConcurrentQueue<PlanWrite> Creates { get; } = new();
+        public ConcurrentQueue<PlanStatusUpdate> StatusUpdates { get; } = new();
+        public ConcurrentQueue<PlanStepUpdate> StepUpdates { get; } = new();
+        public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default)
+        { Creates.Enqueue(plan); return Task.CompletedTask; }
+        public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default)
+        { StatusUpdates.Enqueue(update); return Task.CompletedTask; }
+        public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
+        { StepUpdates.Enqueue(update); return Task.CompletedTask; }
+        public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
+        public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default)
+            => Task.FromResult<PlanDetailDto?>(null);
+        public Task<bool> DeletePlanAsync(string subject, string planId, CancellationToken ct = default)
+            => Task.FromResult(false);
+        public Task<PlanCleanupResult> PurgeExpiredAsync(DateTimeOffset olderThan, CancellationToken ct = default)
+            => Task.FromResult(new PlanCleanupResult(0, 0));
+    }
+
+    private sealed class NoOpTraceCollector : ITraceCollector
+    {
+        public void CaptureSpan(TraceSpan span) { }
+        public IReadOnlyList<TraceSpan>? GetSpans(string traceId) => null;
+        public TraceSummary? GetSummary(string traceId) => null;
+        public IReadOnlyList<TraceSummary> GetRecentTraces(int count = 20) => [];
+        public StructuredTraceSummary? GetStructuredSummary(string traceId) => null;
+        public IReadOnlyList<ToolUsageStat> GetToolStats(DateTimeOffset since, int top = 10) => [];
+        public int TraceCount => 0;
+        public int Capacity => 100;
+    }
+
+    private sealed class NoOpCostTracker : ICostTracker
+    {
+        public Task TrackUsageAsync(UsageEvent usage, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<CostSummary> GetSummaryAsync(CostPeriod period, CancellationToken ct = default)
+            => Task.FromResult(new CostSummary(0, 0, 0, period));
+        public Task<IReadOnlyList<AgentCostBreakdown>> GetByAgentAsync(CostPeriod period, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<AgentCostBreakdown>>([]);
+        public Task<CostTrend> GetTrendAsync(int days = 7, CancellationToken ct = default)
+            => Task.FromResult(new CostTrend([]));
+    }
+
+    private static Api.Models.AgentDefinition PlannerDef() => new()
+    {
+        Key = "planner",
+        Name = "Plan-First Orchestrator",
+        Model = "gpt-test",
+        SystemPrompt = "You are the planner.",
+        Temperature = 0.1,
+    };
+
+    private static IChatClient PlannerChat() => AgentTestFixtures.CreateMockChatClient(
+        /*lang=json,strict*/ @"{ ""steps"": [
+            { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""original scorecard action"" },
+            { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""original demand action"" }
+        ] }");
+
+    private sealed record SpecialistInvocation(string Key, string Message);
+
+    private static (ISpecialistAgent agent, ConcurrentQueue<SpecialistInvocation> invocations)
+        MakeRecordingSpecialist(string key, string reply)
+    {
+        var invocations = new ConcurrentQueue<SpecialistInvocation>();
+        var m = new Mock<ISpecialistAgent>();
+        m.SetupGet(a => a.Key).Returns(key);
+        m.SetupGet(a => a.DisplayName).Returns(key);
+        m.SetupGet(a => a.Model).Returns("gpt-test");
+        m.SetupGet(a => a.SupportedIntents).Returns([key]);
+        m.Setup(a => a.HandleAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()))
+            .Returns((ChatRequest req, CancellationToken _) =>
+            {
+                invocations.Enqueue(new SpecialistInvocation(key, req.Message));
+                return Task.FromResult(new ChatResponse(
+                    reply, req.SessionId ?? "s", [], null, 10, new TokenUsage(1, 1, 2)));
+            });
+        return (m.Object, invocations);
+    }
+
+    private CheckpointManager CreateCheckpointManager() =>
+        CheckpointManager.CreateJson(
+            new FileSystemJsonCheckpointStore(new DirectoryInfo(_checkpointDir)),
+            customOptions: null);
+
+    private SqliteApprovalGate CreateGate() =>
+        new(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(),
+            TimeSpan.FromSeconds(30), TimeProvider.System);
+
+    // ── Edit path — edited plan is what executes ─────────────────────────
+
+    [Fact]
+    public async Task Edited_plan_is_what_actually_executes()
+    {
+        SqliteApprovalGate gate = CreateGate();
+        var options = new PlanReviewOptions
+        {
+            Enabled = true,
+            DefaultReviewTimeout = TimeSpan.FromSeconds(30),
+            MaxReplanRounds = 0,
+        };
+        var coord = new PlanReviewCoordinator(
+            gate,
+            Options.Create(options),
+            CreateCheckpointManager(),
+            NullLogger<PlanReviewCoordinator>.Instance,
+            replanner: null,
+            timeProvider: TimeProvider.System);
+
+        var store = new RecordingPlanStore();
+        var cost = new NoOpCostTracker();
+        var persistenceOpts = new PlanPersistenceOptions();
+        var builder = new PlanBuilder(PlannerChat(), PlannerDef(), persistenceOpts, NullLogger<PlanBuilder>.Instance);
+        var executor = new PlanExecutor(store, cost, new NoOpTraceCollector(), persistenceOpts, NullLogger<PlanExecutor>.Instance);
+        var orchestrator = new PlanOrchestrator(
+            builder, executor, store, cost, persistenceOpts,
+            NullLogger<PlanOrchestrator>.Instance,
+            coord,
+            Options.Create(options));
+
+        (ISpecialistAgent s1, var s1Invocations) = MakeRecordingSpecialist("scorecard", "score");
+        (ISpecialistAgent s2, var s2Invocations) = MakeRecordingSpecialist("demand-forecasting", "demand");
+        var lookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["scorecard"] = s1,
+            ["demand-forecasting"] = s2,
+        };
+
+        Task<PlanOrchestrationResult> runTask = orchestrator.RunAsync(new PlanOrchestrationInput
+        {
+            Request = new ChatRequest("multi", SessionId: "s"),
+            Subject = "user-1",
+            PrincipalKey = "user-1",
+            TenantId = "Contoso",
+            Roster = [s1, s2],
+            SpecialistLookup = lookup,
+            DetectedIntents = ["scorecard", "demand"],
+            TraceId = "t",
+        }, CancellationToken.None);
+
+        ApprovalRequest reviewRow = await WaitForPending(gate, "user-1");
+
+        // Reviewer EDITS the plan: drops demand-forecasting, changes scorecard action.
+        var edited = new List<PlanReviewStepDto>
+        {
+            new() { SpecialistKey = "scorecard", Intent = "scorecard", Action = "EDITED_SCORECARD_ACTION" },
+        };
+        var payload = new PlanReviewResponsePayload { Kind = PlanReviewKinds.Edit, EditedSteps = edited };
+        await gate.RespondAsync(reviewRow.RequestId, ApprovalDecision.Modified,
+            "trimmed", responsePayload: JsonSerializer.Serialize(payload, _json));
+
+        PlanOrchestrationResult result = await runTask;
+        result.Status.Should().Be(PlanStatus.Completed);
+        result.Steps.Should().HaveCount(1, "the edited plan has one step; the demand step must not have executed.");
+
+        s1Invocations.Should().HaveCount(1);
+        s1Invocations.Single().Message.Should().Contain("EDITED_SCORECARD_ACTION",
+            "specialist prompt must include the reviewer's edited action, not the planner's original.");
+        s2Invocations.Should().BeEmpty("dropped steps must never invoke their specialist.");
+
+        // Plan persistence should show ONE Create with the edited step list.
+        store.Creates.Should().HaveCount(1);
+        PlanWrite create = store.Creates.Single();
+        create.Steps.Should().HaveCount(1);
+        create.Steps.Single().Action.Should().Be("EDITED_SCORECARD_ACTION");
+    }
+
+    // ── Reject-with-cap → no specialist invocation, terminal Failed row ─
+
+    [Fact]
+    public async Task Reject_exhausted_terminates_plan_without_executing()
+    {
+        SqliteApprovalGate gate = CreateGate();
+        var options = new PlanReviewOptions
+        {
+            Enabled = true,
+            DefaultReviewTimeout = TimeSpan.FromSeconds(30),
+            MaxReplanRounds = 0, // zero replans — one reject terminates.
+        };
+        var coord = new PlanReviewCoordinator(
+            gate,
+            Options.Create(options),
+            CreateCheckpointManager(),
+            NullLogger<PlanReviewCoordinator>.Instance,
+            replanner: null,
+            timeProvider: TimeProvider.System);
+
+        var store = new RecordingPlanStore();
+        var cost = new NoOpCostTracker();
+        var persistenceOpts = new PlanPersistenceOptions();
+        var builder = new PlanBuilder(PlannerChat(), PlannerDef(), persistenceOpts, NullLogger<PlanBuilder>.Instance);
+        var executor = new PlanExecutor(store, cost, new NoOpTraceCollector(), persistenceOpts, NullLogger<PlanExecutor>.Instance);
+        var orchestrator = new PlanOrchestrator(
+            builder, executor, store, cost, persistenceOpts,
+            NullLogger<PlanOrchestrator>.Instance,
+            coord,
+            Options.Create(options));
+
+        (ISpecialistAgent s1, var s1Invocations) = MakeRecordingSpecialist("scorecard", "score");
+        (ISpecialistAgent s2, var s2Invocations) = MakeRecordingSpecialist("demand-forecasting", "demand");
+        var lookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["scorecard"] = s1,
+            ["demand-forecasting"] = s2,
+        };
+
+        Task<PlanOrchestrationResult> runTask = orchestrator.RunAsync(new PlanOrchestrationInput
+        {
+            Request = new ChatRequest("multi", SessionId: "s"),
+            Subject = "user-1",
+            PrincipalKey = "user-1",
+            TenantId = "Contoso",
+            Roster = [s1, s2],
+            SpecialistLookup = lookup,
+            DetectedIntents = ["scorecard", "demand"],
+            TraceId = "t",
+        }, CancellationToken.None);
+
+        ApprovalRequest reviewRow = await WaitForPending(gate, "user-1");
+        var payload = new PlanReviewResponsePayload { Kind = PlanReviewKinds.Reject, Feedback = "no" };
+        await gate.RespondAsync(reviewRow.RequestId, ApprovalDecision.Rejected,
+            "no", responsePayload: JsonSerializer.Serialize(payload, _json));
+
+        PlanOrchestrationResult result = await runTask;
+
+        result.Status.Should().Be(PlanStatus.Failed);
+        result.FailureReason.Should().Contain(PlanReviewTerminalReason.ReplanExhausted);
+        s1Invocations.Should().BeEmpty("terminal reject before execution — no specialist ran.");
+        s2Invocations.Should().BeEmpty();
+
+        store.StatusUpdates.Should().Contain(u => u.Status == PlanStatus.Failed);
+        // Persisted plan initially recorded as AwaitingReview.
+        store.Creates.Single().Status.Should().Be(PlanStatus.AwaitingReview);
+    }
+
+    // ── Disabled path — pre-#94 hot path preserved ───────────────────────
+
+    [Fact]
+    public async Task Disabled_review_leaves_execution_unchanged()
+    {
+        // No coordinator, no options. The orchestrator must run exactly as
+        // pre-#94 code did — no approval row is written, no plan status is
+        // AwaitingReview, and both planner-provided steps execute.
+        SqliteApprovalGate gate = CreateGate();
+        var store = new RecordingPlanStore();
+        var cost = new NoOpCostTracker();
+        var persistenceOpts = new PlanPersistenceOptions();
+        var builder = new PlanBuilder(PlannerChat(), PlannerDef(), persistenceOpts, NullLogger<PlanBuilder>.Instance);
+        var executor = new PlanExecutor(store, cost, new NoOpTraceCollector(), persistenceOpts, NullLogger<PlanExecutor>.Instance);
+        var orchestrator = new PlanOrchestrator(
+            builder, executor, store, cost, persistenceOpts,
+            NullLogger<PlanOrchestrator>.Instance,
+            reviewCoordinator: null,
+            reviewOptions: null);
+
+        (ISpecialistAgent s1, var s1Invocations) = MakeRecordingSpecialist("scorecard", "score");
+        (ISpecialistAgent s2, var s2Invocations) = MakeRecordingSpecialist("demand-forecasting", "demand");
+        var lookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["scorecard"] = s1,
+            ["demand-forecasting"] = s2,
+        };
+
+        PlanOrchestrationResult result = await orchestrator.RunAsync(new PlanOrchestrationInput
+        {
+            Request = new ChatRequest("multi", SessionId: "s"),
+            Subject = "user-1",
+            PrincipalKey = "user-1",
+            TenantId = "Contoso",
+            Roster = [s1, s2],
+            SpecialistLookup = lookup,
+            DetectedIntents = ["scorecard", "demand"],
+            TraceId = "t",
+        }, CancellationToken.None);
+
+        result.Status.Should().Be(PlanStatus.Completed);
+        result.Steps.Should().HaveCount(2);
+        s1Invocations.Should().HaveCount(1);
+        s2Invocations.Should().HaveCount(1);
+
+        // No approval row written when review is disabled.
+        (await gate.GetPendingAsync("user-1")).Should().BeEmpty();
+        (await gate.GetHistoryAsync(50)).Should().BeEmpty();
+
+        store.Creates.Single().Status.Should().Be(PlanStatus.Running,
+            "disabled path skips AwaitingReview entirely.");
+    }
+
+    private static async Task<ApprovalRequest> WaitForPending(SqliteApprovalGate gate, string subject)
+    {
+        for (int i = 0; i < 400; i++)
+        {
+            IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync(subject);
+            if (pending.Count > 0) return pending[^1];
+            await Task.Delay(10);
+        }
+        throw new InvalidOperationException("Timed out waiting for pending row.");
+    }
+}


### PR DESCRIPTION
Closes #94

## Summary

- adds human review before plan execution with approve, reject-with-feedback, and edit/drop-step decisions
- persists review and clarification suspensions as Microsoft.Agents.AI.Workflows checkpoints and resumes them through the approval reconciliation seam introduced in #91
- supports bounded replanning, mid-plan clarification, mid-execution revision review, owner-only decisions, and configurable terminal timeouts
- returns `202 Accepted` while review is pending, then filters, persists, audits, exports, and broadcasts the resumed final response
- preserves the disabled/default chat path and existing single-tool `ApprovalTool` behavior

## Resume mechanism

#91 remains the single approval startup-reconciliation mechanism. #94 supplies the plan-aware `IApprovalResumeStrategy`: tool approvals retain #91's orphan-terminal behavior, while plan-review and clarification rows with durable workflow checkpoints are adopted and resumed by the plan completion service. There is no second approval reconciler or polling resume path.

## Review

Publix requested changes on the initial implementation because it did not write/resume a real workflow checkpoint, clarification was not reachable from step execution, review-enabled chat could block, and authorization lacked endpoint-level adversarial coverage. Kroger independently revised the implementation. Publix re-reviewed the complete diff and approved it after all four blockers were resolved.

## Validation

- 3,035 .NET tests passed; 5 live Azure AI Search tests skipped; 0 failed
- focused plan-review and clarification tests: 33 passed
- `dotnet format RetailPulse.slnx --verify-no-changes`
- NuGet sources: `azure-default` enabled, `nuget.org` disabled