### PR TITLE
Hybrid execution: fast single-shot path vs plan-first orchestration (#95)

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -516,10 +516,29 @@ Performance regression detection for critical paths:
 | RouterClassification | Keyword fast-path vs LLM classification latency |
 | CacheLookup | MCP response cache hit/miss overhead |
 | VoteParsing | Consensus council vote JSON parsing |
+| HybridFastPath | Decision-layer overhead for the single-specialist fast path (issue #95) |
 
 ```bash
 dotnet run -c Release --project tests/RetailPulse.Benchmarks
 ```
+
+### Hybrid fast-path baseline (issue #95)
+
+A deterministic p50/p95 baseline for the single-specialist fast path is captured
+separately so before/after comparisons for the hybrid-execution decision layer do
+not depend on a full BenchmarkDotNet run. It measures
+`RetailOpsRouter.TryKeywordClassify` against the reference prompt
+`"How is Sierra Gold Tequila performing in the Northeast?"` — no network, LLM, or
+MCP call is issued.
+
+```bash
+dotnet run -c Release --project tests/RetailPulse.Benchmarks -- baseline
+```
+
+Writes `tests/RetailPulse.Benchmarks/baselines/hybrid-fast-path-baseline.json`
+with commit SHA, environment identifier, sample count, and p50/p95 in
+nanoseconds. A material regression (>5% p50 or p95 vs the recorded baseline on
+the same environment) is blocking for the hybrid-execution change.
 
 ---
 

--- a/src/RetailPulse.Api/Agents/Routing/HybridExecutionDecider.cs
+++ b/src/RetailPulse.Api/Agents/Routing/HybridExecutionDecider.cs
@@ -1,0 +1,196 @@
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts.Routing;
+
+namespace RetailPulse.Api.Agents.Routing;
+
+/// <summary>
+/// Pure, allocation-lean decision layer that classifies a routed request as
+/// <see cref="ExecutionPath.Fast"/>, <see cref="ExecutionPath.Plan"/>, or
+/// <see cref="ExecutionPath.Council"/> (issue #95). Kept as a static helper
+/// with no dependencies on the endpoint host so decision-table tests can
+/// exercise the full precedence without spinning up ASP.NET Core.
+///
+/// Precedence — matches the design gate:
+/// <list type="number">
+///   <item>Explicit user override (only when the caller is authenticated and
+///     the requested path is actually available; anonymous or
+///     unavailable-planner overrides are ignored, preserving default safety
+///     behaviour).</item>
+///   <item>Council dedicated route — the portfolio-health intent has its
+///     own trigger and always resolves to <see cref="ExecutionPath.Council"/>
+///     when no valid override wins.</item>
+///   <item>Planner unavailable (anonymous, plan orchestrator not
+///     registered, no detected intents) → fast; the plan path is not a
+///     reachable destination for that request.</item>
+///   <item>Multi-domain — detected intents at or above
+///     <see cref="PlanPersistenceOptions.MinDetectedIntentsForPlan"/>
+///     → plan.</item>
+///   <item>Low confidence — router confidence strictly below
+///     <see cref="PlanPersistenceOptions.MinConfidenceForFastPath"/>
+///     → plan.</item>
+///   <item>Advisory / diagnostic phrase (configured) → plan.</item>
+///   <item>Else → fast.</item>
+/// </list>
+///
+/// The gate is on the hot path for every /api/chat turn. It avoids
+/// per-call allocations (no LINQ, no lowercasing the input, no list
+/// materialisation) so it does not measurably move the fast-path baseline
+/// captured for this issue.
+/// </summary>
+public static class HybridExecutionDecider
+{
+    /// <summary>
+    /// Compute the execution decision for a routed chat turn.
+    /// </summary>
+    /// <param name="decision">Router classification. Must be non-null.</param>
+    /// <param name="message">Original user message; scanned for advisory cues. Must be non-null.</param>
+    /// <param name="context">Endpoint-side signals (auth, planner availability, override).</param>
+    /// <param name="options">Configured thresholds and advisory phrases.</param>
+    public static HybridExecutionResult Decide(
+        RoutingDecision decision,
+        string message,
+        HybridExecutionContext context,
+        PlanPersistenceOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(options);
+
+        bool councilIntent = IsCouncilIntent(decision);
+
+        // 1) Explicit override — authenticated callers only, ignored when
+        //    the requested path is not actually available.
+        if (!string.IsNullOrWhiteSpace(context.ForcedPath) && !context.AnonymousCaller)
+        {
+            if (string.Equals(context.ForcedPath, ExecutionPath.Fast, StringComparison.OrdinalIgnoreCase))
+            {
+                return new HybridExecutionResult(ExecutionPath.Fast, Forced: true, HybridExecutionReason.ForceOverride);
+            }
+
+            if (string.Equals(context.ForcedPath, ExecutionPath.Plan, StringComparison.OrdinalIgnoreCase)
+                && context.PlannerAvailable)
+            {
+                return new HybridExecutionResult(ExecutionPath.Plan, Forced: true, HybridExecutionReason.ForceOverride);
+            }
+
+            // Force=plan but plan orchestrator not wired — fall through to the
+            // deterministic pipeline. The endpoint logs the ignored override so
+            // an operator sees why "force plan" did nothing.
+        }
+
+        // 2) Council dedicated route.
+        if (councilIntent)
+        {
+            return new HybridExecutionResult(ExecutionPath.Council, Forced: false, HybridExecutionReason.CouncilIntent);
+        }
+
+        // 3) Planner unavailable — fast path is the only reachable destination.
+        if (context.AnonymousCaller)
+        {
+            return new HybridExecutionResult(ExecutionPath.Fast, Forced: false, HybridExecutionReason.AnonymousCaller);
+        }
+
+        if (!context.PlannerAvailable)
+        {
+            return new HybridExecutionResult(ExecutionPath.Fast, Forced: false, HybridExecutionReason.PlannerUnavailable);
+        }
+
+        // 4) Multi-domain (detected intents ≥ configured threshold).
+        int planThreshold = options.MinDetectedIntentsForPlan < 1 ? 1 : options.MinDetectedIntentsForPlan;
+        IReadOnlyList<string>? detected = decision.DetectedIntents;
+        if (detected is { Count: > 0 } && detected.Count >= planThreshold)
+        {
+            return new HybridExecutionResult(ExecutionPath.Plan, Forced: false, HybridExecutionReason.MultiDomain);
+        }
+
+        // 5) Low confidence — the router is not sure enough to trust a
+        //    single specialist.
+        if (decision.Confidence < options.MinConfidenceForFastPath)
+        {
+            return new HybridExecutionResult(ExecutionPath.Plan, Forced: false, HybridExecutionReason.LowConfidence);
+        }
+
+        // 6) Advisory phrase. Uses OrdinalIgnoreCase Contains so no
+        //    per-call allocation is required to match.
+        IList<string> phrases = options.AdvisoryPhrases;
+        if (phrases is { Count: > 0 })
+        {
+            for (int i = 0; i < phrases.Count; i++)
+            {
+                string phrase = phrases[i];
+                if (!string.IsNullOrWhiteSpace(phrase)
+                    && message.Contains(phrase, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HybridExecutionResult(ExecutionPath.Plan, Forced: false, HybridExecutionReason.AdvisoryPhrase);
+                }
+            }
+        }
+
+        // 7) Default — fast path.
+        return new HybridExecutionResult(ExecutionPath.Fast, Forced: false, HybridExecutionReason.SingleDomain);
+    }
+
+    /// <summary>
+    /// True when the routing decision would trigger the consensus-council
+    /// interception. Kept identical to the endpoint's own check and the
+    /// <c>AnonymousChatRestrictions</c> check so the three trigger on
+    /// exactly the same condition.
+    /// </summary>
+    public static bool IsCouncilIntent(RoutingDecision decision)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+        if (string.Equals(decision.Intent, AgentIntent.PortfolioHealth, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        IReadOnlyList<string>? intents = decision.DetectedIntents;
+        if (intents is null) return false;
+        for (int i = 0; i < intents.Count; i++)
+        {
+            if (string.Equals(intents[i], AgentIntent.PortfolioHealth, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/// <summary>
+/// Endpoint-side signals the decider consumes. Kept as a struct so
+/// constructing one is allocation-free on the hot path.
+/// </summary>
+public readonly record struct HybridExecutionContext(
+    bool AnonymousCaller,
+    bool PlannerAvailable,
+    string? ForcedPath);
+
+/// <summary>
+/// Outcome of the hybrid decision. <see cref="Path"/> is one of the
+/// <see cref="ExecutionPath"/> constants; <see cref="Forced"/> is set only
+/// when the resolution honoured an explicit user override.
+/// </summary>
+/// <param name="Path">Chosen execution path (fast / plan / council).</param>
+/// <param name="Forced">True when the path came from an explicit user override.</param>
+/// <param name="Reason">Stable reason code for telemetry and diagnostics.</param>
+public readonly record struct HybridExecutionResult(
+    string Path,
+    bool Forced,
+    string Reason);
+
+/// <summary>
+/// Stable, testable reason codes explaining why the decider chose a path.
+/// Emitted on the routing span as <c>agent.routing.decision_reason</c>.
+/// </summary>
+public static class HybridExecutionReason
+{
+    public const string ForceOverride = "force_override";
+    public const string CouncilIntent = "council_intent";
+    public const string AnonymousCaller = "anonymous_caller";
+    public const string PlannerUnavailable = "planner_unavailable";
+    public const string MultiDomain = "multi_domain";
+    public const string LowConfidence = "low_confidence";
+    public const string AdvisoryPhrase = "advisory_phrase";
+    public const string SingleDomain = "single_domain";
+}

--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
 using RetailPulse.Api.Agents;
 using RetailPulse.Api.Agents.Planning;
+using RetailPulse.Api.Agents.Routing;
 using RetailPulse.Api.Auth;
 using RetailPulse.Api.Guardrails;
 using RetailPulse.Api.Hubs;
@@ -211,6 +212,7 @@ public static class ChatEndpoints
 
                 // Router classification with tracing
                 RoutingDecision decision;
+                HybridExecutionResult hybridDecision;
                 {
                     DateTimeOffset classifyStart = DateTimeOffset.UtcNow;
                     using Activity? classifyActivity = AgentTelemetry.StartRouterClassify(request.Message);
@@ -226,6 +228,38 @@ public static class ChatEndpoints
                     classifyActivity?.SetTag("router.intent", decision.Intent);
                     classifyActivity?.SetTag("router.confidence", decision.Confidence);
 
+                    // ── Hybrid execution decision (issue #95) ───────────────────
+                    // Purely functional; runs before council / plan-first
+                    // interception so the chosen path is one authoritative
+                    // signal for both telemetry and the branch that follows.
+                    PlanPersistenceOptions hybridOpts =
+                        planPersistenceOptions?.Value ?? new PlanPersistenceOptions();
+                    string? forcedRequest = string.IsNullOrWhiteSpace(request.ForceExecutionPath)
+                        ? null
+                        : request.ForceExecutionPath;
+                    if (forcedRequest is not null && anonymous)
+                    {
+                        // Anonymous callers may not force a path — preserve the
+                        // default safety posture. Log so an operator can see the
+                        // ignored override rather than debugging a silent no-op.
+                        logger.LogInformation(
+                            "Ignoring ForceExecutionPath '{Path}' for anonymous session {SessionId} — default policy applies",
+                            forcedRequest, sessionId);
+                        forcedRequest = null;
+                    }
+                    hybridDecision = HybridExecutionDecider.Decide(
+                        decision,
+                        request.Message,
+                        new HybridExecutionContext(
+                            AnonymousCaller: anonymous,
+                            PlannerAvailable: planOrchestrator is not null,
+                            ForcedPath: forcedRequest),
+                        hybridOpts);
+
+                    classifyActivity?.SetTag("agent.routing.path", hybridDecision.Path);
+                    classifyActivity?.SetTag("agent.routing.path_forced", hybridDecision.Forced);
+                    classifyActivity?.SetTag("agent.routing.decision_reason", hybridDecision.Reason);
+
                     traceCollector.CaptureSpan(new TraceSpan(
                         SpanId: Guid.NewGuid().ToString("N")[..16],
                         TraceId: traceId,
@@ -238,7 +272,10 @@ public static class ChatEndpoints
                         {
                             ["span.type"] = "routing",
                             ["router.intent"] = decision.Intent,
-                            ["router.confidence"] = decision.Confidence.ToString("F2", CultureInfo.InvariantCulture)
+                            ["router.confidence"] = decision.Confidence.ToString("F2", CultureInfo.InvariantCulture),
+                            ["agent.routing.path"] = hybridDecision.Path,
+                            ["agent.routing.path_forced"] = hybridDecision.Forced ? "true" : "false",
+                            ["agent.routing.decision_reason"] = hybridDecision.Reason,
                         }));
                 }
 
@@ -327,7 +364,9 @@ public static class ChatEndpoints
                     specialist.DisplayName,
                     decision.Intent,
                     decision.Confidence,
-                    routingDurationMs);
+                    routingDurationMs,
+                    ExecutionPath: hybridDecision.Path,
+                    ExecutionPathForced: hybridDecision.Forced);
 
                 // Emit trace_started with routing metadata for frontend telemetry panel
                 traceCollector.EmitTraceStarted(traceId, traceStartTime, decision.Intent, specialist.DisplayName, specialist.Model);
@@ -440,9 +479,11 @@ public static class ChatEndpoints
                     timestamp = DateTimeOffset.UtcNow
                 }, ct);
 
-                // Council interception: if the router classified as council/health, convene the council
-                if (decision.DetectedIntents?.Any(i => string.Equals(i, "council/health", StringComparison.OrdinalIgnoreCase)) == true
-                    || string.Equals(decision.Intent, "council/health", StringComparison.OrdinalIgnoreCase))
+                // Council interception: fires exactly when the hybrid gate
+                // resolved the request to the council path. Dedicated trigger
+                // — unchanged from before issue #95 — so behavior on portfolio-
+                // health prompts is preserved.
+                if (string.Equals(hybridDecision.Path, ExecutionPath.Council, StringComparison.Ordinal))
                 {
                     if (council is not null)
                     {
@@ -503,25 +544,15 @@ public static class ChatEndpoints
                     }
                 }
 
-                // Plan-first interception (issue #93): when the router flags multi-domain
-                // intent AND the caller is a real (non-anonymous) subject AND the plan
-                // orchestrator is registered, hand the whole request to the workflow-
-                // backed plan path. It opens one budget scope for the entire plan,
-                // persists steps as it runs, and either returns a composed reply or
-                // fails fast with an honest terminal state (nothing hangs). The
-                // single-specialist path below is skipped entirely.
+                // Plan-first interception (issue #93). Admission is now
+                // authoritatively controlled by the hybrid execution decider
+                // (issue #95): multi-domain, low-confidence, advisory-cue, and
+                // forced-plan requests all resolve to ExecutionPath.Plan and
+                // land here. The decider is where the "one coherent story"
+                // lives; this branch is the plan path's execution seam.
+                if (planOrchestrator is not null
+                    && string.Equals(hybridDecision.Path, ExecutionPath.Plan, StringComparison.Ordinal))
                 {
-                    PlanPersistenceOptions planOpts =
-                        planPersistenceOptions?.Value ?? new PlanPersistenceOptions();
-                    int planThreshold = Math.Max(1, planOpts.MinDetectedIntentsForPlan);
-                    bool multiDomain = decision.DetectedIntents is { Count: > 0 } &&
-                        decision.DetectedIntents.Count >= planThreshold;
-                    bool councilIntent = decision.DetectedIntents?.Any(i =>
-                        string.Equals(i, "council/health", StringComparison.OrdinalIgnoreCase)) == true
-                        || string.Equals(decision.Intent, "council/health", StringComparison.OrdinalIgnoreCase);
-
-                    if (planOrchestrator is not null && !anonymous && multiDomain && !councilIntent)
-                    {
                         List<ISpecialistAgent> roster = [.. specialists];
                         var specialistLookup =
                             roster.ToDictionary(s => s.Key, s => s, StringComparer.OrdinalIgnoreCase);
@@ -589,7 +620,9 @@ public static class ChatEndpoints
                                 "Plan Orchestrator",
                                 decision.Intent ?? "plan",
                                 decision.Confidence,
-                                planResult.DurationMs));
+                                planResult.DurationMs,
+                                ExecutionPath: hybridDecision.Path,
+                                ExecutionPathForced: hybridDecision.Forced));
 
                         // Audit / export / session-turn parity — a plan turn is still an
                         // accountable interaction from this subject: it produced a user
@@ -629,7 +662,6 @@ public static class ChatEndpoints
                         }
 
                         return Results.Ok(planChatResponse);
-                    }
                 }
 
                 // Agent execution with tracing

--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -553,115 +553,115 @@ public static class ChatEndpoints
                 if (planOrchestrator is not null
                     && string.Equals(hybridDecision.Path, ExecutionPath.Plan, StringComparison.Ordinal))
                 {
-                        List<ISpecialistAgent> roster = [.. specialists];
-                        var specialistLookup =
-                            roster.ToDictionary(s => s.Key, s => s, StringComparer.OrdinalIgnoreCase);
-                        string tenantId = tenantProvider.GetTenant()?.Company ?? string.Empty;
+                    List<ISpecialistAgent> roster = [.. specialists];
+                    var specialistLookup =
+                        roster.ToDictionary(s => s.Key, s => s, StringComparer.OrdinalIgnoreCase);
+                    string tenantId = tenantProvider.GetTenant()?.Company ?? string.Empty;
 
-                        PlanOrchestrationResult planResult =
-                            await planOrchestrator.RunAsync(new PlanOrchestrationInput
+                    PlanOrchestrationResult planResult =
+                        await planOrchestrator.RunAsync(new PlanOrchestrationInput
+                        {
+                            Request = enrichedRequest with { SessionId = sessionId },
+                            Subject = userId,
+                            PrincipalKey = userId,
+                            TenantId = tenantId,
+                            Roster = roster,
+                            SpecialistLookup = specialistLookup,
+                            DetectedIntents = decision.DetectedIntents ?? [],
+                            TraceId = traceId,
+                            ParentSpanId = chatActivity?.SpanId.ToString(),
+                        }, ct);
+
+                    // Plan review (#94) may suspend the plan for reviewer
+                    // input. The endpoint MUST NOT block on the review
+                    // timeout: instead, return 202 Accepted with the plan
+                    // and review request identifiers so the client (a) knows
+                    // its request was accepted and (b) can poll or subscribe
+                    // for the final response. When review is disabled or the
+                    // plan completed without suspension, the shape below
+                    // still returns 200 with the existing ChatResponse
+                    // envelope — no behavior change on that path.
+                    if (planResult.IsSuspended)
+                    {
+                        return Results.Accepted(
+                            uri: $"/api/plans/{planResult.PlanId}",
+                            value: new
                             {
-                                Request = enrichedRequest with { SessionId = sessionId },
-                                Subject = userId,
-                                PrincipalKey = userId,
-                                TenantId = tenantId,
-                                Roster = roster,
-                                SpecialistLookup = specialistLookup,
-                                DetectedIntents = decision.DetectedIntents ?? [],
-                                TraceId = traceId,
-                                ParentSpanId = chatActivity?.SpanId.ToString(),
-                            }, ct);
+                                planId = planResult.PlanId,
+                                status = planResult.Status,
+                                reviewRequestId = planResult.ReviewRequestId,
+                                round = planResult.ReviewRoundNumber,
+                                sessionId,
+                                message = "Plan is awaiting reviewer input. Subscribe to the telemetry hub for 'plan_final_response' or poll GET /api/plans/{planId}.",
+                            });
+                    }
 
-                        // Plan review (#94) may suspend the plan for reviewer
-                        // input. The endpoint MUST NOT block on the review
-                        // timeout: instead, return 202 Accepted with the plan
-                        // and review request identifiers so the client (a) knows
-                        // its request was accepted and (b) can poll or subscribe
-                        // for the final response. When review is disabled or the
-                        // plan completed without suspension, the shape below
-                        // still returns 200 with the existing ChatResponse
-                        // envelope — no behavior change on that path.
-                        if (planResult.IsSuspended)
-                        {
-                            return Results.Accepted(
-                                uri: $"/api/plans/{planResult.PlanId}",
-                                value: new
-                                {
-                                    planId = planResult.PlanId,
-                                    status = planResult.Status,
-                                    reviewRequestId = planResult.ReviewRequestId,
-                                    round = planResult.ReviewRoundNumber,
-                                    sessionId,
-                                    message = "Plan is awaiting reviewer input. Subscribe to the telemetry hub for 'plan_final_response' or poll GET /api/plans/{planId}.",
-                                });
-                        }
+                    // Output guardrail parity — the single-specialist path filters the
+                    // reply through the shared PII/content-safety seam BEFORE returning
+                    // (see FilterOutputAsync call below). The plan-first reply is a
+                    // composed transcript of specialist outputs, each of which arrived
+                    // through the specialist pipeline without an output-guardrail pass,
+                    // so it needs the same filter here or plan responses would leak
+                    // PII the single-specialist path scrubs. This invokes the existing
+                    // GuardrailsMiddleware seam only — no Guardrails implementation or
+                    // configuration change (that surface belongs to issue #99).
+                    string filteredPlanReply =
+                        await guardrails.FilterOutputAsync(planResult.Reply, userId, ct);
 
-                        // Output guardrail parity — the single-specialist path filters the
-                        // reply through the shared PII/content-safety seam BEFORE returning
-                        // (see FilterOutputAsync call below). The plan-first reply is a
-                        // composed transcript of specialist outputs, each of which arrived
-                        // through the specialist pipeline without an output-guardrail pass,
-                        // so it needs the same filter here or plan responses would leak
-                        // PII the single-specialist path scrubs. This invokes the existing
-                        // GuardrailsMiddleware seam only — no Guardrails implementation or
-                        // configuration change (that surface belongs to issue #99).
-                        string filteredPlanReply =
-                            await guardrails.FilterOutputAsync(planResult.Reply, userId, ct);
-
-                        var planChatResponse = new ChatResponse(
-                            filteredPlanReply,
-                            sessionId,
-                            [],
-                            null,
+                    var planChatResponse = new ChatResponse(
+                        filteredPlanReply,
+                        sessionId,
+                        [],
+                        null,
+                        planResult.DurationMs,
+                        new TokenUsage(planResult.InputTokens, planResult.OutputTokens, planResult.TotalTokens),
+                        new RoutingInfo(
+                            "planner",
+                            "Plan Orchestrator",
+                            decision.Intent ?? "plan",
+                            decision.Confidence,
                             planResult.DurationMs,
-                            new TokenUsage(planResult.InputTokens, planResult.OutputTokens, planResult.TotalTokens),
-                            new RoutingInfo(
-                                "planner",
-                                "Plan Orchestrator",
-                                decision.Intent ?? "plan",
-                                decision.Confidence,
-                                planResult.DurationMs,
-                                ExecutionPath: hybridDecision.Path,
-                                ExecutionPathForced: hybridDecision.Forced));
+                            ExecutionPath: hybridDecision.Path,
+                            ExecutionPathForced: hybridDecision.Forced));
 
-                        // Audit / export / session-turn parity — a plan turn is still an
-                        // accountable interaction from this subject: it produced a user
-                        // question and an assistant reply, burned tokens, and (if
-                        // persistence is on) belongs on disk exactly like a single-
-                        // specialist turn. Skipping these on the plan branch left the
-                        // audit log, session preview, and rehydrated conversation blind
-                        // to every multi-domain answer. Per-step cost UsageEvents are
-                        // already recorded by PlanExecutor and PlanOrchestrator, so we
-                        // do not track cost again here to avoid double-charging.
-                        await RecordChatTurnParityAsync(
-                            new ChatTurnParityContext(
-                                Request: request,
-                                SessionId: sessionId,
-                                UserId: userId,
-                                AgentKey: "planner",
-                                Intent: decision.Intent ?? "plan",
-                                Confidence: decision.Confidence,
-                                Action: $"chat.plan.{decision.Intent}",
-                                Reply: filteredPlanReply,
-                                InputTokens: planResult.InputTokens,
-                                OutputTokens: planResult.OutputTokens,
-                                DurationMs: planResult.DurationMs,
-                                SpanSummary: BuildPlanSpanSummary(planResult),
-                                PersistenceEnabled: persistenceEnabled),
-                            auditLog,
-                            conversationExporter,
-                            sessionStore,
-                            sessionPersistenceOptions,
-                            tenantProvider,
-                            logger,
-                            ct);
+                    // Audit / export / session-turn parity — a plan turn is still an
+                    // accountable interaction from this subject: it produced a user
+                    // question and an assistant reply, burned tokens, and (if
+                    // persistence is on) belongs on disk exactly like a single-
+                    // specialist turn. Skipping these on the plan branch left the
+                    // audit log, session preview, and rehydrated conversation blind
+                    // to every multi-domain answer. Per-step cost UsageEvents are
+                    // already recorded by PlanExecutor and PlanOrchestrator, so we
+                    // do not track cost again here to avoid double-charging.
+                    await RecordChatTurnParityAsync(
+                        new ChatTurnParityContext(
+                            Request: request,
+                            SessionId: sessionId,
+                            UserId: userId,
+                            AgentKey: "planner",
+                            Intent: decision.Intent ?? "plan",
+                            Confidence: decision.Confidence,
+                            Action: $"chat.plan.{decision.Intent}",
+                            Reply: filteredPlanReply,
+                            InputTokens: planResult.InputTokens,
+                            OutputTokens: planResult.OutputTokens,
+                            DurationMs: planResult.DurationMs,
+                            SpanSummary: BuildPlanSpanSummary(planResult),
+                            PersistenceEnabled: persistenceEnabled),
+                        auditLog,
+                        conversationExporter,
+                        sessionStore,
+                        sessionPersistenceOptions,
+                        tenantProvider,
+                        logger,
+                        ct);
 
-                        if (!memoryDisabled)
-                        {
-                            await memoryMiddleware.ExtractAndStoreAsync(userId, enrichedRequest.Message, filteredPlanReply, ct);
-                        }
+                    if (!memoryDisabled)
+                    {
+                        await memoryMiddleware.ExtractAndStoreAsync(userId, enrichedRequest.Message, filteredPlanReply, ct);
+                    }
 
-                        return Results.Ok(planChatResponse);
+                    return Results.Ok(planChatResponse);
                 }
 
                 // Agent execution with tracing

--- a/src/RetailPulse.Api/Endpoints/EscalationEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/EscalationEndpoints.cs
@@ -10,9 +10,9 @@ public static class EscalationEndpoints
     /// Maps <c>POST /api/escalate</c> — the legacy L1→L2→L3 fan-out kept for
     /// callers that opt in explicitly. The <c>/api/chat</c> pipeline no longer
     /// routes through this endpoint; its multi-specialist admission is owned
-    /// by <see cref="RetailPulse.Api.Agents.Routing.HybridExecutionDecider"/>
+    /// by <see cref="Agents.Routing.HybridExecutionDecider"/>
     /// (issue #95), which admits into the plan-first orchestrator. See the
-    /// class doc on <see cref="RetailPulse.Api.Escalation.EscalationOrchestrator"/>.
+    /// class doc on <see cref="EscalationOrchestrator"/>.
     /// </summary>
     public static WebApplication MapEscalationEndpoints(this WebApplication app)
     {

--- a/src/RetailPulse.Api/Endpoints/EscalationEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/EscalationEndpoints.cs
@@ -6,6 +6,14 @@ namespace RetailPulse.Api.Endpoints;
 
 public static class EscalationEndpoints
 {
+    /// <summary>
+    /// Maps <c>POST /api/escalate</c> — the legacy L1→L2→L3 fan-out kept for
+    /// callers that opt in explicitly. The <c>/api/chat</c> pipeline no longer
+    /// routes through this endpoint; its multi-specialist admission is owned
+    /// by <see cref="RetailPulse.Api.Agents.Routing.HybridExecutionDecider"/>
+    /// (issue #95), which admits into the plan-first orchestrator. See the
+    /// class doc on <see cref="RetailPulse.Api.Escalation.EscalationOrchestrator"/>.
+    /// </summary>
     public static WebApplication MapEscalationEndpoints(this WebApplication app)
     {
         app.MapPost("/api/escalate", async (ChatRequest request, EscalationOrchestrator escalation, IAgentRouter router, ILogger<Program> logger, CancellationToken ct) =>

--- a/src/RetailPulse.Api/Escalation/EscalationOrchestrator.cs
+++ b/src/RetailPulse.Api/Escalation/EscalationOrchestrator.cs
@@ -19,10 +19,10 @@ namespace RetailPulse.Api.Escalation;
 /// <b>Relationship to hybrid execution (issue #95).</b> The L2 multi-specialist
 /// fan-out predated the plan-first path and was the earlier response to "one
 /// specialist is not enough". Issue #95's hybrid execution decider
-/// (<see cref="RetailPulse.Api.Agents.Routing.HybridExecutionDecider"/>) is now
+/// (<see cref="Agents.Routing.HybridExecutionDecider"/>) is now
 /// the canonical multi-specialist admission signal for <c>/api/chat</c>:
 /// multi-domain / low-confidence / advisory prompts admit into
-/// <see cref="RetailPulse.Api.Agents.Planning.PlanOrchestrator"/>, which owns
+/// <see cref="Agents.Planning.PlanOrchestrator"/>, which owns
 /// planning, execution, review, persistence, and cost attribution. The chat
 /// pipeline does NOT call this orchestrator, so there is no duplicated fan-out
 /// on the primary chat path.

--- a/src/RetailPulse.Api/Escalation/EscalationOrchestrator.cs
+++ b/src/RetailPulse.Api/Escalation/EscalationOrchestrator.cs
@@ -14,6 +14,26 @@ namespace RetailPulse.Api.Escalation;
 /// L1: Single specialist (fast path, 8s timeout).
 /// L2: Multi-specialist fan-out (parallel, 15s timeout).
 /// L3: Flags for human review with context.
+///
+/// <para>
+/// <b>Relationship to hybrid execution (issue #95).</b> The L2 multi-specialist
+/// fan-out predated the plan-first path and was the earlier response to "one
+/// specialist is not enough". Issue #95's hybrid execution decider
+/// (<see cref="RetailPulse.Api.Agents.Routing.HybridExecutionDecider"/>) is now
+/// the canonical multi-specialist admission signal for <c>/api/chat</c>:
+/// multi-domain / low-confidence / advisory prompts admit into
+/// <see cref="RetailPulse.Api.Agents.Planning.PlanOrchestrator"/>, which owns
+/// planning, execution, review, persistence, and cost attribution. The chat
+/// pipeline does NOT call this orchestrator, so there is no duplicated fan-out
+/// on the primary chat path.
+/// </para>
+/// <para>
+/// This class stays wired to its own <c>POST /api/escalate</c> endpoint for
+/// callers that opt in to the older L1→L2→L3 shape explicitly; removing it
+/// without an integration compatibility pass would silently drop that
+/// endpoint's contract. It is deprecated-in-place: no new features land here,
+/// and new callers should prefer the plan path.
+/// </para>
 /// </summary>
 public class EscalationOrchestrator
 {

--- a/src/RetailPulse.Api/Persistence/PlanPersistenceOptions.cs
+++ b/src/RetailPulse.Api/Persistence/PlanPersistenceOptions.cs
@@ -53,4 +53,38 @@ public sealed class PlanPersistenceOptions
     /// work.
     /// </summary>
     public int MinDetectedIntentsForPlan { get; set; } = 2;
+
+    /// <summary>
+    /// Router-confidence floor for staying on the single-specialist fast
+    /// path (issue #95 hybrid execution). When the classifier returns a
+    /// confidence strictly below this value the request is admitted to the
+    /// plan-first path so a multi-step reconciliation can compensate for
+    /// the ambiguous classification. Default 0.6 matches the internal
+    /// <c>RetailOpsRouter</c> confidence threshold so the two decisions
+    /// stay coherent (a request the router would fall back to General on
+    /// low confidence is also the request the hybrid gate hands to the
+    /// plan path).
+    /// </summary>
+    public double MinConfidenceForFastPath { get; set; } = 0.6;
+
+    /// <summary>
+    /// Substring cues, case-insensitive, that force a request onto the
+    /// plan path even when the router returned a single high-confidence
+    /// intent (issue #95 hybrid execution). Advisory / diagnostic prompts
+    /// like "why did X drop" or "what should we do" are single-domain on
+    /// the surface but benefit from a multi-step plan (gather evidence,
+    /// synthesise, recommend). Documented defaults; leave the list empty
+    /// to disable this trigger without changing code.
+    /// </summary>
+    public IList<string> AdvisoryPhrases { get; set; } =
+    [
+        "why did",
+        "why is",
+        "why are",
+        "what should we",
+        "what should i",
+        "what do we do",
+        "recommend",
+        "diagnose",
+    ];
 }

--- a/src/RetailPulse.Api/Validation/ChatRequestValidator.cs
+++ b/src/RetailPulse.Api/Validation/ChatRequestValidator.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using RetailPulse.Contracts;
+using RetailPulse.Contracts.Routing;
 
 namespace RetailPulse.Api.Validation;
 
@@ -79,6 +80,19 @@ public static partial class ChatRequestValidator
             {
                 errors["history.aggregate"] = [$"Combined history content must not exceed {MaxAggregateHistoryChars} characters. Received: {aggregate}."];
             }
+        }
+
+        // Force-execution-path override (issue #95). Optional. Only user-forceable
+        // values are accepted; council is a router-controlled destination and is
+        // never a valid override. Unknown values fail closed with a 400 so a
+        // silent typo can never quietly re-route through the fast path.
+        if (request.ForceExecutionPath is not null
+            && !ExecutionPath.IsForceable(request.ForceExecutionPath))
+        {
+            errors["forceExecutionPath"] =
+            [
+                $"Field 'forceExecutionPath' must be '{ExecutionPath.Fast}' or '{ExecutionPath.Plan}' when specified."
+            ];
         }
 
         return new ValidationResult(errors.Count == 0, errors);

--- a/src/RetailPulse.Api/appsettings.json
+++ b/src/RetailPulse.Api/appsettings.json
@@ -305,6 +305,46 @@
     "MaxSessionsPerList": 200
   },
 
+  // ---- Plan persistence + hybrid execution decision (issues #93 / #95) --
+  // Master switch for the durable plan store AND the source-of-truth for
+  // the hybrid execution decider (fast vs plan admission). Off by default:
+  // when disabled, every request stays on the single-specialist fast path
+  // exactly as before. When enabled, the decider (issue #95) is the
+  // authoritative admission signal for the plan orchestrator.
+  //
+  //   Enabled                    (default: false) — master switch
+  //   RetentionTtl               (default: 14 days) — plan-store retention
+  //   CleanupInterval            (default: 1 hour) — plan-store sweep cadence
+  //   MaxStepCount               (default: 5) — hard cap on planner output
+  //   StepTimeout                (default: 60s) — per-step execution timeout
+  //   PlanTimeout                (default: 3m) — overall plan timeout
+  //   MinDetectedIntentsForPlan  (default: 2) — multi-domain admission floor
+  //   MinConfidenceForFastPath   (default: 0.6) — router confidence floor
+  //                                below which the request is admitted to
+  //                                the plan path; matches the internal
+  //                                RetailOpsRouter confidence threshold so
+  //                                the two decisions stay coherent
+  //   AdvisoryPhrases            — case-insensitive substrings that force
+  //                                the plan path even on a single high-
+  //                                confidence intent (e.g. "why did",
+  //                                "what should we", "recommend").
+  //                                Leave empty to disable this trigger.
+  "PlanPersistence": {
+    "Enabled": false,
+    "MinDetectedIntentsForPlan": 2,
+    "MinConfidenceForFastPath": 0.6,
+    "AdvisoryPhrases": [
+      "why did",
+      "why is",
+      "why are",
+      "what should we",
+      "what should i",
+      "what do we do",
+      "recommend",
+      "diagnose"
+    ]
+  },
+
   // ---- Human-in-the-loop approval lifecycle (issue #91) -----------------
   // Every approval request carries a persisted timeout, the owning-process
   // identity, and a heartbeat. The startup reconciliation service closes any

--- a/src/RetailPulse.Contracts/ChatModels.cs
+++ b/src/RetailPulse.Contracts/ChatModels.cs
@@ -13,7 +13,8 @@ public record ChatRequest(
     string Message,
     string? SessionId = null,
     UserContext? User = null,
-    List<ChatHistoryMessage>? History = null
+    List<ChatHistoryMessage>? History = null,
+    string? ForceExecutionPath = null
 );
 
 /// <summary>
@@ -24,7 +25,9 @@ public record RoutingInfo(
     string AgentName,
     string? Intent,
     double? Confidence,
-    long? DurationMs
+    long? DurationMs,
+    string? ExecutionPath = null,
+    bool? ExecutionPathForced = null
 );
 
 /// <summary>

--- a/src/RetailPulse.Contracts/Routing/ExecutionPath.cs
+++ b/src/RetailPulse.Contracts/Routing/ExecutionPath.cs
@@ -1,0 +1,64 @@
+namespace RetailPulse.Contracts.Routing;
+
+/// <summary>
+/// Stable UI + telemetry contract values for the hybrid execution decision
+/// made in front of the chat pipeline (issue #95). The three values are the
+/// only routes the endpoint can take; anything else is a programming error.
+///
+/// <list type="bullet">
+///   <item><see cref="Fast"/> — the single-specialist single-shot path
+///     (today's default). One router classification, one specialist call,
+///     no plan generation, no plan review.</item>
+///   <item><see cref="Plan"/> — the workflow-backed plan-first path
+///     (issue #93). The plan orchestrator generates a plan, optionally
+///     suspends for review (#94), and composes a reply from specialist
+///     steps.</item>
+///   <item><see cref="Council"/> — the dedicated consensus council
+///     interception (portfolio-health), unchanged from before this issue.
+///     Kept as its own contract value so telemetry and the UI can
+///     distinguish "took the council branch" from "took the plan branch".</item>
+/// </list>
+///
+/// The value is surfaced on <see cref="RoutingInfo.ExecutionPath"/> and
+/// tagged on the routing Activity as <c>agent.routing.path</c>.
+/// </summary>
+public static class ExecutionPath
+{
+    /// <summary>Single-specialist single-shot execution (today's default).</summary>
+    public const string Fast = "fast";
+
+    /// <summary>Plan-first orchestration path (issue #93).</summary>
+    public const string Plan = "plan";
+
+    /// <summary>Consensus-council interception (portfolio-health). Dedicated trigger; unchanged.</summary>
+    public const string Council = "council";
+
+    /// <summary>Every valid contract value for validation/allow-listing.</summary>
+    public static readonly IReadOnlyList<string> All = [Fast, Plan, Council];
+
+    /// <summary>
+    /// True when <paramref name="value"/> is a stable UI/telemetry contract
+    /// value. Case-insensitive because the wire format is user-controlled
+    /// (query params, request bodies) and callers should not have to match
+    /// our exact casing.
+    /// </summary>
+    public static bool IsKnown(string? value)
+    {
+        return !string.IsNullOrWhiteSpace(value)
+            && (string.Equals(value, Fast, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, Plan, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, Council, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// True when <paramref name="value"/> is one of the paths the user is
+    /// allowed to force. Council is a router-controlled destination and is
+    /// never a user override — the council keeps its own dedicated trigger.
+    /// </summary>
+    public static bool IsForceable(string? value)
+    {
+        return !string.IsNullOrWhiteSpace(value)
+            && (string.Equals(value, Fast, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, Plan, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/RetailPulse.Web/src/__tests__/AgentRoutingIndicator.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/AgentRoutingIndicator.test.tsx
@@ -39,4 +39,47 @@ describe('AgentRoutingIndicator', () => {
     expect(screen.getByText('💬')).toBeInTheDocument();
     expect(screen.getByText('87%')).toBeInTheDocument();
   });
+
+  it('omits the execution-path pill when routing has no executionPath (pre-#95 payload)', () => {
+    renderWithTheme(<AgentRoutingIndicator routing={baseRouting} />);
+    expect(screen.queryByTestId('execution-path-pill')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['fast', 'Fast'] as const,
+    ['plan', 'Plan'] as const,
+    ['council', 'Council'] as const,
+  ])('renders the %s execution-path pill without a forced indicator', (path, label) => {
+    renderWithTheme(
+      <AgentRoutingIndicator routing={{ ...baseRouting, executionPath: path }} />,
+    );
+    const pill = screen.getByTestId('execution-path-pill');
+    expect(pill).toHaveAttribute('data-execution-path', path);
+    expect(pill).toHaveAttribute('data-execution-path-forced', 'false');
+    expect(pill).toHaveTextContent(label);
+    expect(pill).toHaveAttribute('aria-label', `Execution path: ${label}`);
+  });
+
+  it('marks the pill as forced when executionPathForced is true', () => {
+    renderWithTheme(
+      <AgentRoutingIndicator
+        routing={{ ...baseRouting, executionPath: 'plan', executionPathForced: true }}
+      />,
+    );
+    const pill = screen.getByTestId('execution-path-pill');
+    expect(pill).toHaveAttribute('data-execution-path', 'plan');
+    expect(pill).toHaveAttribute('data-execution-path-forced', 'true');
+    expect(pill).toHaveAttribute('aria-label', 'Execution path: Plan (forced)');
+  });
+
+  it('does not mark the pill as forced when executionPathForced is explicitly false', () => {
+    renderWithTheme(
+      <AgentRoutingIndicator
+        routing={{ ...baseRouting, executionPath: 'fast', executionPathForced: false }}
+      />,
+    );
+    const pill = screen.getByTestId('execution-path-pill');
+    expect(pill).toHaveAttribute('data-execution-path-forced', 'false');
+    expect(pill).toHaveAttribute('aria-label', 'Execution path: Fast');
+  });
 });

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.anonymousExecutionPath.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.anonymousExecutionPath.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+
+// This suite verifies that anonymous mode (where the backend ignores an
+// override) does not present a misleading execution-path control. It lives
+// in its own file so we can override the `activeAuthMode` mock cleanly.
+const sendMessageMock = vi.fn();
+
+vi.mock('../services/api', () => ({
+  sendMessage: (...args: unknown[]) => sendMessageMock(...args),
+  isErrorReply: (reply: string) => reply.startsWith('⏳'),
+}));
+
+vi.mock('../services/telemetryHub', () => ({
+  joinTelemetrySession: vi.fn(),
+  onProgress: vi.fn(() => () => {}),
+}));
+
+vi.mock('../auth/activeProvider', () => ({
+  activeAuthMode: 'anonymous',
+}));
+
+vi.mock('../components/ChartRenderer', () => ({
+  default: () => <div data-testid="chart-renderer-mock" />,
+}));
+
+beforeEach(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  } else {
+    (Element.prototype.scrollIntoView as unknown as ReturnType<typeof vi.fn>) = vi.fn();
+  }
+  sendMessageMock.mockReset();
+});
+
+import { ChatPanel } from '../components/ChatPanel';
+
+function renderPanel() {
+  return render(
+    <FluentProvider theme={teamsDarkTheme}>
+      <ChatPanel />
+    </FluentProvider>,
+  );
+}
+
+describe('ChatPanel — anonymous mode execution-path guardrail', () => {
+  it('hides the execution-path selector for anonymous sessions', () => {
+    renderPanel();
+    expect(screen.queryByTestId('execution-path-select')).not.toBeInTheDocument();
+  });
+
+  it('never sends forceExecutionPath for anonymous sessions', async () => {
+    sendMessageMock.mockResolvedValue({
+      reply: 'ok',
+      sessionId: 'sess-anon',
+      spans: [],
+      totalDurationMs: 10,
+    });
+
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'hi');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1));
+    const [request] = sendMessageMock.mock.calls[0];
+    expect(request).toMatchObject({ message: 'hi' });
+    expect(request).not.toHaveProperty('forceExecutionPath');
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
@@ -19,6 +19,13 @@ vi.mock('../services/telemetryHub', () => ({
   onProgress: vi.fn(() => () => {}),
 }));
 
+// activeAuthMode drives whether the execution-path selector is rendered.
+// Default to `entra` (privileged mode) so the selector is present; the
+// anonymous-mode test overrides the value via vi.doMock before importing.
+vi.mock('../auth/activeProvider', () => ({
+  activeAuthMode: 'entra',
+}));
+
 // ChartRenderer is lazy-loaded; mock so Suspense resolves synchronously and
 // no Recharts work runs in the test env.
 vi.mock('../components/ChartRenderer', () => ({
@@ -90,9 +97,89 @@ describe('ChatPanel', () => {
     const [request] = sendMessageMock.mock.calls[0];
     expect(request).toMatchObject({ message: 'How are sales?' });
     expect(typeof request.sessionId).toBe('string');
+    // Auto is the default — the field must not appear on the wire so the
+    // fast-path UX is byte-identical for the common case.
+    expect(request).not.toHaveProperty('forceExecutionPath');
 
     // Assistant reply renders once the promise resolves.
     expect(await screen.findByText(/Sales were up 12% in Q1\./)).toBeInTheDocument();
+  });
+
+  it('exposes an Execution path selector defaulting to Auto', () => {
+    renderPanel();
+
+    const select = screen.getByTestId('execution-path-select') as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select).toHaveAccessibleName('Execution path');
+    expect(select.value).toBe('auto');
+    expect(Array.from(select.options).map((o) => o.value)).toEqual(['auto', 'fast', 'plan']);
+  });
+
+  it('includes forceExecutionPath when the user picks Fast', async () => {
+    const user = userEvent.setup();
+    sendMessageMock.mockResolvedValue({
+      reply: 'fast reply',
+      sessionId: 'sess-fast',
+      spans: [],
+      totalDurationMs: 10,
+    });
+
+    renderPanel();
+
+    await user.selectOptions(screen.getByTestId('execution-path-select'), 'fast');
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'quick check');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1));
+    expect(sendMessageMock.mock.calls[0][0]).toMatchObject({
+      message: 'quick check',
+      forceExecutionPath: 'fast',
+    });
+  });
+
+  it('includes forceExecutionPath when the user picks Plan', async () => {
+    const user = userEvent.setup();
+    sendMessageMock.mockResolvedValue({
+      reply: 'plan reply',
+      sessionId: 'sess-plan',
+      spans: [],
+      totalDurationMs: 10,
+    });
+
+    renderPanel();
+
+    await user.selectOptions(screen.getByTestId('execution-path-select'), 'plan');
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'compare regions');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1));
+    expect(sendMessageMock.mock.calls[0][0]).toMatchObject({
+      message: 'compare regions',
+      forceExecutionPath: 'plan',
+    });
+  });
+
+  it('drops back to Auto (omits the field) after switching Plan → Auto', async () => {
+    const user = userEvent.setup();
+    sendMessageMock.mockResolvedValue({
+      reply: 'ok',
+      sessionId: 'sess-toggle',
+      spans: [],
+      totalDurationMs: 10,
+    });
+
+    renderPanel();
+
+    const select = screen.getByTestId('execution-path-select');
+    await user.selectOptions(select, 'plan');
+    await user.selectOptions(select, 'auto');
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'default now');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1));
+    const [request] = sendMessageMock.mock.calls[0];
+    expect(request).toMatchObject({ message: 'default now' });
+    expect(request).not.toHaveProperty('forceExecutionPath');
   });
 
   it('keeps the Prompt ideas library control available before and after a message is sent', async () => {

--- a/src/RetailPulse.Web/src/__tests__/api.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/api.test.ts
@@ -71,6 +71,95 @@ describe('api.sendMessage', () => {
     }));
   });
 
+  it('omits forceExecutionPath from the body when not provided (issue #95 Auto default)', async () => {
+    let captured: RequestInit | undefined;
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: unknown, init?: RequestInit) => {
+        captured = init;
+        return Promise.resolve(
+          new Response(JSON.stringify({ reply: 'ok', sessionId: 's', spans: [] }), { status: 200 })
+        );
+      }
+    ) as unknown as typeof fetch;
+
+    await sendMessage({ message: 'hi', sessionId: 's' });
+
+    // Auto (the default) never sends the field so the payload is
+    // byte-identical to pre-#95 requests. This preserves today's fast-path
+    // UX for the common case.
+    expect(captured?.body).toBe(JSON.stringify({ message: 'hi', sessionId: 's' }));
+    expect((captured?.body as string) ?? '').not.toContain('forceExecutionPath');
+  });
+
+  it.each([
+    ['fast' as const],
+    ['plan' as const],
+  ])('serializes forceExecutionPath=%s when the caller forces the path', async (path) => {
+    let captured: RequestInit | undefined;
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: unknown, init?: RequestInit) => {
+        captured = init;
+        return Promise.resolve(
+          new Response(JSON.stringify({ reply: 'ok', sessionId: 's', spans: [] }), { status: 200 })
+        );
+      }
+    ) as unknown as typeof fetch;
+
+    await sendMessage({ message: 'hi', sessionId: 's', forceExecutionPath: path });
+
+    expect(captured?.body).toBe(
+      JSON.stringify({ message: 'hi', sessionId: 's', forceExecutionPath: path }),
+    );
+  });
+
+  it('parses executionPath + executionPathForced on the routing payload (issue #95)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          reply: 'ok',
+          sessionId: 's',
+          spans: [],
+          routing: {
+            agentKey: 'demand-forecasting',
+            agentName: 'Demand Agent',
+            intent: 'demand/forecasting',
+            confidence: 0.91,
+            executionPath: 'plan',
+            executionPathForced: true,
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    ) as unknown as typeof fetch;
+
+    const result = await sendMessage({ message: 'hi' });
+
+    expect(result.routing?.executionPath).toBe('plan');
+    expect(result.routing?.executionPathForced).toBe(true);
+  });
+
+  it('rejects a routing payload with an unknown executionPath value', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          reply: 'ok',
+          sessionId: 's',
+          spans: [],
+          routing: {
+            agentKey: 'x',
+            agentName: 'x',
+            intent: 'demand/x',
+            confidence: 0.9,
+            executionPath: 'nope',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    ) as unknown as typeof fetch;
+
+    await expect(sendMessage({ message: 'hi' })).rejects.toThrow(/malformed/i);
+  });
+
   it('uses the configured direct ACA origin for long-running chat', async () => {
     vi.stubEnv('VITE_API_ORIGIN', 'https://api.example.test');
     globalThis.fetch = vi.fn().mockResolvedValue(

--- a/src/RetailPulse.Web/src/components/AgentRoutingIndicator.tsx
+++ b/src/RetailPulse.Web/src/components/AgentRoutingIndicator.tsx
@@ -1,5 +1,5 @@
 import { Tooltip, makeStyles } from '@fluentui/react-components';
-import type { RoutingInfo } from '../types';
+import type { ExecutionPath, RoutingInfo } from '../types';
 import { getIntentCategory } from '../types';
 import { AGENT_COLORS, AGENT_EMOJIS } from '../constants/agentRouting';
 
@@ -11,7 +11,8 @@ const useStyles = makeStyles({
   container: {
     display: 'inline-flex',
     alignItems: 'center',
-    gap: '4px',
+    gap: '6px',
+    flexWrap: 'wrap',
     marginTop: '4px',
   },
   pill: {
@@ -28,6 +29,32 @@ const useStyles = makeStyles({
     ':hover': {
       opacity: '0.9',
     },
+  },
+  pathPill: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '4px',
+    padding: '2px 8px',
+    borderRadius: '10px',
+    fontSize: '10px',
+    fontWeight: '600',
+    letterSpacing: '0.02em',
+    textTransform: 'uppercase',
+    color: 'var(--color-text-muted)',
+    backgroundColor: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+  },
+  pathPillForced: {
+    color: 'var(--brand-accent)',
+    backgroundColor: 'var(--brand-accent-soft)',
+    border: '1px solid var(--brand-accent-border)',
+  },
+  forcedDot: {
+    display: 'inline-block',
+    width: '5px',
+    height: '5px',
+    borderRadius: '50%',
+    backgroundColor: 'var(--brand-accent)',
   },
   agentName: {
     fontWeight: '600',
@@ -54,6 +81,18 @@ const useStyles = makeStyles({
   },
 });
 
+const PATH_LABEL: Record<ExecutionPath, string> = {
+  fast: 'Fast',
+  plan: 'Plan',
+  council: 'Council',
+};
+
+const PATH_DESCRIPTION: Record<ExecutionPath, string> = {
+  fast: 'single-specialist single-shot execution',
+  plan: 'plan-first workflow',
+  council: 'consensus-council interception',
+};
+
 export function AgentRoutingIndicator({ routing }: AgentRoutingIndicatorProps) {
   const styles = useStyles();
 
@@ -61,6 +100,8 @@ export function AgentRoutingIndicator({ routing }: AgentRoutingIndicatorProps) {
   const color = AGENT_COLORS[category] ?? AGENT_COLORS.general;
   const emoji = AGENT_EMOJIS[category] ?? AGENT_EMOJIS.general;
   const pct = Math.round(routing.confidence * 100);
+  const path: ExecutionPath | undefined = routing.executionPath;
+  const forced = routing.executionPathForced === true;
 
   const pillStyle: React.CSSProperties = {
     backgroundColor: `${color}18`,
@@ -97,6 +138,27 @@ export function AgentRoutingIndicator({ routing }: AgentRoutingIndicatorProps) {
           {pillContent}
         </Tooltip>
       </div>
+      {path && (
+        <Tooltip
+          content={`Execution path: ${PATH_LABEL[path]} — ${PATH_DESCRIPTION[path]}${forced ? ' (forced by user override)' : ''}.`}
+          relationship="description"
+        >
+          <span
+            className={`${styles.pathPill} ${forced ? styles.pathPillForced : ''}`}
+            data-testid="execution-path-pill"
+            data-execution-path={path}
+            data-execution-path-forced={forced ? 'true' : 'false'}
+            aria-label={
+              forced
+                ? `Execution path: ${PATH_LABEL[path]} (forced)`
+                : `Execution path: ${PATH_LABEL[path]}`
+            }
+          >
+            {forced && <span aria-hidden="true" className={styles.forcedDot} />}
+            <span>{PATH_LABEL[path]}</span>
+          </span>
+        </Tooltip>
+      )}
     </div>
   );
 }

--- a/src/RetailPulse.Web/src/components/ChatPanel.tsx
+++ b/src/RetailPulse.Web/src/components/ChatPanel.tsx
@@ -12,10 +12,11 @@ import {
   makeStyles,
 } from '@fluentui/react-components';
 import { Send24Regular, ChevronRight16Regular } from '@fluentui/react-icons';
-import type { AgentSpan, ChatHistoryMessage, ChartSpec, RoutingInfo, TokenUsage, MemoryContext, ApprovalRequest, ApprovalDecision, CacheInfo } from '../types';
+import type { AgentSpan, ChatHistoryMessage, ChartSpec, RoutingInfo, TokenUsage, MemoryContext, ApprovalRequest, ApprovalDecision, CacheInfo, ForceableExecutionPath } from '../types';
 import type { SendMessageOptions } from '../services/api';
 import { sendMessage, isErrorReply } from '../services/api';
 import { joinTelemetrySession, onProgress } from '../services/telemetryHub';
+import { activeAuthMode } from '../auth/activeProvider';
 import { BrandLogo } from './BrandLogo';
 import { AgentRoutingIndicator } from './AgentRoutingIndicator';
 import { MemoryIndicator } from './MemoryIndicator';
@@ -370,6 +371,47 @@ const useChatStyles = makeStyles({
       padding: '12px 16px',
     },
   },
+  executionPathSelect: {
+    flexShrink: '0',
+    height: '32px',
+    padding: '0 26px 0 10px',
+    borderRadius: '8px',
+    border: '1px solid var(--color-border)',
+    background: 'var(--color-surface)',
+    color: 'var(--color-text-muted)',
+    fontSize: '12px',
+    fontWeight: '500',
+    cursor: 'pointer',
+    appearance: 'none',
+    backgroundImage:
+      "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='%239aa0a6' d='M0 0l5 6 5-6z'/></svg>\")",
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'right 10px center',
+    transition: 'all 0.2s ease',
+    ':hover': {
+      background: 'var(--color-surface-hover)',
+      border: '1px solid var(--brand-accent-soft-hover)',
+      color: 'var(--brand-accent-light)',
+      backgroundImage:
+        "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='%239aa0a6' d='M0 0l5 6 5-6z'/></svg>\")",
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: 'right 10px center',
+    },
+    ':focus-visible': {
+      outline: '2px solid var(--brand-accent)',
+      outlineOffset: '1px',
+    },
+    ':disabled': {
+      opacity: '0.5',
+      cursor: 'not-allowed',
+    },
+  },
+  executionPathForced: {
+    color: 'var(--brand-accent)',
+    border: '1px solid var(--brand-accent-border)',
+    background: 'var(--brand-accent-soft)',
+    fontWeight: '600',
+  },
   loadingContainer: {
     display: 'flex',
     alignItems: 'center',
@@ -390,6 +432,14 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved }:
   const [loadingText, setLoadingText] = useState<string>('Thinking...');
   const [progressSteps, setProgressSteps] = useState<ProgressStep[]>([]);
   const [sessionId] = useState<string>(() => crypto.randomUUID().replace(/-/g, ''));
+  // "auto" is the default — omit the field so the backend chooses. Only
+  // `fast` / `plan` are ever sent to the server; council keeps its own
+  // dedicated trigger and is not a valid override server-side.
+  const [forcePath, setForcePath] = useState<'auto' | ForceableExecutionPath>('auto');
+  // Anonymous sessions cannot force a path (backend ignores the field for
+  // anonymous users). Hide the selector so we don't present a misleading
+  // control that the server would silently drop.
+  const supportsExecutionPathOverride = activeAuthMode !== 'anonymous';
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const styles = useChatStyles();
 
@@ -466,8 +516,19 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved }:
           .map(m => ({ role: m.role, content: m.content }));
 
         const options: SendMessageOptions = { signal: controller.signal };
+        // Only include `forceExecutionPath` when the user has explicitly
+        // picked a path AND the current auth mode supports the override.
+        // Auto (the default) omits the field so the request payload for the
+        // common case is byte-identical to the pre-#95 shape.
+        const forceExecutionPath: ForceableExecutionPath | undefined =
+          supportsExecutionPathOverride && forcePath !== 'auto' ? forcePath : undefined;
         const response = await sendMessage(
-          { message: trimmed, sessionId, history },
+          {
+            message: trimmed,
+            sessionId,
+            history,
+            ...(forceExecutionPath ? { forceExecutionPath } : {}),
+          },
           options,
         );
         if (!isMountedRef.current || controller.signal.aborted) return;
@@ -514,7 +575,7 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved }:
         }
       }
     },
-    [sessionId],
+    [sessionId, forcePath, supportsExecutionPathOverride],
   );
 
   const handleSend = useCallback(async () => {
@@ -707,6 +768,33 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved }:
           onSelect={handleSuggestedClick}
           disabled={loading}
         />
+        {supportsExecutionPathOverride && (
+          <>
+            <label htmlFor="execution-path-select" className="visually-hidden">
+              Execution path
+            </label>
+            <select
+              id="execution-path-select"
+              className={`${styles.executionPathSelect} ${forcePath !== 'auto' ? styles.executionPathForced : ''}`}
+              value={forcePath}
+              onChange={(e) => setForcePath(e.target.value as 'auto' | ForceableExecutionPath)}
+              disabled={loading}
+              aria-label="Execution path"
+              title={
+                forcePath === 'auto'
+                  ? 'Execution path: Auto — the router picks fast or plan for you.'
+                  : forcePath === 'fast'
+                    ? 'Execution path: Fast (forced) — single specialist, single shot.'
+                    : 'Execution path: Plan (forced) — plan-first workflow with review when required.'
+              }
+              data-testid="execution-path-select"
+            >
+              <option value="auto">Auto</option>
+              <option value="fast">Fast</option>
+              <option value="plan">Plan</option>
+            </select>
+          </>
+        )}
         <Input
           id="chat-input"
           value={input}

--- a/src/RetailPulse.Web/src/services/api.ts
+++ b/src/RetailPulse.Web/src/services/api.ts
@@ -26,12 +26,34 @@ async function parseErrorBody(res: Response): Promise<string> {
 function isRoutingInfo(value: unknown): value is RoutingInfo {
   if (!value || typeof value !== 'object') return false;
   const v = value as Record<string, unknown>;
-  return (
-    typeof v.agentKey === 'string' &&
-    typeof v.agentName === 'string' &&
-    typeof v.intent === 'string' &&
-    typeof v.confidence === 'number'
-  );
+  if (
+    typeof v.agentKey !== 'string' ||
+    typeof v.agentName !== 'string' ||
+    typeof v.intent !== 'string' ||
+    typeof v.confidence !== 'number'
+  ) {
+    return false;
+  }
+  // Hybrid execution fields (issue #95). Optional, but reject wrong-typed
+  // values instead of silently coercing — the UI relies on the type to
+  // decide when to render the path badge / forced indicator.
+  if (v.executionPath !== undefined && v.executionPath !== null) {
+    if (
+      v.executionPath !== 'fast' &&
+      v.executionPath !== 'plan' &&
+      v.executionPath !== 'council'
+    ) {
+      return false;
+    }
+  }
+  if (
+    v.executionPathForced !== undefined &&
+    v.executionPathForced !== null &&
+    typeof v.executionPathForced !== 'boolean'
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function isChatResponse(value: unknown): value is ChatResponse {

--- a/src/RetailPulse.Web/src/types/index.ts
+++ b/src/RetailPulse.Web/src/types/index.ts
@@ -3,10 +3,32 @@ export interface ChatHistoryMessage {
   content: string;
 }
 
+/**
+ * Hybrid execution decision (issue #95). Mirrors the stable UI + telemetry
+ * contract values in `RetailPulse.Contracts.Routing.ExecutionPath`:
+ *   - `fast`    — single-specialist single-shot path (today's default)
+ *   - `plan`    — plan-first workflow path (issue #93)
+ *   - `council` — dedicated portfolio-health council interception
+ */
+export type ExecutionPath = 'fast' | 'plan' | 'council';
+
+/**
+ * Paths the UI is allowed to force via the composer. Council is a
+ * router-controlled destination with its own dedicated trigger and is never
+ * a user override — the backend validator rejects it with a 400.
+ */
+export type ForceableExecutionPath = 'fast' | 'plan';
+
 export interface ChatRequest {
   message: string;
   sessionId?: string;
   history?: ChatHistoryMessage[];
+  /**
+   * Optional user override for the hybrid execution decider (issue #95).
+   * Omitted for the "Auto" composer default so the backend chooses. Only
+   * `fast` or `plan` are accepted; anything else 400s server-side.
+   */
+  forceExecutionPath?: ForceableExecutionPath;
 }
 
 export type IntentCategory =
@@ -23,6 +45,17 @@ export interface RoutingInfo {
   intent: string;
   confidence: number;
   durationMs?: number;
+  /**
+   * Execution path the backend chose for this reply (issue #95). Optional
+   * to stay backward-compatible with pre-#95 responses that never carry it.
+   */
+  executionPath?: ExecutionPath;
+  /**
+   * True when the chosen path came from an explicit `forceExecutionPath`
+   * override rather than the router's automatic decision. Optional for
+   * pre-#95 payload compatibility.
+   */
+  executionPathForced?: boolean;
 }
 
 /** Extract the top-level intent category from a slash-separated intent string.

--- a/tests/RetailPulse.Benchmarks/HybridFastPathBaselineRunner.cs
+++ b/tests/RetailPulse.Benchmarks/HybridFastPathBaselineRunner.cs
@@ -100,7 +100,7 @@ internal static class HybridFastPathBaselineRunner
                 Framework = RuntimeInformation.FrameworkDescription,
                 OsPlatform = ResolveOsPlatform(),
                 ProcessArchitecture = RuntimeInformation.ProcessArchitecture.ToString(),
-                ProcessorCount = System.Environment.ProcessorCount,
+                ProcessorCount = Environment.ProcessorCount,
                 Configuration = ResolveBuildConfiguration(),
             },
             Method = new MethodDescriptor
@@ -121,7 +121,7 @@ internal static class HybridFastPathBaselineRunner
 
         Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
         string json = JsonSerializer.Serialize(artifact, s_jsonOptions);
-        File.WriteAllText(outputPath, json + System.Environment.NewLine);
+        File.WriteAllText(outputPath, json + Environment.NewLine);
 
         Console.WriteLine("[baseline] Wrote " + outputPath);
         Console.WriteLine($"[baseline] samples={SampleCount}  p50={artifact.Results.P50} ns  p95={artifact.Results.P95} ns  commit={artifact.CommitSha}");
@@ -186,14 +186,12 @@ internal static class HybridFastPathBaselineRunner
             : "unknown";
     }
 
-    private static string ResolveBuildConfiguration()
-    {
+    private static string ResolveBuildConfiguration() =>
 #if DEBUG
-        return "Debug";
+        "Debug";
 #else
-        return "Release";
+        "Release";
 #endif
-    }
 
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {

--- a/tests/RetailPulse.Benchmarks/HybridFastPathBaselineRunner.cs
+++ b/tests/RetailPulse.Benchmarks/HybridFastPathBaselineRunner.cs
@@ -1,0 +1,240 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using RetailPulse.Api.Agents.Routing;
+
+namespace RetailPulse.Benchmarks;
+
+/// <summary>
+/// Deterministic p50/p95 baseline harness for the single-specialist fast path
+/// consumed by issue #95. Invoked via <c>dotnet run -c Release --project
+/// tests/RetailPulse.Benchmarks -- baseline</c> (see <see cref="Program"/>).
+///
+/// The measured code path is <c>RetailOpsRouter.TryKeywordClassify</c> for the
+/// reference prompt "How is Sierra Gold Tequila performing in the Northeast?".
+/// The prompt hits the <c>BrandPerformingRegex</c> single-brand-lookup fast path
+/// and returns the General intent without any network, LLM, or MCP call — so
+/// repeated timings are stable and represent decision-layer overhead only.
+///
+/// Writes a compact JSON artifact under
+/// <c>tests/RetailPulse.Benchmarks/baselines/hybrid-fast-path-baseline.json</c>
+/// containing commit SHA, coarse environment identifier (framework, OS platform,
+/// process architecture, processor count) sufficient for before/after matching,
+/// sample count, p50, and p95 in nanoseconds. No secrets, usernames, or machine
+/// names are captured.
+/// </summary>
+internal static class HybridFastPathBaselineRunner
+{
+    /// <summary>Reference prompt from issue #95. Do not change without re-baselining.</summary>
+    internal const string ReferencePrompt =
+        "How is Sierra Gold Tequila performing in the Northeast?";
+
+    /// <summary>Warmup iterations before timed samples. Keeps JIT + regex-init cost out.</summary>
+    private const int WarmupIterations = 2_000;
+
+    /// <summary>Timed sample count. Small enough to run in &lt;1s, large enough for stable p95.</summary>
+    private const int SampleCount = 20_000;
+
+    private static readonly MethodInfo TryKeywordClassifyMethod =
+        typeof(RetailOpsRouter).GetMethod("TryKeywordClassify", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    /// <summary>
+    /// Creates a <see cref="RetailOpsRouter"/> without invoking its constructor so
+    /// benchmarks can reach the private <c>TryKeywordClassify</c> instance method
+    /// without wiring the full DI graph (IChatClient, specialists, metrics, etc.).
+    /// The method only reads the message argument and static regexes — no instance
+    /// state is touched — so an uninitialized instance is safe here.
+    /// </summary>
+    internal static RetailOpsRouter CreateRouterUninitialized()
+        => (RetailOpsRouter)RuntimeHelpers.GetUninitializedObject(typeof(RetailOpsRouter));
+
+    public static int Run(string[] args)
+    {
+        string outputPath = ResolveOutputPath(args);
+        RetailOpsRouter router = CreateRouterUninitialized();
+
+        // Sanity check: the reference prompt must hit the fast path. If someone
+        // moves the router logic and this stops returning a classification, the
+        // baseline is meaningless — fail loudly instead of writing zeros.
+        object? sanity = TryKeywordClassifyMethod.Invoke(router, [ReferencePrompt]);
+        if (sanity is null)
+        {
+            Console.Error.WriteLine(
+                "[baseline] Reference prompt no longer hits the keyword fast path — refusing to record a misleading baseline.");
+            return 2;
+        }
+
+        // Warmup
+        for (int i = 0; i < WarmupIterations; i++)
+        {
+            _ = TryKeywordClassifyMethod.Invoke(router, [ReferencePrompt]);
+        }
+
+        long[] samples = new long[SampleCount];
+        var sw = new Stopwatch();
+        for (int i = 0; i < SampleCount; i++)
+        {
+            sw.Restart();
+            _ = TryKeywordClassifyMethod.Invoke(router, [ReferencePrompt]);
+            sw.Stop();
+            samples[i] = sw.ElapsedTicks;
+        }
+
+        Array.Sort(samples);
+        double ticksToNanos = 1_000_000_000.0 / Stopwatch.Frequency;
+        double p50Ns = samples[(int)(SampleCount * 0.50)] * ticksToNanos;
+        double p95Ns = samples[(int)(SampleCount * 0.95)] * ticksToNanos;
+
+        var artifact = new BaselineArtifact
+        {
+            Issue = "#95",
+            Scenario = "hybrid-execution-fast-path",
+            Prompt = ReferencePrompt,
+            MeasuredCodePath = "RetailPulse.Api.Agents.Routing.RetailOpsRouter.TryKeywordClassify",
+            CommitSha = ResolveCommitSha(),
+            Environment = new EnvironmentIdentifier
+            {
+                Framework = RuntimeInformation.FrameworkDescription,
+                OsPlatform = ResolveOsPlatform(),
+                ProcessArchitecture = RuntimeInformation.ProcessArchitecture.ToString(),
+                ProcessorCount = System.Environment.ProcessorCount,
+                Configuration = ResolveBuildConfiguration(),
+            },
+            Method = new MethodDescriptor
+            {
+                WarmupIterations = WarmupIterations,
+                SampleCount = SampleCount,
+                TimerFrequencyHz = Stopwatch.Frequency,
+                Deterministic = true,
+            },
+            Results = new ResultBlock
+            {
+                Units = "nanoseconds",
+                P50 = Math.Round(p50Ns, 2),
+                P95 = Math.Round(p95Ns, 2),
+            },
+            RecordedAtUtc = DateTime.UtcNow.ToString("O"),
+        };
+
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+        string json = JsonSerializer.Serialize(artifact, s_jsonOptions);
+        File.WriteAllText(outputPath, json + System.Environment.NewLine);
+
+        Console.WriteLine("[baseline] Wrote " + outputPath);
+        Console.WriteLine($"[baseline] samples={SampleCount}  p50={artifact.Results.P50} ns  p95={artifact.Results.P95} ns  commit={artifact.CommitSha}");
+        return 0;
+    }
+
+    private static string ResolveOutputPath(string[] args)
+    {
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], "--out", StringComparison.OrdinalIgnoreCase))
+                return Path.GetFullPath(args[i + 1]);
+        }
+        string projectDir = ResolveProjectDirectory();
+        return Path.Combine(projectDir, "baselines", "hybrid-fast-path-baseline.json");
+    }
+
+    private static string ResolveProjectDirectory()
+    {
+        // AppContext.BaseDirectory in Release is
+        // tests/RetailPulse.Benchmarks/bin/Release/net10.0/. Walk up to the .csproj.
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "RetailPulse.Benchmarks.csproj")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        return AppContext.BaseDirectory;
+    }
+
+    private static string ResolveCommitSha()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git", "rev-parse HEAD")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = ResolveProjectDirectory(),
+            };
+            using var p = Process.Start(psi);
+            if (p is null) return "unknown";
+            string sha = p.StandardOutput.ReadToEnd().Trim();
+            p.WaitForExit(2_000);
+            return string.IsNullOrEmpty(sha) ? "unknown" : sha;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("[baseline] Could not resolve git HEAD: " + ex.Message);
+            return "unknown";
+        }
+    }
+
+    private static string ResolveOsPlatform()
+    {
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows"
+            : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux"
+            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "macos"
+            : "unknown";
+    }
+
+    private static string ResolveBuildConfiguration()
+    {
+#if DEBUG
+        return "Debug";
+#else
+        return "Release";
+#endif
+    }
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    private sealed class BaselineArtifact
+    {
+        [JsonPropertyName("issue")] public string Issue { get; set; } = "";
+        [JsonPropertyName("scenario")] public string Scenario { get; set; } = "";
+        [JsonPropertyName("prompt")] public string Prompt { get; set; } = "";
+        [JsonPropertyName("measured_code_path")] public string MeasuredCodePath { get; set; } = "";
+        [JsonPropertyName("commit_sha")] public string CommitSha { get; set; } = "";
+        [JsonPropertyName("environment")] public EnvironmentIdentifier Environment { get; set; } = new();
+        [JsonPropertyName("method")] public MethodDescriptor Method { get; set; } = new();
+        [JsonPropertyName("results")] public ResultBlock Results { get; set; } = new();
+        [JsonPropertyName("recorded_at_utc")] public string RecordedAtUtc { get; set; } = "";
+    }
+
+    private sealed class EnvironmentIdentifier
+    {
+        [JsonPropertyName("framework")] public string Framework { get; set; } = "";
+        [JsonPropertyName("os_platform")] public string OsPlatform { get; set; } = "";
+        [JsonPropertyName("process_architecture")] public string ProcessArchitecture { get; set; } = "";
+        [JsonPropertyName("processor_count")] public int ProcessorCount { get; set; }
+        [JsonPropertyName("configuration")] public string Configuration { get; set; } = "";
+    }
+
+    private sealed class MethodDescriptor
+    {
+        [JsonPropertyName("warmup_iterations")] public int WarmupIterations { get; set; }
+        [JsonPropertyName("sample_count")] public int SampleCount { get; set; }
+        [JsonPropertyName("timer_frequency_hz")] public long TimerFrequencyHz { get; set; }
+        [JsonPropertyName("deterministic")] public bool Deterministic { get; set; }
+    }
+
+    private sealed class ResultBlock
+    {
+        [JsonPropertyName("units")] public string Units { get; set; } = "";
+        [JsonPropertyName("p50")] public double P50 { get; set; }
+        [JsonPropertyName("p95")] public double P95 { get; set; }
+    }
+}

--- a/tests/RetailPulse.Benchmarks/HybridFastPathBenchmark.cs
+++ b/tests/RetailPulse.Benchmarks/HybridFastPathBenchmark.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using RetailPulse.Api.Agents.Routing;
+
+namespace RetailPulse.Benchmarks;
+
+/// <summary>
+/// Measures the decision-layer fast-path overhead for the reference single-specialist
+/// prompt used by issue #95 ("hybrid execution: fast single-shot path vs plan path").
+///
+/// This exercises <c>RetailOpsRouter.TryKeywordClassify</c> only — a pure, in-process
+/// call with no network, LLM, or MCP dependency — so it produces a deterministic
+/// pre-change baseline against which the post-change hybrid decision layer can be
+/// compared without model or transport variance.
+///
+/// A concise, machine-readable p50/p95 baseline artifact is produced by the
+/// companion runner in <see cref="HybridFastPathBaselineRunner"/>; this
+/// BenchmarkDotNet class exists so the same code path also lives under the
+/// project's standard benchmark suite for future BDN-based comparison.
+/// </summary>
+[MemoryDiagnoser]
+public class HybridFastPathBenchmark
+{
+    private static readonly MethodInfo TryKeywordClassifyMethod =
+        typeof(RetailOpsRouter).GetMethod("TryKeywordClassify", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private RetailOpsRouter _router = null!;
+    private string _referencePrompt = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _referencePrompt = HybridFastPathBaselineRunner.ReferencePrompt;
+        _router = HybridFastPathBaselineRunner.CreateRouterUninitialized();
+    }
+
+    [Benchmark(Description = "Fast-path: 'How is Sierra Gold Tequila performing in the Northeast?'")]
+    public object? SingleSpecialistFastPath()
+        => TryKeywordClassifyMethod.Invoke(_router, [_referencePrompt]);
+}

--- a/tests/RetailPulse.Benchmarks/Program.cs
+++ b/tests/RetailPulse.Benchmarks/Program.cs
@@ -1,7 +1,25 @@
 using BenchmarkDotNet.Running;
+using RetailPulse.Benchmarks;
 
 internal sealed class BenchmarkEntry
 {
-    public static void Main(string[] args)
-        => BenchmarkSwitcher.FromAssembly(typeof(BenchmarkEntry).Assembly).Run(args);
+    public static int Main(string[] args)
+    {
+        // Deterministic p50/p95 baseline runner for the hybrid-execution fast path
+        // (issue #95). Kept alongside BenchmarkDotNet so both live under the same
+        // project entry point:
+        //
+        //   dotnet run -c Release --project tests/RetailPulse.Benchmarks -- baseline
+        //   dotnet run -c Release --project tests/RetailPulse.Benchmarks -- baseline --out <path>
+        //
+        // Anything else falls through to BenchmarkDotNet as before.
+        if (args.Length > 0 && string.Equals(args[0], "baseline", StringComparison.OrdinalIgnoreCase))
+        {
+            string[] rest = args.Length > 1 ? args[1..] : [];
+            return HybridFastPathBaselineRunner.Run(rest);
+        }
+
+        BenchmarkSwitcher.FromAssembly(typeof(BenchmarkEntry).Assembly).Run(args);
+        return 0;
+    }
 }

--- a/tests/RetailPulse.Benchmarks/baselines/hybrid-fast-path-baseline.json
+++ b/tests/RetailPulse.Benchmarks/baselines/hybrid-fast-path-baseline.json
@@ -1,0 +1,26 @@
+{
+  "issue": "#95",
+  "scenario": "hybrid-execution-fast-path",
+  "prompt": "How is Sierra Gold Tequila performing in the Northeast?",
+  "measured_code_path": "RetailPulse.Api.Agents.Routing.RetailOpsRouter.TryKeywordClassify",
+  "commit_sha": "e445f0c8bb408f940425c99aac930234dc771909",
+  "environment": {
+    "framework": ".NET 10.0.11",
+    "os_platform": "windows",
+    "process_architecture": "X64",
+    "processor_count": 24,
+    "configuration": "Release"
+  },
+  "method": {
+    "warmup_iterations": 2000,
+    "sample_count": 20000,
+    "timer_frequency_hz": 10000000,
+    "deterministic": true
+  },
+  "results": {
+    "units": "nanoseconds",
+    "p50": 5200,
+    "p95": 7700
+  },
+  "recorded_at_utc": "2026-08-21T01:53:23.8284405Z"
+}

--- a/tests/RetailPulse.Tests/Routing/HybridExecutionDeciderTests.cs
+++ b/tests/RetailPulse.Tests/Routing/HybridExecutionDeciderTests.cs
@@ -306,10 +306,7 @@ public sealed class HybridExecutionDeciderTests
     }
 
     [Fact]
-    public void IsCouncilIntent_returns_false_for_non_council_decision()
-    {
-        HybridExecutionDecider.IsCouncilIntent(SingleHighConfidence()).Should().BeFalse();
-    }
+    public void IsCouncilIntent_returns_false_for_non_council_decision() => HybridExecutionDecider.IsCouncilIntent(SingleHighConfidence()).Should().BeFalse();
 
     // ── Ordering — override outranks council when planner is available ─
 

--- a/tests/RetailPulse.Tests/Routing/HybridExecutionDeciderTests.cs
+++ b/tests/RetailPulse.Tests/Routing/HybridExecutionDeciderTests.cs
@@ -1,0 +1,332 @@
+using FluentAssertions;
+using RetailPulse.Api.Agents.Routing;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts.Routing;
+
+namespace RetailPulse.Tests.Routing;
+
+/// <summary>
+/// Decision-table coverage for the hybrid execution decider (issue #95).
+/// Every precedence rung in the design gate — explicit override, council
+/// dedicated route, planner-unavailable short-circuit, multi-domain,
+/// low-confidence, advisory phrase, single-domain default — is pinned as
+/// a discrete case so future refactors can't silently reorder them.
+/// </summary>
+public sealed class HybridExecutionDeciderTests
+{
+    private static PlanPersistenceOptions DefaultOptions() => new()
+    {
+        MinDetectedIntentsForPlan = 2,
+        MinConfidenceForFastPath = 0.6,
+        AdvisoryPhrases = ["why did", "what should we", "recommend"],
+    };
+
+    private static RoutingDecision SingleHighConfidence(
+        string intent = AgentIntent.DemandForecasting,
+        double confidence = 0.92)
+        => new("demand", intent, confidence, [intent]);
+
+    // ── Precedence 1: explicit override ────────────────────────────────
+
+    [Fact]
+    public void Force_fast_wins_over_multi_domain_when_authenticated_and_planner_available()
+    {
+        var decision = new RoutingDecision(
+            "demand", AgentIntent.DemandForecasting, 0.9,
+            [AgentIntent.DemandForecasting, AgentIntent.SupplyShipments]);
+
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            decision,
+            "compare demand and supply for Q1",
+            new HybridExecutionContext(
+                AnonymousCaller: false,
+                PlannerAvailable: true,
+                ForcedPath: ExecutionPath.Fast),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Fast);
+        result.Forced.Should().BeTrue();
+        result.Reason.Should().Be(HybridExecutionReason.ForceOverride);
+    }
+
+    [Fact]
+    public void Force_plan_wins_over_single_domain_when_authenticated_and_planner_available()
+    {
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            SingleHighConfidence(),
+            "How is Sierra Gold Tequila performing in the Northeast?",
+            new HybridExecutionContext(
+                AnonymousCaller: false,
+                PlannerAvailable: true,
+                ForcedPath: ExecutionPath.Plan),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Plan);
+        result.Forced.Should().BeTrue();
+        result.Reason.Should().Be(HybridExecutionReason.ForceOverride);
+    }
+
+    [Fact]
+    public void Force_plan_is_ignored_when_planner_unavailable_and_falls_through_to_default_flow()
+    {
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            SingleHighConfidence(),
+            "How is Sierra Gold Tequila performing in the Northeast?",
+            new HybridExecutionContext(
+                AnonymousCaller: false,
+                PlannerAvailable: false,
+                ForcedPath: ExecutionPath.Plan),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Fast);
+        result.Forced.Should().BeFalse();
+        result.Reason.Should().Be(HybridExecutionReason.PlannerUnavailable);
+    }
+
+    [Fact]
+    public void Force_override_is_ignored_for_anonymous_callers_and_falls_through()
+    {
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            SingleHighConfidence(),
+            "How is Sierra Gold Tequila performing in the Northeast?",
+            new HybridExecutionContext(
+                AnonymousCaller: true,
+                PlannerAvailable: true,
+                ForcedPath: ExecutionPath.Plan),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Fast);
+        result.Forced.Should().BeFalse();
+        result.Reason.Should().Be(HybridExecutionReason.AnonymousCaller);
+    }
+
+    // ── Precedence 2: council dedicated route ──────────────────────────
+
+    [Fact]
+    public void Council_intent_resolves_to_council_regardless_of_planner_availability()
+    {
+        var decision = new RoutingDecision(
+            "council", AgentIntent.PortfolioHealth, 0.95, [AgentIntent.PortfolioHealth]);
+
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            decision,
+            "how is the portfolio performing",
+            new HybridExecutionContext(
+                AnonymousCaller: false,
+                PlannerAvailable: true,
+                ForcedPath: null),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Council);
+        result.Forced.Should().BeFalse();
+        result.Reason.Should().Be(HybridExecutionReason.CouncilIntent);
+    }
+
+    [Fact]
+    public void Council_intent_detected_as_secondary_intent_still_resolves_to_council()
+    {
+        var decision = new RoutingDecision(
+            "demand", AgentIntent.DemandForecasting, 0.9,
+            [AgentIntent.DemandForecasting, AgentIntent.PortfolioHealth]);
+
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            decision,
+            "how are demand and portfolio doing",
+            new HybridExecutionContext(false, true, null),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Council);
+    }
+
+    // ── Precedence 3: planner unavailable → fast ───────────────────────
+
+    [Fact]
+    public void Anonymous_caller_always_resolves_to_fast_when_council_intent_is_absent()
+    {
+        var decision = new RoutingDecision(
+            "demand", AgentIntent.DemandForecasting, 0.4,
+            [AgentIntent.DemandForecasting, AgentIntent.SupplyShipments]);
+
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            decision,
+            "why did demand drop and what should we do",
+            new HybridExecutionContext(
+                AnonymousCaller: true,
+                PlannerAvailable: true,
+                ForcedPath: null),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Fast);
+        result.Reason.Should().Be(HybridExecutionReason.AnonymousCaller);
+    }
+
+    [Fact]
+    public void Planner_unavailable_resolves_to_fast_even_on_multi_domain_request()
+    {
+        var decision = new RoutingDecision(
+            "demand", AgentIntent.DemandForecasting, 0.9,
+            [AgentIntent.DemandForecasting, AgentIntent.SupplyShipments]);
+
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            decision,
+            "compare demand and supply",
+            new HybridExecutionContext(false, PlannerAvailable: false, ForcedPath: null),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Fast);
+        result.Reason.Should().Be(HybridExecutionReason.PlannerUnavailable);
+    }
+
+    // ── Precedence 4: multi-domain → plan ──────────────────────────────
+
+    [Fact]
+    public void Detected_intents_at_or_above_threshold_resolve_to_plan()
+    {
+        var decision = new RoutingDecision(
+            "demand", AgentIntent.DemandForecasting, 0.85,
+            [AgentIntent.DemandForecasting, AgentIntent.SupplyShipments]);
+
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            decision,
+            "reconcile demand forecast and shipment plan",
+            new HybridExecutionContext(false, true, null),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Plan);
+        result.Reason.Should().Be(HybridExecutionReason.MultiDomain);
+    }
+
+    [Fact]
+    public void Threshold_is_configurable_and_disables_multi_domain_admission_when_high()
+    {
+        PlanPersistenceOptions options = DefaultOptions();
+        options.MinDetectedIntentsForPlan = 5;
+
+        var decision = new RoutingDecision(
+            "demand", AgentIntent.DemandForecasting, 0.9,
+            [AgentIntent.DemandForecasting, AgentIntent.SupplyShipments]);
+
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            decision,
+            "compare demand and supply",
+            new HybridExecutionContext(false, true, null),
+            options);
+
+        result.Path.Should().Be(ExecutionPath.Fast);
+        result.Reason.Should().Be(HybridExecutionReason.SingleDomain);
+    }
+
+    // ── Precedence 5: low confidence → plan ────────────────────────────
+
+    [Fact]
+    public void Confidence_strictly_below_configured_floor_resolves_to_plan()
+    {
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            SingleHighConfidence(confidence: 0.5),
+            "How is Sierra Gold Tequila performing in the Northeast?",
+            new HybridExecutionContext(false, true, null),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Plan);
+        result.Reason.Should().Be(HybridExecutionReason.LowConfidence);
+    }
+
+    [Fact]
+    public void Confidence_at_configured_floor_stays_on_fast_path()
+    {
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            SingleHighConfidence(confidence: 0.6),
+            "How is Sierra Gold Tequila performing in the Northeast?",
+            new HybridExecutionContext(false, true, null),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Fast);
+        result.Reason.Should().Be(HybridExecutionReason.SingleDomain);
+    }
+
+    // ── Precedence 6: advisory phrase → plan ───────────────────────────
+
+    [Theory]
+    [InlineData("Why did depletions drop in the Northeast?")]
+    [InlineData("What should we do about the Southwest region?")]
+    [InlineData("Recommend a promotion strategy for Q3")]
+    public void Advisory_phrase_resolves_to_plan_even_on_single_high_confidence_intent(string message)
+    {
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            SingleHighConfidence(),
+            message,
+            new HybridExecutionContext(false, true, null),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Plan);
+        result.Reason.Should().Be(HybridExecutionReason.AdvisoryPhrase);
+    }
+
+    [Fact]
+    public void Empty_advisory_phrase_list_disables_the_trigger()
+    {
+        PlanPersistenceOptions options = DefaultOptions();
+        options.AdvisoryPhrases = [];
+
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            SingleHighConfidence(),
+            "Why did depletions drop?",
+            new HybridExecutionContext(false, true, null),
+            options);
+
+        result.Path.Should().Be(ExecutionPath.Fast);
+        result.Reason.Should().Be(HybridExecutionReason.SingleDomain);
+    }
+
+    // ── Precedence 7: default fast ─────────────────────────────────────
+
+    [Fact]
+    public void Single_high_confidence_intent_resolves_to_fast_by_default()
+    {
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            SingleHighConfidence(),
+            "How is Sierra Gold Tequila performing in the Northeast?",
+            new HybridExecutionContext(false, true, null),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Fast);
+        result.Forced.Should().BeFalse();
+        result.Reason.Should().Be(HybridExecutionReason.SingleDomain);
+    }
+
+    // ── IsCouncilIntent helper ─────────────────────────────────────────
+
+    [Fact]
+    public void IsCouncilIntent_detects_council_intent_case_insensitively()
+    {
+        var decision = new RoutingDecision(
+            "council", "COUNCIL/HEALTH", 0.9, ["Council/Health"]);
+
+        HybridExecutionDecider.IsCouncilIntent(decision).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsCouncilIntent_returns_false_for_non_council_decision()
+    {
+        HybridExecutionDecider.IsCouncilIntent(SingleHighConfidence()).Should().BeFalse();
+    }
+
+    // ── Ordering — override outranks council when planner is available ─
+
+    [Fact]
+    public void Force_fast_overrides_council_intent_when_authenticated()
+    {
+        var decision = new RoutingDecision(
+            "council", AgentIntent.PortfolioHealth, 0.95, [AgentIntent.PortfolioHealth]);
+
+        HybridExecutionResult result = HybridExecutionDecider.Decide(
+            decision,
+            "how is the portfolio performing",
+            new HybridExecutionContext(false, true, ExecutionPath.Fast),
+            DefaultOptions());
+
+        result.Path.Should().Be(ExecutionPath.Fast);
+        result.Forced.Should().BeTrue();
+        result.Reason.Should().Be(HybridExecutionReason.ForceOverride);
+    }
+}

--- a/tests/RetailPulse.Tests/Security/ChatRequestValidatorTests.cs
+++ b/tests/RetailPulse.Tests/Security/ChatRequestValidatorTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using RetailPulse.Api.Validation;
 using RetailPulse.Contracts;
+using RetailPulse.Contracts.Routing;
 
 namespace RetailPulse.Tests.Security;
 
@@ -124,6 +125,73 @@ public class ChatRequestValidatorTests
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("sessionId");
+    }
+
+    // ── ForceExecutionPath (issue #95 hybrid execution) ───────────────
+
+    [Fact]
+    public void NullForceExecutionPath_IsValid()
+    {
+        var request = new ChatRequest("Hello", "session1");
+
+        ValidationResult result = ChatRequestValidator.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("fast")]
+    [InlineData("Fast")]
+    [InlineData("FAST")]
+    [InlineData("plan")]
+    [InlineData("PLAN")]
+    public void ForceExecutionPath_AllowsFastOrPlan_CaseInsensitive(string forcePath)
+    {
+        var request = new ChatRequest("Hello", "session1", ForceExecutionPath: forcePath);
+
+        ValidationResult result = ChatRequestValidator.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("council")]
+    [InlineData("bypass")]
+    [InlineData("l3")]
+    public void ForceExecutionPath_RejectsUnknownOrCouncilValues(string forcePath)
+    {
+        var request = new ChatRequest("Hello", "session1", ForceExecutionPath: forcePath);
+
+        ValidationResult result = ChatRequestValidator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainKey("forceExecutionPath");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ForceExecutionPath_RejectsWhitespaceOrEmpty(string forcePath)
+    {
+        var request = new ChatRequest("Hello", "session1", ForceExecutionPath: forcePath);
+
+        ValidationResult result = ChatRequestValidator.Validate(request);
+
+        result.IsValid.Should().BeFalse(
+            "an empty or whitespace-only ForceExecutionPath is a client bug and must not silently pass through");
+        result.Errors.Should().ContainKey("forceExecutionPath");
+    }
+
+    [Fact]
+    public void ForceExecutionPath_ErrorMessageMentionsFastAndPlan()
+    {
+        var request = new ChatRequest("Hello", "session1", ForceExecutionPath: "council");
+
+        ValidationResult result = ChatRequestValidator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors["forceExecutionPath"].Should().Contain(e => e.Contains(ExecutionPath.Fast));
+        result.Errors["forceExecutionPath"].Should().Contain(e => e.Contains(ExecutionPath.Plan));
     }
 
     [Theory]


### PR DESCRIPTION
Closes #95

## Summary

Adds an explicit **hybrid execution decision layer** in front of `/api/chat` that chooses between today's single-specialist fast path and the plan-first orchestrator (issue #93). Most turns keep the fast path unchanged; only genuinely multi-domain, low-confidence, or advisory prompts are admitted to the plan path. Council routing keeps its own dedicated trigger.

## Decision rule (`HybridExecutionDecider`)

Pure, allocation-lean static helper. Precedence, applied in order:

1. **Explicit user override** — authenticated callers only, honored only when the requested path is reachable (anonymous or unavailable-planner overrides are ignored and logged).
2. **Council dedicated route** — portfolio-health intent → `ExecutionPath.Council` (unchanged trigger).
3. **Planner unavailable** — anonymous session, orchestrator not registered, or no detected intents → `Fast`.
4. **Multi-domain** — `DetectedIntents.Count >= MinDetectedIntentsForPlan` → `Plan`.
5. **Low confidence** — `Confidence < MinConfidenceForFastPath` → `Plan`.
6. **Advisory phrase** — case-insensitive substring match on configured cues → `Plan`.
7. **Else** → `Fast`.

Configurable defaults (`PlanPersistence` section in `appsettings.json`, documented inline):

| Setting | Default | Purpose |
| --- | --- | --- |
| `MinDetectedIntentsForPlan` | `2` | Multi-domain admission floor |
| `MinConfidenceForFastPath` | `0.6` | Router-confidence floor — matches internal `RetailOpsRouter` threshold so both decisions stay coherent |
| `AdvisoryPhrases` | `["why did","why is","why are","what should we","what should i","what do we do","recommend","diagnose"]` | Substring cues that force plan on single-domain high-confidence prompts. Leave empty to disable this trigger. |

## Forced path + UI/telemetry visibility

- `ChatRequest.ForceExecutionPath` (`fast` \| `plan`) added; validator rejects any other value with a 400. Council is router-owned and never a valid override.
- Anonymous callers cannot force a path — override is silently ignored and logged.
- `RoutingInfo` now carries `ExecutionPath` + `ExecutionPathForced`.
- Routing Activity tags: `agent.routing.path`, `agent.routing.path_forced`, `agent.routing.decision_reason` (stable reason codes: `force_override`, `council_intent`, `anonymous_caller`, `planner_unavailable`, `multi_domain`, `low_confidence`, `advisory_phrase`, `single_domain`). Same values on the routing `TraceSpan` attributes.
- Frontend `AgentRoutingIndicator` renders a Fast/Plan/Council pill with a `data-testid="execution-path-pill"` and a distinct "forced" accent when the user overrode the router. Composer exposes an Auto / Force Fast / Force Plan select for authenticated sessions only.

## Relationship to `EscalationOrchestrator`

`/api/chat` now uses `HybridExecutionDecider` + `PlanOrchestrator` end-to-end. The multi-specialist admission signal — multi-domain, low-confidence, advisory — is owned by the decider and admits directly into the plan-first orchestrator (planning, execution, review, persistence, cost attribution).

The chat pipeline **no longer calls** `EscalationOrchestrator`. Its L1→L2→L3 fan-out is preserved only under `POST /api/escalate` for legacy callers that opt in explicitly; it is **deprecated-in-place** (no new features land there, class-level docs say so, and new callers should prefer the plan path). There is no duplicated fan-out on the primary chat path.

A follow-up compatibility pass will propose full removal of `/api/escalate` after callers migrate; leaving it in-place-but-marked here rather than half-deleted so no consumer contract silently drops in this change.

## Council trigger — unchanged

`HybridExecutionDecider.IsCouncilIntent` matches the exact predicate used previously (`AgentIntent.PortfolioHealth` on either `decision.Intent` or any `DetectedIntent`). Council path resolves before any override that would target it, so behavior on portfolio-health prompts is preserved.

## Defaults / disabled / anonymous / guardrails / audit / review verified

- **Default off.** With `PlanPersistence.Enabled = false` (repo default), the plan branch is inert and every turn stays on the fast path exactly as before.
- **Anonymous sessions.** Cannot force a path; decider short-circuits to `Fast` with reason `anonymous_caller`; UI hides the override control when `activeAuthMode === 'anonymous'`.
- **PII / output guardrail parity.** Plan-first replies pass through `guardrails.FilterOutputAsync` before the response is returned, so the composed multi-specialist transcript is scrubbed by the same seam the single-specialist path uses.
- **Audit / conversation export / session-turn persistence parity.** Plan-branch turns go through `RecordChatTurnParityAsync` so the audit log, exporter, and session store see multi-domain answers the same as single-specialist ones. Per-step cost `UsageEvent`s are recorded by `PlanExecutor`/`PlanOrchestrator`; not double-counted here.
- **202 review suspension.** When plan review (#94) suspends, the endpoint returns `202 Accepted` with `planId`, `status`, `reviewRequestId`, `round`, `sessionId`, and a subscribe/poll hint — no blocking on the review timeout.

## Fast-path latency — before/after

Deterministic p50/p95 baseline of `RetailOpsRouter.TryKeywordClassify` against the reference prompt `"How is Sierra Gold Tequila performing in the Northeast?"` (no network, LLM, or MCP), Release configuration, same machine, 2 000 warmup + 20 000 samples:

| Measurement | p50 (ns) | p95 (ns) | Delta vs baseline |
| --- | --- | --- | --- |
| Pre-change baseline (commit `e445f0c`) | 5 200 | 7 700 | — |
| Post-change (final representative rerun) | 5 200 | 7 300 | **p50 0.0%, p95 −5.2%** |

Runner is included as `HybridFastPathBaselineRunner` and companion BDN benchmark `HybridFastPathBenchmark`; baseline JSON checked in at `tests/RetailPulse.Benchmarks/baselines/hybrid-fast-path-baseline.json`. **Explicitly no material regression** — the two runs are inside the same machine's sample noise on p50 and slightly faster on p95.

## Testing

**.NET (local, full):**
- `dotnet build RetailPulse.slnx -c Release` — clean.
- `dotnet test RetailPulse.slnx -c Release` — **3 078 passed / 5 skipped / 0 failed**, including new decision-table coverage for every precedence rung in `HybridExecutionDeciderTests` and forceable-path validator coverage in `ChatRequestValidatorTests`.
- `dotnet format RetailPulse.slnx --verify-no-changes` — clean (mandatory, re-verified on the review commit).
- Two matching-environment benchmark reruns — see table above.

**Frontend:**
Static review only. Local `npm`/`npx` is prohibited in this environment; frontend build/test/typecheck for the added `AgentRoutingIndicator`, `ChatPanel`, and `api` tests is **deferred to CI**.

## Scope notes

- Council behavior unchanged.
- Guardrails, audit, exporter, session store, memory middleware — all reused, no configuration surface change.
- No accelerator, competitive, or third-party analysis references were used in this change.
