### PR TITLE
Close pre-commit -> CI lint gap with a pre-push whole-solution hook (#124)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# .githooks/pre-push - Retail Pulse whole-solution formatting gate
+#
+# Purpose:
+#   Runs the CI `lint` job's exact command (dotnet format on the full
+#   RetailPulse.slnx) locally, before the push leaves your machine. Together
+#   with the fast staged-file .githooks/pre-commit hook this closes the gap
+#   the commit-time hook alone could not:
+#
+#   pre-commit  -> fast (~6-8s), staged .cs files only, catches most drift.
+#   pre-push    -> slower (~30-40s), whole solution, matches CI exactly.
+#
+#   Whole-solution analysis surfaces diagnostics that a `--include`-scoped
+#   run does not - notably import-ordering / analyzer style issues that
+#   depend on the compilation - and it still fires when a commit only
+#   touches non-C# files but earlier commits in the push range include C#
+#   drift. CI remains the authority; this hook makes the CI signal reach
+#   you before your teammates see it.
+#
+# What it runs:
+#   dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic
+#
+#   Identical to `.github/workflows/ci.yml` -> `Lint (dotnet format)`. If
+#   this hook passes without --no-verify, that CI job will pass on the same
+#   commits. If it does not, CI is still authoritative.
+#
+# When it skips:
+#   - The push range touches no C# / build-graph inputs (docs-only, infra
+#     text, workflow YAML that does not change compilation). CI still runs
+#     its own full check on every push.
+#   - `dotnet` is not on PATH. CI still enforces.
+#   - The user passed `git push --no-verify`.
+#
+# Bypass:
+#   git push --no-verify
+#
+#   Legitimate reasons: same as pre-commit (emergency hotfix, WIP private
+#   branch, local SDK diverges from CI). See docs/contributing.md.
+#
+# Shell:
+#   Bash. Git for Windows runs hooks under its bundled bash even when
+#   `git push` is invoked from PowerShell or cmd, so a single script covers
+#   Windows, Linux, and macOS.
+
+set -eo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+ZERO_SHA='0000000000000000000000000000000000000000'
+
+# Whitelist of path suffixes / exact names that participate in the
+# dotnet-format compilation graph. Anything else in the push range cannot
+# change the formatter's verdict, so we can skip the ~30s full-solution
+# analysis for docs- or workflow-only pushes.
+path_touches_dotnet() {
+    case "$1" in
+        *.cs|*.csproj|*.props|*.targets|*.slnx|*.sln|*.editorconfig|.editorconfig|global.json|Directory.Build.props|Directory.Packages.props|Directory.Build.targets)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+# `git push` writes one line per ref being pushed on stdin:
+#     <local_ref> <local_sha> <remote_ref> <remote_sha>
+# We inspect each range and short-circuit as soon as any C# / build-graph
+# file appears.
+touches_dotnet=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+    [ -n "${local_ref:-}" ] || continue
+
+    # Ref deletion: nothing to lint.
+    if [ "$local_sha" = "$ZERO_SHA" ]; then
+        continue
+    fi
+
+    if [ "$remote_sha" = "$ZERO_SHA" ]; then
+        # New branch on the remote. Diffing against every remote ref is
+        # expensive and brittle; a first push is a legitimate moment to
+        # run the full check.
+        touches_dotnet=1
+        break
+    fi
+
+    range_files=$(git log --format= --name-only "${remote_sha}..${local_sha}" 2>/dev/null | sort -u || true)
+    [ -n "$range_files" ] || continue
+
+    while IFS= read -r path; do
+        [ -n "$path" ] || continue
+        if path_touches_dotnet "$path"; then
+            touches_dotnet=1
+            break
+        fi
+    done <<< "$range_files"
+
+    [ "$touches_dotnet" -eq 1 ] && break
+done
+
+if [ "$touches_dotnet" -eq 0 ]; then
+    echo "pre-push: no C#/build-graph files in the push range; skipping dotnet format check." >&2
+    exit 0
+fi
+
+if ! command -v dotnet >/dev/null 2>&1; then
+    echo "pre-push: 'dotnet' not on PATH; skipping full-solution format check (CI will still enforce)." >&2
+    exit 0
+fi
+
+echo "pre-push: running whole-solution dotnet format (matches CI lint job; ~30-40s)..." >&2
+echo "pre-push:   dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic" >&2
+
+if dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic; then
+    echo "pre-push: dotnet format passed." >&2
+    exit 0
+fi
+
+cat >&2 <<'MSG'
+
+pre-push: dotnet format --verify-no-changes reported violations above.
+
+  This is the same command CI runs. Fix locally and re-push:
+      dotnet format RetailPulse.slnx
+      git add -A && git commit --amend --no-edit    # or a new commit
+      git push
+
+  Bypass (only when you know why - see docs/contributing.md):
+      git push --no-verify
+
+CI runs the full-solution formatter on every push and remains the authority.
+MSG
+exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -24,6 +24,25 @@
 #   this hook passes without --no-verify, that CI job will pass on the same
 #   commits. If it does not, CI is still authoritative.
 #
+# Tree identity (advisory, not a block):
+#   `dotnet format` operates on the working tree - the files on disk in this
+#   clone. CI, by contrast, operates on the pushed commit tree fetched into a
+#   fresh clone. In the normal case (`git push` of the currently checked-out
+#   branch after committing, with a clean working tree) those two trees are
+#   byte-identical and the guarantee above holds. Two ways they can diverge
+#   without the hook noticing:
+#     - the pushed ref's tip differs from your checked-out HEAD (for example
+#       `git push origin some-other-branch` or `git push --all`);
+#     - the working tree has uncommitted or untracked build-graph files
+#       (.cs / .csproj / .props / .targets / .slnx / .sln / .editorconfig /
+#       RetailPulse.slnx / global.json / Directory.*.props).
+#   The hook detects both cases and, when either holds, prints an advisory
+#   note on success ("CI is authoritative for the pushed commit tree").
+#   It does NOT block the push: doing so would break `git push --all` and
+#   dirty-tree pushes with only unrelated edits, and CI is already the
+#   final authority on the pushed tree. See docs/contributing.md ->
+#   "What the hooks guarantee" for the boundary wording.
+#
 # When it skips:
 #   - The push range touches no C# / build-graph inputs (docs-only, infra
 #     text, workflow YAML that does not change compilation). CI still runs
@@ -48,6 +67,7 @@ repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
 ZERO_SHA='0000000000000000000000000000000000000000'
+HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || printf '')
 
 # Whitelist of path suffixes / exact names that participate in the
 # dotnet-format compilation graph. Anything else in the push range cannot
@@ -62,11 +82,26 @@ path_touches_dotnet() {
     return 1
 }
 
+# Reads NUL-delimited paths from stdin. Returns 0 if any of those paths
+# matches path_touches_dotnet, 1 otherwise. Used for working-tree identity
+# checks; keeps the mismatch detection cheap and portable.
+any_dotnet_path_on_stdin() {
+    local path
+    while IFS= read -r -d '' path; do
+        [ -n "$path" ] || continue
+        if path_touches_dotnet "$path"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 # `git push` writes one line per ref being pushed on stdin:
 #     <local_ref> <local_sha> <remote_ref> <remote_sha>
 # We inspect each range and short-circuit as soon as any C# / build-graph
 # file appears.
 touches_dotnet=0
+non_head_push=""
 while read -r local_ref local_sha remote_ref remote_sha; do
     [ -n "${local_ref:-}" ] || continue
 
@@ -75,12 +110,20 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         continue
     fi
 
+    # Tree identity: note the first pushed ref whose tip is not the
+    # checked-out HEAD. The formatter still runs against the working tree,
+    # but the closing message will flag that the analysed tree is not the
+    # pushed tree so the reader knows CI is authoritative for this push.
+    if [ -n "$HEAD_SHA" ] && [ "$local_sha" != "$HEAD_SHA" ] && [ -z "$non_head_push" ]; then
+        non_head_push="${local_ref} -> ${local_sha}"
+    fi
+
     if [ "$remote_sha" = "$ZERO_SHA" ]; then
         # New branch on the remote. Diffing against every remote ref is
         # expensive and brittle; a first push is a legitimate moment to
         # run the full check.
         touches_dotnet=1
-        break
+        continue
     fi
 
     range_files=$(git log --format= --name-only "${remote_sha}..${local_sha}" 2>/dev/null | sort -u || true)
@@ -93,8 +136,6 @@ while read -r local_ref local_sha remote_ref remote_sha; do
             break
         fi
     done <<< "$range_files"
-
-    [ "$touches_dotnet" -eq 1 ] && break
 done
 
 if [ "$touches_dotnet" -eq 0 ]; then
@@ -107,11 +148,49 @@ if ! command -v dotnet >/dev/null 2>&1; then
     exit 0
 fi
 
+# Working-tree identity vs the pushed commit tree: the formatter is about to
+# analyse the working tree. CI will analyse the pushed commit tree. Note any
+# build-graph divergence so the closing message can be honest about scope.
+dirty_reasons=()
+if any_dotnet_path_on_stdin < <(git diff --name-only -z --diff-filter=ACMR 2>/dev/null); then
+    dirty_reasons+=("unstaged working-tree edits")
+fi
+if any_dotnet_path_on_stdin < <(git diff --cached --name-only -z --diff-filter=ACMR 2>/dev/null); then
+    dirty_reasons+=("staged-but-uncommitted edits")
+fi
+if any_dotnet_path_on_stdin < <(git ls-files --others --exclude-standard -z 2>/dev/null); then
+    dirty_reasons+=("untracked new files")
+fi
+
+identity_note=""
+if [ -n "$non_head_push" ]; then
+    identity_note="pushing ${non_head_push}, which differs from checked-out HEAD (${HEAD_SHA})"
+fi
+if [ ${#dirty_reasons[@]} -gt 0 ]; then
+    joined=$(printf '%s, ' "${dirty_reasons[@]}")
+    joined=${joined%, }
+    if [ -n "$identity_note" ]; then
+        identity_note="${identity_note}; working tree also has ${joined} to build-graph files"
+    else
+        identity_note="working tree has ${joined} to build-graph files"
+    fi
+fi
+
+if [ -n "$identity_note" ]; then
+    echo "pre-push: NOTE: analysed tree is not identical to the pushed commit tree." >&2
+    echo "pre-push:   reason: ${identity_note}" >&2
+    echo "pre-push:   the formatter run below is an early-warning check; CI is authoritative for the pushed tree." >&2
+fi
+
 echo "pre-push: running whole-solution dotnet format (matches CI lint job; ~30-40s)..." >&2
 echo "pre-push:   dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic" >&2
 
 if dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic; then
-    echo "pre-push: dotnet format passed." >&2
+    if [ -n "$identity_note" ]; then
+        echo "pre-push: dotnet format passed on the working tree (advisory only; see NOTE above)." >&2
+    else
+        echo "pre-push: dotnet format passed; working tree matches the pushed commit tree." >&2
+    fi
     exit 0
 fi
 

--- a/README.md
+++ b/README.md
@@ -105,12 +105,14 @@ cd src/RetailPulse.Web && npm ci && cd ../..
 dotnet run --project src/RetailPulse.AppHost
 ```
 
-### 5. Enable the pre-commit formatting hook
+### 5. Enable the formatting hooks
 
-The repo ships a versioned pre-commit hook under [`.githooks/`](.githooks) that
-runs `dotnet format --verify-no-changes` on staged C# files before every
-commit, so the CI `lint` job is never the first place a formatting failure
-shows up. It is not enabled by `git clone` — run it once per clone:
+The repo ships versioned pre-commit and pre-push hooks under
+[`.githooks/`](.githooks). The pre-commit hook runs `dotnet format
+--verify-no-changes` on staged C# files (fast); the pre-push hook runs the
+same whole-solution command CI runs, so the CI `lint` job is never the
+first place a formatting failure shows up. Neither is enabled by `git
+clone` — run the setup once per clone to install both:
 
 ```powershell
 # Windows
@@ -128,9 +130,11 @@ Equivalent one-liner:
 git config core.hooksPath .githooks
 ```
 
-Bypass a single commit with `git commit --no-verify`. See
-[docs/contributing.md](docs/contributing.md#pre-commit-formatting-hook) for
-the full behaviour, bypass guidance, and line-ending troubleshooting.
+Bypass a single commit with `git commit --no-verify` or a single push with
+`git push --no-verify`. See
+[docs/contributing.md](docs/contributing.md#pre-commit-and-pre-push-formatting-hooks)
+for the full behaviour, guarantee boundaries, bypass guidance, and
+line-ending troubleshooting.
 
 ### 6. Open the React dashboard
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -102,7 +102,17 @@ On every `git push` it:
    whose commits touch no C# / build-graph files skip the check.
 2. First-time pushes of a new branch always run the check — a new branch
    is a legitimate moment to verify the full solution.
-3. Runs `dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic` — byte-for-byte the CI command.
+3. Checks whether the tree it is about to analyse — your working tree — is
+   identical to the tree CI will analyse (the pushed commit tree). It
+   flags two cases: pushing a ref whose tip differs from your checked-out
+   `HEAD` (for example `git push origin some-other-branch` or
+   `git push --all`), and a working tree with uncommitted / untracked
+   build-graph files. Both cases are surfaced as an advisory `NOTE:` line
+   before the formatter runs and again in the success message; the hook
+   does not block, because CI is already the authority on the pushed tree
+   and blocking would break legitimate `git push --all` and unrelated-WIP
+   pushes.
+4. Runs `dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic` — byte-for-byte the CI command.
 
 If the formatter finds violations, the push is blocked and the diagnostics
 are printed. If `dotnet` is not on PATH the hook skips with a warning; CI
@@ -110,13 +120,17 @@ still enforces.
 
 ### What the hooks guarantee
 
-If the applicable hook set completes without error and you do not pass
-`--no-verify`, the CI `Lint (dotnet format)` job will pass on the same
-commits. The pre-push hook is what makes that guarantee true in every
-case, because it runs the exact CI command against the whole solution;
-the pre-commit hook is a fast partial gate on top of it.
+If the pre-push hook completes without error, you do not pass
+`--no-verify`, **and** the hook confirms tree identity in its success
+message (working tree matches the pushed commit tree), the CI
+`Lint (dotnet format)` job will pass on the same commits. The pre-push
+hook is the load-bearing gate: it runs the exact CI command against the
+whole solution; the pre-commit hook is a fast partial gate on top of it.
+When tree identity does not hold, the hook still runs as an early
+warning but explicitly downgrades its success message — CI is
+authoritative for the pushed commit tree in that case.
 
-The guarantee has three explicit boundaries. Documenting them here rather
+The guarantee has four explicit boundaries. Documenting them here rather
 than implying a stronger promise:
 
 - **Bypass**: `git commit --no-verify` and `git push --no-verify` skip
@@ -127,6 +141,20 @@ than implying a stronger promise:
 - **PATH**: if `dotnet` is not on PATH when a hook runs, the hook exits 0
   with a warning rather than blocking the workflow, because a working
   install cannot be assumed. CI still enforces.
+- **Tree identity**: the hook runs `dotnet format` against your **working
+  tree**; CI runs it against the **pushed commit tree**. In the normal
+  case (`git push` of your currently checked-out branch after committing,
+  with a clean working tree) those two trees are byte-identical and the
+  guarantee holds. They diverge when you push a ref whose tip is not your
+  checked-out `HEAD` (for example `git push origin some-other-branch` or
+  `git push --all`) or the working tree has uncommitted / untracked
+  `.cs`, `.csproj`, `.props`, `.targets`, `.editorconfig`,
+  `RetailPulse.slnx`, `global.json`, or `Directory.*.props` content. The
+  hook detects both cases and prints an advisory `NOTE:` line plus an
+  "advisory only" tag on the success message; CI is authoritative for
+  the pushed commits. We chose the advisory over a fail-closed guard so
+  the hook does not break legitimate multi-branch pushes or pushes with
+  unrelated in-progress edits — CI already enforces the pushed tree.
 
 ### Bypass
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,18 +5,53 @@ the repo. The [README](../README.md#quick-start) covers the runtime
 prerequisites (.NET 10 SDK, Node.js 20+, OpenAI credentials); this doc covers
 the developer ergonomics that keep pull requests healthy.
 
-## Pre-commit formatting hook
+## Pre-commit and pre-push formatting hooks
 
-Retail Pulse ships a versioned pre-commit hook under [`.githooks/`](../.githooks)
-that runs the same `dotnet format --verify-no-changes` check the CI `lint` job
-enforces (see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)). The
-CI job remains the authority; the hook is an early warning that catches
-mechanical problems locally so a review round-trip is not spent on them.
+Retail Pulse ships two versioned Git hooks under
+[`.githooks/`](../.githooks). Together they mirror what the CI `lint` job
+enforces (see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)) so a
+review round-trip is not spent on mechanical formatting problems. The CI
+`Lint (dotnet format)` job remains the authority; the hooks are the early
+warning.
+
+| Hook | Scope | Typical runtime | Purpose |
+|------|-------|-----------------|---------|
+| `pre-commit` | staged `.cs` files (`dotnet format --include ...`) | ~6-8s | Fast per-commit gate; catches most drift at the point of edit. |
+| `pre-push`   | whole solution (`dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic`) | ~30-40s | Same command CI runs; catches whole-solution diagnostics (import ordering, cross-file analyzer warnings) before the push leaves your machine. |
+
+Timings above were measured on a warm developer workstation against the
+current solution; first invocations are slower while the analyzer cache
+warms.
+
+### Why two hooks
+
+`dotnet format --include <staged files>` scopes the analysis to the files
+staged for that commit. This is deliberately fast but structurally
+incomplete versus the CI job, which passes no `--include` and analyses the
+whole compilation. Two classes of diagnostic slip through a staged-only
+run:
+
+1. **Whole-solution style analyzers** (e.g. import ordering, some
+   `IDE00xx` diagnostics) inspect the full compilation. Their verdict on
+   any one file can depend on symbols defined in another. A `--include`
+   run may skip the diagnostic on files it does not touch.
+2. **Commits that stage no `.cs` files** (docs-only, workflow YAML,
+   configuration text) short-circuit the pre-commit hook, but CI still
+   runs the full-solution formatter on the pushed content. Any latent
+   drift already on your branch survives to CI.
+
+The pre-push hook runs the exact CI command against the push range and
+closes both gaps in one place: it fires at most once per push regardless
+of how many commits the push contains, and it fires whether or not the
+individual commits touched `.cs` files, as long as any commit in the push
+range touches C#, `.csproj`, `.props`, `.targets`, `.editorconfig`,
+`RetailPulse.slnx`, `global.json`, or `Directory.*.props`. Pushes that
+touch none of those (docs-only) skip the check.
 
 ### One-time setup after cloning
 
 Hooks are not enabled by `git clone`. Run **one** of the following once per
-clone:
+clone to install both the pre-commit and pre-push hooks:
 
 ```powershell
 # Windows / PowerShell
@@ -41,7 +76,9 @@ git config --get core.hooksPath
 # expected output: .githooks
 ```
 
-### What the hook does
+### What each hook does
+
+#### `pre-commit`
 
 On every `git commit` it:
 
@@ -57,10 +94,45 @@ diagnostics are printed. If no `.cs` files are staged (docs, infra text,
 config), the hook exits cleanly without invoking the formatter. If `dotnet` is
 not on PATH the hook skips with a warning; CI still enforces.
 
+#### `pre-push`
+
+On every `git push` it:
+
+1. Walks the ranges being pushed (one per ref). Ref deletions and pushes
+   whose commits touch no C# / build-graph files skip the check.
+2. First-time pushes of a new branch always run the check — a new branch
+   is a legitimate moment to verify the full solution.
+3. Runs `dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic` — byte-for-byte the CI command.
+
+If the formatter finds violations, the push is blocked and the diagnostics
+are printed. If `dotnet` is not on PATH the hook skips with a warning; CI
+still enforces.
+
+### What the hooks guarantee
+
+If the applicable hook set completes without error and you do not pass
+`--no-verify`, the CI `Lint (dotnet format)` job will pass on the same
+commits. The pre-push hook is what makes that guarantee true in every
+case, because it runs the exact CI command against the whole solution;
+the pre-commit hook is a fast partial gate on top of it.
+
+The guarantee has three explicit boundaries. Documenting them here rather
+than implying a stronger promise:
+
+- **Bypass**: `git commit --no-verify` and `git push --no-verify` skip
+  the hooks by design. CI will still enforce.
+- **SDK drift**: your local `dotnet` SDK may resolve a different analyzer
+  version than CI's `setup-dotnet`. When that happens the two verdicts can
+  disagree; CI is authoritative.
+- **PATH**: if `dotnet` is not on PATH when a hook runs, the hook exits 0
+  with a warning rather than blocking the workflow, because a working
+  install cannot be assumed. CI still enforces.
+
 ### Bypass
 
 ```bash
 git commit --no-verify
+git push   --no-verify
 ```
 
 Legitimate reasons to bypass:
@@ -109,5 +181,6 @@ Then `git add` and commit again.
 |---------|-----|
 | Hook did not run | `git config --get core.hooksPath` — must print `.githooks`. Re-run the setup script. |
 | Hook runs but is slow on huge commits | Scoping is already applied; the first invocation warms the analyzer cache. Subsequent commits reuse it. Bypass with `--no-verify` for genuinely oversized commits. |
+| Pre-push takes ~30-40s | Expected — it runs the same whole-solution formatter CI runs. Bypass with `git push --no-verify` for genuinely emergency pushes; CI still enforces. |
 | `dotnet` not on PATH | Install the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or bypass with `--no-verify`; CI enforces on push. |
 | Formatter flags `ENDOFLINE` after a normalization pass | The working tree has real unstaged edits with CRLF. Convert to LF (see above) and re-stage. |

--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -1,4 +1,9 @@
-# Enables the versioned pre-commit hook in .githooks/ for this clone.
+# Enables the versioned Git hooks in .githooks/ for this clone.
+#
+# Installs both the pre-commit (fast staged-file check) and pre-push
+# (whole-solution CI-equivalent check) hooks by pointing core.hooksPath
+# at the versioned .githooks/ directory. Any new hooks added there in
+# the future are picked up automatically.
 #
 # Run once after cloning:
 #     pwsh scripts/setup-hooks.ps1
@@ -18,9 +23,14 @@ try {
     if ($LASTEXITCODE -ne 0) {
         throw "git config core.hooksPath .githooks failed."
     }
-    Write-Host "pre-commit hook enabled (core.hooksPath = .githooks)."
+
+    Write-Host "Git hooks enabled (core.hooksPath = .githooks):"
+    Write-Host "  pre-commit -> dotnet format on staged C# files (fast)"
+    Write-Host "  pre-push   -> dotnet format on the whole solution (matches CI)"
+    Write-Host ""
     Write-Host "Bypass a single commit with:  git commit --no-verify"
-    Write-Host "Details: docs/contributing.md#pre-commit-formatting-hook"
+    Write-Host "Bypass a single push   with:  git push   --no-verify"
+    Write-Host "Details: docs/contributing.md#pre-commit-and-pre-push-formatting-hooks"
 }
 finally {
     Pop-Location

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# Enables the versioned pre-commit hook in .githooks/ for this clone.
+# Enables the versioned Git hooks in .githooks/ for this clone.
+#
+# Installs both the pre-commit (fast staged-file check) and pre-push
+# (whole-solution CI-equivalent check) hooks by pointing core.hooksPath
+# at the versioned .githooks/ directory. Any new hooks added there in
+# the future are picked up automatically.
 #
 # Run once after cloning:
 #     ./scripts/setup-hooks.sh
@@ -13,6 +18,10 @@ cd "$repo_root"
 
 git config core.hooksPath .githooks
 
-echo "pre-commit hook enabled (core.hooksPath = .githooks)."
+echo "Git hooks enabled (core.hooksPath = .githooks):"
+echo "  pre-commit -> dotnet format on staged C# files (fast)"
+echo "  pre-push   -> dotnet format on the whole solution (matches CI)"
+echo ""
 echo "Bypass a single commit with:  git commit --no-verify"
-echo "Details: docs/contributing.md#pre-commit-formatting-hook"
+echo "Bypass a single push   with:  git push   --no-verify"
+echo "Details: docs/contributing.md#pre-commit-and-pre-push-formatting-hooks"


### PR DESCRIPTION
Closes #124

Working as Costco (Backend Dev).

## Problem

The pre-commit hook added in #116 scopes `dotnet format` to staged
`.cs` files (`--include <files>`) and finishes in ~6-8 s, which is fast
enough for routine commits. CI, on the other hand, runs
`dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic`
against the whole solution. That structural difference leaves two
classes of failure that can pass the hook and still land in CI:

1. Whole-solution style analyzers (import ordering,
   compilation-context IDE diagnostics) whose verdict on file A
   depends on symbols in file B - a `--include`-scoped run may not
   report the diagnostic on files it does not touch.
2. Commits that stage no `.cs` files (docs, workflow YAML, config
   text). The hook short-circuits ("no staged C# files; skipping"),
   but CI still runs the full-solution formatter on the pushed content
   and any latent drift already on the branch survives.

## Reproduction (before)

Staged-only `--include` gate against a single working-tree edit that
adds a misordered alias `using`:

```
$ dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic \
    --include "src/RetailPulse.Contracts/ITenantProvider.cs"
Format complete in 6338ms.  (exit 0 - passes)
```

Whole-solution gate (byte-for-byte CI command) against the same tree:

```
$ dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic
src/RetailPulse.Contracts/ITenantProvider.cs(1,1): error IMPORTS: Fix imports ordering.
Format complete in 31918ms.  (exit 2 - fails)
```

The exclusive-gap case (issue #124's second class) reproduces even
without in-file drift: staging a single non-`.cs` file (any docs edit)
and running the current pre-commit hook prints
`pre-commit: no staged C# files; skipping dotnet format check.` and
exits 0, regardless of what else is in the push range.

## Options considered

| Option | Verdict |
|--------|---------|
| (a) Full-solution verification in **pre-commit** | Rejected. ~32 s per commit turns routine "commit early, commit often" into a bypass magnet. Once developers habitually pass `--no-verify` on pre-commit, the guarantee is worse than either partial hook alone. |
| (b) Fast staged pre-commit **plus** cross-platform pre-push running the CI-equivalent command | **Chosen.** ~30-40 s runs at most once per push (not per commit) and executes the byte-for-byte CI command, so if it passes without `--no-verify` and the working tree matches the pushed commit tree the CI `Lint (dotnet format)` job passes on the same commits. |
| (c) Align analyzer/style severities so the staged run matches CI | Rejected. `dotnet format --include <files>` filters diagnostics to the included files' documents; severity alignment cannot make an analyzer report a diagnostic on file B when file B is not in the include set. The `--include` scoping is the structural gap, not the severity table. |

## Implementation (chosen: option b)

Added `.githooks/pre-push` (bash, LF, `100755`) that:

1. Walks each ref being pushed. Ref deletions skip. New-branch pushes
   (remote sha = zero) always run the check.
2. Aggregates the file names touched by every commit in the push range
   and skips the check if none match `.cs`, `.csproj`, `.props`,
   `.targets`, `.editorconfig`, `RetailPulse.slnx`, `global.json`, or
   `Directory.{Build,Packages}.{props,targets}`. Docs-only pushes are
   free.
3. **Detects tree-identity mismatch before running the formatter**
   (added in the follow-up commit `2246a37`). The formatter operates
   on the working tree, but CI operates on the pushed commit tree. If
   the pushed ref's tip differs from checked-out `HEAD` (e.g.
   `git push origin some-other-branch`, `git push --all`), or the
   working tree has uncommitted / untracked build-graph files, the
   hook prints an advisory `NOTE:` naming the reason and tags the
   success message as `advisory only`. It does **not** block: a
   fail-closed guard would break legitimate `git push --all` and
   unrelated-WIP pushes, and CI already enforces the pushed tree.
4. If `dotnet` is not on PATH, logs and exits 0 (CI still enforces).
5. Otherwise runs `dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic` - byte-for-byte the CI command.
6. On non-zero exit, prints a fix / bypass block and exits 1.

`scripts/setup-hooks.ps1` and `scripts/setup-hooks.sh` are unchanged
in behaviour - `git config core.hooksPath .githooks` already picks up
any hook file we add - and now advertise both hooks and both bypass
paths. `README.md` step 5 and `docs/contributing.md` cover the
two-hook set, timing, guarantee, and boundaries (four boundaries
after the follow-up: Bypass, SDK drift, PATH, Tree identity).

## Guarantee

> If the pre-push hook completes without error, you do not pass
> ``--no-verify``, **and** the hook confirms tree identity in its
> success message (working tree matches the pushed commit tree), the
> CI ``Lint (dotnet format)`` job will pass on the same commits.

Four explicit boundaries, documented at the same place as the
guarantee (`docs/contributing.md` -> "What the hooks guarantee"):

1. **Bypass**: `git commit --no-verify` and `git push --no-verify`
   skip the hooks by design. CI still enforces.
2. **SDK drift**: local `dotnet` may resolve a different analyzer
   version than CI's `setup-dotnet`. When that happens, CI wins.
3. **PATH**: if `dotnet` is not on PATH when a hook runs, the hook
   logs and exits 0 rather than blocking (a working install cannot be
   assumed). CI still enforces.
4. **Tree identity**: the hook runs against the working tree; CI
   runs against the pushed commit tree. Normal `git push` of the
   currently checked-out branch with a clean working tree makes those
   byte-identical and the guarantee holds. When they diverge (non-HEAD
   ref push or dirty/untracked build-graph files) the hook prints an
   advisory `NOTE:` and tags success as `advisory only`; CI is
   authoritative for the pushed commits. Chosen as an advisory rather
   than a fail-closed guard because blocking would break
   `git push --all` and pushes with unrelated in-progress edits.

## Proof (after)

Test 1 - current push range (this PR: `.githooks/pre-push`, docs,
scripts only, no C# in the range):

```
$ echo "<ref> <local> <ref> <remote>" | bash .githooks/pre-push origin <url>
pre-push: no C#/build-graph files in the push range; skipping dotnet format check.
elapsed=0.66 s
```

Test 2 - same push range plus a temporary commit that adds the same
misordered alias `using` to `ITenantProvider.cs`:

```
pre-push: running whole-solution dotnet format (matches CI lint job; ~30-40s)...
pre-push:   dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic
C:\src\rp-c\src\RetailPulse.Contracts\ITenantProvider.cs(1,1): error IMPORTS: Fix imports ordering.
pre-push: dotnet format --verify-no-changes reported violations above.
elapsed=32.64 s  (exit 1 - blocks push)
```

Test 3 - real push of this branch (clean, HEAD-matched ref, docs +
hook + scripts):

```
pre-push: running whole-solution dotnet format (matches CI lint job; ~30-40s)...
Formatted 0 of 669 files.
Format complete in 31918ms.
pre-push: dotnet format passed; working tree matches the pushed commit tree.
elapsed=31.92 s  (exit 0)
```

Test 4 (tree-identity follow-up, commit `2246a37`) - untracked
build-graph file in working tree, HEAD-matched ref:

```
pre-push: NOTE: analysed tree is not identical to the pushed commit tree.
pre-push:   reason: working tree has untracked new files to build-graph files
pre-push:   the formatter run below is an early-warning check; CI is authoritative for the pushed tree.
pre-push: running whole-solution dotnet format (matches CI lint job; ~30-40s)...
Formatted 0 of 669 files.
pre-push: dotnet format passed on the working tree (advisory only; see NOTE above).
elapsed=31.39 s  (exit 0)
```

Test 5 (tree-identity follow-up) - non-HEAD ref pushed, clean working
tree:

```
pre-push: NOTE: analysed tree is not identical to the pushed commit tree.
pre-push:   reason: pushing refs/heads/other -> 951b76b..., which differs from checked-out HEAD (2246a37...)
pre-push:   the formatter run below is an early-warning check; CI is authoritative for the pushed tree.
pre-push: running whole-solution dotnet format (matches CI lint job; ~30-40s)...
Formatted 0 of 669 files.
pre-push: dotnet format passed on the working tree (advisory only; see NOTE above).
```

All temporary probe files were removed before commit; there is no
`TEMP repro` or `_identity_probe.cs` commit in the pushed branch
history.

Bypass smoke-tested with `git push --no-verify` on a scratch commit
(not pushed to origin): pre-push does not execute; CI is left as the
sole enforcer, as documented.

## Timings

| Gate | Command | Runtime (measured) |
|------|---------|--------------------|
| pre-commit (staged, 1 `.cs` file) | `dotnet format ... --include <file>` | ~6.5 s |
| pre-push (whole solution, clean, identity holds) | `dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic` | ~31.6 s |
| pre-push (whole solution, identity mismatch, advisory) | same, plus NOTE header | ~31.4 s |
| pre-push (whole solution, blocking) | same, with a real diagnostic | ~32.6 s |
| pre-push (docs-only push range, skip) | short-circuit, no formatter invoked | ~0.7 s |

First invocations are slower while the analyzer cache warms; the
numbers above are on a warm workstation.

## Cross-platform validation

- **Bash syntax**: `bash -n .githooks/pre-push` and `bash -n .githooks/pre-commit` both pass under Git for Windows' bundled bash on the tree-identity follow-up commit.
- **Windows (Git for Windows)**: `git push` from PowerShell invokes the hook via `C:\Program Files\Git\bin\bash.exe`; the whole-solution runs and identity smoke tests above are the actual output on this box.
- **Linux/macOS**: not executed here - the same portable bash (no MSYS-only constructs, no `winpty`, no CRLF assumptions; LF enforced via `.gitattributes` `.githooks/* text eol=lf`; the identity detection uses `git diff --name-only -z` and `git ls-files --others --exclude-standard -z` plus a NUL-delimited read loop, all POSIX bash 3.2+ safe) will run under `/bin/bash` on any POSIX host. This is a portability claim by construction, not a Linux run I performed - flagging it explicitly per the acceptance criteria.

## Kroger residual review point (resolved in `2246a37`)

Kroger's approval flagged, non-blocking, that the pre-push guarantee
wording assumed the working tree equals the pushed commit tree. That
holds for `git push` of a currently-checked-out clean branch but not
for `git push --all`, non-HEAD ref pushes, or dirty/untracked
build-graph edits. The follow-up commit `2246a37` addresses the
residual point directly:

- Hook detects both mismatch conditions (non-HEAD ref, dirty /
  untracked build-graph files), prints an advisory `NOTE:` naming
  the reason, and tags the success message as `advisory only` so
  the reader never confuses the working-tree verdict with the
  pushed-tree verdict.
- On identity-holds pushes, the success message now explicitly says
  `working tree matches the pushed commit tree` so the guarantee is
  bound to a message the reader can see, not an implicit assumption.
- `docs/contributing.md` restates the guarantee as conditional on
  that confirmation and adds `Tree identity` as an explicit fourth
  boundary alongside Bypass, SDK drift, and PATH. Rationale for the
  advisory-over-fail-closed choice is documented in the same place.

No CI, application source, or `.gitattributes`/`.editorconfig`
changes in the follow-up. `dotnet format RetailPulse.slnx
--verify-no-changes --verbosity diagnostic` reported `Formatted 0 of
669 files` locally before push.

## What did not change

- CI (`.github/workflows/ci.yml`) is untouched. CI remains the
  authority.
- Application source is untouched. The C# repro edit was made and
  fully reverted before commit; `git log` on this branch shows three
  commits (hook, docs, tree-identity follow-up), none of which
  changes any file under `src/` or `tests/`.
- `.gitattributes` and `.editorconfig` are untouched.
- No packages installed, no `npm`/`npx` executed.