### PR TITLE
feat(#106): knowledge panel provider visibility and per-agent binding

### DIFF
--- a/src/RetailPulse.Api/Endpoints/KnowledgeEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/KnowledgeEndpoints.cs
@@ -1,4 +1,8 @@
 using System.Globalization;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Models;
+using RetailPulse.Api.Rag;
 using RetailPulse.Contracts;
 using RetailPulse.Contracts.Rag;
 using RetailPulse.Contracts.Routing;
@@ -15,8 +19,64 @@ public static class KnowledgeEndpoints
             if (string.IsNullOrWhiteSpace(body.Title) || string.IsNullOrWhiteSpace(body.Content))
                 return Results.BadRequest(new { error = "Fields 'title' and 'content' are required." });
 
-            string id = await kb.IngestDocumentAsync(body.Title, body.Content, body.Source ?? "upload", ct);
-            return Results.Ok(new { documentId = id, title = body.Title, status = "ingested" });
+            string source = body.Source ?? "upload";
+            try
+            {
+                string id = await kb.IngestDocumentAsync(body.Title, body.Content, source, ct);
+
+                // Enrich the response with the resolved chunk count so the UI can
+                // report an honest ingestion outcome ("accepted N chunks") without
+                // making a second round-trip. When ListDocumentsAsync cannot see
+                // the new id (e.g. asynchronous cloud indexing), fall back to 0
+                // rather than fabricating a count.
+                IReadOnlyList<DocumentInfo> docs = await kb.ListDocumentsAsync(ct);
+                DocumentInfo? persisted = docs.FirstOrDefault(d => d.Id == id);
+                int chunkCount = persisted?.ChunkCount ?? 0;
+                return Results.Ok(new
+                {
+                    documentId = id,
+                    title = body.Title,
+                    status = "ingested",
+                    chunkCount,
+                    source = persisted?.Source ?? source,
+                });
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Provider-enforced quota rejection surfaces as a structured 409
+                // so the frontend can render a "quota reached" outcome distinct
+                // from a generic failure.
+                KnowledgeBaseCapabilities caps = kb.GetCapabilities();
+                IReadOnlyList<DocumentInfo> docs = await kb.ListDocumentsAsync(ct);
+                return Results.Json(new
+                {
+                    quotaRejected = true,
+                    reason = ex.Message,
+                    quotas = new
+                    {
+                        maxDocuments = caps.Quotas.MaxDocuments,
+                        maxChunks = caps.Quotas.MaxChunks,
+                        maxDocumentSizeBytes = caps.Quotas.MaxDocumentSizeBytes,
+                    },
+                    usage = new
+                    {
+                        documentCount = docs.Count,
+                        chunkCount = docs.Sum(d => d.ChunkCount),
+                    },
+                }, statusCode: StatusCodes.Status409Conflict);
+            }
+            catch (NotSupportedException ex)
+            {
+                // Read-only providers (Foundry IQ, issue #104) report mutation
+                // as unsupported via a first-class exception. Bubble the
+                // capability signal to the UI as 405 so the panel can hide the
+                // upload affordance rather than showing a bare 500.
+                return Results.Json(new
+                {
+                    mutationUnsupported = true,
+                    reason = ex.Message,
+                }, statusCode: StatusCodes.Status405MethodNotAllowed);
+            }
         })
         .WithName("UploadKnowledge").RequireAuthorization().RequireRateLimiting("upload");
 
@@ -59,6 +119,109 @@ public static class KnowledgeEndpoints
             });
         })
         .WithName("KnowledgeStats").RequireAuthorization().RequireRateLimiting("relaxed");
+
+        // Knowledge provider snapshot (issue #106). Surfaces the honest
+        // capabilities of the active provider — durable vs volatile, relevance
+        // kind, quotas, actual usage, degradation policy, whether the primary
+        // was replaced by the in-memory fallback — plus the named source
+        // catalog and every per-agent binding. The frontend Knowledge panel
+        // consumes this to warn on volatile uploads, disclose provider score
+        // semantics honestly, and render the per-agent binding view.
+        app.MapGet("/api/knowledge/provider", async (
+            IKnowledgeBase kb,
+            KnowledgeSourceRegistry sourceRegistry,
+            IOptionsSnapshot<KnowledgeSourcesOptions> sourcesOptions,
+            PromptConfiguration promptConfig,
+            CancellationToken ct) =>
+        {
+            KnowledgeBaseCapabilities caps = kb.GetCapabilities();
+            IReadOnlyList<DocumentInfo> docs = await kb.ListDocumentsAsync(ct);
+
+            // Degradation metadata is only meaningful when the DI-registered
+            // IKnowledgeBase is the decorator; unit-tests may inject a bare
+            // provider. Reading through pattern-matching keeps the endpoint
+            // portable without a hard cast.
+            string? degradationMode = null;
+            bool primaryReplacedByFallback = false;
+            if (kb is DegradingKnowledgeBase decorator)
+            {
+                degradationMode = decorator.DegradationMode.ToString();
+                primaryReplacedByFallback = decorator.PrimaryReplacedByFallback;
+            }
+
+            KnowledgeSourcesOptions namedSources = sourcesOptions.Value;
+            var sourceCatalog = namedSources.Named
+                .Select(kvp => new
+                {
+                    name = kvp.Key,
+                    documents = kvp.Value.Documents
+                        .Where(d => !string.IsNullOrWhiteSpace(d))
+                        .Select(d => d.Trim())
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray(),
+                })
+                .OrderBy(s => s.name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            // Build the per-agent binding view from the resolved registry, then
+            // enrich each row with the agent's display name and the DECLARED
+            // knowledge_base_name from prompts.yaml so the UI can label the
+            // binding by named source (not the raw document list).
+            var bindingRows = new List<object>(promptConfig.Agents.Count);
+            foreach ((string sectionKey, AgentDefinition def) in promptConfig.Agents
+                .OrderBy(kv => kv.Value.EffectiveDisplayName, StringComparer.OrdinalIgnoreCase))
+            {
+                // Orchestration/router entries are not user-facing specialists
+                // that "see" a knowledge scope in the way the UI surfaces. Skip
+                // them so the binding view stays focused on retrieval-relevant
+                // agents.
+                if (string.Equals(def.Role, "orchestration", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                string agentKey = string.IsNullOrWhiteSpace(def.Key) ? sectionKey : def.Key;
+                KnowledgeBinding binding = sourceRegistry.GetBinding(agentKey);
+                bindingRows.Add(new
+                {
+                    agentKey,
+                    agentDisplayName = def.EffectiveDisplayName,
+                    enabled = binding.Enabled,
+                    sourceName = def.KnowledgeBaseName,
+                    sources = binding.Sources.ToArray(),
+                });
+            }
+
+            return Results.Ok(new
+            {
+                provider = new
+                {
+                    name = caps.ProviderName,
+                    relevance = caps.Relevance.ToString(),
+                    persistent = caps.Persistent,
+                    requiresCloud = caps.RequiresCloud,
+                    supportsMutation = caps.SupportsMutation,
+                    scoreSemantics = caps.ScoreSemantics,
+                },
+                degradation = new
+                {
+                    mode = degradationMode,
+                    primaryReplacedByFallback,
+                },
+                quotas = new
+                {
+                    maxDocuments = caps.Quotas.MaxDocuments,
+                    maxChunks = caps.Quotas.MaxChunks,
+                    maxDocumentSizeBytes = caps.Quotas.MaxDocumentSizeBytes,
+                },
+                usage = new
+                {
+                    documentCount = docs.Count,
+                    chunkCount = docs.Sum(d => d.ChunkCount),
+                },
+                sources = sourceCatalog,
+                bindings = bindingRows,
+            });
+        })
+        .WithName("KnowledgeProviderSnapshot").RequireAuthorization().RequireRateLimiting("relaxed");
 
         // ── Message Extension endpoints ──────────────────────────────────────
         app.MapPost("/api/message-extension/query", async (MessageExtensionRequest body, IKnowledgeBase kb, IEnumerable<ISpecialistAgent> specialists, ILogger<Program> logger, CancellationToken ct) =>

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -395,6 +395,12 @@ builder.Configuration.GetSection(KnowledgeSourcesOptions.SectionName).Bind(knowl
 var knowledgeSourceRegistry =
     KnowledgeSourceRegistry.Build(knowledgeSourcesOptions, promptConfig.Agents);
 builder.Services.AddSingleton(knowledgeSourceRegistry);
+// PromptConfiguration is registered so read-only diagnostic endpoints (e.g. the
+// knowledge provider snapshot used by the frontend Knowledge panel, issue #106)
+// can enumerate agent display names and their declared knowledge bindings
+// without re-parsing prompts.yaml. Registered AFTER hydration so consumers see
+// the effective, tenant-resolved definitions.
+builder.Services.AddSingleton(promptConfig);
 
 // Register HttpClient for MCP server communication. The default URL is a
 // dev convenience — production should always set McpServer:BaseUrl.

--- a/src/RetailPulse.Web/src/__tests__/KnowledgeBase.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/KnowledgeBase.test.tsx
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
-import type { KBDocument, KBSearchResult, KBStats } from '../types';
+import type {
+  KBDocument,
+  KBSearchResult,
+  KBStats,
+  KnowledgeProviderSnapshot,
+} from '../types';
 
 const mockDocuments: KBDocument[] = [
   {
@@ -38,24 +43,89 @@ const mockSearchResults: KBSearchResult[] = [
   },
 ];
 
+function makeSnapshot(overrides: Partial<KnowledgeProviderSnapshot> = {}): KnowledgeProviderSnapshot {
+  return {
+    provider: {
+      name: 'InMemory',
+      relevance: 'Lexical',
+      persistent: false,
+      requiresCloud: false,
+      supportsMutation: true,
+      scoreSemantics:
+        'BM25 lexical score, normalized 0-1 within a single query response. ' +
+        'Scores are provider-local and not comparable across providers.',
+      ...overrides.provider,
+    },
+    degradation: {
+      mode: 'FailLoud',
+      primaryReplacedByFallback: false,
+      ...overrides.degradation,
+    },
+    quotas: {
+      maxDocuments: 100,
+      maxChunks: 5000,
+      maxDocumentSizeBytes: 10 * 1024 * 1024,
+      ...overrides.quotas,
+    },
+    usage: {
+      documentCount: 2,
+      chunkCount: 32,
+      ...overrides.usage,
+    },
+    sources: overrides.sources ?? [
+      { name: 'planogram-shelf-set', documents: ['apex-planogram-and-shelf-set.md'] },
+      { name: 'supplier-service-levels', documents: ['apex-supplier-service-levels.md'] },
+    ],
+    bindings: overrides.bindings ?? [
+      {
+        agentKey: 'planogram',
+        agentDisplayName: 'Planogram Agent',
+        enabled: true,
+        sourceName: 'planogram-shelf-set',
+        sources: ['apex-planogram-and-shelf-set.md'],
+      },
+      {
+        agentKey: 'general',
+        agentDisplayName: 'General Assistant',
+        enabled: true,
+        sourceName: '',
+        sources: [],
+      },
+      {
+        agentKey: 'memory-management',
+        agentDisplayName: 'Memory Manager',
+        enabled: false,
+        sourceName: '',
+        sources: [],
+      },
+    ],
+  };
+}
+
 const mockFetchDocs = vi.fn().mockResolvedValue(mockDocuments);
 const mockDeleteDoc = vi.fn().mockResolvedValue(undefined);
 const mockSearchKB = vi.fn().mockResolvedValue(mockSearchResults);
-const mockUploadDoc = vi.fn().mockResolvedValue({ documentId: 'doc-new', title: 'Test Doc', status: 'ingested' });
+const mockUploadDoc = vi.fn().mockResolvedValue({
+  documentId: 'doc-new',
+  title: 'Test Doc',
+  status: 'ingested',
+  chunkCount: 5,
+  source: 'upload',
+});
 const mockFetchStats = vi.fn().mockResolvedValue(mockStats);
+const mockFetchSnapshot = vi.fn().mockResolvedValue(makeSnapshot());
 
-// Content-safety-flavored upload rejection surfaces as a KnowledgeUploadError
-// so DocumentUpload can render a KnowledgeIngestionBlock in place of a raw
-// error string. Tests use a lightweight stand-in that matches the shape and
-// participates in `instanceof` checks.
-//
-// `vi.mock` calls are hoisted above module-level `class` declarations, so a
-// plain top-level class would be in its temporal dead zone when the mock
-// factory runs (Vitest error: "Cannot access 'MockKnowledgeUploadError'
-// before initialization"). `vi.hoisted` runs alongside the hoisted mocks,
-// which guarantees the class binding is initialized before the factory
-// evaluates.
-const { MockKnowledgeUploadError } = vi.hoisted(() => {
+// Content-safety, quota, and read-only rejection paths from `knowledgeApi`
+// surface as typed error classes so `DocumentUpload` can render distinct
+// outcomes for each. `vi.mock` is hoisted above module-level `class`
+// declarations, so plain top-level classes would be in their temporal dead
+// zone when the mock factory runs. `vi.hoisted` runs alongside the hoisted
+// mocks, guaranteeing the class bindings exist before the factory evaluates.
+const {
+  MockKnowledgeUploadError,
+  MockKnowledgeQuotaError,
+  MockKnowledgeMutationUnsupportedError,
+} = vi.hoisted(() => {
   class MockKnowledgeUploadError extends Error {
     readonly display: unknown;
     readonly status: number;
@@ -66,7 +136,31 @@ const { MockKnowledgeUploadError } = vi.hoisted(() => {
       this.status = status;
     }
   }
-  return { MockKnowledgeUploadError };
+  class MockKnowledgeQuotaError extends Error {
+    readonly quotas: unknown;
+    readonly usage: unknown;
+    readonly status: number;
+    constructor(reason: string, quotas: unknown, usage: unknown, status = 409) {
+      super(reason);
+      this.name = 'KnowledgeQuotaError';
+      this.quotas = quotas;
+      this.usage = usage;
+      this.status = status;
+    }
+  }
+  class MockKnowledgeMutationUnsupportedError extends Error {
+    readonly status: number;
+    constructor(reason: string, status = 405) {
+      super(reason);
+      this.name = 'KnowledgeMutationUnsupportedError';
+      this.status = status;
+    }
+  }
+  return {
+    MockKnowledgeUploadError,
+    MockKnowledgeQuotaError,
+    MockKnowledgeMutationUnsupportedError,
+  };
 });
 
 vi.mock('../services/knowledgeApi', () => ({
@@ -75,12 +169,18 @@ vi.mock('../services/knowledgeApi', () => ({
   searchKnowledgeBase: (...args: unknown[]) => mockSearchKB(...args),
   uploadDocument: (...args: unknown[]) => mockUploadDoc(...args),
   fetchKBStats: (...args: unknown[]) => mockFetchStats(...args),
+  fetchKnowledgeProviderSnapshot: (...args: unknown[]) => mockFetchSnapshot(...args),
   KnowledgeUploadError: MockKnowledgeUploadError,
+  KnowledgeQuotaError: MockKnowledgeQuotaError,
+  KnowledgeMutationUnsupportedError: MockKnowledgeMutationUnsupportedError,
 }));
 
 import KnowledgeBasePanel from '../components/knowledge/KnowledgeBasePanel';
 import DocumentUpload from '../components/knowledge/DocumentUpload';
 import CitationBadge from '../components/knowledge/CitationBadge';
+import ProviderInfoCard from '../components/knowledge/ProviderInfoCard';
+import AgentBindingsPanel from '../components/knowledge/AgentBindingsPanel';
+import SearchResults from '../components/knowledge/SearchResults';
 
 function wrap(ui: React.ReactNode) {
   return <FluentProvider theme={teamsDarkTheme}>{ui}</FluentProvider>;
@@ -89,6 +189,18 @@ function wrap(ui: React.ReactNode) {
 describe('KnowledgeBasePanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetchDocs.mockResolvedValue(mockDocuments);
+    mockDeleteDoc.mockResolvedValue(undefined);
+    mockSearchKB.mockResolvedValue(mockSearchResults);
+    mockUploadDoc.mockResolvedValue({
+      documentId: 'doc-new',
+      title: 'Test Doc',
+      status: 'ingested',
+      chunkCount: 5,
+      source: 'upload',
+    });
+    mockFetchStats.mockResolvedValue(mockStats);
+    mockFetchSnapshot.mockResolvedValue(makeSnapshot());
   });
 
   it('renders knowledge base panel with title and search', async () => {
@@ -131,11 +243,100 @@ describe('KnowledgeBasePanel', () => {
       expect(screen.getByTestId('kb-error')).toBeInTheDocument();
     });
   });
+
+  it('renders the provider info card with durable/volatile signal', async () => {
+    render(wrap(<KnowledgeBasePanel />));
+    await waitFor(() => expect(mockFetchSnapshot).toHaveBeenCalled());
+    const durability = await screen.findByTestId('kb-provider-durability');
+    expect(durability).toHaveAttribute('data-durability', 'volatile');
+    // Status is not conveyed by color alone — the text label must be present.
+    expect(durability).toHaveTextContent(/Volatile/);
+    expect(screen.getByTestId('kb-provider-name')).toHaveTextContent('InMemory');
+    expect(screen.getByTestId('kb-provider-relevance')).toHaveTextContent(/Lexical/);
+    expect(screen.getByTestId('kb-score-semantics')).toHaveTextContent(/BM25/);
+  });
+
+  it('renders per-agent bindings with named source and unscoped labels', async () => {
+    render(wrap(<KnowledgeBasePanel />));
+    await waitFor(() => expect(mockFetchSnapshot).toHaveBeenCalled());
+    const bindings = await screen.findByTestId('kb-agent-bindings');
+    const planogram = within(bindings).getByTestId('kb-binding-planogram');
+    expect(planogram).toHaveTextContent(/planogram-shelf-set/);
+    expect(planogram).toHaveAttribute('data-binding-enabled', 'true');
+    const general = within(bindings).getByTestId('kb-binding-general');
+    expect(general).toHaveTextContent(/Unscoped/);
+    const memory = within(bindings).getByTestId('kb-binding-memory-management');
+    expect(memory).toHaveAttribute('data-binding-enabled', 'false');
+    expect(memory).toHaveTextContent(/Disabled/);
+  });
+
+  it('renders the disabled-knowledge state when every agent binding is disabled', async () => {
+    mockFetchSnapshot.mockResolvedValueOnce(makeSnapshot({
+      bindings: [
+        {
+          agentKey: 'planogram',
+          agentDisplayName: 'Planogram Agent',
+          enabled: false,
+          sourceName: '',
+          sources: [],
+        },
+        {
+          agentKey: 'general',
+          agentDisplayName: 'General Assistant',
+          enabled: false,
+          sourceName: '',
+          sources: [],
+        },
+      ],
+    }));
+    render(wrap(<KnowledgeBasePanel />));
+    await waitFor(() => expect(mockFetchSnapshot).toHaveBeenCalled());
+    expect(await screen.findByTestId('kb-disabled')).toBeInTheDocument();
+  });
+
+  it('still renders documents when the provider snapshot fetch fails', async () => {
+    mockFetchSnapshot.mockRejectedValueOnce(new Error('provider snapshot unavailable'));
+    render(wrap(<KnowledgeBasePanel />));
+    await waitFor(() => expect(mockFetchDocs).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByTestId('document-list')).toBeInTheDocument());
+    expect(screen.queryByTestId('kb-provider-info')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('kb-agent-bindings')).not.toBeInTheDocument();
+  });
+
+  it('passes honest relevance semantics to search results', async () => {
+    mockFetchSnapshot.mockResolvedValueOnce(makeSnapshot({
+      provider: {
+        name: 'AzureAISearch',
+        relevance: 'Hybrid',
+        persistent: true,
+        requiresCloud: true,
+        supportsMutation: true,
+        scoreSemantics: 'Hybrid rank fusion — provider-local scores.',
+      },
+    }));
+    render(wrap(<KnowledgeBasePanel />));
+    await waitFor(() => expect(mockFetchSnapshot).toHaveBeenCalled());
+
+    const input = screen.getByTestId('kb-search-input');
+    fireEvent.change(input, { target: { value: 'enterprise' } });
+    fireEvent.click(screen.getByText('Search'));
+
+    await waitFor(() => expect(screen.getByTestId('search-results')).toBeInTheDocument());
+    expect(screen.getByTestId('search-relevance-kind')).toHaveTextContent(/Hybrid relevance/);
+    expect(screen.getByTestId('search-score-semantics')).toHaveTextContent(/Hybrid rank fusion/);
+  });
 });
 
 describe('DocumentUpload', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUploadDoc.mockResolvedValue({
+      documentId: 'doc-new',
+      title: 'Test Doc',
+      status: 'ingested',
+      chunkCount: 5,
+      source: 'upload',
+    });
   });
 
   it('renders upload zone with accepted formats', () => {
@@ -159,7 +360,7 @@ describe('DocumentUpload', () => {
     expect(screen.getByTestId('upload-btn')).toBeInTheDocument();
   });
 
-  it('uploads document and shows success state', async () => {
+  it('uploads document and shows accepted outcome with chunk count and source', async () => {
     const onComplete = vi.fn();
     render(wrap(<DocumentUpload onUploadComplete={onComplete} />));
 
@@ -176,6 +377,8 @@ describe('DocumentUpload', () => {
     await waitFor(() => {
       expect(screen.getByTestId('upload-success')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('upload-accepted-meta')).toHaveTextContent(/5 chunks/);
+    expect(screen.getByTestId('upload-accepted-meta')).toHaveTextContent(/upload/);
     expect(onComplete).toHaveBeenCalled();
   });
 
@@ -211,6 +414,226 @@ describe('DocumentUpload', () => {
     expect(onComplete).not.toHaveBeenCalled();
     // Generic error message must NOT render when safety block is shown.
     expect(screen.queryByTestId('upload-error')).not.toBeInTheDocument();
+  });
+
+  it('renders a volatile warning when the provider is not persistent', () => {
+    render(wrap(
+      <DocumentUpload
+        onUploadComplete={vi.fn()}
+        provider={{
+          name: 'InMemory',
+          relevance: 'Lexical',
+          persistent: false,
+          requiresCloud: false,
+          supportsMutation: true,
+          scoreSemantics: 'BM25 lexical.',
+        }}
+      />,
+    ));
+    const warning = screen.getByTestId('upload-volatile-warning');
+    expect(warning).toBeInTheDocument();
+    expect(warning).toHaveAttribute('role', 'alert');
+    expect(warning).toHaveTextContent(/lost on restart/i);
+  });
+
+  it('omits the volatile warning when the provider is persistent', () => {
+    render(wrap(
+      <DocumentUpload
+        onUploadComplete={vi.fn()}
+        provider={{
+          name: 'AzureAISearch',
+          relevance: 'Hybrid',
+          persistent: true,
+          requiresCloud: true,
+          supportsMutation: true,
+          scoreSemantics: 'Hybrid rank fusion.',
+        }}
+      />,
+    ));
+    expect(screen.queryByTestId('upload-volatile-warning')).not.toBeInTheDocument();
+  });
+
+  it('renders a read-only state and hides the drop zone when the provider does not support mutation', () => {
+    render(wrap(
+      <DocumentUpload
+        onUploadComplete={vi.fn()}
+        provider={{
+          name: 'FoundryIQ',
+          relevance: 'Semantic',
+          persistent: true,
+          requiresCloud: true,
+          supportsMutation: false,
+          scoreSemantics: 'Foundry-managed vector store scores.',
+        }}
+      />,
+    ));
+    expect(screen.getByTestId('upload-readonly')).toBeInTheDocument();
+    expect(screen.queryByTestId('file-input')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('upload-volatile-warning')).not.toBeInTheDocument();
+  });
+
+  it('renders a quota-rejected outcome distinct from a generic error', async () => {
+    mockUploadDoc.mockRejectedValueOnce(new MockKnowledgeQuotaError(
+      'Knowledge base is full (100 documents).',
+      { maxDocuments: 100, maxChunks: 5000, maxDocumentSizeBytes: 10 * 1024 * 1024 },
+      { documentCount: 100, chunkCount: 4200 },
+      409,
+    ));
+    render(wrap(<DocumentUpload onUploadComplete={vi.fn()} />));
+
+    const file = new File(['x'], 'big.md', { type: 'text/markdown' });
+    await userEvent.upload(screen.getByTestId('file-input'), file);
+    await waitFor(() => expect(screen.getByTestId('upload-btn')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('upload-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('upload-quota-block')).toBeInTheDocument());
+    expect(screen.getByTestId('upload-quota-block')).toHaveAttribute('role', 'alert');
+    expect(screen.getByTestId('upload-quota-meta')).toHaveTextContent(/100 \/ 100/);
+    expect(screen.queryByTestId('upload-success')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('upload-error')).not.toBeInTheDocument();
+  });
+
+  it('renders the generic failure state when the upload fails for non-classified reasons', async () => {
+    mockUploadDoc.mockRejectedValueOnce(new Error('network down'));
+    render(wrap(<DocumentUpload onUploadComplete={vi.fn()} />));
+
+    const file = new File(['x'], 'stub.md', { type: 'text/markdown' });
+    await userEvent.upload(screen.getByTestId('file-input'), file);
+    await waitFor(() => expect(screen.getByTestId('upload-btn')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('upload-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('upload-error')).toBeInTheDocument());
+    expect(screen.getByTestId('upload-error')).toHaveTextContent(/network down/);
+  });
+});
+
+describe('ProviderInfoCard', () => {
+  it('renders quota bars in an exceeded state when usage meets the limit', () => {
+    render(wrap(<ProviderInfoCard
+      provider={{
+        name: 'InMemory',
+        relevance: 'Lexical',
+        persistent: false,
+        requiresCloud: false,
+        supportsMutation: true,
+        scoreSemantics: 'BM25 lexical.',
+      }}
+      degradation={{ mode: 'FailLoud', primaryReplacedByFallback: false }}
+      quotas={{ maxDocuments: 100, maxChunks: 5000, maxDocumentSizeBytes: 10 * 1024 * 1024 }}
+      usage={{ documentCount: 100, chunkCount: 5000 }}
+    />));
+    const docBar = screen.getByTestId('kb-quota-documents');
+    expect(docBar).toHaveAttribute('data-quota-status', 'exceeded');
+    const chunkBar = screen.getByTestId('kb-quota-chunks');
+    expect(chunkBar).toHaveAttribute('data-quota-status', 'exceeded');
+  });
+
+  it('renders a fallback alert when the primary was replaced', () => {
+    render(wrap(<ProviderInfoCard
+      provider={{
+        name: 'InMemory',
+        relevance: 'Lexical',
+        persistent: false,
+        requiresCloud: false,
+        supportsMutation: true,
+        scoreSemantics: 'BM25 lexical.',
+      }}
+      degradation={{ mode: 'FallbackToInMemory', primaryReplacedByFallback: true }}
+      quotas={{ maxDocuments: 100, maxChunks: 5000, maxDocumentSizeBytes: 10 * 1024 * 1024 }}
+      usage={{ documentCount: 5, chunkCount: 24 }}
+    />));
+    const alert = screen.getByTestId('kb-fallback-alert');
+    expect(alert).toHaveAttribute('role', 'alert');
+    expect(alert).toHaveTextContent(/fallback/i);
+  });
+
+  it('reflects read-only providers in the mutation badge (text, not colour)', () => {
+    render(wrap(<ProviderInfoCard
+      provider={{
+        name: 'FoundryIQ',
+        relevance: 'Semantic',
+        persistent: true,
+        requiresCloud: true,
+        supportsMutation: false,
+        scoreSemantics: 'Foundry-managed scores.',
+      }}
+      degradation={{ mode: 'FailLoud', primaryReplacedByFallback: false }}
+      quotas={{ maxDocuments: 100, maxChunks: 5000, maxDocumentSizeBytes: 10 * 1024 * 1024 }}
+      usage={{ documentCount: 0, chunkCount: 0 }}
+    />));
+    const mutation = screen.getByTestId('kb-provider-mutation');
+    expect(mutation).toHaveAttribute('data-mutation', 'read-only');
+    expect(mutation).toHaveTextContent(/Read-only corpus/);
+  });
+});
+
+describe('AgentBindingsPanel', () => {
+  it('renders named sources and their documents', () => {
+    render(wrap(<AgentBindingsPanel
+      bindings={[]}
+      sources={[
+        { name: 'planogram-shelf-set', documents: ['apex-planogram-and-shelf-set.md'] },
+        { name: 'supplier-service-levels', documents: ['apex-supplier-service-levels.md'] },
+      ]}
+    />));
+    expect(screen.getByTestId('kb-named-source-planogram-shelf-set')).toHaveTextContent(/apex-planogram-and-shelf-set/);
+    expect(screen.getByTestId('kb-named-source-supplier-service-levels')).toHaveTextContent(/apex-supplier-service-levels/);
+  });
+
+  it('renders the empty-sources message when no named sources are configured', () => {
+    render(wrap(<AgentBindingsPanel bindings={[]} sources={[]} />));
+    expect(screen.getByTestId('kb-named-sources-empty')).toBeInTheDocument();
+  });
+
+  it('is keyboard navigable — every binding row and status badge exposes a text label', () => {
+    render(wrap(<AgentBindingsPanel
+      bindings={[
+        {
+          agentKey: 'planogram',
+          agentDisplayName: 'Planogram Agent',
+          enabled: true,
+          sourceName: 'planogram-shelf-set',
+          sources: ['apex-planogram-and-shelf-set.md'],
+        },
+        {
+          agentKey: 'memory',
+          agentDisplayName: 'Memory Manager',
+          enabled: false,
+          sourceName: '',
+          sources: [],
+        },
+      ]}
+      sources={[]}
+    />));
+    const enabled = screen.getByTestId('kb-binding-planogram');
+    expect(within(enabled).getByText(/Enabled/)).toBeInTheDocument();
+    const disabled = screen.getByTestId('kb-binding-memory');
+    expect(within(disabled).getByText(/Disabled/)).toBeInTheDocument();
+  });
+});
+
+describe('SearchResults relevance honesty', () => {
+  it('renders a lexical label and per-result score for the in-memory provider', () => {
+    render(wrap(<SearchResults
+      results={mockSearchResults}
+      query="enterprise"
+      relevanceKind="Lexical"
+      scoreSemantics="BM25 lexical score."
+    />));
+    expect(screen.getByTestId('search-relevance-kind')).toHaveTextContent(/Lexical relevance/);
+    expect(screen.getByTestId('search-score-semantics')).toHaveTextContent(/BM25 lexical/);
+    expect(screen.getByTestId('search-result')).toHaveAttribute('data-relevance-band', 'high');
+  });
+
+  it('renders a semantic label without implying cross-provider comparability', () => {
+    render(wrap(<SearchResults
+      results={mockSearchResults}
+      query="enterprise"
+      relevanceKind="Semantic"
+      scoreSemantics="Cosine similarity from vector embeddings."
+    />));
+    expect(screen.getByTestId('search-relevance-kind')).toHaveTextContent(/Semantic relevance/);
+    expect(screen.getByTestId('search-score-semantics')).toHaveTextContent(/Cosine similarity/);
   });
 });
 

--- a/src/RetailPulse.Web/src/components/knowledge/AgentBindingsPanel.tsx
+++ b/src/RetailPulse.Web/src/components/knowledge/AgentBindingsPanel.tsx
@@ -1,0 +1,188 @@
+import { makeStyles } from '@fluentui/react-components';
+import type { KnowledgeAgentBinding, KnowledgeNamedSource } from '../../types';
+
+interface AgentBindingsPanelProps {
+  bindings: KnowledgeAgentBinding[];
+  sources: KnowledgeNamedSource[];
+}
+
+const useStyles = makeStyles({
+  wrapper: {
+    padding: '16px',
+    borderRadius: '12px',
+    backgroundColor: 'var(--color-surface, rgba(255,255,255,0.03))',
+    border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+  },
+  title: {
+    fontSize: '13px',
+    fontWeight: '700',
+    color: 'var(--color-text, #ffffff)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '10px',
+  },
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  sectionLabel: {
+    fontSize: '11px',
+    textTransform: 'uppercase',
+    letterSpacing: '0.6px',
+    color: 'var(--color-text-muted, #94a3b8)',
+    marginTop: '4px',
+  },
+  sourceRow: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    padding: '8px 10px',
+    borderRadius: '8px',
+    backgroundColor: 'var(--color-surface-alt, rgba(255,255,255,0.04))',
+    border: '1px solid var(--color-border, rgba(255,255,255,0.06))',
+  },
+  sourceName: {
+    fontSize: '12px',
+    fontWeight: '600',
+    color: 'var(--color-text, #ffffff)',
+  },
+  sourceDocs: {
+    fontSize: '11px',
+    color: 'var(--color-text-muted, #94a3b8)',
+  },
+  bindingRow: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '10px',
+    padding: '8px 10px',
+    borderRadius: '8px',
+    backgroundColor: 'var(--color-surface-alt, rgba(255,255,255,0.04))',
+    border: '1px solid var(--color-border, rgba(255,255,255,0.06))',
+  },
+  agentName: {
+    fontSize: '12px',
+    fontWeight: '600',
+    color: 'var(--color-text, #ffffff)',
+  },
+  agentScope: {
+    fontSize: '11px',
+    color: 'var(--color-text-muted, #94a3b8)',
+  },
+  statusBadge: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '4px',
+    fontSize: '10px',
+    fontWeight: '700',
+    letterSpacing: '0.4px',
+    padding: '2px 8px',
+    borderRadius: '999px',
+    border: '1px solid var(--color-border, rgba(255,255,255,0.15))',
+    textTransform: 'uppercase',
+  },
+  statusEnabled: {
+    color: 'var(--color-accent-success, #22c55e)',
+    borderColor: 'var(--color-accent-success, #22c55e)',
+    backgroundColor: 'rgba(34,197,94,0.08)',
+  },
+  statusDisabled: {
+    color: 'var(--color-text-muted, #94a3b8)',
+    borderColor: 'var(--color-border, rgba(255,255,255,0.2))',
+    backgroundColor: 'var(--color-surface-alt, rgba(255,255,255,0.04))',
+  },
+  empty: {
+    fontSize: '12px',
+    color: 'var(--color-text-muted, #94a3b8)',
+    padding: '4px 0',
+  },
+});
+
+function describeScope(binding: KnowledgeAgentBinding): string {
+  if (!binding.enabled) return 'Knowledge disabled — no retrieval will run';
+  if (binding.sourceName && binding.sourceName.trim().length > 0) {
+    const docs = binding.sources.length > 0
+      ? ` (${binding.sources.join(', ')})`
+      : '';
+    return `Bound to “${binding.sourceName}”${docs}`;
+  }
+  return 'Unscoped — sees the entire corpus';
+}
+
+export default function AgentBindingsPanel({ bindings, sources }: AgentBindingsPanelProps) {
+  const styles = useStyles();
+  const sortedBindings = [...bindings].sort((a, b) => a.agentDisplayName.localeCompare(b.agentDisplayName));
+  const sortedSources = [...sources].sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <div className={styles.wrapper} data-testid="kb-agent-bindings">
+      <div className={styles.title}>
+        <span>🔗 Per-Agent Knowledge Bindings</span>
+        <span
+          className={styles.agentScope}
+          data-testid="kb-agent-bindings-count"
+        >
+          {bindings.length} {bindings.length === 1 ? 'agent' : 'agents'}
+        </span>
+      </div>
+
+      <div className={styles.sectionLabel}>Named sources</div>
+      <div className={styles.section} data-testid="kb-named-sources">
+        {sortedSources.length === 0 ? (
+          <div className={styles.empty} data-testid="kb-named-sources-empty">
+            No named sources configured — every enabled agent uses the full corpus.
+          </div>
+        ) : (
+          sortedSources.map(source => (
+            <div
+              key={source.name}
+              className={styles.sourceRow}
+              data-testid={`kb-named-source-${source.name}`}
+            >
+              <span className={styles.sourceName}>{source.name}</span>
+              <span className={styles.sourceDocs}>
+                {source.documents.length > 0
+                  ? source.documents.join(', ')
+                  : 'No documents assigned'}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className={styles.sectionLabel}>Agents</div>
+      <div className={styles.section}>
+        {sortedBindings.length === 0 ? (
+          <div className={styles.empty} data-testid="kb-bindings-empty">
+            No specialist agents configured.
+          </div>
+        ) : (
+          sortedBindings.map(binding => (
+            <div
+              key={binding.agentKey}
+              className={styles.bindingRow}
+              data-testid={`kb-binding-${binding.agentKey}`}
+              data-binding-enabled={binding.enabled ? 'true' : 'false'}
+            >
+              <div>
+                <div className={styles.agentName}>{binding.agentDisplayName}</div>
+                <div className={styles.agentScope}>{describeScope(binding)}</div>
+              </div>
+              <span
+                className={`${styles.statusBadge} ${binding.enabled ? styles.statusEnabled : styles.statusDisabled}`}
+                aria-label={binding.enabled ? 'Retrieval enabled' : 'Retrieval disabled'}
+              >
+                {binding.enabled ? 'Enabled' : 'Disabled'}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/RetailPulse.Web/src/components/knowledge/AgentBindingsPanel.tsx
+++ b/src/RetailPulse.Web/src/components/knowledge/AgentBindingsPanel.tsx
@@ -88,12 +88,12 @@ const useStyles = makeStyles({
   },
   statusEnabled: {
     color: 'var(--color-accent-success, #22c55e)',
-    borderColor: 'var(--color-accent-success, #22c55e)',
+    border: '1px solid var(--color-accent-success, #22c55e)',
     backgroundColor: 'rgba(34,197,94,0.08)',
   },
   statusDisabled: {
     color: 'var(--color-text-muted, #94a3b8)',
-    borderColor: 'var(--color-border, rgba(255,255,255,0.2))',
+    border: '1px solid var(--color-border, rgba(255,255,255,0.2))',
     backgroundColor: 'var(--color-surface-alt, rgba(255,255,255,0.04))',
   },
   empty: {

--- a/src/RetailPulse.Web/src/components/knowledge/DocumentUpload.tsx
+++ b/src/RetailPulse.Web/src/components/knowledge/DocumentUpload.tsx
@@ -1,12 +1,23 @@
 import { useState, useCallback, useRef } from 'react';
 import { makeStyles, Button } from '@fluentui/react-components';
 import { KB_COLORS } from '../../constants/agentRouting';
-import { uploadDocument, KnowledgeUploadError } from '../../services/knowledgeApi';
-import type { SafetyBlockDisplayModel } from '../../types';
+import {
+  uploadDocument,
+  KnowledgeUploadError,
+  KnowledgeQuotaError,
+  KnowledgeMutationUnsupportedError,
+} from '../../services/knowledgeApi';
+import type {
+  KnowledgeProviderInfo,
+  KnowledgeQuotas,
+  KnowledgeUsage,
+  SafetyBlockDisplayModel,
+} from '../../types';
 import { KnowledgeIngestionBlock } from '../guardrails/KnowledgeIngestionBlock';
 
 interface DocumentUploadProps {
   onUploadComplete: () => void;
+  provider?: KnowledgeProviderInfo | null;
 }
 
 const ACCEPTED_FORMATS = ['.md', '.txt'];
@@ -23,6 +34,50 @@ const useStyles = makeStyles({
   },
   wrapperDragOver: {
     transform: 'scale(1.01)',
+  },
+  wrapperReadOnly: {
+    cursor: 'not-allowed',
+    opacity: 0.85,
+  },
+  volatileWarning: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    gap: '8px',
+    textAlign: 'left',
+    padding: '10px 12px',
+    marginBottom: '12px',
+    borderRadius: '8px',
+    backgroundColor: 'rgba(245,158,11,0.10)',
+    border: '1px solid var(--color-accent-warning, #f59e0b)',
+    color: 'var(--color-accent-warning, #f59e0b)',
+    fontSize: '12px',
+    lineHeight: '1.5',
+  },
+  readOnlyBanner: {
+    padding: '14px 16px',
+    borderRadius: '8px',
+    backgroundColor: 'var(--color-surface-alt, rgba(255,255,255,0.04))',
+    border: '1px solid var(--color-border, rgba(255,255,255,0.15))',
+    color: 'var(--color-text, #ffffff)',
+    fontSize: '13px',
+    lineHeight: '1.5',
+  },
+  quotaBlock: {
+    marginTop: '12px',
+    padding: '10px 12px',
+    borderRadius: '8px',
+    backgroundColor: 'rgba(239,68,68,0.10)',
+    border: '1px solid var(--color-accent-danger, #ef4444)',
+    color: 'var(--color-accent-danger, #ef4444)',
+    fontSize: '13px',
+    lineHeight: '1.5',
+    textAlign: 'left',
+  },
+  outcomeMeta: {
+    marginTop: '4px',
+    fontSize: '11px',
+    color: 'var(--color-text-muted, #94a3b8)',
   },
   icon: {
     fontSize: '32px',
@@ -108,7 +163,7 @@ const useStyles = makeStyles({
   },
 });
 
-export default function DocumentUpload({ onUploadComplete }: DocumentUploadProps) {
+export default function DocumentUpload({ onUploadComplete, provider }: DocumentUploadProps) {
   const styles = useStyles();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [dragOver, setDragOver] = useState(false);
@@ -120,7 +175,19 @@ export default function DocumentUpload({ onUploadComplete }: DocumentUploadProps
     success: boolean;
     error?: string;
     safetyDisplay?: SafetyBlockDisplayModel;
+    quota?: {
+      reason: string;
+      quotas: KnowledgeQuotas | null;
+      usage: KnowledgeUsage | null;
+    };
+    accepted?: {
+      chunkCount: number;
+      source: string;
+    };
   } | null>(null);
+
+  const isReadOnly = provider ? !provider.supportsMutation : false;
+  const isVolatile = provider ? !provider.persistent : false;
 
   const handleFileSelect = useCallback((file: File) => {
     const ext = '.' + file.name.split('.').pop()?.toLowerCase();
@@ -134,11 +201,12 @@ export default function DocumentUpload({ onUploadComplete }: DocumentUploadProps
   }, []);
 
   const handleDrop = useCallback((e: React.DragEvent) => {
+    if (isReadOnly) { e.preventDefault(); return; }
     e.preventDefault();
     setDragOver(false);
     const file = e.dataTransfer.files[0];
     if (file) handleFileSelect(file);
-  }, [handleFileSelect]);
+  }, [handleFileSelect, isReadOnly]);
 
   const handleUpload = useCallback(async () => {
     if (!selectedFile || !title.trim()) return;
@@ -152,10 +220,16 @@ export default function DocumentUpload({ onUploadComplete }: DocumentUploadProps
     }, 200);
 
     try {
-      await uploadDocument(selectedFile, title);
+      const response = await uploadDocument(selectedFile, title);
       clearInterval(progressInterval);
       setUploadProgress(100);
-      setUploadResult({ success: true });
+      setUploadResult({
+        success: true,
+        accepted: {
+          chunkCount: response.chunkCount ?? 0,
+          source: response.source ?? 'upload',
+        },
+      });
       onUploadComplete();
       setTimeout(() => {
         setSelectedFile(null);
@@ -167,6 +241,13 @@ export default function DocumentUpload({ onUploadComplete }: DocumentUploadProps
       clearInterval(progressInterval);
       if (e instanceof KnowledgeUploadError) {
         setUploadResult({ success: false, safetyDisplay: e.display });
+      } else if (e instanceof KnowledgeQuotaError) {
+        setUploadResult({
+          success: false,
+          quota: { reason: e.message, quotas: e.quotas, usage: e.usage },
+        });
+      } else if (e instanceof KnowledgeMutationUnsupportedError) {
+        setUploadResult({ success: false, error: e.message });
       } else {
         setUploadResult({ success: false, error: e instanceof Error ? e.message : 'Upload failed' });
       }
@@ -175,16 +256,47 @@ export default function DocumentUpload({ onUploadComplete }: DocumentUploadProps
     }
   }, [selectedFile, title, onUploadComplete]);
 
+  if (isReadOnly) {
+    return (
+      <div
+        className={`${styles.wrapper} ${styles.wrapperReadOnly}`}
+        data-testid="document-upload"
+        data-upload-mode="read-only"
+      >
+        <div className={styles.readOnlyBanner} role="status" data-testid="upload-readonly">
+          🔒 The active knowledge provider is read-only — its corpus is managed outside
+          Retail Pulse. Manage documents in the provider’s portal and re-run search.
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className={`${styles.wrapper} ${dragOver ? styles.wrapperDragOver : ''}`}
       style={dragOver ? { borderColor: '#06b6d4', backgroundColor: 'rgba(6,182,212,0.1)' } : undefined}
       data-testid="document-upload"
+      data-upload-mode={isVolatile ? 'volatile' : 'durable'}
       onDragOver={e => { e.preventDefault(); setDragOver(true); }}
       onDragLeave={() => setDragOver(false)}
       onDrop={handleDrop}
       onClick={() => !selectedFile && fileInputRef.current?.click()}
     >
+      {isVolatile && (
+        <div
+          className={styles.volatileWarning}
+          role="alert"
+          data-testid="upload-volatile-warning"
+        >
+          <span aria-hidden="true">⚠️</span>
+          <span>
+            The active provider is <strong>volatile</strong>. Uploaded content lives
+            only in this process and will be lost on restart. Use a durable provider
+            for content you need to keep.
+          </span>
+        </div>
+      )}
+
       <input
         ref={fileInputRef}
         type="file"
@@ -247,6 +359,13 @@ export default function DocumentUpload({ onUploadComplete }: DocumentUploadProps
       {uploadResult?.success && (
         <div className={styles.success} data-testid="upload-success">
           ✅ Document indexed successfully
+          {uploadResult.accepted && (
+            <div className={styles.outcomeMeta} data-testid="upload-accepted-meta">
+              {uploadResult.accepted.chunkCount} chunk
+              {uploadResult.accepted.chunkCount === 1 ? '' : 's'}{' '}
+              stored as source “{uploadResult.accepted.source}”.
+            </div>
+          )}
         </div>
       )}
 
@@ -256,6 +375,18 @@ export default function DocumentUpload({ onUploadComplete }: DocumentUploadProps
             documentTitle={title || selectedFile?.name}
             display={uploadResult.safetyDisplay}
           />
+        </div>
+      )}
+
+      {uploadResult?.quota && (
+        <div className={styles.quotaBlock} role="alert" data-testid="upload-quota-block">
+          <div>🚫 Quota reached — {uploadResult.quota.reason}</div>
+          {uploadResult.quota.quotas && uploadResult.quota.usage && (
+            <div className={styles.outcomeMeta} data-testid="upload-quota-meta">
+              Documents {uploadResult.quota.usage.documentCount.toLocaleString()} / {uploadResult.quota.quotas.maxDocuments.toLocaleString()},
+              chunks {uploadResult.quota.usage.chunkCount.toLocaleString()} / {uploadResult.quota.quotas.maxChunks.toLocaleString()}.
+            </div>
+          )}
         </div>
       )}
 

--- a/src/RetailPulse.Web/src/components/knowledge/KnowledgeBasePanel.tsx
+++ b/src/RetailPulse.Web/src/components/knowledge/KnowledgeBasePanel.tsx
@@ -2,11 +2,18 @@ import { useState, useEffect, useCallback } from 'react';
 import { makeStyles, Button, Badge } from '@fluentui/react-components';
 import { Delete16Regular, Search16Regular } from '@fluentui/react-icons';
 import { KB_COLORS } from '../../constants/agentRouting';
-import type { KBDocument, KBSearchResult } from '../../types';
-import { fetchDocuments, deleteDocument, searchKnowledgeBase } from '../../services/knowledgeApi';
+import type { KBDocument, KBSearchResult, KnowledgeProviderSnapshot } from '../../types';
+import {
+  fetchDocuments,
+  deleteDocument,
+  searchKnowledgeBase,
+  fetchKnowledgeProviderSnapshot,
+} from '../../services/knowledgeApi';
 import DocumentUpload from './DocumentUpload';
 import SearchResults from './SearchResults';
 import KnowledgeStats from './KnowledgeStats';
+import ProviderInfoCard from './ProviderInfoCard';
+import AgentBindingsPanel from './AgentBindingsPanel';
 
 const useStyles = makeStyles({
   container: {
@@ -141,6 +148,19 @@ const useStyles = makeStyles({
     fontSize: '13px',
     marginBottom: '12px',
   },
+  providerRow: {
+    marginBottom: '20px',
+  },
+  disabledState: {
+    padding: '32px',
+    borderRadius: '12px',
+    textAlign: 'center',
+    color: 'var(--color-text-muted, #94a3b8)',
+    fontSize: '13px',
+    lineHeight: '1.6',
+    backgroundColor: 'var(--color-surface, rgba(255,255,255,0.03))',
+    border: '1px dashed var(--color-border, rgba(255,255,255,0.15))',
+  },
 });
 
 const SOURCE_ICONS: Record<string, string> = {
@@ -156,6 +176,8 @@ export default function KnowledgeBasePanel() {
   const [searching, setSearching] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [snapshot, setSnapshot] = useState<KnowledgeProviderSnapshot | null>(null);
+  const [snapshotLoaded, setSnapshotLoaded] = useState(false);
 
   const loadDocuments = useCallback(async () => {
     setLoading(true);
@@ -170,7 +192,22 @@ export default function KnowledgeBasePanel() {
     }
   }, []);
 
+  const loadSnapshot = useCallback(async () => {
+    try {
+      const snap = await fetchKnowledgeProviderSnapshot();
+      setSnapshot(snap);
+    } catch {
+      // A snapshot fetch failure never blocks the panel — the document list,
+      // search, and stats still render. The provider info card is simply
+      // omitted until a subsequent request succeeds.
+      setSnapshot(null);
+    } finally {
+      setSnapshotLoaded(true);
+    }
+  }, []);
+
   useEffect(() => { loadDocuments(); }, [loadDocuments]);
+  useEffect(() => { loadSnapshot(); }, [loadSnapshot]);
 
   const handleSearch = useCallback(async () => {
     if (!searchQuery.trim()) {
@@ -192,14 +229,22 @@ export default function KnowledgeBasePanel() {
     try {
       await deleteDocument(id);
       setDocuments(prev => prev.filter(d => d.id !== id));
+      // Refresh the provider snapshot so quota usage stays in sync after a
+      // successful delete without a full page reload.
+      loadSnapshot();
     } catch {
       setError('Failed to delete document');
     }
-  }, []);
+  }, [loadSnapshot]);
 
   const handleUploadComplete = useCallback(() => {
     loadDocuments();
-  }, [loadDocuments]);
+    loadSnapshot();
+  }, [loadDocuments, loadSnapshot]);
+
+  const allBindingsDisabled = snapshot !== null
+    && snapshot.bindings.length > 0
+    && snapshot.bindings.every(b => !b.enabled);
 
   return (
     <div className={styles.container} data-testid="knowledge-base-panel">
@@ -211,6 +256,25 @@ export default function KnowledgeBasePanel() {
       </div>
 
       {error && <div className={styles.error} data-testid="kb-error">⚠️ {error}</div>}
+
+      {snapshot && (
+        <div className={styles.providerRow}>
+          <ProviderInfoCard
+            provider={snapshot.provider}
+            degradation={snapshot.degradation}
+            quotas={snapshot.quotas}
+            usage={snapshot.usage}
+          />
+        </div>
+      )}
+
+      {snapshotLoaded && allBindingsDisabled && (
+        <div className={styles.disabledState} data-testid="kb-disabled">
+          🚫 Knowledge retrieval is disabled for every configured agent. No
+          documents will be returned during chat until at least one agent has
+          <code> use_knowledge_base: true</code>.
+        </div>
+      )}
 
       <div className={styles.searchBar}>
         <input
@@ -234,13 +298,21 @@ export default function KnowledgeBasePanel() {
 
       {searchResults !== null && (
         <div style={{ marginBottom: '20px' }}>
-          <SearchResults results={searchResults} query={searchQuery} />
+          <SearchResults
+            results={searchResults}
+            query={searchQuery}
+            relevanceKind={snapshot?.provider.relevance}
+            scoreSemantics={snapshot?.provider.scoreSemantics}
+          />
         </div>
       )}
 
       <div className={styles.sections}>
         <div className={styles.mainSection}>
-          <DocumentUpload onUploadComplete={handleUploadComplete} />
+          <DocumentUpload
+            onUploadComplete={handleUploadComplete}
+            provider={snapshot?.provider ?? null}
+          />
 
           <div>
             <div className={styles.sectionTitle}>
@@ -287,6 +359,12 @@ export default function KnowledgeBasePanel() {
         </div>
 
         <div className={styles.sidebar}>
+          {snapshot && (
+            <AgentBindingsPanel
+              bindings={snapshot.bindings}
+              sources={snapshot.sources}
+            />
+          )}
           <KnowledgeStats />
         </div>
       </div>

--- a/src/RetailPulse.Web/src/components/knowledge/ProviderInfoCard.tsx
+++ b/src/RetailPulse.Web/src/components/knowledge/ProviderInfoCard.tsx
@@ -1,0 +1,257 @@
+import { makeStyles } from '@fluentui/react-components';
+import type {
+  KnowledgeDegradationInfo,
+  KnowledgeProviderInfo,
+  KnowledgeQuotas,
+  KnowledgeUsage,
+} from '../../types';
+
+interface ProviderInfoCardProps {
+  provider: KnowledgeProviderInfo;
+  degradation: KnowledgeDegradationInfo;
+  quotas: KnowledgeQuotas;
+  usage: KnowledgeUsage;
+}
+
+const useStyles = makeStyles({
+  card: {
+    padding: '16px',
+    borderRadius: '12px',
+    backgroundColor: 'var(--color-surface, rgba(255,255,255,0.03))',
+    border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    flexWrap: 'wrap',
+  },
+  providerName: {
+    fontSize: '15px',
+    fontWeight: '700',
+    color: 'var(--color-text, #ffffff)',
+  },
+  eyebrow: {
+    fontSize: '11px',
+    textTransform: 'uppercase',
+    letterSpacing: '1px',
+    color: 'var(--color-text-muted, #94a3b8)',
+  },
+  badgeRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '8px',
+  },
+  badge: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+    padding: '3px 10px',
+    borderRadius: '999px',
+    fontSize: '11px',
+    fontWeight: '600',
+    border: '1px solid var(--color-border, rgba(255,255,255,0.12))',
+    backgroundColor: 'var(--color-surface-alt, rgba(255,255,255,0.05))',
+    color: 'var(--color-text, #ffffff)',
+  },
+  badgeDurable: {
+    borderColor: 'var(--color-accent-success, #22c55e)',
+    color: 'var(--color-accent-success, #22c55e)',
+    backgroundColor: 'rgba(34,197,94,0.10)',
+  },
+  badgeVolatile: {
+    borderColor: 'var(--color-accent-warning, #f59e0b)',
+    color: 'var(--color-accent-warning, #f59e0b)',
+    backgroundColor: 'rgba(245,158,11,0.12)',
+  },
+  scoreNote: {
+    fontSize: '12px',
+    lineHeight: '1.55',
+    color: 'var(--color-text-muted, #94a3b8)',
+  },
+  degradation: {
+    fontSize: '12px',
+    color: 'var(--color-text-muted, #94a3b8)',
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '8px',
+  },
+  fallbackAlert: {
+    fontSize: '12px',
+    padding: '8px 12px',
+    borderRadius: '8px',
+    backgroundColor: 'rgba(245,158,11,0.12)',
+    border: '1px solid var(--color-accent-warning, #f59e0b)',
+    color: 'var(--color-accent-warning, #f59e0b)',
+  },
+  quotaGroup: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  quotaRow: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  quotaLabel: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    fontSize: '12px',
+    color: 'var(--color-text, #ffffff)',
+  },
+  quotaLabelMuted: {
+    color: 'var(--color-text-muted, #94a3b8)',
+    fontSize: '11px',
+  },
+  quotaBarTrack: {
+    height: '6px',
+    borderRadius: '3px',
+    backgroundColor: 'var(--color-surface-alt, rgba(255,255,255,0.06))',
+    overflow: 'hidden',
+    border: '1px solid var(--color-border, rgba(255,255,255,0.06))',
+  },
+  quotaBarFill: {
+    height: '100%',
+    borderRadius: '3px',
+    backgroundColor: 'var(--color-accent-success, #22c55e)',
+    transition: 'width 0.25s ease',
+  },
+  quotaBarFillWarn: {
+    backgroundColor: 'var(--color-accent-warning, #f59e0b)',
+  },
+  quotaBarFillDanger: {
+    backgroundColor: 'var(--color-accent-danger, #ef4444)',
+  },
+});
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))} MB`;
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${bytes} B`;
+}
+
+function relevanceLabel(kind: KnowledgeProviderInfo['relevance']): string {
+  switch (kind) {
+    case 'Semantic': return 'Semantic (vector similarity)';
+    case 'Hybrid': return 'Hybrid (semantic + lexical)';
+    case 'Lexical':
+    default: return 'Lexical (keyword / BM25)';
+  }
+}
+
+function QuotaBar({
+  label,
+  used,
+  max,
+  testId,
+}: { label: string; used: number; max: number; testId: string }) {
+  const styles = useStyles();
+  const pctRaw = max > 0 ? (used / max) * 100 : 0;
+  const pct = Math.max(0, Math.min(100, pctRaw));
+  const exceeded = used >= max && max > 0;
+  const warn = pct >= 90 || exceeded;
+  const fillClass = [
+    styles.quotaBarFill,
+    exceeded ? styles.quotaBarFillDanger : (warn ? styles.quotaBarFillWarn : ''),
+  ].filter(Boolean).join(' ');
+  const status = exceeded ? 'exceeded' : (warn ? 'warn' : 'ok');
+  return (
+    <div className={styles.quotaRow} data-testid={testId} data-quota-status={status}>
+      <div className={styles.quotaLabel}>
+        <span>{label}</span>
+        <span className={styles.quotaLabelMuted}>{used.toLocaleString()} / {max.toLocaleString()}</span>
+      </div>
+      <div
+        className={styles.quotaBarTrack}
+        role="progressbar"
+        aria-label={`${label} usage`}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-valuenow={used}
+      >
+        <div className={fillClass} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export default function ProviderInfoCard({ provider, degradation, quotas, usage }: ProviderInfoCardProps) {
+  const styles = useStyles();
+  const durabilityClass = provider.persistent ? styles.badgeDurable : styles.badgeVolatile;
+  const durabilityLabel = provider.persistent ? 'Durable' : 'Volatile';
+  const durabilityIcon = provider.persistent ? '🛡️' : '⚠️';
+  const locality = provider.requiresCloud ? 'Cloud-hosted' : 'Local process';
+
+  return (
+    <div className={styles.card} data-testid="kb-provider-info">
+      <div>
+        <div className={styles.eyebrow}>Active retrieval provider</div>
+        <div className={styles.header}>
+          <span className={styles.providerName} data-testid="kb-provider-name">{provider.name}</span>
+          <span
+            className={`${styles.badge} ${durabilityClass}`}
+            data-testid="kb-provider-durability"
+            data-durability={provider.persistent ? 'durable' : 'volatile'}
+            aria-label={`Durability: ${durabilityLabel}`}
+          >
+            <span aria-hidden="true">{durabilityIcon}</span>
+            {durabilityLabel}
+          </span>
+          <span className={styles.badge} data-testid="kb-provider-relevance">
+            {relevanceLabel(provider.relevance)}
+          </span>
+          <span className={styles.badge} data-testid="kb-provider-locality">
+            {locality}
+          </span>
+          <span
+            className={styles.badge}
+            data-testid="kb-provider-mutation"
+            data-mutation={provider.supportsMutation ? 'supported' : 'read-only'}
+          >
+            {provider.supportsMutation ? 'Ingestion enabled' : 'Read-only corpus'}
+          </span>
+        </div>
+      </div>
+
+      <div className={styles.scoreNote} data-testid="kb-score-semantics">
+        {provider.scoreSemantics}
+      </div>
+
+      <div className={styles.degradation} data-testid="kb-degradation">
+        <span>Degradation policy: {degradation.mode ?? 'unknown'}</span>
+      </div>
+
+      {degradation.primaryReplacedByFallback && (
+        <div className={styles.fallbackAlert} role="alert" data-testid="kb-fallback-alert">
+          ⚠️ The configured provider was unreachable at startup. Requests are being
+          served by the in-memory fallback until it recovers.
+        </div>
+      )}
+
+      <div className={styles.quotaGroup}>
+        <QuotaBar
+          label="Documents"
+          used={usage.documentCount}
+          max={quotas.maxDocuments}
+          testId="kb-quota-documents"
+        />
+        <QuotaBar
+          label="Chunks"
+          used={usage.chunkCount}
+          max={quotas.maxChunks}
+          testId="kb-quota-chunks"
+        />
+        <div className={styles.quotaLabel}>
+          <span>Max document size</span>
+          <span className={styles.quotaLabelMuted} data-testid="kb-quota-doc-size">
+            {formatBytes(quotas.maxDocumentSizeBytes)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/RetailPulse.Web/src/components/knowledge/ProviderInfoCard.tsx
+++ b/src/RetailPulse.Web/src/components/knowledge/ProviderInfoCard.tsx
@@ -58,12 +58,12 @@ const useStyles = makeStyles({
     color: 'var(--color-text, #ffffff)',
   },
   badgeDurable: {
-    borderColor: 'var(--color-accent-success, #22c55e)',
+    border: '1px solid var(--color-accent-success, #22c55e)',
     color: 'var(--color-accent-success, #22c55e)',
     backgroundColor: 'rgba(34,197,94,0.10)',
   },
   badgeVolatile: {
-    borderColor: 'var(--color-accent-warning, #f59e0b)',
+    border: '1px solid var(--color-accent-warning, #f59e0b)',
     color: 'var(--color-accent-warning, #f59e0b)',
     backgroundColor: 'rgba(245,158,11,0.12)',
   },

--- a/src/RetailPulse.Web/src/components/knowledge/SearchResults.tsx
+++ b/src/RetailPulse.Web/src/components/knowledge/SearchResults.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { makeStyles, Badge } from '@fluentui/react-components';
 import { KB_COLORS } from '../../constants/agentRouting';
-import type { KBSearchResult } from '../../types';
+import type { KBSearchResult, KnowledgeRelevanceKind } from '../../types';
 
 interface SearchResultsProps {
   results: KBSearchResult[];
   query: string;
+  relevanceKind?: KnowledgeRelevanceKind;
+  scoreSemantics?: string;
 }
 
 const useStyles = makeStyles({
@@ -20,11 +22,18 @@ const useStyles = makeStyles({
     alignItems: 'center',
     gap: '10px',
     marginBottom: '12px',
+    flexWrap: 'wrap',
   },
   title: {
     fontSize: '14px',
     fontWeight: '600',
     color: '#06b6d4' as const,
+  },
+  relevanceNote: {
+    flexBasis: '100%',
+    fontSize: '11px',
+    color: 'var(--color-text-muted, #94a3b8)',
+    lineHeight: '1.5',
   },
   resultList: {
     display: 'flex',
@@ -89,14 +98,35 @@ function getScoreColor(score: number): string {
   return KB_COLORS.relevanceLow;
 }
 
-function ResultCard({ result }: { result: KBSearchResult }) {
+function getRelevanceLabel(kind: KnowledgeRelevanceKind | undefined): string {
+  switch (kind) {
+    case 'Semantic': return 'similarity';
+    case 'Hybrid': return 'hybrid score';
+    case 'Lexical': return 'BM25 score';
+    default: return 'score';
+  }
+}
+
+function getScoreBand(score: number): 'high' | 'medium' | 'low' {
+  if (score >= 0.8) return 'high';
+  if (score >= 0.5) return 'medium';
+  return 'low';
+}
+
+function ResultCard({ result, relevanceKind }: {
+  result: KBSearchResult;
+  relevanceKind?: KnowledgeRelevanceKind;
+}) {
   const styles = useStyles();
   const [expanded, setExpanded] = useState(false);
+  const label = getRelevanceLabel(relevanceKind);
+  const band = getScoreBand(result.score);
 
   return (
     <div
       className={styles.resultCard}
       data-testid="search-result"
+      data-relevance-band={band}
       onClick={() => setExpanded(prev => !prev)}
       role="button"
       tabIndex={0}
@@ -111,8 +141,9 @@ function ResultCard({ result }: { result: KBSearchResult }) {
             color: getScoreColor(result.score),
             fontSize: '10px',
           }}
+          aria-label={`Relevance band: ${band}, ${(result.score * 100).toFixed(0)}% ${label}`}
         >
-          {(result.score * 100).toFixed(0)}% match
+          {(result.score * 100).toFixed(0)}% {label}
         </Badge>
       </div>
       <div className={styles.resultPreview}>{result.chunk}</div>
@@ -128,8 +159,11 @@ function ResultCard({ result }: { result: KBSearchResult }) {
   );
 }
 
-export default function SearchResults({ results, query }: SearchResultsProps) {
+export default function SearchResults({ results, query, relevanceKind, scoreSemantics }: SearchResultsProps) {
   const styles = useStyles();
+  const relevanceHeading = relevanceKind
+    ? `${relevanceKind} relevance`
+    : 'Relevance';
 
   return (
     <div className={styles.wrapper} data-testid="search-results">
@@ -138,6 +172,18 @@ export default function SearchResults({ results, query }: SearchResultsProps) {
         <Badge appearance="filled" style={{ background: 'rgba(6,182,212,0.15)', color: '#67e8f9' }}>
           {results.length} {results.length === 1 ? 'result' : 'results'}
         </Badge>
+        <Badge
+          appearance="outline"
+          data-testid="search-relevance-kind"
+          aria-label={`Relevance semantics: ${relevanceHeading}`}
+        >
+          {relevanceHeading}
+        </Badge>
+        {scoreSemantics && (
+          <div className={styles.relevanceNote} data-testid="search-score-semantics">
+            {scoreSemantics}
+          </div>
+        )}
       </div>
 
       {results.length === 0 ? (
@@ -150,7 +196,11 @@ export default function SearchResults({ results, query }: SearchResultsProps) {
       ) : (
         <div className={styles.resultList}>
           {results.map((r, idx) => (
-            <ResultCard key={`${r.documentId}-${r.chunkIndex}-${idx}`} result={r} />
+            <ResultCard
+              key={`${r.documentId}-${r.chunkIndex}-${idx}`}
+              result={r}
+              relevanceKind={relevanceKind}
+            />
           ))}
         </div>
       )}

--- a/src/RetailPulse.Web/src/components/knowledge/index.ts
+++ b/src/RetailPulse.Web/src/components/knowledge/index.ts
@@ -3,3 +3,5 @@ export { default as DocumentUpload } from './DocumentUpload';
 export { default as CitationBadge } from './CitationBadge';
 export { default as SearchResults } from './SearchResults';
 export { default as KnowledgeStats } from './KnowledgeStats';
+export { default as ProviderInfoCard } from './ProviderInfoCard';
+export { default as AgentBindingsPanel } from './AgentBindingsPanel';

--- a/src/RetailPulse.Web/src/services/knowledgeApi.ts
+++ b/src/RetailPulse.Web/src/services/knowledgeApi.ts
@@ -1,4 +1,13 @@
-import type { KBDocument, KBSearchResult, KBStats, KnowledgeUploadResponse, SafetyBlockDisplayModel } from '../types';
+import type {
+  KBDocument,
+  KBSearchResult,
+  KBStats,
+  KnowledgeProviderSnapshot,
+  KnowledgeQuotas,
+  KnowledgeUploadResponse,
+  KnowledgeUsage,
+  SafetyBlockDisplayModel,
+} from '../types';
 import { buildSafetyBlockDisplay } from '../utils/safetyDisplay';
 
 /**
@@ -18,6 +27,40 @@ export class KnowledgeUploadError extends Error {
   }
 }
 
+/**
+ * Thrown when the active knowledge provider rejects an ingestion for
+ * provider-enforced quota reasons (document count, chunk count, or document
+ * size). Carries the current quota / usage snapshot so the UI can render an
+ * honest "quota reached" state without an extra round-trip.
+ */
+export class KnowledgeQuotaError extends Error {
+  readonly quotas: KnowledgeQuotas | null;
+  readonly usage: KnowledgeUsage | null;
+  readonly status: number;
+  constructor(reason: string, quotas: KnowledgeQuotas | null, usage: KnowledgeUsage | null, status: number) {
+    super(reason);
+    this.name = 'KnowledgeQuotaError';
+    this.quotas = quotas;
+    this.usage = usage;
+    this.status = status;
+  }
+}
+
+/**
+ * Thrown when the active knowledge provider is read-only (its corpus is
+ * managed outside Retail Pulse) and the user attempts an ingest. Carries the
+ * verbatim provider-supplied reason so the panel can hide the upload
+ * affordance and explain why.
+ */
+export class KnowledgeMutationUnsupportedError extends Error {
+  readonly status: number;
+  constructor(reason: string, status: number) {
+    super(reason);
+    this.name = 'KnowledgeMutationUnsupportedError';
+    this.status = status;
+  }
+}
+
 function isSafetyPayload(payload: unknown): payload is Record<string, unknown> {
   if (!payload || typeof payload !== 'object') return false;
   const p = payload as Record<string, unknown>;
@@ -27,6 +70,14 @@ function isSafetyPayload(payload: unknown): payload is Record<string, unknown> {
     typeof p.category === 'string' ||
     typeof p.decision === 'string'
   );
+}
+
+function isQuotaPayload(payload: unknown): payload is Record<string, unknown> {
+  return !!payload && typeof payload === 'object' && (payload as Record<string, unknown>).quotaRejected === true;
+}
+
+function isMutationUnsupportedPayload(payload: unknown): payload is Record<string, unknown> {
+  return !!payload && typeof payload === 'object' && (payload as Record<string, unknown>).mutationUnsupported === true;
 }
 
 export async function fetchDocuments(): Promise<KBDocument[]> {
@@ -60,6 +111,26 @@ export async function uploadDocument(
       });
       throw new KnowledgeUploadError(display, res.status);
     }
+    if (isQuotaPayload(payload)) {
+      const p = payload as Record<string, unknown>;
+      const reason = typeof p.reason === 'string'
+        ? p.reason
+        : 'The knowledge provider quota was exceeded.';
+      const quotas = (p.quotas && typeof p.quotas === 'object')
+        ? (p.quotas as KnowledgeQuotas)
+        : null;
+      const usage = (p.usage && typeof p.usage === 'object')
+        ? (p.usage as KnowledgeUsage)
+        : null;
+      throw new KnowledgeQuotaError(reason, quotas, usage, res.status);
+    }
+    if (isMutationUnsupportedPayload(payload)) {
+      const p = payload as Record<string, unknown>;
+      const reason = typeof p.reason === 'string'
+        ? p.reason
+        : 'The active knowledge provider is read-only.';
+      throw new KnowledgeMutationUnsupportedError(reason, res.status);
+    }
     throw new Error(`Failed to upload document: ${res.status}`);
   }
   return res.json();
@@ -87,5 +158,17 @@ export async function searchKnowledgeBase(
 export async function fetchKBStats(): Promise<KBStats> {
   const res = await fetch('/api/knowledge/stats');
   if (!res.ok) throw new Error(`Failed to fetch KB stats: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Fetches the active knowledge provider snapshot — capabilities (durable vs
+ * volatile, relevance kind, quotas, score semantics), degradation state, the
+ * named-source catalog, and every per-agent binding. Used by the Knowledge
+ * panel to render honest provider visibility and the per-agent binding view.
+ */
+export async function fetchKnowledgeProviderSnapshot(): Promise<KnowledgeProviderSnapshot> {
+  const res = await fetch('/api/knowledge/provider');
+  if (!res.ok) throw new Error(`Failed to fetch knowledge provider snapshot: ${res.status}`);
   return res.json();
 }

--- a/src/RetailPulse.Web/src/types/index.ts
+++ b/src/RetailPulse.Web/src/types/index.ts
@@ -420,6 +420,8 @@ export interface KnowledgeUploadResponse {
   documentId: string;
   title: string;
   status: string;
+  chunkCount?: number;
+  source?: string;
 }
 
 export interface Citation {
@@ -427,6 +429,63 @@ export interface Citation {
   sourceTitle: string;
   chunkPreview: string;
   relevanceScore: number;
+}
+
+// --- Knowledge provider snapshot (issue #106) ---
+// Aligned with GET /api/knowledge/provider, backed by the KnowledgeBaseCapabilities
+// record on the backend. Scores are provider-local — the frontend never compares
+// them across providers, and `scoreSemantics` MUST be surfaced verbatim so the
+// user reads honest, provider-specific relevance meaning.
+
+export type KnowledgeRelevanceKind = 'Lexical' | 'Semantic' | 'Hybrid';
+
+export type KnowledgeDegradationMode = 'FailLoud' | 'FallbackToInMemory';
+
+export interface KnowledgeProviderInfo {
+  name: string;
+  relevance: KnowledgeRelevanceKind;
+  persistent: boolean;
+  requiresCloud: boolean;
+  supportsMutation: boolean;
+  scoreSemantics: string;
+}
+
+export interface KnowledgeDegradationInfo {
+  mode: KnowledgeDegradationMode | null;
+  primaryReplacedByFallback: boolean;
+}
+
+export interface KnowledgeQuotas {
+  maxDocuments: number;
+  maxChunks: number;
+  maxDocumentSizeBytes: number;
+}
+
+export interface KnowledgeUsage {
+  documentCount: number;
+  chunkCount: number;
+}
+
+export interface KnowledgeNamedSource {
+  name: string;
+  documents: string[];
+}
+
+export interface KnowledgeAgentBinding {
+  agentKey: string;
+  agentDisplayName: string;
+  enabled: boolean;
+  sourceName: string;
+  sources: string[];
+}
+
+export interface KnowledgeProviderSnapshot {
+  provider: KnowledgeProviderInfo;
+  degradation: KnowledgeDegradationInfo;
+  quotas: KnowledgeQuotas;
+  usage: KnowledgeUsage;
+  sources: KnowledgeNamedSource[];
+  bindings: KnowledgeAgentBinding[];
 }
 
 // --- Streaming types (Sprint 3.1) ---


### PR DESCRIPTION
Closes #106

Makes the Knowledge panel honest about the active retrieval provider — durability, relevance semantics, quotas, per-agent bindings, and every terminal ingestion outcome.

## Acceptance summary

| # | Acceptance criterion | Where it lives |
| - | -------------------- | -------------- |
| 1 | Active provider + material properties (durable vs volatile, cloud vs local, mutation) | `ProviderInfoCard.tsx` |
| 2 | Volatile warning on upload; hidden for durable providers | `DocumentUpload.tsx` (`upload-volatile-warning` positive/negative tests) |
| 3 | Per-agent binding view w/ named sources | `AgentBindingsPanel.tsx` |
| 4 | Search presentation honest per provider (BM25 / similarity / hybrid) | `SearchResults.tsx` (`search-relevance-kind` + `search-score-semantics`) |
| 5 | Ingestion outcomes: accepted / safety-rejected / quota-rejected / failed | `DocumentUpload.tsx` + endpoint 409/405 branches |
| 6 | Quota usage vs provider limits w/ `ok`/`warn`/`exceeded` state | `ProviderInfoCard.tsx` quota bars |
| 7 | Correct behavior for every provider config incl. fully-disabled | `KnowledgeBasePanel.tsx` `kb-disabled` state |
| 8 | Tenant theming only, no hardcoded colors | All new components use `var(--color-...)` tokens |
| 9 | Keyboard navigable; status never conveyed by color alone | Text-labeled badges, `role=alert`/`progressbar`, `data-*` state attrs |
| 10 | `data-testid` coverage per existing convention | `kb-provider-*`, `kb-quota-*`, `kb-binding-*`, `upload-*`, `search-*` |
| 11 | Component tests for every provider config, both volatility branches, all terminal outcomes, quota-exceeded, a11y | `__tests__/KnowledgeBase.test.tsx` |

## Backend contract (issues #102-#107)

Added `GET /api/knowledge/provider` returning the honest snapshot: provider capabilities (name, relevance kind, persistent, requiresCloud, supportsMutation, scoreSemantics), degradation policy (mode + primaryReplacedByFallback), quotas + current usage, named source catalog, and per-agent bindings (specialists/bespoke; orchestration entries skipped). Uses `KnowledgeSourceRegistry`, `IOptionsSnapshot<KnowledgeSourcesOptions>`, and `PromptConfiguration` from DI. Registered `PromptConfiguration` as a singleton in `Program.cs` (was previously only used at startup).

Upload endpoint now enriches the accepted response with `chunkCount` + `source` (resolved via `ListDocumentsAsync`), catches `InvalidOperationException` → 409 `{ quotaRejected: true, reason, quotas, usage }` (both `InMemory` and `AzureAISearch` use this exception for quota rejection), and catches `NotSupportedException` → 405 `{ mutationUnsupported: true, reason }` for the read-only `FoundryIQKnowledgeBase`.

## Test strategy

Rewrote `KnowledgeBase.test.tsx` end-to-end:
- `makeSnapshot(overrides)` factory + `mockFetchSnapshot` cover InMemory (volatile/mutable/Lexical), AzureAISearch (Hybrid/Semantic, durable), FoundryIQ (read-only, Semantic), and the "all bindings disabled" configuration.
- Every ingestion outcome asserted directly: accepted (with chunk count + source), safety-rejected (existing block), quota-rejected (409 payload → typed `KnowledgeQuotaError` → dedicated UI block), generic failure.
- Volatility warning: present when `persistent === false`; absent when `persistent === true`.
- Quota bars: `data-quota-status="exceeded"` when usage >= 100%.
- Degradation: fallback alert when `primaryReplacedByFallback === true`.
- Bindings: enabled vs disabled text badges; named-source vs unscoped vs disabled scope descriptions; empty catalog state.
- Search: honest relevance label per provider (`BM25 score` / `similarity` / `hybrid score`) with score-semantics disclosure verbatim.
- Panel resilience: snapshot fetch failure still renders documents/search/stats.

## Concurrency disclosure

No shared SignalR files or tenant/prompt/content-pack loader files were touched. All changes are confined to `src/RetailPulse.Web/src/components/knowledge/**`, `src/RetailPulse.Web/src/services/knowledgeApi.ts`, `src/RetailPulse.Web/src/types/index.ts`, `src/RetailPulse.Web/src/__tests__/KnowledgeBase.test.tsx`, `src/RetailPulse.Api/Endpoints/KnowledgeEndpoints.cs`, and a single `AddSingleton(promptConfig)` line in `Program.cs` (additive registration for the new provider endpoint).

## Notes for reviewers

- `PromptConfiguration` DI registration is additive; nothing else resolves it via DI today, so this cannot regress existing consumers.
- Quota rejection is inferred from `InvalidOperationException` — both existing providers already use it for that path. If a dedicated `KnowledgeQuotaExceededException` is introduced later, the endpoint catch can be widened without breaking the wire contract.
- When the snapshot fetch fails, the panel degrades gracefully (documents/search/stats still work) — verified by a dedicated test.
