### PR TITLE
Real-time resilience for long-running execution

### DIFF
--- a/docs/resilience-operations.md
+++ b/docs/resilience-operations.md
@@ -87,6 +87,34 @@ authenticated and anonymous callers (previously anonymous-only). A hostile
 client that reconnects and attempts to rejoin another subject's session group is
 refused with a `HubException`.
 
+### Frontend behavior on top of these contracts
+
+The SPA layers a small set of user-visible affordances on top of the backend
+contracts above so a long-running plan or a dropped channel never presents as
+a silent spinner. All of these live under `src/RetailPulse.Web/src` and are
+covered by Vitest units in `src/__tests__` (see the plan below).
+
+| UI concern | Module | Notes |
+|------------|--------|-------|
+| Reconnect schedule | `services/reconnectBackoff.ts` | Capped exponential-ish schedule (`1s → 30s` cap, 8 attempts). Returning `null` from the SignalR `IRetryPolicy` triggers `onclose` and the terminal `disconnected` state. |
+| Connection status | `services/telemetryHub.ts`, `hooks/useConnectionStatus.ts` | Exposes `connecting / connected / reconnecting / disconnected` plus a `stalled` flag (Connected but no `heartbeat` in `2 × ApplicationHeartbeatInterval`). |
+| Visible indicator | `components/ConnectionStatusIndicator.tsx` | Rendered inline in the chat composer next to Send so a dropped hub is visible where the user actually types. |
+| Timeout dialog | `components/TimeoutDialog.tsx` | Replaces the pre-#92 hung spinner when `sendMessage` throws `ChatRequestTimeoutError`; offers Retry (replay the same prompt) or Abandon (clear the in-flight state). |
+| User cancel | `services/executionControlApi.ts`, `components/ChatPanel.tsx` | The Send button flips to Cancel while a run is in flight. Cancel aborts the local fetch AND posts `/api/chat/{sessionId}/cancel`; when a `planId` is known the plan-owning UI can call `cancelPlan(planId)` from the same module. |
+| Reconcile after reconnect | `services/planReconciler.ts`, `services/executionControlApi.ts#reconcilePlan` | Deterministic merge by `stepIndex` with terminal-state monotonicity. Overlap collapses to a single entry; gaps are preserved so streaming can fill them in. |
+
+**Cross-session rejoin safety.** `joinPendingSessions()` in `telemetryHub.ts`
+only re-invokes `JoinSession` for sessionIds this client previously joined via
+`joinTelemetrySession()`. Server payloads never influence that set, so a
+hostile server message cannot trick the client into rejoining a foreign
+group. The hub also enforces subject ownership on every join and rejoin.
+
+**Deferred APIM verification.** Local Vitest units cover the schedule, ceiling,
+terminal transition, dedupe/overlap/no-gaps, and the timeout / cancel UX.
+They do not exercise a real intermediary idle timeout. The multi-minute idle
+survival criterion in the issue must be verified end-to-end through APIM
+against a deployed environment and the result recorded in the PR.
+
 ---
 
 ## Circuit Breaker

--- a/docs/resilience-operations.md
+++ b/docs/resilience-operations.md
@@ -20,6 +20,75 @@ Requests flow through this middleware stack (in order):
 
 ---
 
+## Real-time channel resilience (issue #92)
+
+Wave 2 turns a chat "turn" into a multi-step plan that can run far longer than a
+single-shot answer. Three configuration surfaces keep the real-time channel and
+its UX honest under those long-running conditions.
+
+### SignalR keep-alive + application heartbeat — `RealtimeResilience`
+
+SignalR transport pings satisfy intermediary proxies but are opaque to the
+browser layer. RetailPulse layers an application-level heartbeat on top so the
+frontend can render "connected / stalled" without probing transport internals.
+
+| Setting                        | Default    | Purpose                                                                 |
+|--------------------------------|------------|-------------------------------------------------------------------------|
+| `KeepAliveInterval`            | `00:00:15` | Server-to-client transport ping cadence (bound to `HubOptions`).        |
+| `ClientTimeoutInterval`        | `00:00:30` | Server-side disconnect threshold. SignalR guidance: `>= 2 x KeepAlive`. |
+| `HandshakeTimeout`             | `00:00:15` | Initial protocol negotiation timeout.                                   |
+| `ApplicationHeartbeatInterval` | `00:00:15` | Cadence of the observable `heartbeat` event on both hubs.               |
+| `ApplicationHeartbeatEnabled`  | `true`     | Master switch for the hosted heartbeat emitter.                         |
+
+The 15-second keep-alive default stays well under the shortest plausible
+intermediary idle timeout we see in front of Container Apps (APIM at 240s,
+corporate proxies frequently at 60s). The `heartbeat` event is emitted on both
+`/hubs/telemetry` and `/hubs/streaming`.
+
+### Chat request timeouts — `ChatTimeout`
+
+Separate ceilings for the single-shot fast path and the long-running plan path.
+Preserves the pre-#92 single-shot 90s behavior; the plan ceiling is applied only
+when the hybrid execution decider (#95) selects the plan path.
+
+| Setting      | Default    | Purpose                                                                                     |
+|--------------|------------|---------------------------------------------------------------------------------------------|
+| `SingleShot` | `00:01:30` | Per-request timeout for a fast-path (single-specialist) run.                                |
+| `Plan`       | `00:06:00` | Replacement ceiling when the hybrid execution decider selects the plan path. Applied to `/api/chat` only after admission to the plan branch. |
+
+Keep `Plan >= PlanPersistence.PlanTimeout + 60s` so the plan orchestrator's own
+per-plan timeout fires first with a plan-specific failure reason rather than the
+request seam timing out with the generic 504.
+
+### User-initiated cancellation
+
+`POST /api/chat/{sessionId}/cancel` and `POST /api/plans/{planId}/cancel` end an
+in-flight run the caller owns. Ownership is enforced by
+`IExecutionCancellationRegistry`: a foreign-subject cancel collapses to `404` so
+the endpoints cannot be used to probe another user's live sessions or plan ids.
+Anonymous callers cannot cancel plans (`plan_cancel_unavailable`). The
+cancellation flows through the same `CancellationToken` the pipeline uses to
+invoke specialists and tools, so an in-flight tool call actually observes the
+cancellation and ceases work — not merely that the HTTP response returned.
+
+### Reconciliation after reconnect
+
+`GET /api/plans/{planId}/reconcile?afterStepIndex=N` returns durable plan status
+plus any step records with `StepIndex > N`, filtered to the caller's subject at
+the SQL layer. A cross-subject probe or unknown plan id resolves to `404`.
+Mapped only when `PlanPersistence:Enabled` is `true`, matching the rest of the
+`/api/plans` surface.
+
+### Hub ownership on reconnect
+
+Every `JoinSession` on both hubs binds the sessionId to the caller's immutable
+subject via `ISessionOwnershipRegistry`. This is now enforced for BOTH
+authenticated and anonymous callers (previously anonymous-only). A hostile
+client that reconnects and attempts to rejoin another subject's session group is
+refused with a `HubException`.
+
+---
+
 ## Circuit Breaker
 
 **Scope:** MCP Server HTTP client (all tool calls)

--- a/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
+++ b/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
@@ -5,6 +5,7 @@ using Microsoft.Agents.AI.Workflows;
 using RetailPulse.Api.Approval;
 using RetailPulse.Api.Budget;
 using RetailPulse.Api.Charts;
+using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Middleware;
 using RetailPulse.Api.Persistence;
 using RetailPulse.Contracts;
@@ -48,6 +49,7 @@ public sealed class PlanExecutor
     private readonly ILogger<PlanExecutor> _logger;
     private readonly PlanClarifier? _clarifier;
     private readonly PlanReviewCoordinator? _reviewCoordinator;
+    private readonly IExecutionCancellationRegistry? _cancellationRegistry;
 
     public PlanExecutor(
         IPlanStore planStore,
@@ -56,7 +58,8 @@ public sealed class PlanExecutor
         PlanPersistenceOptions options,
         ILogger<PlanExecutor> logger,
         PlanClarifier? clarifier = null,
-        PlanReviewCoordinator? reviewCoordinator = null)
+        PlanReviewCoordinator? reviewCoordinator = null,
+        IExecutionCancellationRegistry? cancellationRegistry = null)
     {
         _planStore = planStore ?? throw new ArgumentNullException(nameof(planStore));
         _costTracker = costTracker ?? throw new ArgumentNullException(nameof(costTracker));
@@ -65,6 +68,7 @@ public sealed class PlanExecutor
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _clarifier = clarifier;
         _reviewCoordinator = reviewCoordinator;
+        _cancellationRegistry = cancellationRegistry;
     }
 
     /// <summary>
@@ -207,6 +211,17 @@ public sealed class PlanExecutor
         using var planCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         if (_options.PlanTimeout > TimeSpan.Zero)
             planCts.CancelAfter(_options.PlanTimeout);
+
+        // Register the plan CTS for user-initiated cancellation (issue #92).
+        // Scope = "plan" keyed on the plan id so POST /api/plans/{planId}/cancel
+        // can end an in-flight plan run — including any tool invocation the
+        // running specialist is blocked in, because every specialist and tool
+        // call receives planCts.Token via the workflow.
+        using IDisposable? planCancelHandle = _cancellationRegistry?.Register(
+            ExecutionCancellationRegistry.PlanScope,
+            execution.PlanId,
+            execution.Subject,
+            planCts);
 
         string terminalStatus = PlanStatus.Completed;
         string? failureReason = null;

--- a/src/RetailPulse.Api/Configuration/ChatTimeoutOptions.cs
+++ b/src/RetailPulse.Api/Configuration/ChatTimeoutOptions.cs
@@ -1,0 +1,32 @@
+namespace RetailPulse.Api.Configuration;
+
+/// <summary>
+/// Separate ceilings for the single-shot chat pipeline and long-running plan
+/// execution (issue #92). The pre-Wave-2 pipeline used a single hard-coded 90s
+/// wall on every /api/chat request; a multi-step plan run through the hybrid
+/// decider (issue #95) can honestly need longer than that, but globally raising
+/// 90s would silently unbound single-shot requests. Two knobs, two ceilings.
+///
+/// <para>Defaults preserve current single-shot behavior at 90s. The plan
+/// ceiling defaults to 6 minutes — larger than <c>PlanPersistenceOptions.PlanTimeout</c>
+/// (default 3m) plus a small safety buffer, so the plan orchestrator's own timeout
+/// fires first with a plan-specific failure reason rather than the request seam
+/// timing out with the generic 504 message. Operators tuning either value should
+/// keep this invariant: <c>Plan &gt;= PlanPersistence.PlanTimeout + 60s</c>.</para>
+/// </summary>
+public sealed class ChatTimeoutOptions
+{
+    public const string SectionName = "ChatTimeout";
+
+    /// <summary>
+    /// Ceiling applied to every /api/chat request at entry, and to any
+    /// request that resolves to the single-specialist fast path. Default 90s.
+    /// </summary>
+    public TimeSpan SingleShot { get; set; } = TimeSpan.FromSeconds(90);
+
+    /// <summary>
+    /// Ceiling applied only to requests admitted to the plan-first path by
+    /// the hybrid execution decider (issue #95). Default 6 minutes.
+    /// </summary>
+    public TimeSpan Plan { get; set; } = TimeSpan.FromMinutes(6);
+}

--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -8,6 +8,7 @@ using RetailPulse.Api.Agents;
 using RetailPulse.Api.Agents.Planning;
 using RetailPulse.Api.Agents.Routing;
 using RetailPulse.Api.Auth;
+using RetailPulse.Api.Configuration;
 using RetailPulse.Api.Guardrails;
 using RetailPulse.Api.Hubs;
 using RetailPulse.Api.Memory;
@@ -37,7 +38,7 @@ public static class ChatEndpoints
     public static WebApplication MapChatEndpoints(this WebApplication app, AgentDefinition agentDef)
     {
         // Chat endpoint — routes through guardrails → cache → multi-agent router with memory and tracing
-        app.MapPost("/api/chat", async (HttpContext httpContext, ChatRequest request, IAgentRouter router, IEnumerable<ISpecialistAgent> specialists, ConversationMemoryMiddleware memoryMiddleware, InMemoryTraceCollector traceCollector, GuardrailsMiddleware guardrails, IResponseCache responseCache, ICostTracker costTracker, IAuditLog auditLog, ConversationExporter conversationExporter, ITenantProvider tenantProvider, RagContextProvider ragProvider, MemoryExtractionChannel memoryChannel, IHubContext<TelemetryHub> hubContext, ILogger<Program> logger, CancellationToken clientCt, IAnonymousChatPolicy? anonymousChatPolicy = null, ISessionOwnershipRegistry? sessionOwnership = null, IConsensusCouncil? council = null, [FromServices] ISessionStore? sessionStore = null, [FromServices] IOptions<SessionPersistenceOptions>? sessionPersistenceOptions = null, [FromServices] PlanOrchestrator? planOrchestrator = null, [FromServices] IOptions<PlanPersistenceOptions>? planPersistenceOptions = null) =>
+        app.MapPost("/api/chat", async (HttpContext httpContext, ChatRequest request, IAgentRouter router, IEnumerable<ISpecialistAgent> specialists, ConversationMemoryMiddleware memoryMiddleware, InMemoryTraceCollector traceCollector, GuardrailsMiddleware guardrails, IResponseCache responseCache, ICostTracker costTracker, IAuditLog auditLog, ConversationExporter conversationExporter, ITenantProvider tenantProvider, RagContextProvider ragProvider, MemoryExtractionChannel memoryChannel, IHubContext<TelemetryHub> hubContext, ILogger<Program> logger, CancellationToken clientCt, IAnonymousChatPolicy? anonymousChatPolicy = null, ISessionOwnershipRegistry? sessionOwnership = null, IConsensusCouncil? council = null, [FromServices] ISessionStore? sessionStore = null, [FromServices] IOptions<SessionPersistenceOptions>? sessionPersistenceOptions = null, [FromServices] PlanOrchestrator? planOrchestrator = null, [FromServices] IOptions<PlanPersistenceOptions>? planPersistenceOptions = null, [FromServices] IOptions<ChatTimeoutOptions>? chatTimeoutOptions = null, [FromServices] IExecutionCancellationRegistry? cancellationRegistry = null) =>
         {
             // Input validation — fail fast before expensive LLM pipeline
             ValidationResult validation = ChatRequestValidator.Validate(request);
@@ -49,12 +50,13 @@ public static class ChatEndpoints
             // Add Sunset header for legacy unversioned route
             httpContext.Response.Headers.Append("Sunset", "Sat, 31 Dec 2025 23:59:59 GMT");
 
-            // Per-request timeout: caps the whole pipeline (router classify + agent execute
-            // + tool calls) so a hung AI Gateway call cannot leave the UI spinning forever.
-            // 90s accommodates MaxIterations=3 × ~20-30s per iteration. Typical requests
-            // complete in 15-40s; this ceiling catches only pathological cases.
+            // Per-request timeout — configurable, separate ceilings for the single-shot
+            // fast path and the long-running plan path (issue #92). Preserves the pre-#92
+            // 90s default for the fast path; the plan ceiling is applied later, only when
+            // the hybrid execution decider (issue #95) selects the plan path.
+            ChatTimeoutOptions timeouts = chatTimeoutOptions?.Value ?? new ChatTimeoutOptions();
             using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(clientCt);
-            requestCts.CancelAfter(TimeSpan.FromSeconds(90));
+            requestCts.CancelAfter(timeouts.SingleShot);
             CancellationToken ct = requestCts.Token;
 
             try
@@ -84,8 +86,13 @@ public static class ChatEndpoints
                 // and this subject can never write into another subject's persisted transcript.
                 // Bound for anonymous callers unconditionally (existing Sprint 1 guard) and,
                 // now that authenticated turns can be persisted, whenever persistence is on.
+                // Bind the sessionId to this subject BEFORE the hub can join. Enforced
+                // unconditionally now (issue #92) — the same registry is consulted by the
+                // hubs for authenticated and anonymous callers alike, so a client-supplied
+                // id owned by a different subject would refuse the hub join later. If a
+                // conflict is detected here we mint a fresh id up-front so telemetry has
+                // one coherent id from turn to hub-join.
                 if (sessionOwnership is not null
-                    && (anonymous || persistenceEnabled)
                     && !sessionOwnership.TryBind(sessionId, userId))
                 {
                     sessionId = Guid.NewGuid().ToString("N");
@@ -100,6 +107,13 @@ public static class ChatEndpoints
                         ? new UserContext(userId, httpContext.User?.Identity?.Name ?? "Anonymous", string.Empty)
                         : request.User with { ObjectId = userId }
                 };
+
+                // Register the in-flight run for user-initiated cancellation (issue #92).
+                // Scope = "chat" keyed on the sessionId; the cancel endpoint validates the
+                // caller owns this scope before cancelling. The disposable is released on
+                // request completion so a finished run cannot be re-cancelled.
+                using IDisposable? cancellationHandle = cancellationRegistry?.Register(
+                    ExecutionCancellationRegistry.ChatScope, sessionId, userId, requestCts);
 
                 // ── Guardrails: input check ──────────────────────────────────────
                 GuardrailResult guardrailResult = await guardrails.CheckInputAsync(request, ct);
@@ -553,6 +567,17 @@ public static class ChatEndpoints
                 if (planOrchestrator is not null
                     && string.Equals(hybridDecision.Path, ExecutionPath.Plan, StringComparison.Ordinal))
                 {
+                    // Plan-path ceiling (issue #92): the single-shot 90s wall is not
+                    // honest for a multi-step plan run through the plan orchestrator.
+                    // Replace the request timer with the plan ceiling before entering
+                    // orchestration. CancelAfter overwrites the pending timer; the
+                    // linked clientCt still triggers immediate cancellation on user
+                    // abort, so this only lengthens the timeout, never the abort.
+                    if (timeouts.Plan > timeouts.SingleShot)
+                    {
+                        requestCts.CancelAfter(timeouts.Plan);
+                    }
+
                     List<ISpecialistAgent> roster = [.. specialists];
                     var specialistLookup =
                         roster.ToDictionary(s => s.Key, s => s, StringComparer.OrdinalIgnoreCase);
@@ -955,7 +980,7 @@ public static class ChatEndpoints
         .RequireRateLimiting("strict");
 
         // Streaming chat endpoint — SSE/SignalR progressive token delivery
-        app.MapPost("/api/chat/stream", async (HttpContext httpContext, ChatRequest request, IAgentRouter router, IEnumerable<ISpecialistAgent> specialists, ConversationMemoryMiddleware memoryMiddleware, GuardrailsMiddleware guardrails, StreamingMiddleware streaming, StreamingProgressFeature streamingProgressFeature, MemoryExtractionChannel memoryChannel, ILogger<Program> logger, CancellationToken clientCt) =>
+        app.MapPost("/api/chat/stream", async (HttpContext httpContext, ChatRequest request, IAgentRouter router, IEnumerable<ISpecialistAgent> specialists, ConversationMemoryMiddleware memoryMiddleware, GuardrailsMiddleware guardrails, StreamingMiddleware streaming, StreamingProgressFeature streamingProgressFeature, MemoryExtractionChannel memoryChannel, ILogger<Program> logger, CancellationToken clientCt, [FromServices] IOptions<ChatTimeoutOptions>? chatTimeoutOptions = null, [FromServices] IExecutionCancellationRegistry? cancellationRegistry = null, [FromServices] ISessionOwnershipRegistry? sessionOwnership = null) =>
         {
             // Input validation — fail fast before expensive LLM pipeline
             ValidationResult validation = ChatRequestValidator.Validate(request);
@@ -967,9 +992,10 @@ public static class ChatEndpoints
             // Add Sunset header for legacy unversioned route
             httpContext.Response.Headers.Append("Sunset", "Sat, 31 Dec 2025 23:59:59 GMT");
 
-            // Per-request timeout (see /api/chat for rationale).
+            // Per-request timeout — configurable single-shot ceiling (issue #92).
+            ChatTimeoutOptions timeouts = chatTimeoutOptions?.Value ?? new ChatTimeoutOptions();
             using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(clientCt);
-            requestCts.CancelAfter(TimeSpan.FromSeconds(90));
+            requestCts.CancelAfter(timeouts.SingleShot);
             CancellationToken ct = requestCts.Token;
 
             try
@@ -982,6 +1008,21 @@ public static class ChatEndpoints
                         ? new UserContext(userId, httpContext.User?.Identity?.Name ?? "Anonymous", string.Empty)
                         : request.User with { ObjectId = userId }
                 };
+
+                // Same ownership binding as /api/chat so a streaming session's hub
+                // rejoin cannot land on another subject's group (issue #92).
+                if (sessionOwnership is not null
+                    && !sessionOwnership.TryBind(sessionId, userId))
+                {
+                    sessionId = Guid.NewGuid().ToString("N");
+                    sessionOwnership.TryBind(sessionId, userId);
+                }
+
+                // Register for user-initiated cancellation. Streaming endpoint uses
+                // the same "chat" scope so a single cancel targets whichever surface
+                // the client is currently using.
+                using IDisposable? cancellationHandle = cancellationRegistry?.Register(
+                    ExecutionCancellationRegistry.ChatScope, sessionId, userId, requestCts);
 
                 // Guardrails input check
                 GuardrailResult guardrailResult = await guardrails.CheckInputAsync(request, ct);

--- a/src/RetailPulse.Api/Endpoints/ExecutionControlEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ExecutionControlEndpoints.cs
@@ -1,0 +1,160 @@
+using RetailPulse.Api.Auth;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Api.Security.Anonymous;
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Api.Endpoints;
+
+/// <summary>
+/// User-initiated execution control (issue #92) — cancel an in-flight run and
+/// reconcile durable plan state after a reconnect.
+///
+/// <para><b>Cancel</b> maps to a subject-scoped
+/// <see cref="IExecutionCancellationRegistry"/> entry so the endpoint returns
+/// 204 only when the caller owns the scope. Any other outcome — no registration
+/// or a foreign owner — collapses to 404 so the endpoint cannot be used to
+/// probe another subject's live sessions or plan ids.</para>
+///
+/// <para><b>Reconcile</b> reads durable plan state (steps + status + tokens)
+/// after a reconnect. Ownership is enforced by the plan store, which filters by
+/// subject at the SQL layer — a cross-subject plan id resolves to 404.</para>
+/// </summary>
+public static class ExecutionControlEndpoints
+{
+    public static WebApplication MapExecutionControlEndpoints(this WebApplication app)
+    {
+        // POST /api/chat/{sessionId}/cancel — cancels the caller's in-flight
+        // fast-path or streaming request keyed on sessionId.
+        app.MapPost("/api/chat/{sessionId}/cancel", (
+            string sessionId,
+            HttpContext http,
+            IExecutionCancellationRegistry registry) =>
+        {
+            if (string.IsNullOrWhiteSpace(sessionId))
+            {
+                return Results.BadRequest(new { error = "sessionId is required." });
+            }
+
+            string subject = UserIdentity.Resolve(http.User);
+            ExecutionCancelResult result = registry.TryCancel(
+                ExecutionCancellationRegistry.ChatScope, sessionId, subject);
+
+            return result switch
+            {
+                ExecutionCancelResult.Cancelled => Results.NoContent(),
+                // Forbidden collapses to 404 so the endpoint cannot be used
+                // to probe another subject's live sessions.
+                ExecutionCancelResult.NotFound or ExecutionCancelResult.Forbidden or _ =>
+                    Results.NotFound(new { error = "No in-flight chat run for this session." }),
+            };
+        })
+        .WithName("CancelChat")
+        .WithSummary("Cancel the caller's in-flight /api/chat run for this session")
+        .WithTags("Chat")
+        .Produces(StatusCodes.Status204NoContent)
+        .Produces(StatusCodes.Status404NotFound)
+        .RequireAuthorization()
+        .RequireRateLimiting("moderate");
+
+        // POST /api/plans/{planId}/cancel — cancels the caller's in-flight
+        // plan orchestration keyed on planId. Anonymous callers are refused
+        // (plans are never anonymous — see PlanEndpoints).
+        app.MapPost("/api/plans/{planId}/cancel", (
+            string planId,
+            HttpContext http,
+            IExecutionCancellationRegistry registry) =>
+        {
+            if (AnonymousCapabilityPolicy.IsAnonymousPrincipal(http.User))
+            {
+                return Results.Json(
+                    new { error = "Anonymous callers do not own plans.", code = "plan_cancel_unavailable" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            if (string.IsNullOrWhiteSpace(planId))
+            {
+                return Results.BadRequest(new { error = "planId is required." });
+            }
+
+            string subject = UserIdentity.Resolve(http.User);
+            ExecutionCancelResult result = registry.TryCancel(
+                ExecutionCancellationRegistry.PlanScope, planId, subject);
+
+            return result switch
+            {
+                ExecutionCancelResult.Cancelled => Results.NoContent(),
+                ExecutionCancelResult.NotFound or ExecutionCancelResult.Forbidden or _ =>
+                    Results.NotFound(new { error = $"No in-flight plan '{planId}'." }),
+            };
+        })
+        .WithName("CancelPlan")
+        .WithSummary("Cancel the caller's in-flight plan orchestration")
+        .WithTags("Plans")
+        .Produces(StatusCodes.Status204NoContent)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .RequireAuthorization()
+        .RequireRateLimiting("moderate");
+
+        return app;
+    }
+
+    /// <summary>
+    /// GET /api/plans/{planId}/reconcile — durable plan state for a
+    /// reconnecting client, optionally filtered to steps whose index exceeds
+    /// <c>afterStepIndex</c> so the caller can render only the ones it missed.
+    /// Requires the plan store; mapped only when plan persistence is enabled.
+    /// </summary>
+    public static WebApplication MapPlanReconciliationEndpoint(this WebApplication app)
+    {
+        app.MapGet("/api/plans/{planId}/reconcile", async (
+            string planId,
+            int? afterStepIndex,
+            IPlanStore store,
+            HttpContext http,
+            CancellationToken ct) =>
+        {
+            if (AnonymousCapabilityPolicy.IsAnonymousPrincipal(http.User))
+            {
+                return Results.Json(
+                    new { error = "Anonymous callers do not own plans.", code = "plan_reconcile_unavailable" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            string subject = UserIdentity.Resolve(http.User);
+            PlanDetailDto? detail = await store.GetPlanAsync(subject, planId, ct);
+            if (detail is null)
+            {
+                // Not found OR cross-subject probe; both collapse to 404 (see
+                // SqlitePlanStore for the subject-filter enforcement).
+                return Results.NotFound(new { error = $"Plan '{planId}' not found." });
+            }
+
+            int cursor = afterStepIndex ?? -1;
+            IReadOnlyList<PlanStepRecordDto> missedSteps = [.. detail.Steps.Where(s => s.StepIndex > cursor)];
+
+            return Results.Ok(new
+            {
+                planId = detail.PlanId,
+                sessionId = detail.SessionId,
+                status = detail.Status,
+                failureReason = detail.FailureReason,
+                updatedAt = detail.UpdatedAt,
+                totalStepCount = detail.Steps.Count,
+                afterStepIndex = cursor,
+                steps = missedSteps,
+            });
+        })
+        .WithName("ReconcilePlan")
+        .WithSummary("Return durable plan status and any steps the caller has not yet rendered")
+        .WithTags("Plans")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .RequireAuthorization()
+        .RequireRateLimiting("relaxed");
+
+        return app;
+    }
+}

--- a/src/RetailPulse.Api/Hubs/ExecutionCancellationRegistry.cs
+++ b/src/RetailPulse.Api/Hubs/ExecutionCancellationRegistry.cs
@@ -1,0 +1,164 @@
+using System.Collections.Concurrent;
+
+namespace RetailPulse.Api.Hubs;
+
+/// <summary>
+/// Bounds the "cancel my in-flight run" surface (issue #92) to the caller
+/// that owns the work. The registry is a subject-scoped map from
+/// <c>(scope, key)</c> to the <see cref="CancellationTokenSource"/> that drives
+/// the request pipeline (fast path) or the plan orchestrator (plan path).
+///
+/// <para>Ownership is enforced at cancellation time: a caller can cancel only
+/// a scope/key it registered itself. An attacker calling <c>POST /api/chat/{id}/cancel</c>
+/// with someone else's session id resolves to a 404 the same way the plan and
+/// session endpoints resolve cross-subject probes.</para>
+///
+/// <para>Storage is replica-local and bounded. Registrations return an
+/// <see cref="IDisposable"/> that the caller MUST dispose (via
+/// <c>using</c>) so a completed request cannot leak a live entry — the
+/// registered CTS itself is not disposed by the registry.</para>
+/// </summary>
+public interface IExecutionCancellationRegistry
+{
+    /// <summary>Registers a running scope so a matching cancel endpoint can end it.</summary>
+    IDisposable Register(string scope, string key, string subject, CancellationTokenSource cts);
+
+    /// <summary>Returns true when <paramref name="subject"/> owns the scope/key and cancellation was triggered.</summary>
+    ExecutionCancelResult TryCancel(string scope, string key, string subject);
+
+    /// <summary>Diagnostic: returns the owning subject for a registered scope, or null when absent.</summary>
+    string? OwnerOf(string scope, string key);
+}
+
+/// <summary>Outcome of <see cref="IExecutionCancellationRegistry.TryCancel"/>.</summary>
+public enum ExecutionCancelResult
+{
+    /// <summary>No registration for the requested scope/key.</summary>
+    NotFound,
+
+    /// <summary>Registration exists but is owned by a different subject.</summary>
+    Forbidden,
+
+    /// <summary>Cancellation was requested on the caller's own registration.</summary>
+    Cancelled,
+}
+
+/// <inheritdoc />
+public sealed class ExecutionCancellationRegistry : IExecutionCancellationRegistry
+{
+    /// <summary>Scope key for /api/chat single-shot fast-path runs.</summary>
+    public const string ChatScope = "chat";
+
+    /// <summary>Scope key for plan-first orchestrator runs.</summary>
+    public const string PlanScope = "plan";
+
+    private const int _maxEntries = 20_000;
+
+    private readonly ConcurrentDictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+
+    public IDisposable Register(string scope, string key, string subject, CancellationTokenSource cts)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+        ArgumentNullException.ThrowIfNull(cts);
+
+        EvictIfNeeded();
+
+        string composite = Compose(scope, key);
+        var entry = new Entry(subject, cts);
+
+        // Last-writer-wins: a concurrent duplicate registration is expected only
+        // when the same subject re-issues a request under the same key. Overwrite
+        // rather than throwing so the fast path never fails on a benign retry.
+        _entries[composite] = entry;
+
+        return new Deregistration(this, composite, entry);
+    }
+
+    public ExecutionCancelResult TryCancel(string scope, string key, string subject)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+
+        string composite = Compose(scope, key);
+        if (!_entries.TryGetValue(composite, out Entry? entry))
+        {
+            return ExecutionCancelResult.NotFound;
+        }
+
+        if (!string.Equals(entry.Subject, subject, StringComparison.Ordinal))
+        {
+            return ExecutionCancelResult.Forbidden;
+        }
+
+        try
+        {
+            entry.Cts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Race with request-completion disposing the CTS; treat as not
+            // found so the endpoint returns 404 (the run already ended).
+            return ExecutionCancelResult.NotFound;
+        }
+
+        return ExecutionCancelResult.Cancelled;
+    }
+
+    public string? OwnerOf(string scope, string key)
+    {
+        string composite = Compose(scope, key);
+        return _entries.TryGetValue(composite, out Entry? entry) ? entry.Subject : null;
+    }
+
+    private static string Compose(string scope, string key) => $"{scope}::{key}";
+
+    private void EvictIfNeeded()
+    {
+        if (_entries.Count < _maxEntries)
+        {
+            return;
+        }
+
+        // Bounded eviction: drop a batch of arbitrary entries when the cap is
+        // reached. A dropped entry only prevents cancellation of that specific
+        // in-flight run — the run itself finishes normally.
+        foreach (string composite in _entries.Keys.Take(_maxEntries / 10))
+        {
+            _entries.TryRemove(composite, out _);
+        }
+    }
+
+    private sealed record Entry(string Subject, CancellationTokenSource Cts);
+
+    private sealed class Deregistration : IDisposable
+    {
+        private readonly ExecutionCancellationRegistry _owner;
+        private readonly string _composite;
+        private readonly Entry _entry;
+        private int _disposed;
+
+        public Deregistration(ExecutionCancellationRegistry owner, string composite, Entry entry)
+        {
+            _owner = owner;
+            _composite = composite;
+            _entry = entry;
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
+            {
+                return;
+            }
+
+            // Only remove when the still-live entry is ours; a later
+            // registration under the same composite key must not be dropped
+            // by a completing older run.
+            _ = ((ICollection<KeyValuePair<string, Entry>>)_owner._entries)
+                .Remove(new KeyValuePair<string, Entry>(_composite, _entry));
+        }
+    }
+}

--- a/src/RetailPulse.Api/Hubs/HubHeartbeatBackgroundService.cs
+++ b/src/RetailPulse.Api/Hubs/HubHeartbeatBackgroundService.cs
@@ -1,0 +1,120 @@
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+
+namespace RetailPulse.Api.Hubs;
+
+/// <summary>
+/// Emits an observable application-level heartbeat to both the telemetry and
+/// streaming hubs at <see cref="RealtimeResilienceOptions.ApplicationHeartbeatInterval"/>.
+///
+/// <para>Why this exists in addition to the SignalR keep-alive: the transport
+/// keep-alive is invisible to the browser layer and cannot be asserted by a
+/// backend test. An application-level heartbeat is a real hub message on the
+/// same channel clients already subscribe to, so the frontend has a signal it
+/// can render ("connected" vs "stalled") and tests can assert emission
+/// cadence without spinning up Kestrel or SignalR's negotiate pipeline.</para>
+///
+/// <para>Emission is best-effort: an <see cref="OperationCanceledException"/>
+/// during shutdown is expected; any other failure is logged and swallowed so a
+/// transient hub error cannot crash the host. The counters are exposed for
+/// tests to assert cadence deterministically.</para>
+/// </summary>
+public sealed class HubHeartbeatBackgroundService : BackgroundService
+{
+    /// <summary>Event name emitted on both hubs.</summary>
+    public const string EventName = "heartbeat";
+
+    private readonly IHubContext<TelemetryHub> _telemetryHub;
+    private readonly IHubContext<StreamingHub> _streamingHub;
+    private readonly RealtimeResilienceOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<HubHeartbeatBackgroundService> _logger;
+
+    private long _emittedCount;
+
+    public HubHeartbeatBackgroundService(
+        IHubContext<TelemetryHub> telemetryHub,
+        IHubContext<StreamingHub> streamingHub,
+        IOptions<RealtimeResilienceOptions> options,
+        TimeProvider timeProvider,
+        ILogger<HubHeartbeatBackgroundService> logger)
+    {
+        _telemetryHub = telemetryHub ?? throw new ArgumentNullException(nameof(telemetryHub));
+        _streamingHub = streamingHub ?? throw new ArgumentNullException(nameof(streamingHub));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>Total heartbeats successfully emitted since process start (test hook).</summary>
+    public long EmittedCount => Interlocked.Read(ref _emittedCount);
+
+    /// <summary>Configured emission interval. Exposed so tests can assert config binding.</summary>
+    public TimeSpan Interval => _options.ApplicationHeartbeatInterval;
+
+    /// <summary>
+    /// Emits one heartbeat to both hubs. Public so tests can drive emission
+    /// deterministically without waiting on the timer.
+    /// </summary>
+    public async Task EmitOnceAsync(CancellationToken ct)
+    {
+        var payload = new
+        {
+            timestamp = _timeProvider.GetUtcNow(),
+            intervalMs = (long)_options.ApplicationHeartbeatInterval.TotalMilliseconds,
+        };
+
+        await _telemetryHub.Clients.All.SendAsync(EventName, payload, ct).ConfigureAwait(false);
+        await _streamingHub.Clients.All.SendAsync(EventName, payload, ct).ConfigureAwait(false);
+        Interlocked.Increment(ref _emittedCount);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.ApplicationHeartbeatEnabled)
+        {
+            _logger.LogInformation("Hub application heartbeat disabled by config.");
+            return;
+        }
+
+        TimeSpan interval = _options.ApplicationHeartbeatInterval;
+        if (interval <= TimeSpan.Zero)
+        {
+            _logger.LogWarning(
+                "Hub application heartbeat interval {Interval} is non-positive; disabling emission.",
+                interval);
+            return;
+        }
+
+        _logger.LogInformation(
+            "Hub application heartbeat starting at {Interval} interval (keepalive={KeepAlive}, clientTimeout={ClientTimeout}).",
+            interval, _options.KeepAliveInterval, _options.ClientTimeoutInterval);
+
+        using var timer = new PeriodicTimer(interval, _timeProvider);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    await EmitOnceAsync(stoppingToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // Log-and-continue: a hub emission failure must not kill the host.
+                    // Missing one heartbeat surfaces as a UI stall on the next tick,
+                    // which is the desired signal.
+                    _logger.LogWarning(ex, "Hub heartbeat emission failed; will retry on the next tick.");
+                }
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Expected on shutdown.
+        }
+    }
+}

--- a/src/RetailPulse.Api/Hubs/RealtimeResilienceOptions.cs
+++ b/src/RetailPulse.Api/Hubs/RealtimeResilienceOptions.cs
@@ -1,0 +1,65 @@
+namespace RetailPulse.Api.Hubs;
+
+/// <summary>
+/// Real-time channel resilience knobs (issue #92). Governs both the SignalR
+/// transport-level timers (keep-alive / client-timeout / handshake) and the
+/// application-level heartbeat emitted by <see cref="HubHeartbeatBackgroundService"/>.
+///
+/// <para>The application heartbeat is defence-in-depth on top of the SignalR
+/// keep-alive: transport pings satisfy proxies that reset connections mid-flight,
+/// but they are opaque to the browser layer and cannot be asserted from a unit
+/// test. An application-level heartbeat is an observable event on the same hub
+/// clients already subscribe to, so the frontend can render a "connected /
+/// stalled" indicator without probing transport internals.</para>
+///
+/// <para>Defaults target the shortest plausible intermediary idle timeout we
+/// see in front of Container Apps (Azure Front Door / APIM at 240s idle,
+/// corporate proxies frequently at 60s). A 15s keep-alive stays well under any
+/// of those and matches the SignalR guidance that the client timeout be at
+/// least double the keep-alive interval.</para>
+/// </summary>
+public sealed class RealtimeResilienceOptions
+{
+    public const string SectionName = "RealtimeResilience";
+
+    /// <summary>
+    /// Server -> client transport ping cadence. Bound to
+    /// <c>HubOptions.KeepAliveInterval</c>. Default 15s.
+    /// </summary>
+    public TimeSpan KeepAliveInterval { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Server-side client-timeout — how long the server waits without a
+    /// client message before disconnecting the client. SignalR guidance is
+    /// >= 2x KeepAliveInterval so a single missed ping does not sever the
+    /// connection. Default 30s.
+    /// </summary>
+    public TimeSpan ClientTimeoutInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Handshake timeout for the initial protocol negotiation. Default 15s.
+    /// </summary>
+    public TimeSpan HandshakeTimeout { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Application-level heartbeat cadence. Distinct from the transport
+    /// keep-alive so the frontend can render a "we're still here" signal on
+    /// the hub itself and tests can assert its cadence. Default 15s.
+    /// </summary>
+    public TimeSpan ApplicationHeartbeatInterval { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Application heartbeat master switch. Turn off to disable the hosted
+    /// heartbeat emitter without dropping the transport-level keep-alive.
+    /// Default true.
+    /// </summary>
+    public bool ApplicationHeartbeatEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Validates the SignalR guidance <c>ClientTimeoutInterval &gt;= 2 * KeepAliveInterval</c>.
+    /// Returned so <see cref="Program"/> can log a startup warning without
+    /// blocking boot on operator misconfiguration.
+    /// </summary>
+    public bool IsClientTimeoutSafe =>
+        ClientTimeoutInterval >= KeepAliveInterval + KeepAliveInterval;
+}

--- a/src/RetailPulse.Api/Hubs/StreamingHub.cs
+++ b/src/RetailPulse.Api/Hubs/StreamingHub.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.SignalR;
 using RetailPulse.Api.Auth;
-using RetailPulse.Api.Security.Anonymous;
 
 namespace RetailPulse.Api.Hubs;
 
@@ -27,17 +26,22 @@ public class StreamingHub : Hub
     /// <summary>
     /// Subscribes the caller to streaming events for a specific chat session.
     ///
-    /// For an Anonymous caller the session is bound to the caller's immutable subject: the caller may
-    /// only join a session it owns (or an as-yet-unclaimed one). This blocks an anonymous attacker
-    /// from subscribing to another subject's streamed tokens with a known/guessed session id
-    /// (Finding 6). Entra/dev callers are unchanged.
+    /// Ownership is enforced for BOTH authenticated and anonymous callers (issue #92): every
+    /// join and every rejoin binds the sessionId to the caller's immutable subject via
+    /// <see cref="ISessionOwnershipRegistry.TryBind"/>. A hostile client that reconnects and
+    /// attempts to rejoin another subject's session group is refused. The first join for a
+    /// server-minted sessionId claims ownership; every subsequent join (including reconnects)
+    /// must match the recorded owner.
     /// </summary>
     public Task JoinSession(string sessionId)
     {
-        return string.IsNullOrWhiteSpace(sessionId)
-            ? Task.CompletedTask
-            : AnonymousCapabilityPolicy.IsAnonymousPrincipal(Context.User)
-            && !_ownership.TryBind(sessionId, UserIdentity.Resolve(Context.User))
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return Task.CompletedTask;
+        }
+
+        string subject = UserIdentity.Resolve(Context.User);
+        return !_ownership.TryBind(sessionId, subject)
             ? throw new HubException("Not authorized to join this session.")
             : Groups.AddToGroupAsync(Context.ConnectionId, $"stream:{sessionId}");
     }

--- a/src/RetailPulse.Api/Hubs/TelemetryHub.cs
+++ b/src/RetailPulse.Api/Hubs/TelemetryHub.cs
@@ -23,17 +23,22 @@ public class TelemetryHub : Hub
     /// Subscribes the caller to spans for a specific chat session.
     /// Used to scope telemetry per session instead of broadcasting to all clients.
     ///
-    /// For an Anonymous caller the session is bound to the caller's immutable subject: the caller may
-    /// only join a session it owns (or an as-yet-unclaimed one). This blocks an anonymous attacker
-    /// from subscribing to another subject's telemetry with a known/guessed session id (Finding 6).
-    /// Entra/dev callers are unchanged.
+    /// Ownership is enforced for BOTH authenticated and anonymous callers (issue #92):
+    /// every join and every rejoin binds the sessionId to the caller's immutable subject
+    /// via <see cref="ISessionOwnershipRegistry.TryBind"/>. A hostile client that reconnects
+    /// and attempts to rejoin another subject's session id is refused. The first join for a
+    /// server-minted sessionId claims ownership; every subsequent join (including reconnects)
+    /// must match the recorded owner.
     /// </summary>
     public Task JoinSession(string sessionId)
     {
-        return string.IsNullOrWhiteSpace(sessionId)
-            ? Task.CompletedTask
-            : AnonymousCapabilityPolicy.IsAnonymousPrincipal(Context.User)
-            && !_ownership.TryBind(sessionId, UserIdentity.Resolve(Context.User))
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return Task.CompletedTask;
+        }
+
+        string subject = UserIdentity.Resolve(Context.User);
+        return !_ownership.TryBind(sessionId, subject)
             ? throw new HubException("Not authorized to join this session.")
             : Groups.AddToGroupAsync(Context.ConnectionId, sessionId);
     }

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -131,6 +131,11 @@ builder.Services.AddSignalR(hub =>
 builder.Services.Configure<ChatTimeoutOptions>(
     builder.Configuration.GetSection(ChatTimeoutOptions.SectionName));
 
+// User-initiated cancellation registry (issue #92) — subject-scoped map from
+// (scope, key) to the request/plan CTS so /api/chat/{sessionId}/cancel and
+// /api/plans/{planId}/cancel can end an in-flight run they own.
+builder.Services.AddSingleton<IExecutionCancellationRegistry, ExecutionCancellationRegistry>();
+
 // Application-level hub heartbeat emitter (issue #92) — periodically emits an
 // observable heartbeat event on the telemetry and streaming hubs so the frontend
 // can render a stalled/connected signal and tests can assert cadence.
@@ -1187,7 +1192,8 @@ if (plannerDef is not null && planPersistenceOptsAtRegistration.Enabled)
             opts.Value,
             sp.GetRequiredService<ILogger<PlanExecutor>>(),
             sp.GetService<PlanClarifier>(),
-            sp.GetService<PlanReviewCoordinator>());
+            sp.GetService<PlanReviewCoordinator>(),
+            sp.GetService<IExecutionCancellationRegistry>());
     });
     builder.Services.AddScoped(sp =>
     {
@@ -1387,6 +1393,12 @@ app.MapDeadLetterEndpoints();
 app.MapMemoryEndpoints();
 app.MapCacheEndpoints();
 
+// User-initiated execution control (issue #92): cancel endpoints for the
+// in-flight fast-path / streaming request and for the plan orchestrator.
+// Registered unconditionally because the cancellation registry is always
+// present; a cancel with no matching in-flight run resolves to 404.
+app.MapExecutionControlEndpoints();
+
 // Durable session endpoints — mapped only when SessionPersistence:Enabled is true so
 // no session surface exists when the feature is off. See MapSessionEndpoints and
 // SessionPersistenceServiceExtensions for the rationale (mirrors the Anonymous/GitHub
@@ -1402,6 +1414,9 @@ if (app.Services.GetService<ISessionStore>() is not null)
 if (app.Services.GetService<IPlanStore>() is not null)
 {
     app.MapPlanEndpoints();
+    // Reconciliation surface (issue #92) — mapped only when plan persistence is
+    // enabled so no reconciliation endpoint exists when the durable store is off.
+    app.MapPlanReconciliationEndpoint();
     // Plan review endpoints (#94) — mapped only when the plan store is available
     // AND PlanReview is enabled. Cross-subject decisions collapse to 404.
     if (planReviewOptsAtRegistration.Enabled)

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -106,9 +106,36 @@ builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing.AddSource("RetailPulse.Agent").AddSource("RetailPulse.Alerts"))
     .WithMetrics(metrics => metrics.AddMeter(RetailPulseMetrics.MeterName));
 
+// Real-time channel resilience (issue #92) — configurable keep-alive / client-timeout
+// / handshake and an observable application-level heartbeat. Defaults target 15s
+// keepalive with the SignalR-recommended 2x client-timeout so short-lived intermediary
+// idle drops (APIM/ACA ingress/proxies) do not sever an idle connection during a long
+// plan pause. Bound before AddSignalR so the timers reflect the resolved config.
+builder.Services.Configure<RealtimeResilienceOptions>(
+    builder.Configuration.GetSection(RealtimeResilienceOptions.SectionName));
+RealtimeResilienceOptions realtimeOptsAtRegistration = builder.Configuration
+    .GetSection(RealtimeResilienceOptions.SectionName)
+    .Get<RealtimeResilienceOptions>() ?? new RealtimeResilienceOptions();
+
 // SignalR for real-time telemetry
-builder.Services.AddSignalR()
+builder.Services.AddSignalR(hub =>
+    {
+        hub.KeepAliveInterval = realtimeOptsAtRegistration.KeepAliveInterval;
+        hub.ClientTimeoutInterval = realtimeOptsAtRegistration.ClientTimeoutInterval;
+        hub.HandshakeTimeout = realtimeOptsAtRegistration.HandshakeTimeout;
+    })
     .AddJsonProtocol(options => options.PayloadSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase);
+
+// Chat-request timeout ceilings (issue #92) — separate single-shot vs plan values so
+// long-running plan runs don't force us to widen the single-shot ceiling globally.
+builder.Services.Configure<ChatTimeoutOptions>(
+    builder.Configuration.GetSection(ChatTimeoutOptions.SectionName));
+
+// Application-level hub heartbeat emitter (issue #92) — periodically emits an
+// observable heartbeat event on the telemetry and streaming hubs so the frontend
+// can render a stalled/connected signal and tests can assert cadence.
+builder.Services.AddSingleton<HubHeartbeatBackgroundService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<HubHeartbeatBackgroundService>());
 
 // Session-ownership registry — binds a chat sessionId to its owning subject so the hubs can refuse
 // a caller that tries to join another subject's session group (Finding 6). Consulted only for

--- a/src/RetailPulse.Api/appsettings.json
+++ b/src/RetailPulse.Api/appsettings.json
@@ -151,6 +151,51 @@
     "CheckIntervalMinutes": 5
   },
 
+  // ---- Real-time channel resilience (issue #92) -------------------------
+  // Governs SignalR transport-level timers and the observable application-
+  // level heartbeat emitted on both /hubs/telemetry and /hubs/streaming.
+  //
+  //   KeepAliveInterval             (default: 00:00:15) — server-to-client
+  //                                 transport ping cadence; bound to
+  //                                 HubOptions.KeepAliveInterval.
+  //   ClientTimeoutInterval         (default: 00:00:30) — server-side
+  //                                 disconnect threshold; SignalR guidance
+  //                                 is >= 2 x KeepAliveInterval.
+  //   HandshakeTimeout              (default: 00:00:15) — protocol negotiate
+  //                                 timeout for the initial connection.
+  //   ApplicationHeartbeatInterval  (default: 00:00:15) — observable
+  //                                 "heartbeat" event on both hubs. Distinct
+  //                                 from the transport keep-alive so the
+  //                                 frontend can render a "connected /
+  //                                 stalled" indicator without probing
+  //                                 transport internals.
+  //   ApplicationHeartbeatEnabled   (default: true) — master switch for the
+  //                                 hosted heartbeat emitter.
+  "RealtimeResilience": {
+    "KeepAliveInterval": "00:00:15",
+    "ClientTimeoutInterval": "00:00:30",
+    "HandshakeTimeout": "00:00:15",
+    "ApplicationHeartbeatInterval": "00:00:15",
+    "ApplicationHeartbeatEnabled": true
+  },
+
+  // ---- Chat request timeout ceilings (issue #92) ------------------------
+  // Separate ceilings for the single-shot fast path and the long-running
+  // plan path so plan-first admission doesn't force us to globally raise the
+  // fast-path 90s wall. Applied by /api/chat and /api/chat/stream.
+  //
+  //   SingleShot   (default: 00:01:30) — per-request timeout for a fast-path
+  //                run; matches the pre-#92 hard-coded value.
+  //   Plan         (default: 00:06:00) — replacement ceiling when the hybrid
+  //                execution decider selects the plan path (#95). Must stay
+  //                >= PlanPersistence.PlanTimeout + 60s so the plan
+  //                orchestrator's own timeout fires first with a plan-
+  //                specific failure reason.
+  "ChatTimeout": {
+    "SingleShot": "00:01:30",
+    "Plan": "00:06:00"
+  },
+
   // ---- Knowledge base (RAG) limits --------------------------------------
   "Knowledge": {
     "MaxDocumentSizeBytes": 10485760,

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.anonymousExecutionPath.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.anonymousExecutionPath.test.tsx
@@ -11,11 +11,23 @@ const sendMessageMock = vi.fn();
 vi.mock('../services/api', () => ({
   sendMessage: (...args: unknown[]) => sendMessageMock(...args),
   isErrorReply: (reply: string) => reply.startsWith('⏳'),
+  isChatRequestTimeoutError: () => false,
 }));
 
 vi.mock('../services/telemetryHub', () => ({
   joinTelemetrySession: vi.fn(),
   onProgress: vi.fn(() => () => {}),
+  onHubConnectionStatus: (listener: (s: string) => void) => {
+    listener('connected');
+    return () => {};
+  },
+  onHubHeartbeat: () => () => {},
+  getHubConnectionStatus: () => 'connected',
+  getLastHubHeartbeatAt: () => null,
+}));
+
+vi.mock('../services/executionControlApi', () => ({
+  cancelChatSession: vi.fn().mockResolvedValue('cancelled'),
 }));
 
 vi.mock('../auth/activeProvider', () => ({

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.anonymousExecutionPath.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.anonymousExecutionPath.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../services/telemetryHub', () => ({
 
 vi.mock('../services/executionControlApi', () => ({
   cancelChatSession: vi.fn().mockResolvedValue('cancelled'),
+  cancelPlan: vi.fn().mockResolvedValue('cancelled'),
 }));
 
 vi.mock('../auth/activeProvider', () => ({

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.resilience.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.resilience.test.tsx
@@ -9,14 +9,22 @@ const isErrorReplyMock = vi.fn((reply: string) => reply.startsWith('⏳'));
 const cancelChatSessionMock = vi.fn().mockResolvedValue('cancelled');
 const cancelPlanMock = vi.fn().mockResolvedValue('cancelled');
 
-class ChatRequestTimeoutError extends Error {
-  readonly name = 'ChatRequestTimeoutError';
-  readonly timeoutMs: number;
-  constructor(timeoutMs: number) {
-    super('Request timed out');
-    this.timeoutMs = timeoutMs;
+// `vi.mock` factories are hoisted above module-level `class` declarations, so
+// a plain top-level class would be in its temporal dead zone when the
+// `../services/api` factory below evaluates the `ChatRequestTimeoutError`
+// shorthand. `vi.hoisted` runs alongside the hoisted mocks, guaranteeing the
+// class binding exists before the factory runs.
+const { ChatRequestTimeoutError } = vi.hoisted(() => {
+  class ChatRequestTimeoutError extends Error {
+    readonly name = 'ChatRequestTimeoutError';
+    readonly timeoutMs: number;
+    constructor(timeoutMs: number) {
+      super('Request timed out');
+      this.timeoutMs = timeoutMs;
+    }
   }
-}
+  return { ChatRequestTimeoutError };
+});
 
 vi.mock('../services/api', () => ({
   sendMessage: (...args: unknown[]) => sendMessageMock(...args),

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.resilience.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.resilience.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+
+// --- Mocks -----------------------------------------------------------------
+const sendMessageMock = vi.fn();
+const isErrorReplyMock = vi.fn((reply: string) => reply.startsWith('⏳'));
+const cancelChatSessionMock = vi.fn().mockResolvedValue('cancelled');
+
+class ChatRequestTimeoutError extends Error {
+  readonly name = 'ChatRequestTimeoutError';
+  readonly timeoutMs: number;
+  constructor(timeoutMs: number) {
+    super('Request timed out');
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+vi.mock('../services/api', () => ({
+  sendMessage: (...args: unknown[]) => sendMessageMock(...args),
+  isErrorReply: (reply: string) => isErrorReplyMock(reply),
+  isChatRequestTimeoutError: (err: unknown) => err instanceof ChatRequestTimeoutError,
+  ChatRequestTimeoutError,
+}));
+
+vi.mock('../services/executionControlApi', () => ({
+  cancelChatSession: (...args: unknown[]) => cancelChatSessionMock(...args),
+}));
+
+vi.mock('../services/telemetryHub', () => ({
+  joinTelemetrySession: vi.fn(),
+  onProgress: vi.fn(() => () => {}),
+  onHubConnectionStatus: vi.fn((listener: (s: string) => void) => {
+    // Fire an initial connected status so the indicator has something to
+    // render deterministically. Return a no-op unsubscribe.
+    listener('connected');
+    return () => {};
+  }),
+  onHubHeartbeat: vi.fn(() => () => {}),
+  getHubConnectionStatus: () => 'connected',
+  getLastHubHeartbeatAt: () => null,
+}));
+
+vi.mock('../auth/activeProvider', () => ({
+  activeAuthMode: 'entra',
+}));
+
+vi.mock('../components/ChartRenderer', () => ({
+  default: () => <div data-testid="chart-renderer-mock" />,
+}));
+
+beforeEach(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  } else {
+    (Element.prototype.scrollIntoView as unknown as ReturnType<typeof vi.fn>) = vi.fn();
+  }
+  sendMessageMock.mockReset();
+  cancelChatSessionMock.mockClear();
+  cancelChatSessionMock.mockResolvedValue('cancelled');
+  isErrorReplyMock.mockClear();
+  isErrorReplyMock.mockImplementation((reply: string) => reply.startsWith('⏳'));
+});
+
+// Import AFTER vi.mock so the mocked modules are used.
+import { ChatPanel } from '../components/ChatPanel';
+
+function renderPanel() {
+  return render(
+    <FluentProvider theme={teamsDarkTheme}>
+      <ChatPanel />
+    </FluentProvider>,
+  );
+}
+
+describe('ChatPanel resilience surface (issue #92)', () => {
+  it('renders the ConnectionStatusIndicator inside the composer', () => {
+    renderPanel();
+    const indicator = screen.getByTestId('connection-status-indicator');
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveAttribute('data-status', 'connected');
+  });
+
+  it('shows a visible Cancel button while a run is in flight and hides Send', async () => {
+    const user = userEvent.setup();
+    sendMessageMock.mockImplementation(() => new Promise(() => {})); // never resolves
+
+    renderPanel();
+
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'take a while');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    const cancel = await screen.findByTestId('chat-cancel-button');
+    expect(cancel).toBeInTheDocument();
+    // Send button is replaced by Cancel while loading.
+    expect(screen.queryByRole('button', { name: /Send message/i })).not.toBeInTheDocument();
+  });
+
+  it('invokes cancelChatSession and clears loading when Cancel is pressed', async () => {
+    const user = userEvent.setup();
+    sendMessageMock.mockImplementation(() => new Promise(() => {}));
+
+    renderPanel();
+
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'question');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    await user.click(await screen.findByTestId('chat-cancel-button'));
+
+    await waitFor(() => expect(cancelChatSessionMock).toHaveBeenCalledTimes(1));
+    // The chat sessionId must be a non-empty string — ChatPanel mints its own.
+    expect(typeof cancelChatSessionMock.mock.calls[0][0]).toBe('string');
+    expect((cancelChatSessionMock.mock.calls[0][0] as string).length).toBeGreaterThan(0);
+
+    // Loading state cleared → the Send button is back.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Send message/i })).toBeInTheDocument(),
+    );
+    // A "Cancelled." bubble is rendered so the user sees the outcome.
+    expect(screen.getByText('Cancelled.')).toBeInTheDocument();
+  });
+
+  it('opens the timeout dialog on ChatRequestTimeoutError instead of an error bubble', async () => {
+    const user = userEvent.setup();
+    sendMessageMock.mockRejectedValueOnce(new ChatRequestTimeoutError(90_000));
+
+    renderPanel();
+
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'timeout me');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    expect(await screen.findByTestId('timeout-dialog')).toBeInTheDocument();
+    // No "Error:" bubble should have been appended — the dialog IS the feedback.
+    expect(screen.queryByText(/^Error:/)).not.toBeInTheDocument();
+  });
+
+  it('Retry from the timeout dialog re-sends the same prompt', async () => {
+    const user = userEvent.setup();
+    sendMessageMock
+      .mockRejectedValueOnce(new ChatRequestTimeoutError(90_000))
+      .mockResolvedValueOnce({
+        reply: 'second try works',
+        sessionId: 'sess-retry',
+        spans: [],
+        totalDurationMs: 10,
+      });
+
+    renderPanel();
+
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'do it again');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    await user.click(await screen.findByTestId('timeout-dialog-retry'));
+
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(2));
+    expect(sendMessageMock.mock.calls[1][0]).toMatchObject({ message: 'do it again' });
+    expect(await screen.findByText('second try works')).toBeInTheDocument();
+  });
+
+  it('Abandon closes the dialog and restores an editable composer', async () => {
+    const user = userEvent.setup();
+    sendMessageMock.mockRejectedValueOnce(new ChatRequestTimeoutError(90_000));
+
+    renderPanel();
+
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'abandon me');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    await user.click(await screen.findByTestId('timeout-dialog-abandon'));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('timeout-dialog')).not.toBeInTheDocument(),
+    );
+    // The Send button is back so the composer is editable.
+    expect(screen.getByRole('button', { name: /Send message/i })).toBeInTheDocument();
+    // Only the initial call — no retry was issued.
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.resilience.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.resilience.test.tsx
@@ -7,6 +7,7 @@ import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
 const sendMessageMock = vi.fn();
 const isErrorReplyMock = vi.fn((reply: string) => reply.startsWith('⏳'));
 const cancelChatSessionMock = vi.fn().mockResolvedValue('cancelled');
+const cancelPlanMock = vi.fn().mockResolvedValue('cancelled');
 
 class ChatRequestTimeoutError extends Error {
   readonly name = 'ChatRequestTimeoutError';
@@ -26,6 +27,7 @@ vi.mock('../services/api', () => ({
 
 vi.mock('../services/executionControlApi', () => ({
   cancelChatSession: (...args: unknown[]) => cancelChatSessionMock(...args),
+  cancelPlan: (...args: unknown[]) => cancelPlanMock(...args),
 }));
 
 vi.mock('../services/telemetryHub', () => ({
@@ -59,6 +61,8 @@ beforeEach(() => {
   sendMessageMock.mockReset();
   cancelChatSessionMock.mockClear();
   cancelChatSessionMock.mockResolvedValue('cancelled');
+  cancelPlanMock.mockClear();
+  cancelPlanMock.mockResolvedValue('cancelled');
   isErrorReplyMock.mockClear();
   isErrorReplyMock.mockImplementation((reply: string) => reply.startsWith('⏳'));
 });

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.resilience.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.resilience.test.tsx
@@ -152,10 +152,18 @@ describe('ChatPanel resilience surface (issue #92)', () => {
     sendMessageMock
       .mockRejectedValueOnce(new ChatRequestTimeoutError(90_000))
       .mockResolvedValueOnce({
-        reply: 'second try works',
-        sessionId: 'sess-retry',
-        spans: [],
-        totalDurationMs: 10,
+        // Must match the actual `SendMessageResult` union returned by
+        // `sendMessage` — the fast path is `{ kind: 'complete', response }`.
+        // Returning a bare `ChatResponse` here would leave `result.response`
+        // undefined in ChatPanel and blow up with
+        // "Cannot read properties of undefined (reading 'reply')".
+        kind: 'complete',
+        response: {
+          reply: 'second try works',
+          sessionId: 'sess-retry',
+          spans: [],
+          totalDurationMs: 10,
+        },
       });
 
     renderPanel();

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
@@ -12,11 +12,23 @@ const isErrorReplyMock = vi.fn((reply: string) => reply.startsWith('⏳'));
 vi.mock('../services/api', () => ({
   sendMessage: (...args: unknown[]) => sendMessageMock(...args),
   isErrorReply: (reply: string) => isErrorReplyMock(reply),
+  isChatRequestTimeoutError: () => false,
 }));
 
 vi.mock('../services/telemetryHub', () => ({
   joinTelemetrySession: vi.fn(),
   onProgress: vi.fn(() => () => {}),
+  onHubConnectionStatus: (listener: (s: string) => void) => {
+    listener('connected');
+    return () => {};
+  },
+  onHubHeartbeat: () => () => {},
+  getHubConnectionStatus: () => 'connected',
+  getLastHubHeartbeatAt: () => null,
+}));
+
+vi.mock('../services/executionControlApi', () => ({
+  cancelChatSession: vi.fn().mockResolvedValue('cancelled'),
 }));
 
 // activeAuthMode drives whether the execution-path selector is rendered.

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../services/telemetryHub', () => ({
 
 vi.mock('../services/executionControlApi', () => ({
   cancelChatSession: vi.fn().mockResolvedValue('cancelled'),
+  cancelPlan: vi.fn().mockResolvedValue('cancelled'),
 }));
 
 // activeAuthMode drives whether the execution-path selector is rendered.

--- a/src/RetailPulse.Web/src/__tests__/ConnectionStatusIndicator.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ConnectionStatusIndicator.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+import { ConnectionStatusIndicator } from '../components/ConnectionStatusIndicator';
+
+function renderWith(node: React.ReactElement) {
+  return render(<FluentProvider theme={teamsDarkTheme}>{node}</FluentProvider>);
+}
+
+describe('ConnectionStatusIndicator', () => {
+  it('renders a live label when connected', () => {
+    renderWith(<ConnectionStatusIndicator status="connected" />);
+    const indicator = screen.getByTestId('connection-status-indicator');
+    expect(indicator).toHaveAttribute('data-status', 'connected');
+    expect(indicator).toHaveAttribute('aria-label', 'Real-time channel: Live');
+  });
+
+  it('renders a connecting label during initial handshake', () => {
+    renderWith(<ConnectionStatusIndicator status="connecting" />);
+    const indicator = screen.getByTestId('connection-status-indicator');
+    expect(indicator).toHaveAttribute('data-status', 'connecting');
+    expect(screen.getByText(/Connecting/)).toBeInTheDocument();
+  });
+
+  it('renders a reconnecting label during transport retries', () => {
+    renderWith(<ConnectionStatusIndicator status="reconnecting" />);
+    const indicator = screen.getByTestId('connection-status-indicator');
+    expect(indicator).toHaveAttribute('data-status', 'reconnecting');
+  });
+
+  it('renders a disconnected label after the retry budget is exhausted', () => {
+    renderWith(<ConnectionStatusIndicator status="disconnected" />);
+    const indicator = screen.getByTestId('connection-status-indicator');
+    expect(indicator).toHaveAttribute('data-status', 'disconnected');
+    expect(screen.getByText(/Disconnected/)).toBeInTheDocument();
+  });
+
+  it('presents a stalled connected channel as reconnecting', () => {
+    renderWith(<ConnectionStatusIndicator status="connected" stalled={true} />);
+    const indicator = screen.getByTestId('connection-status-indicator');
+    expect(indicator).toHaveAttribute('data-status', 'reconnecting');
+  });
+
+  it('publishes live-region semantics for assistive tech', () => {
+    renderWith(<ConnectionStatusIndicator status="reconnecting" />);
+    const indicator = screen.getByTestId('connection-status-indicator');
+    expect(indicator).toHaveAttribute('role', 'status');
+    expect(indicator).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/DashboardChatPersistence.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/DashboardChatPersistence.test.tsx
@@ -44,6 +44,16 @@ vi.mock('../services/telemetryHub', () => ({
   joinTelemetrySession: (...args: unknown[]) => joinTelemetrySessionMock(...args),
   onProgress: vi.fn(() => () => {}),
   subscribeHubEvent: vi.fn(() => () => {}),
+  // ChatPanel's ConnectionStatusIndicator (issue #92) calls useConnectionStatus,
+  // which pulls these hub-status/heartbeat exports. Stub them so navigation
+  // tests can render the real ChatPanel without needing a live SignalR stack.
+  onHubConnectionStatus: (listener: (s: string) => void) => {
+    listener('connected');
+    return () => {};
+  },
+  onHubHeartbeat: () => () => {},
+  getHubConnectionStatus: () => 'connected',
+  getLastHubHeartbeatAt: () => null,
 }));
 
 // planApi is used by the plan controller wired into the Dashboard (issue #96).

--- a/src/RetailPulse.Web/src/__tests__/TimeoutDialog.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/TimeoutDialog.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+import { TimeoutDialog } from '../components/TimeoutDialog';
+
+function renderWith(open: boolean, onRetry: () => void, onAbandon: () => void, timeoutMs = 180_000) {
+  return render(
+    <FluentProvider theme={teamsDarkTheme}>
+      <TimeoutDialog open={open} timeoutMs={timeoutMs} onRetry={onRetry} onAbandon={onAbandon} />
+    </FluentProvider>,
+  );
+}
+
+describe('TimeoutDialog', () => {
+  it('is not rendered while closed', () => {
+    renderWith(false, vi.fn(), vi.fn());
+    expect(screen.queryByTestId('timeout-dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the timeout duration in a human-readable way', () => {
+    renderWith(true, vi.fn(), vi.fn(), 180_000);
+    expect(screen.getByText(/180\s?seconds/)).toBeInTheDocument();
+  });
+
+  it('invokes onRetry when the retry button is pressed', async () => {
+    const onRetry = vi.fn();
+    renderWith(true, onRetry, vi.fn());
+    await userEvent.click(screen.getByTestId('timeout-dialog-retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onAbandon when the abandon button is pressed', async () => {
+    const onAbandon = vi.fn();
+    renderWith(true, vi.fn(), onAbandon);
+    await userEvent.click(screen.getByTestId('timeout-dialog-abandon'));
+    expect(onAbandon).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/executionControlApi.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/executionControlApi.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  cancelChatSession,
+  cancelPlan,
+  reconcilePlan,
+} from '../services/executionControlApi';
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('executionControlApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('cancelChatSession', () => {
+    it('POSTs to /api/chat/{sessionId}/cancel with a JSON content type', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await cancelChatSession('sess-123');
+
+      expect(result).toBe('cancelled');
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/chat/sess-123/cancel',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    it('URL-encodes the sessionId to prevent path injection', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await cancelChatSession('has/slash?and=query');
+
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toBe('/api/chat/has%2Fslash%3Fand%3Dquery/cancel');
+    });
+
+    it('maps 404 to not_found (no in-flight run for this caller)', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 404 })) as unknown as typeof fetch;
+      await expect(cancelChatSession('sess-x')).resolves.toBe('not_found');
+    });
+
+    it('throws on unexpected status codes', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 500 })) as unknown as typeof fetch;
+      await expect(cancelChatSession('sess-x')).rejects.toThrow(/HTTP 500/);
+    });
+
+    it('rejects an empty sessionId synchronously', () => {
+      expect(() => cancelChatSession('')).toThrow(/non-empty sessionId/);
+    });
+  });
+
+  describe('cancelPlan', () => {
+    it('maps 403 to forbidden so the UI can hide the affordance', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 403 })) as unknown as typeof fetch;
+      await expect(cancelPlan('plan-1')).resolves.toBe('forbidden');
+    });
+
+    it('POSTs to /api/plans/{planId}/cancel', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await cancelPlan('plan-abc');
+
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toBe('/api/plans/plan-abc/cancel');
+    });
+  });
+
+  describe('reconcilePlan', () => {
+    it('includes afterStepIndex when supplied and parses the response', async () => {
+      const payload = {
+        planId: 'plan-1',
+        sessionId: 'sess-1',
+        status: 'running',
+        totalStepCount: 5,
+        afterStepIndex: 2,
+        steps: [
+          { stepIndex: 3, status: 'succeeded' },
+          { stepIndex: 4, status: 'running' },
+        ],
+      };
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse(payload));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await reconcilePlan('plan-1', { afterStepIndex: 2 });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/plans/plan-1/reconcile?afterStepIndex=2',
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(result?.steps).toHaveLength(2);
+      expect(result?.status).toBe('running');
+    });
+
+    it('omits afterStepIndex from the query string when not supplied', async () => {
+      const payload = {
+        planId: 'plan-1',
+        sessionId: 'sess-1',
+        status: 'running',
+        totalStepCount: 0,
+        afterStepIndex: -1,
+        steps: [],
+      };
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse(payload));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await reconcilePlan('plan-1');
+
+      expect(fetchMock.mock.calls[0][0]).toBe('/api/plans/plan-1/reconcile');
+    });
+
+    it('returns null when the plan is unknown or foreign (404 / 403)', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 404 })) as unknown as typeof fetch;
+      await expect(reconcilePlan('missing')).resolves.toBeNull();
+
+      globalThis.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 403 })) as unknown as typeof fetch;
+      await expect(reconcilePlan('missing')).resolves.toBeNull();
+    });
+
+    it('rejects a malformed payload rather than propagating unknown shape', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ nope: true }));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(reconcilePlan('plan-1')).rejects.toThrow(/malformed payload/);
+    });
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/planReconciler.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/planReconciler.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  reconcilePlanSteps,
+  applyReconciliation,
+  isTerminalStatus,
+} from '../services/planReconciler';
+import type { PlanStepRecord } from '../services/executionControlApi';
+
+function step(index: number, status: string, extra: Partial<PlanStepRecord> = {}): PlanStepRecord {
+  return { stepIndex: index, status, ...extra };
+}
+
+describe('planReconciler.isTerminalStatus', () => {
+  it('recognises terminal lifecycle statuses regardless of case', () => {
+    expect(isTerminalStatus('succeeded')).toBe(true);
+    expect(isTerminalStatus('Completed')).toBe(true);
+    expect(isTerminalStatus('FAILED')).toBe(true);
+    expect(isTerminalStatus('cancelled')).toBe(true);
+    expect(isTerminalStatus('canceled')).toBe(true);
+    expect(isTerminalStatus('skipped')).toBe(true);
+  });
+
+  it('treats in-flight statuses as non-terminal', () => {
+    expect(isTerminalStatus('pending')).toBe(false);
+    expect(isTerminalStatus('running')).toBe(false);
+    expect(isTerminalStatus('waiting_approval')).toBe(false);
+    expect(isTerminalStatus(null)).toBe(false);
+    expect(isTerminalStatus(undefined)).toBe(false);
+  });
+});
+
+describe('planReconciler.reconcilePlanSteps', () => {
+  it('yields unique step entries sorted by stepIndex', () => {
+    const rendered = [step(0, 'succeeded'), step(2, 'running')];
+    const reconciled = [step(1, 'succeeded'), step(3, 'pending')];
+
+    const merged = reconcilePlanSteps(rendered, reconciled);
+    expect(merged.map(s => s.stepIndex)).toEqual([0, 1, 2, 3]);
+    // No duplicates.
+    expect(new Set(merged.map(s => s.stepIndex)).size).toBe(merged.length);
+  });
+
+  it('never regresses a terminal rendered step (monotonicity)', () => {
+    const rendered = [step(0, 'succeeded', { summary: 'rendered-final' })];
+    const reconciled = [step(0, 'running', { summary: 'late-arrival' })];
+
+    const merged = reconcilePlanSteps(rendered, reconciled);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].status).toBe('succeeded');
+    expect(merged[0].summary).toBe('rendered-final');
+  });
+
+  it('promotes an incoming terminal record over a non-terminal rendered one', () => {
+    const rendered = [step(0, 'running', { summary: 'stream-placeholder' })];
+    const reconciled = [step(0, 'succeeded', { summary: 'durable-final', durationMs: 1200 })];
+
+    const merged = reconcilePlanSteps(rendered, reconciled);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].status).toBe('succeeded');
+    expect(merged[0].summary).toBe('durable-final');
+    expect(merged[0].durationMs).toBe(1200);
+  });
+
+  it('produces no duplicates when overlap is a subset (rendered ⊇ reconciled)', () => {
+    const rendered = [step(0, 'succeeded'), step(1, 'succeeded'), step(2, 'running')];
+    const reconciled = [step(1, 'succeeded'), step(2, 'succeeded')];
+
+    const merged = reconcilePlanSteps(rendered, reconciled);
+    expect(merged.map(s => s.stepIndex)).toEqual([0, 1, 2]);
+    // The overlapping non-terminal (index 2) was promoted to succeeded.
+    expect(merged.find(s => s.stepIndex === 2)?.status).toBe('succeeded');
+  });
+
+  it('leaves a gap when the reconcile response omits an intermediate step', () => {
+    // Simulates streaming still delivering step 1 while reconcile has only
+    // returned steps 0 and 2 so far. The caller relies on the gap to know
+    // MORE data is incoming, so we must not paper over it.
+    const rendered = [step(0, 'succeeded')];
+    const reconciled = [step(2, 'succeeded')];
+
+    const merged = reconcilePlanSteps(rendered, reconciled);
+    expect(merged.map(s => s.stepIndex)).toEqual([0, 2]);
+  });
+
+  it('drops step records with a non-finite stepIndex', () => {
+    const rendered = [step(0, 'succeeded')];
+    const reconciled = [
+      { stepIndex: Number.NaN, status: 'succeeded' } as PlanStepRecord,
+      step(1, 'succeeded'),
+    ];
+
+    const merged = reconcilePlanSteps(rendered, reconciled);
+    expect(merged.map(s => s.stepIndex)).toEqual([0, 1]);
+  });
+});
+
+describe('planReconciler.applyReconciliation', () => {
+  it('returns the next cursor as max(stepIndex) so the caller keeps advancing', () => {
+    const rendered = [step(0, 'succeeded')];
+    const reconciled = [step(1, 'succeeded'), step(4, 'running')];
+
+    const result = applyReconciliation(rendered, reconciled);
+    expect(result.steps.map(s => s.stepIndex)).toEqual([0, 1, 4]);
+    expect(result.nextAfterStepIndex).toBe(4);
+  });
+
+  it('returns -1 when nothing has been rendered yet', () => {
+    const result = applyReconciliation<PlanStepRecord>([], []);
+    expect(result.steps).toEqual([]);
+    expect(result.nextAfterStepIndex).toBe(-1);
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/planReconciler.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/planReconciler.test.ts
@@ -41,23 +41,23 @@ describe('planReconciler.reconcilePlanSteps', () => {
   });
 
   it('never regresses a terminal rendered step (monotonicity)', () => {
-    const rendered = [step(0, 'succeeded', { summary: 'rendered-final' })];
-    const reconciled = [step(0, 'running', { summary: 'late-arrival' })];
+    const rendered = [step(0, 'succeeded', { result: 'rendered-final' })];
+    const reconciled = [step(0, 'running', { result: 'late-arrival' })];
 
     const merged = reconcilePlanSteps(rendered, reconciled);
     expect(merged).toHaveLength(1);
     expect(merged[0].status).toBe('succeeded');
-    expect(merged[0].summary).toBe('rendered-final');
+    expect(merged[0].result).toBe('rendered-final');
   });
 
   it('promotes an incoming terminal record over a non-terminal rendered one', () => {
-    const rendered = [step(0, 'running', { summary: 'stream-placeholder' })];
-    const reconciled = [step(0, 'succeeded', { summary: 'durable-final', durationMs: 1200 })];
+    const rendered = [step(0, 'running', { result: 'stream-placeholder' })];
+    const reconciled = [step(0, 'succeeded', { result: 'durable-final', durationMs: 1200 })];
 
     const merged = reconcilePlanSteps(rendered, reconciled);
     expect(merged).toHaveLength(1);
     expect(merged[0].status).toBe('succeeded');
-    expect(merged[0].summary).toBe('durable-final');
+    expect(merged[0].result).toBe('durable-final');
     expect(merged[0].durationMs).toBe(1200);
   });
 

--- a/src/RetailPulse.Web/src/__tests__/planReducer.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/planReducer.test.ts
@@ -471,6 +471,144 @@ describe('planReducer', () => {
     expect(up.active?.connectionLost).toBe(false);
   });
 
+  it('STEPS_RECONCILED merges new step records after a reconnect delta', () => {
+    // Seed: two rendered steps (0 completed, 1 running) — the reconcile
+    // response then delivers a new step 2 the client never saw plus a
+    // refreshed durable record for step 1.
+    const hydrated = planReducer(initialPlanState, {
+      type: 'PLAN_STARTED',
+      planId: 'p1',
+      request: 'q',
+    });
+    const withDetail = planReducer(hydrated, {
+      type: 'PLAN_HYDRATED',
+      detail: detail('p1', [
+        { index: 0, status: 'completed' },
+        { index: 1, status: 'running' },
+      ]),
+    });
+    const reconciled = planReducer(withDetail, {
+      type: 'STEPS_RECONCILED',
+      planId: 'p1',
+      steps: [
+        {
+          stepId: 'p1-1',
+          planId: 'p1',
+          stepIndex: 1,
+          specialistKey: 'demand-forecasting',
+          intent: 'demand',
+          action: 'run step 1',
+          status: 'completed',
+          durationMs: 1200,
+        },
+        {
+          stepId: 'p1-2',
+          planId: 'p1',
+          stepIndex: 2,
+          specialistKey: 'promo-planning',
+          intent: 'promo',
+          action: 'run step 2',
+          status: 'running',
+        },
+      ],
+      status: 'running',
+    });
+    const steps = reconciled.active!.steps;
+    expect(steps.map(s => s.stepIndex)).toEqual([0, 1, 2]);
+    // Non-terminal (running) rendered step 1 is refreshed with the durable
+    // completed record, including the new durationMs field.
+    expect(steps[1].status).toBe('completed');
+    expect(steps[1].durationMs).toBe(1200);
+    // Step 2 is added.
+    expect(steps[2].specialistKey).toBe('promo-planning');
+  });
+
+  it('STEPS_RECONCILED never regresses a terminal rendered step', () => {
+    const hydrated = planReducer(initialPlanState, {
+      type: 'PLAN_STARTED',
+      planId: 'p1',
+      request: 'q',
+    });
+    const withDetail = planReducer(hydrated, {
+      type: 'PLAN_HYDRATED',
+      detail: detail('p1', [
+        { index: 0, status: 'completed' },
+      ]),
+    });
+    // Simulate a stale delta the endpoint should never send but the merge
+    // must still be safe against — a 'pending' record for a step the
+    // rendered state already saw complete.
+    const reconciled = planReducer(withDetail, {
+      type: 'STEPS_RECONCILED',
+      planId: 'p1',
+      steps: [
+        {
+          stepId: 'p1-0',
+          planId: 'p1',
+          stepIndex: 0,
+          specialistKey: 'demand-forecasting',
+          intent: 'demand',
+          action: 'run step 0',
+          status: 'pending',
+        },
+      ],
+    });
+    expect(reconciled.active!.steps[0].status).toBe('completed');
+  });
+
+  it('STEPS_RECONCILED refreshes the plan header from the durable snapshot', () => {
+    const hydrated = planReducer(initialPlanState, {
+      type: 'PLAN_STARTED',
+      planId: 'p1',
+      request: 'q',
+    });
+    const withDetail = planReducer(hydrated, {
+      type: 'PLAN_HYDRATED',
+      detail: detail('p1', [{ index: 0, status: 'running' }]),
+    });
+    const originalUpdatedAt = withDetail.active!.updatedAt;
+    const reconciled = planReducer(withDetail, {
+      type: 'STEPS_RECONCILED',
+      planId: 'p1',
+      steps: [],
+      status: 'failed',
+      updatedAt: new Date(9_000_000).toISOString(),
+      failureReason: 'specialist error',
+    });
+    expect(reconciled.active!.status).toBe('failed');
+    expect(reconciled.active!.updatedAt).not.toBe(originalUpdatedAt);
+    expect(reconciled.active!.failureReason).toBe('specialist error');
+    expect(reconciled.active!.finishedAt).toBeGreaterThan(0);
+  });
+
+  it('STEPS_RECONCILED for a foreign planId is a no-op', () => {
+    const hydrated = planReducer(initialPlanState, {
+      type: 'PLAN_STARTED',
+      planId: 'p1',
+      request: 'q',
+    });
+    const before = planReducer(hydrated, {
+      type: 'PLAN_HYDRATED',
+      detail: detail('p1', [{ index: 0, status: 'running' }]),
+    });
+    const after = planReducer(before, {
+      type: 'STEPS_RECONCILED',
+      planId: 'p2',
+      steps: [
+        {
+          stepId: 'p2-0',
+          planId: 'p2',
+          stepIndex: 0,
+          specialistKey: 'demand-forecasting',
+          intent: 'demand',
+          action: 'run step 0',
+          status: 'completed',
+        },
+      ],
+    });
+    expect(after).toBe(before);
+  });
+
   it('history load/error/removal keep the active plan intact', () => {
     const seed = planReducer(initialPlanState, {
       type: 'PLAN_STARTED',

--- a/src/RetailPulse.Web/src/__tests__/reconnectBackoff.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/reconnectBackoff.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeReconnectDelayMs,
+  buildReconnectSchedule,
+  DEFAULT_RECONNECT_BACKOFF,
+} from '../services/reconnectBackoff';
+
+describe('reconnectBackoff.computeReconnectDelayMs', () => {
+  const options = {
+    initialDelayMs: 1_000,
+    maxDelayMs: 10_000,
+    multiplier: 2,
+    maxAttempts: 6,
+  } as const;
+
+  it('grows exponentially from initialDelay by multiplier', () => {
+    expect(computeReconnectDelayMs(0, options)).toBe(1_000);
+    expect(computeReconnectDelayMs(1, options)).toBe(2_000);
+    expect(computeReconnectDelayMs(2, options)).toBe(4_000);
+    expect(computeReconnectDelayMs(3, options)).toBe(8_000);
+  });
+
+  it('caps the delay at maxDelayMs', () => {
+    expect(computeReconnectDelayMs(4, options)).toBe(10_000);
+    expect(computeReconnectDelayMs(5, options)).toBe(10_000);
+  });
+
+  it('returns null once the retry budget is exhausted (terminal transition)', () => {
+    expect(computeReconnectDelayMs(6, options)).toBeNull();
+    expect(computeReconnectDelayMs(7, options)).toBeNull();
+    expect(computeReconnectDelayMs(99, options)).toBeNull();
+  });
+
+  it('rejects negative or non-finite retry counts', () => {
+    expect(() => computeReconnectDelayMs(-1, options)).toThrow(RangeError);
+    expect(() => computeReconnectDelayMs(Number.NaN, options)).toThrow(RangeError);
+    expect(() => computeReconnectDelayMs(Number.POSITIVE_INFINITY, options)).toThrow(RangeError);
+  });
+
+  it('applies deterministic jitter when an RNG is supplied', () => {
+    // rng always returns 0.5 → factor = 1 - jitter/2 + 0.5*jitter = 1
+    const delay = computeReconnectDelayMs(2, {
+      ...options,
+      jitter: 0.4,
+      rng: () => 0.5,
+    });
+    expect(delay).toBe(4_000);
+
+    // rng returns 0 → factor = 1 - jitter/2 = 0.8 for jitter=0.4
+    const low = computeReconnectDelayMs(2, {
+      ...options,
+      jitter: 0.4,
+      rng: () => 0,
+    });
+    expect(low).toBe(3_200);
+  });
+});
+
+describe('reconnectBackoff.buildReconnectSchedule', () => {
+  it('materialises the schedule ending with the terminal null marker', () => {
+    const schedule = buildReconnectSchedule({
+      initialDelayMs: 500,
+      maxDelayMs: 4_000,
+      multiplier: 2,
+      maxAttempts: 4,
+    });
+
+    expect(schedule).toEqual([500, 1_000, 2_000, 4_000, null]);
+  });
+
+  it('DEFAULT_RECONNECT_BACKOFF is bounded and terminates', () => {
+    const schedule = buildReconnectSchedule(DEFAULT_RECONNECT_BACKOFF);
+    // Must terminate with null → prevents infinite reconnect loops.
+    expect(schedule[schedule.length - 1]).toBeNull();
+    // Every non-null entry is <= maxDelayMs.
+    for (const entry of schedule) {
+      if (entry === null) continue;
+      expect(entry).toBeLessThanOrEqual(DEFAULT_RECONNECT_BACKOFF.maxDelayMs);
+      expect(entry).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/telemetryHub.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/telemetryHub.test.ts
@@ -28,13 +28,21 @@ interface StubConnection {
   __emit: (event: string, payload?: unknown) => void;
 }
 
-const HubConnectionState = {
-  Disconnected: 0,
-  Connecting: 1,
-  Connected: 2,
-  Reconnecting: 3,
-  Disconnecting: 4,
-} as const;
+// `vi.mock('@microsoft/signalr', ...)` is hoisted above this module-level
+// `const`, so referencing `HubConnectionState` directly on the factory's
+// returned object (below) would hit its temporal dead zone when
+// telemetryHub.ts imports @microsoft/signalr during the hoisted `import`
+// on line ~124. `vi.hoisted` runs alongside the hoisted mocks so the
+// binding exists before the factory evaluates.
+const { HubConnectionState } = vi.hoisted(() => ({
+  HubConnectionState: {
+    Disconnected: 0,
+    Connecting: 1,
+    Connected: 2,
+    Reconnecting: 3,
+    Disconnecting: 4,
+  } as const,
+}));
 
 function createStubConnection(): StubConnection {
   let resolveStart!: () => void;

--- a/src/RetailPulse.Web/src/__tests__/telemetryHub.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/telemetryHub.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock @microsoft/signalr with a controllable stub so we can drive status
+// transitions deterministically without opening a real socket. This is
+// enough to prove the connect-status pipeline, the reconnect-rejoin path,
+// the heartbeat listener, and the terminal transition on onclose.
+type Handler<T = unknown> = (arg?: T) => void;
+
+interface StubConnection {
+  state: number;
+  __handlers: {
+    reconnecting?: Handler<Error>;
+    reconnected?: Handler<string>;
+    close?: Handler<Error>;
+    events: Map<string, Set<Handler<unknown>>>;
+  };
+  __start: { resolve: () => void; reject: (err: Error) => void; promise: Promise<void> };
+  __invokeCalls: Array<[string, ...unknown[]]>;
+  __retryPolicy?: { nextRetryDelayInMilliseconds: (ctx: unknown) => number | null };
+  onreconnecting: (cb: Handler<Error>) => void;
+  onreconnected: (cb: Handler<string>) => void;
+  onclose: (cb: Handler<Error>) => void;
+  on: (event: string, cb: Handler<unknown>) => void;
+  off: (event: string, cb?: Handler<unknown>) => void;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  invoke: (name: string, ...args: unknown[]) => Promise<void>;
+  __emit: (event: string, payload?: unknown) => void;
+}
+
+const HubConnectionState = {
+  Disconnected: 0,
+  Connecting: 1,
+  Connected: 2,
+  Reconnecting: 3,
+  Disconnecting: 4,
+} as const;
+
+function createStubConnection(): StubConnection {
+  let resolveStart!: () => void;
+  let rejectStart!: (err: Error) => void;
+  const startPromise = new Promise<void>((resolve, reject) => {
+    resolveStart = resolve;
+    rejectStart = reject;
+  });
+
+  const events = new Map<string, Set<Handler<unknown>>>();
+  const invokeCalls: Array<[string, ...unknown[]]> = [];
+
+  const conn: StubConnection = {
+    state: HubConnectionState.Disconnected,
+    __handlers: { events },
+    __start: { resolve: resolveStart, reject: rejectStart, promise: startPromise },
+    __invokeCalls: invokeCalls,
+    onreconnecting(cb) {
+      conn.__handlers.reconnecting = cb as Handler<Error>;
+    },
+    onreconnected(cb) {
+      conn.__handlers.reconnected = cb as Handler<string>;
+    },
+    onclose(cb) {
+      conn.__handlers.close = cb as Handler<Error>;
+    },
+    on(event, cb) {
+      let set = events.get(event);
+      if (!set) {
+        set = new Set();
+        events.set(event, set);
+      }
+      set.add(cb);
+    },
+    off(event, cb) {
+      if (!cb) {
+        events.delete(event);
+        return;
+      }
+      events.get(event)?.delete(cb);
+    },
+    async start() {
+      conn.state = HubConnectionState.Connected;
+      return startPromise;
+    },
+    async stop() {
+      conn.state = HubConnectionState.Disconnected;
+    },
+    async invoke(name, ...args) {
+      invokeCalls.push([name, ...args]);
+    },
+    __emit(event, payload) {
+      const set = events.get(event);
+      if (!set) return;
+      set.forEach((cb) => cb(payload));
+    },
+  };
+
+  return conn;
+}
+
+let currentStub: StubConnection | null = null;
+
+vi.mock('@microsoft/signalr', () => {
+  class HubConnectionBuilder {
+    private policy?: { nextRetryDelayInMilliseconds: (ctx: unknown) => number | null };
+    withUrl() { return this; }
+    withAutomaticReconnect(policy?: { nextRetryDelayInMilliseconds: (ctx: unknown) => number | null }) {
+      this.policy = policy;
+      return this;
+    }
+    build() {
+      const conn = createStubConnection();
+      conn.__retryPolicy = this.policy;
+      currentStub = conn;
+      return conn;
+    }
+  }
+
+  return {
+    HubConnectionBuilder,
+    HubConnectionState,
+  };
+});
+
+// Import AFTER vi.mock so telemetryHub picks up the stub.
+import {
+  connectTelemetryHub,
+  joinTelemetrySession,
+  disconnectTelemetryHub,
+  onHubConnectionStatus,
+  onHubHeartbeat,
+  getHubConnectionStatus,
+  __resetTelemetryHubForTests,
+  type HubConnectionStatus,
+} from '../services/telemetryHub';
+import { DEFAULT_RECONNECT_BACKOFF } from '../services/reconnectBackoff';
+
+function waitForStart(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('telemetryHub status + reconnect wiring (issue #92)', () => {
+  beforeEach(() => {
+    currentStub = null;
+    __resetTelemetryHubForTests();
+  });
+
+  afterEach(async () => {
+    await disconnectTelemetryHub();
+    __resetTelemetryHubForTests();
+  });
+
+  it('emits connecting → connected transitions to subscribers', async () => {
+    const seen: HubConnectionStatus[] = [];
+    onHubConnectionStatus((s) => { seen.push(s); });
+
+    connectTelemetryHub(() => {}, undefined, undefined);
+    // Resolve the pending start promise so the .then() branch fires.
+    currentStub!.__start.resolve();
+    await waitForStart();
+
+    // Subscribers see the initial disconnected value (from before connect),
+    // then connecting, then connected.
+    expect(seen).toContain('connecting');
+    expect(seen[seen.length - 1]).toBe('connected');
+    expect(getHubConnectionStatus()).toBe('connected');
+  });
+
+  it('installs an IRetryPolicy backed by the default backoff schedule', () => {
+    connectTelemetryHub(() => {});
+    expect(currentStub?.__retryPolicy).toBeDefined();
+
+    const policy = currentStub!.__retryPolicy!;
+    expect(policy.nextRetryDelayInMilliseconds({ previousRetryCount: 0, elapsedMilliseconds: 0, retryReason: new Error() })).toBe(DEFAULT_RECONNECT_BACKOFF.initialDelayMs);
+    // Retry budget must be terminal at maxAttempts.
+    expect(policy.nextRetryDelayInMilliseconds({
+      previousRetryCount: DEFAULT_RECONNECT_BACKOFF.maxAttempts,
+      elapsedMilliseconds: 0,
+      retryReason: new Error(),
+    })).toBeNull();
+  });
+
+  it('surfaces reconnecting → connected and re-joins active sessions after reconnect', async () => {
+    const seen: HubConnectionStatus[] = [];
+    onHubConnectionStatus((s) => { seen.push(s); });
+
+    connectTelemetryHub(() => {});
+    currentStub!.__start.resolve();
+    await waitForStart();
+
+    await joinTelemetrySession('sess-mine');
+    expect(currentStub!.__invokeCalls.find(c => c[0] === 'JoinSession' && c[1] === 'sess-mine')).toBeDefined();
+
+    // Clear invoke history and drive a reconnect cycle.
+    currentStub!.__invokeCalls.length = 0;
+    currentStub!.__handlers.reconnecting?.(new Error('transport dropped'));
+    currentStub!.__handlers.reconnected?.('new-connection-id');
+
+    expect(seen).toContain('reconnecting');
+    expect(seen[seen.length - 1]).toBe('connected');
+
+    // The rejoin MUST use only the client-tracked session id, not anything
+    // provided by server payloads (the reconnected callback receives a
+    // connection id string, which we deliberately ignore).
+    const rejoinCalls = currentStub!.__invokeCalls.filter(c => c[0] === 'JoinSession');
+    expect(rejoinCalls).toEqual([['JoinSession', 'sess-mine']]);
+  });
+
+  it('transitions to the terminal disconnected state when the connection closes', async () => {
+    const seen: HubConnectionStatus[] = [];
+    onHubConnectionStatus((s) => { seen.push(s); });
+
+    connectTelemetryHub(() => {});
+    currentStub!.__start.resolve();
+    await waitForStart();
+
+    currentStub!.__handlers.close?.(new Error('retry budget exhausted'));
+
+    expect(seen[seen.length - 1]).toBe('disconnected');
+    expect(getHubConnectionStatus()).toBe('disconnected');
+  });
+
+  it('delivers heartbeat events to subscribers', async () => {
+    const heartbeats: unknown[] = [];
+    onHubHeartbeat((e) => { heartbeats.push(e); });
+
+    connectTelemetryHub(() => {});
+    currentStub!.__start.resolve();
+    await waitForStart();
+
+    currentStub!.__emit('heartbeat', { timestamp: '2026-08-20T00:00:00Z', intervalMs: 15000 });
+    currentStub!.__emit('heartbeat', { timestamp: '2026-08-20T00:00:15Z', intervalMs: 15000 });
+
+    expect(heartbeats).toHaveLength(2);
+    expect(heartbeats[0]).toMatchObject({ intervalMs: 15000 });
+  });
+
+  it('ignores duplicate joinTelemetrySession calls for the same id', async () => {
+    connectTelemetryHub(() => {});
+    currentStub!.__start.resolve();
+    await waitForStart();
+
+    await joinTelemetrySession('sess-dup');
+    await joinTelemetrySession('sess-dup');
+    await joinTelemetrySession('sess-dup');
+
+    const joinCalls = currentStub!.__invokeCalls.filter(c => c[0] === 'JoinSession' && c[1] === 'sess-dup');
+    expect(joinCalls).toHaveLength(1);
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/telemetryHub.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/telemetryHub.test.ts
@@ -90,6 +90,13 @@ function createStubConnection(): StubConnection {
     },
     async stop() {
       conn.state = HubConnectionState.Disconnected;
+      // If a test never explicitly resolved __start, reject the pending
+      // start now so the `connection.start().then(...).catch(...)` chain
+      // inside connectTelemetryHub settles. Otherwise
+      // disconnectTelemetryHub awaits a promise that never resolves and
+      // hangs the afterEach hook until vitest's 10s hook timeout fires,
+      // which is then reported against the next test's beforeEach.
+      rejectStart(new Error('stub connection stopped before start settled'));
     },
     async invoke(name, ...args) {
       invokeCalls.push([name, ...args]);
@@ -152,8 +159,23 @@ describe('telemetryHub status + reconnect wiring (issue #92)', () => {
   });
 
   afterEach(async () => {
-    await disconnectTelemetryHub();
-    __resetTelemetryHubForTests();
+    // Deterministic cleanup: any test that called connectTelemetryHub but
+    // never resolved the stub's start promise would leave the chained
+    // module-level startPromise pending. disconnectTelemetryHub awaits
+    // that startPromise before calling stop(), so a pending stub start
+    // would hang the hook until the 10s hook timeout fires and get
+    // reported against the NEXT test's beforeEach. Resolving the pending
+    // start here settles the chain synchronously in the microtask queue.
+    currentStub?.__start.resolve();
+    try {
+      await disconnectTelemetryHub();
+    } finally {
+      __resetTelemetryHubForTests();
+      // Guarantee real timers regardless of whether any test in this
+      // file (now or later) turned on fake timers and threw before
+      // restoring them. Cheap when timers are already real.
+      vi.useRealTimers();
+    }
   });
 
   it('emits connecting → connected transitions to subscribers', async () => {
@@ -172,8 +194,13 @@ describe('telemetryHub status + reconnect wiring (issue #92)', () => {
     expect(getHubConnectionStatus()).toBe('connected');
   });
 
-  it('installs an IRetryPolicy backed by the default backoff schedule', () => {
+  it('installs an IRetryPolicy backed by the default backoff schedule', async () => {
     connectTelemetryHub(() => {});
+    // Match the lifecycle used by every other test in this file so the
+    // module-level startPromise chained inside connectTelemetryHub
+    // settles and afterEach can tear down cleanly.
+    currentStub!.__start.resolve();
+    await waitForStart();
     expect(currentStub?.__retryPolicy).toBeDefined();
 
     const policy = currentStub!.__retryPolicy!;

--- a/src/RetailPulse.Web/src/__tests__/usePlanController.reconnectReconcile.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/usePlanController.reconnectReconcile.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+// Issue #92 integration: on a hub reconnect (connection.connected transitions
+// false -> true) while a plan is still running, the controller must call
+// reconcilePlan with the highest KNOWN-terminal stepIndex, merge without
+// duplicates or regressed terminal steps, and refresh the plan header from
+// the durable snapshot.
+
+const fetchPlanDetailMock = vi.fn();
+const fetchPlanReviewsMock = vi.fn();
+const decidePlanReviewMock = vi.fn();
+const answerPlanClarificationMock = vi.fn();
+const deletePlanMock = vi.fn();
+const fetchPlansMock = vi.fn();
+const reconcilePlanMock = vi.fn();
+
+vi.mock('../services/planApi', () => ({
+  answerPlanClarification: (...args: unknown[]) => answerPlanClarificationMock(...args),
+  fetchPlanDetail: (...args: unknown[]) => fetchPlanDetailMock(...args),
+  fetchPlanReviews: (...args: unknown[]) => fetchPlanReviewsMock(...args),
+  decidePlanReview: (...args: unknown[]) => decidePlanReviewMock(...args),
+  deletePlan: (...args: unknown[]) => deletePlanMock(...args),
+  fetchPlans: (...args: unknown[]) => fetchPlansMock(...args),
+  parseClarificationPrompt: () => null,
+  parseReviewProposal: () => null,
+}));
+
+vi.mock('../services/executionControlApi', () => ({
+  reconcilePlan: (...args: unknown[]) => reconcilePlanMock(...args),
+}));
+
+import { usePlanController, type PlanControllerConnection } from '../state/usePlanController';
+
+function makeConnection(initialConnected: boolean): PlanControllerConnection {
+  return {
+    connected: initialConnected,
+    on: () => () => {},
+  };
+}
+
+function stepRecord(index: number, status: string, extra: Record<string, unknown> = {}) {
+  return {
+    stepId: `p1-${index}`,
+    planId: 'p1',
+    stepIndex: index,
+    specialistKey: 'demand-forecasting',
+    intent: 'demand',
+    action: `run step ${index}`,
+    status,
+    ...extra,
+  };
+}
+
+function hydratedDetail(steps: Array<{ index: number; status: string }>) {
+  return {
+    planId: 'p1',
+    sessionId: 'sess-1',
+    tenantId: null,
+    request: 'q',
+    status: 'running',
+    detectedIntents: ['demand'],
+    failureReason: null,
+    totalInputTokens: null,
+    totalOutputTokens: null,
+    totalTokens: null,
+    totalDurationMs: null,
+    createdAt: new Date(1_000_000).toISOString(),
+    updatedAt: new Date(1_500_000).toISOString(),
+    steps: steps.map(s => ({
+      stepId: `p1-${s.index}`,
+      planId: 'p1',
+      stepIndex: s.index,
+      specialistKey: 'demand-forecasting',
+      intent: 'demand',
+      action: `run step ${s.index}`,
+      status: s.status,
+    })),
+  };
+}
+
+describe('usePlanController reconcile-on-reconnect (issue #92)', () => {
+  beforeEach(() => {
+    fetchPlanDetailMock.mockReset();
+    reconcilePlanMock.mockReset();
+  });
+
+  it('does NOT reconcile on the first-mount connect (no prior drop)', async () => {
+    fetchPlanDetailMock.mockResolvedValue(hydratedDetail([{ index: 0, status: 'running' }]));
+
+    const connection = makeConnection(true);
+    const { result } = renderHook(() => usePlanController({ connection }));
+    await act(async () => {
+      await result.current.startPlan({ planId: 'p1', sessionId: 'sess-1', request: 'q' });
+    });
+
+    expect(reconcilePlanMock).not.toHaveBeenCalled();
+  });
+
+  it('calls reconcilePlan on the false -> true edge with the max terminal stepIndex', async () => {
+    fetchPlanDetailMock.mockResolvedValue(hydratedDetail([
+      { index: 0, status: 'completed' },
+      { index: 1, status: 'running' },
+    ]));
+    reconcilePlanMock.mockResolvedValue({
+      planId: 'p1',
+      sessionId: 'sess-1',
+      status: 'running',
+      failureReason: null,
+      updatedAt: new Date(2_500_000).toISOString(),
+      totalStepCount: 3,
+      afterStepIndex: 0,
+      steps: [stepRecord(1, 'completed', { durationMs: 1200 }), stepRecord(2, 'running')],
+    });
+
+    const connection = makeConnection(true);
+    const { result, rerender } = renderHook(
+      ({ conn }: { conn: PlanControllerConnection }) => usePlanController({ connection: conn }),
+      { initialProps: { conn: connection } },
+    );
+    await act(async () => {
+      await result.current.startPlan({ planId: 'p1', sessionId: 'sess-1', request: 'q' });
+    });
+
+    rerender({ conn: makeConnection(false) });
+    rerender({ conn: makeConnection(true) });
+
+    await waitFor(() => {
+      expect(reconcilePlanMock).toHaveBeenCalledTimes(1);
+    });
+    expect(reconcilePlanMock).toHaveBeenCalledWith('p1', { afterStepIndex: 0 });
+
+    await waitFor(() => {
+      const steps = result.current.active!.steps;
+      expect(steps.map(s => s.stepIndex)).toEqual([0, 1, 2]);
+      expect(steps[1].status).toBe('completed');
+      expect(steps[1].durationMs).toBe(1200);
+      expect(steps[2].status).toBe('running');
+    });
+  });
+
+  it('never regresses a terminal rendered step even if the endpoint reports a lower status', async () => {
+    fetchPlanDetailMock.mockResolvedValue(hydratedDetail([
+      { index: 0, status: 'completed' },
+    ]));
+    reconcilePlanMock.mockResolvedValue({
+      planId: 'p1',
+      sessionId: 'sess-1',
+      status: 'running',
+      failureReason: null,
+      updatedAt: new Date(2_500_000).toISOString(),
+      totalStepCount: 1,
+      afterStepIndex: 0,
+      steps: [stepRecord(0, 'pending')],
+    });
+
+    const connection = makeConnection(true);
+    const { result, rerender } = renderHook(
+      ({ conn }: { conn: PlanControllerConnection }) => usePlanController({ connection: conn }),
+      { initialProps: { conn: connection } },
+    );
+    await act(async () => {
+      await result.current.startPlan({ planId: 'p1', sessionId: 'sess-1', request: 'q' });
+    });
+
+    rerender({ conn: makeConnection(false) });
+    rerender({ conn: makeConnection(true) });
+
+    await waitFor(() => {
+      expect(result.current.active!.steps[0].status).toBe('completed');
+    });
+  });
+
+  it('does NOT reconcile when the active plan is already in a terminal state', async () => {
+    fetchPlanDetailMock.mockResolvedValue({
+      ...hydratedDetail([{ index: 0, status: 'completed' }]),
+      status: 'completed',
+    });
+
+    const connection = makeConnection(true);
+    const { result, rerender } = renderHook(
+      ({ conn }: { conn: PlanControllerConnection }) => usePlanController({ connection: conn }),
+      { initialProps: { conn: connection } },
+    );
+    await act(async () => {
+      await result.current.startPlan({ planId: 'p1', sessionId: 'sess-1', request: 'q' });
+    });
+
+    rerender({ conn: makeConnection(false) });
+    rerender({ conn: makeConnection(true) });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(reconcilePlanMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/RetailPulse.Web/src/components/ChatPanel.tsx
+++ b/src/RetailPulse.Web/src/components/ChatPanel.tsx
@@ -16,7 +16,7 @@ import type { AgentSpan, ChatHistoryMessage, ChartSpec, RoutingInfo, TokenUsage,
 import type { SendMessageOptions } from '../services/api';
 import { sendMessage, isErrorReply, isChatRequestTimeoutError } from '../services/api';
 import { joinTelemetrySession, onProgress } from '../services/telemetryHub';
-import { cancelChatSession } from '../services/executionControlApi';
+import { cancelChatSession, cancelPlan } from '../services/executionControlApi';
 import { useConnectionStatus } from '../hooks/useConnectionStatus';
 import { ConnectionStatusIndicator } from './ConnectionStatusIndicator';
 import { TimeoutDialog } from './TimeoutDialog';
@@ -36,6 +36,7 @@ import { PROMPT_CATEGORIES } from '../constants/prompts';
 import { sanitizeMessage } from '../utils';
 import { PlanView } from './plan';
 import type { PlanController } from '../state/usePlanController';
+import { isPlanRunning } from '../state/planReducer';
 
 const ChartRenderer = lazy(() => import('./ChartRenderer'));
 
@@ -687,7 +688,19 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved, p
     // Fire-and-forget: the local abort has already resolved the UI. A
     // 404 (nothing to cancel) is expected on the race where the run just
     // completed on the server; we don't surface it as an error.
-    cancelChatSession(sessionId).catch((err) => {
+    // Prefer the plan-scoped cancel when the current turn is a running
+    // plan (#96 populated planController.active with a real planId).
+    // Falls back to the session-scoped cancel for the fast/single-shot
+    // path and for anonymous callers who cannot own a plan.
+    const activePlan = planController?.active;
+    const usePlanCancel =
+      activePlan != null &&
+      activePlan.planId.length > 0 &&
+      isPlanRunning(activePlan.status);
+    const cancelPromise = usePlanCancel
+      ? cancelPlan(activePlan.planId)
+      : cancelChatSession(sessionId);
+    cancelPromise.catch((err) => {
       if (import.meta.env.DEV) console.error('Server-side cancel failed:', err);
     });
     if (isMountedRef.current) {
@@ -697,7 +710,7 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved, p
         { role: 'assistant', content: 'Cancelled.' },
       ]);
     }
-  }, [loading, sessionId]);
+  }, [loading, sessionId, planController]);
 
   const handleTimeoutRetry = useCallback(() => {
     const prompt = timeoutInfo?.prompt ?? lastPromptRef.current;

--- a/src/RetailPulse.Web/src/components/ChatPanel.tsx
+++ b/src/RetailPulse.Web/src/components/ChatPanel.tsx
@@ -14,8 +14,12 @@ import {
 import { Send24Regular, ChevronRight16Regular } from '@fluentui/react-icons';
 import type { AgentSpan, ChatHistoryMessage, ChartSpec, RoutingInfo, TokenUsage, MemoryContext, ApprovalRequest, ApprovalDecision, CacheInfo, ForceableExecutionPath } from '../types';
 import type { SendMessageOptions } from '../services/api';
-import { sendMessage, isErrorReply } from '../services/api';
+import { sendMessage, isErrorReply, isChatRequestTimeoutError } from '../services/api';
 import { joinTelemetrySession, onProgress } from '../services/telemetryHub';
+import { cancelChatSession } from '../services/executionControlApi';
+import { useConnectionStatus } from '../hooks/useConnectionStatus';
+import { ConnectionStatusIndicator } from './ConnectionStatusIndicator';
+import { TimeoutDialog } from './TimeoutDialog';
 import { activeAuthMode } from '../auth/activeProvider';
 import { BrandLogo } from './BrandLogo';
 import { AgentRoutingIndicator } from './AgentRoutingIndicator';
@@ -461,6 +465,19 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved, p
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const styles = useChatStyles();
 
+  // Real-time channel status surfaced next to the composer so a dropped
+  // hub is visible where the user actually types, not buried in a drawer.
+  const { status: hubStatus, stalled: hubStalled } = useConnectionStatus();
+
+  // Timeout dialog state (issue #92). Populated when sendMessage throws
+  // ChatRequestTimeoutError so the user can Retry or Abandon instead of
+  // staring at a spinner that will never resolve.
+  const [timeoutInfo, setTimeoutInfo] = useState<{ prompt: string; timeoutMs: number } | null>(null);
+
+  // Retains the most recent user prompt so the timeout dialog's Retry
+  // button can replay the same request without asking the user to retype.
+  const lastPromptRef = useRef<string | null>(null);
+
   // Track mounted state and abort in-flight requests on unmount so async work
   // doesn't call setState on a torn-down component (e.g. when Dashboard
   // increments chatKey to start a "New Chat").
@@ -521,6 +538,9 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved, p
       abortControllerRef.current?.abort();
       const controller = new AbortController();
       abortControllerRef.current = controller;
+
+      lastPromptRef.current = trimmed;
+      setTimeoutInfo(null);
 
       setMessages(prev => [...prev, { role: 'user', content: trimmed }]);
       onResponseReceivedRef.current?.({ totalDurationMs: undefined });
@@ -636,6 +656,12 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved, p
       } catch (err) {
         if (!isMountedRef.current || controller.signal.aborted) return;
         if (err instanceof DOMException && err.name === 'AbortError') return;
+        if (isChatRequestTimeoutError(err)) {
+          // Replace the hung-spinner behavior with a decision dialog. Do NOT
+          // append an error bubble — the dialog is the visible feedback.
+          setTimeoutInfo({ prompt: trimmed, timeoutMs: err.timeoutMs });
+          return;
+        }
         setMessages(prev => [
           ...prev,
           { role: 'assistant', content: `Error: ${err instanceof Error ? err.message : 'Unknown error'}` },
@@ -649,6 +675,48 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved, p
     },
     [sessionId, forcePath, supportsExecutionPathOverride, planController],
   );
+
+  // User-initiated cancel while a run is in flight (issue #92). Aborts the
+  // local fetch so the UI clears immediately, then asks the server to end
+  // the run so tools stop consuming budget. Server response is treated as
+  // fire-and-forget — the local abort already gave the user their signal.
+  const handleCancel = useCallback(() => {
+    if (!loading) return;
+    const controller = abortControllerRef.current;
+    controller?.abort();
+    // Fire-and-forget: the local abort has already resolved the UI. A
+    // 404 (nothing to cancel) is expected on the race where the run just
+    // completed on the server; we don't surface it as an error.
+    cancelChatSession(sessionId).catch((err) => {
+      if (import.meta.env.DEV) console.error('Server-side cancel failed:', err);
+    });
+    if (isMountedRef.current) {
+      setLoading(false);
+      setMessages(prev => [
+        ...prev,
+        { role: 'assistant', content: 'Cancelled.' },
+      ]);
+    }
+  }, [loading, sessionId]);
+
+  const handleTimeoutRetry = useCallback(() => {
+    const prompt = timeoutInfo?.prompt ?? lastPromptRef.current;
+    setTimeoutInfo(null);
+    if (prompt) {
+      void sendChatMessage(prompt);
+    }
+  }, [timeoutInfo, sendChatMessage]);
+
+  const handleTimeoutAbandon = useCallback(() => {
+    setTimeoutInfo(null);
+    // Ensure any lingering abort controller is released so the UI is
+    // fully editable again.
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    if (isMountedRef.current) {
+      setLoading(false);
+    }
+  }, []);
 
   const handleSend = useCallback(async () => {
     if (!input.trim() || loading) return;
@@ -858,6 +926,7 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved, p
         <label htmlFor="chat-input" className="visually-hidden">
           Ask about retail performance
         </label>
+        <ConnectionStatusIndicator status={hubStatus} stalled={hubStalled} />
         <PromptLibrary
           categories={PROMPT_CATEGORIES}
           onSelect={handleSuggestedClick}
@@ -899,17 +968,34 @@ export function ChatPanel({ onResponseReceived, approvals, onApprovalResolved, p
           disabled={loading}
           style={FLEX_ONE_STYLE}
         />
-        <Button
-          appearance="primary"
-          icon={<Send24Regular style={{ color: '#ffffff' }} />}
-          onClick={handleSend}
-          disabled={loading || !input.trim()}
-          aria-label="Send message"
-          style={SEND_BUTTON_STYLE}
-        >
-          Send
-        </Button>
+        {loading ? (
+          <Button
+            appearance="secondary"
+            onClick={handleCancel}
+            aria-label="Cancel in-flight request"
+            data-testid="chat-cancel-button"
+          >
+            Cancel
+          </Button>
+        ) : (
+          <Button
+            appearance="primary"
+            icon={<Send24Regular style={{ color: '#ffffff' }} />}
+            onClick={handleSend}
+            disabled={!input.trim()}
+            aria-label="Send message"
+            style={SEND_BUTTON_STYLE}
+          >
+            Send
+          </Button>
+        )}
       </div>
+      <TimeoutDialog
+        open={timeoutInfo !== null}
+        timeoutMs={timeoutInfo?.timeoutMs ?? 0}
+        onRetry={handleTimeoutRetry}
+        onAbandon={handleTimeoutAbandon}
+      />
     </div>
   );
 }

--- a/src/RetailPulse.Web/src/components/ConnectionStatusIndicator.tsx
+++ b/src/RetailPulse.Web/src/components/ConnectionStatusIndicator.tsx
@@ -1,0 +1,80 @@
+import { Badge, makeStyles } from '@fluentui/react-components';
+import type { HubConnectionStatus } from '../services/telemetryHub';
+
+/**
+ * Compact "connected / reconnecting / disconnected" pill used inline in the
+ * chat composer so a dropped real-time channel is visible next to the
+ * message the user is about to send, not buried in a drawer (issue #92).
+ *
+ * A subtle "stalled" state (SignalR still reports Connected but no
+ * application-level heartbeat in `staleAfterMs`) renders the same
+ * "reconnecting" label so we degrade gracefully in front of intermediaries
+ * that swallow frames.
+ */
+export interface ConnectionStatusIndicatorProps {
+  readonly status: HubConnectionStatus;
+  readonly stalled?: boolean;
+  /** Optional className override for layout tweaks by the parent. */
+  readonly className?: string;
+}
+
+type PresentedState = 'connected' | 'reconnecting' | 'disconnected' | 'connecting';
+
+function presentedState(status: HubConnectionStatus, stalled: boolean | undefined): PresentedState {
+  if (status === 'connected' && stalled) return 'reconnecting';
+  return status;
+}
+
+const useStyles = makeStyles({
+  wrapper: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '4px',
+    flexShrink: 0,
+  },
+});
+
+const LABELS: Readonly<Record<PresentedState, string>> = {
+  connected: 'Live',
+  connecting: 'Connecting…',
+  reconnecting: 'Reconnecting…',
+  disconnected: 'Disconnected',
+};
+
+const ICONS: Readonly<Record<PresentedState, string>> = {
+  connected: '🟢',
+  connecting: '🟡',
+  reconnecting: '🟡',
+  disconnected: '🔴',
+};
+
+const COLORS: Readonly<Record<PresentedState, 'success' | 'warning' | 'danger'>> = {
+  connected: 'success',
+  connecting: 'warning',
+  reconnecting: 'warning',
+  disconnected: 'danger',
+};
+
+export function ConnectionStatusIndicator({
+  status,
+  stalled,
+  className,
+}: ConnectionStatusIndicatorProps) {
+  const styles = useStyles();
+  const presented = presentedState(status, stalled);
+  return (
+    <span
+      className={className ? `${styles.wrapper} ${className}` : styles.wrapper}
+      data-testid="connection-status-indicator"
+      data-status={presented}
+      role="status"
+      aria-live="polite"
+      aria-label={`Real-time channel: ${LABELS[presented]}`}
+      title={LABELS[presented]}
+    >
+      <Badge appearance="filled" color={COLORS[presented]} size="small">
+        <span aria-hidden="true">{ICONS[presented]}</span>&nbsp;{LABELS[presented]}
+      </Badge>
+    </span>
+  );
+}

--- a/src/RetailPulse.Web/src/components/TimeoutDialog.tsx
+++ b/src/RetailPulse.Web/src/components/TimeoutDialog.tsx
@@ -1,0 +1,84 @@
+import {
+  Dialog,
+  DialogSurface,
+  DialogBody,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  makeStyles,
+} from '@fluentui/react-components';
+
+/**
+ * Replacement for the "hung spinner" behavior when a chat request exceeds
+ * the frontend timeout (issue #92). Users get a clear choice: retry the
+ * same prompt (creates a fresh request) or abandon the run entirely so
+ * the UI returns to an editable state without a stale in-flight banner.
+ */
+export interface TimeoutDialogProps {
+  readonly open: boolean;
+  readonly timeoutMs: number;
+  readonly onRetry: () => void;
+  readonly onAbandon: () => void;
+}
+
+const useStyles = makeStyles({
+  bodyText: {
+    fontSize: '14px',
+    lineHeight: '1.5',
+    color: 'var(--color-text)',
+  },
+  hint: {
+    fontSize: '13px',
+    color: 'var(--color-text-muted)',
+    marginTop: '8px',
+  },
+});
+
+export function TimeoutDialog({ open, timeoutMs, onRetry, onAbandon }: TimeoutDialogProps) {
+  const styles = useStyles();
+  const seconds = Math.max(1, Math.round(timeoutMs / 1000));
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(_e, data) => {
+        if (!data.open) onAbandon();
+      }}
+      modalType="alert"
+    >
+      <DialogSurface data-testid="timeout-dialog">
+        <DialogBody>
+          <DialogTitle>This is taking longer than expected</DialogTitle>
+          <DialogContent>
+            <div className={styles.bodyText}>
+              We didn&apos;t hear back from Retail Pulse within {seconds}&nbsp;seconds. The
+              server may still be working, but the browser has stopped waiting so you
+              can decide what to do next.
+            </div>
+            <div className={styles.hint}>
+              <strong>Retry</strong> sends the same question again. <strong>Abandon</strong> clears
+              the in-flight indicator and lets you edit or try a different prompt.
+            </div>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              appearance="secondary"
+              onClick={onAbandon}
+              data-testid="timeout-dialog-abandon"
+            >
+              Abandon
+            </Button>
+            <Button
+              appearance="primary"
+              onClick={onRetry}
+              data-testid="timeout-dialog-retry"
+            >
+              Retry
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+}

--- a/src/RetailPulse.Web/src/hooks/useConnectionStatus.ts
+++ b/src/RetailPulse.Web/src/hooks/useConnectionStatus.ts
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import {
+  getHubConnectionStatus,
+  onHubConnectionStatus,
+  onHubHeartbeat,
+  type HubConnectionStatus,
+} from '../services/telemetryHub';
+
+export interface ConnectionStatusState {
+  readonly status: HubConnectionStatus;
+  /**
+   * True when SignalR reports "connected" but we have not observed an
+   * application-level heartbeat within `staleAfterMs`. This flags a hub
+   * that's technically alive but silent (e.g. an intermediary swallowing
+   * frames) so the UI can render "Reconnecting…" instead of a stale
+   * "Connected" badge.
+   */
+  readonly stalled: boolean;
+}
+
+export interface UseConnectionStatusOptions {
+  /**
+   * Milliseconds of heartbeat silence tolerated before we flag the channel
+   * as stalled. Defaults to `2 × ApplicationHeartbeatInterval` — matches
+   * the backend's 15s cadence, so 30s of silence trips the stalled flag.
+   */
+  readonly staleAfterMs?: number;
+}
+
+const DEFAULT_STALE_AFTER_MS = 30_000;
+
+/**
+ * Subscribes to the telemetry hub's connection-status transitions plus its
+ * application-level heartbeat. Returns a stable `{ status, stalled }` pair
+ * a component can render as a "connected / reconnecting / disconnected"
+ * badge (issue #92).
+ */
+export function useConnectionStatus(
+  options: UseConnectionStatusOptions = {},
+): ConnectionStatusState {
+  const staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+
+  const [status, setStatus] = useState<HubConnectionStatus>(() => getHubConnectionStatus());
+  const [stalled, setStalled] = useState(false);
+
+  useEffect(() => {
+    const off = onHubConnectionStatus((next) => {
+      setStatus(next);
+      if (next !== 'connected') {
+        // Only "connected" can be stalled; other states already surface a
+        // non-live indicator, so clear the stalled flag to avoid a
+        // "reconnecting + stalled" double-signal.
+        setStalled(false);
+      }
+    });
+    return off;
+  }, []);
+
+  useEffect(() => {
+    if (staleAfterMs <= 0) return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const arm = () => {
+      if (cancelled) return;
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(() => {
+        if (!cancelled && getHubConnectionStatus() === 'connected') {
+          setStalled(true);
+        }
+      }, staleAfterMs);
+    };
+
+    const offHeartbeat = onHubHeartbeat(() => {
+      if (cancelled) return;
+      setStalled(false);
+      arm();
+    });
+
+    // Arm the initial stall detector so a connection that never emits a
+    // heartbeat eventually flags itself.
+    arm();
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+      offHeartbeat();
+    };
+  }, [staleAfterMs]);
+
+  return { status, stalled };
+}

--- a/src/RetailPulse.Web/src/services/api.ts
+++ b/src/RetailPulse.Web/src/services/api.ts
@@ -120,6 +120,24 @@ export interface SendMessageOptions {
 const DEFAULT_TIMEOUT_MS = 180_000;
 
 /**
+ * Thrown when the frontend request timer trips before the server responds.
+ * Distinct from a generic network error so the UI can raise a dedicated
+ * retry-or-abandon dialog (issue #92) instead of showing a stuck spinner.
+ */
+export class ChatRequestTimeoutError extends Error {
+  readonly name = 'ChatRequestTimeoutError';
+  readonly timeoutMs: number;
+  constructor(timeoutMs: number) {
+    super(`Request timed out after ${Math.round(timeoutMs / 1000)}s. The server may be busy — please try again.`);
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export function isChatRequestTimeoutError(err: unknown): err is ChatRequestTimeoutError {
+  return err instanceof ChatRequestTimeoutError;
+}
+
+/**
  * Combines an optional caller signal with a timeout signal. Returns the
  * combined AbortSignal, a flag we can read to detect a timeout-driven abort,
  * and a cleanup callback that clears the timer.
@@ -175,9 +193,7 @@ export async function sendMessage(
     });
   } catch (err) {
     if (didTimeOut()) {
-      throw new Error(
-        `Request timed out after ${Math.round(timeoutMs / 1000)}s. The server may be busy — please try again.`,
-      );
+      throw new ChatRequestTimeoutError(timeoutMs);
     }
     throw err;
   } finally {

--- a/src/RetailPulse.Web/src/services/executionControlApi.ts
+++ b/src/RetailPulse.Web/src/services/executionControlApi.ts
@@ -77,21 +77,30 @@ export function cancelPlan(
 }
 
 /**
- * Durable plan record returned by `/api/plans/{planId}/reconcile`. Mirrors
- * the shape from `ExecutionControlEndpoints.MapPlanReconciliationEndpoint`.
+ * Durable plan step returned by `/api/plans/{planId}/reconcile`. Field
+ * names mirror the wire shape from `PlanStepRecordDto`
+ * (`RetailPulse.Contracts/Persistence/PlanDtos.cs`) after the ASP.NET
+ * default camelCase serialisation, so the type contract matches what
+ * `res.json()` actually delivers — no phantom UI-only fields that would
+ * silently be `undefined` on read and be overwritten to `undefined` when
+ * a reconciled record replaces a rendered one during merge.
  */
 export interface PlanStepRecord {
+  readonly stepId?: string;
+  readonly planId?: string;
   readonly stepIndex: number;
+  readonly specialistKey?: string | null;
+  readonly intent?: string | null;
+  readonly action?: string | null;
   readonly status: string;
-  readonly summary?: string | null;
-  readonly detail?: string | null;
+  readonly result?: string | null;
+  readonly error?: string | null;
+  readonly inputTokens?: number | null;
+  readonly outputTokens?: number | null;
+  readonly totalTokens?: number | null;
+  readonly durationMs?: number | null;
   readonly startedAt?: string | null;
   readonly completedAt?: string | null;
-  readonly durationMs?: number | null;
-  readonly toolName?: string | null;
-  readonly agentKey?: string | null;
-  readonly tokensIn?: number | null;
-  readonly tokensOut?: number | null;
 }
 
 export interface PlanReconciliationResponse {

--- a/src/RetailPulse.Web/src/services/executionControlApi.ts
+++ b/src/RetailPulse.Web/src/services/executionControlApi.ts
@@ -1,0 +1,170 @@
+import { resolveApiUrl } from '../config/apiOrigin';
+
+/**
+ * User-initiated execution control (issue #92). Wraps the two `cancel`
+ * endpoints and the plan reconciliation endpoint so components never build
+ * fetch payloads by hand.
+ *
+ * All calls go through `resolveApiUrl` (same-origin under Static Web Apps,
+ * direct to the configured ACA origin when `VITE_API_ORIGIN` is set) and
+ * pick up the bearer token via the authorized-fetch interceptor.
+ */
+
+/**
+ * Result of a cancel call so the UI can distinguish "we cancelled it" from
+ * "there was nothing to cancel" — both are non-error outcomes, but the
+ * second one still means the caller's abort took effect locally.
+ */
+export type CancelResult = 'cancelled' | 'not_found' | 'forbidden';
+
+export interface CancelOptions {
+  readonly signal?: AbortSignal;
+}
+
+function encode(segment: string): string {
+  return encodeURIComponent(segment);
+}
+
+async function postCancel(url: string, options: CancelOptions): Promise<CancelResult> {
+  const res = await fetch(url, {
+    method: 'POST',
+    // The endpoint takes no body; still send the content type header so
+    // any intermediary proxy doesn't misclassify the empty POST.
+    headers: { 'Content-Type': 'application/json' },
+    signal: options.signal,
+  });
+
+  if (res.status === 204) return 'cancelled';
+  if (res.status === 404) return 'not_found';
+  if (res.status === 403) return 'forbidden';
+
+  // Any other status is an unexpected server error; surface a plain message so
+  // the caller can decide whether to raise it (e.g. the cancel button UI can
+  // ignore this — the local abort already ran).
+  throw new Error(`Cancel failed with HTTP ${res.status}`);
+}
+
+/**
+ * `POST /api/chat/{sessionId}/cancel` — end the caller's in-flight
+ * fast-path or streaming chat run. A `not_found` result means either the
+ * run has already completed or a foreign session was probed; treat both as
+ * a successful no-op from the UI's perspective.
+ */
+export function cancelChatSession(
+  sessionId: string,
+  options: CancelOptions = {},
+): Promise<CancelResult> {
+  if (!sessionId) {
+    throw new Error('cancelChatSession requires a non-empty sessionId.');
+  }
+  return postCancel(resolveApiUrl(`/api/chat/${encode(sessionId)}/cancel`), options);
+}
+
+/**
+ * `POST /api/plans/{planId}/cancel` — end the caller's in-flight plan
+ * orchestration when we know the planId (plan persistence enabled, plan
+ * path selected). Anonymous callers cannot own a plan; the backend returns
+ * 403 which we surface as `forbidden` so the UI can hide the affordance.
+ */
+export function cancelPlan(
+  planId: string,
+  options: CancelOptions = {},
+): Promise<CancelResult> {
+  if (!planId) {
+    throw new Error('cancelPlan requires a non-empty planId.');
+  }
+  return postCancel(resolveApiUrl(`/api/plans/${encode(planId)}/cancel`), options);
+}
+
+/**
+ * Durable plan record returned by `/api/plans/{planId}/reconcile`. Mirrors
+ * the shape from `ExecutionControlEndpoints.MapPlanReconciliationEndpoint`.
+ */
+export interface PlanStepRecord {
+  readonly stepIndex: number;
+  readonly status: string;
+  readonly summary?: string | null;
+  readonly detail?: string | null;
+  readonly startedAt?: string | null;
+  readonly completedAt?: string | null;
+  readonly durationMs?: number | null;
+  readonly toolName?: string | null;
+  readonly agentKey?: string | null;
+  readonly tokensIn?: number | null;
+  readonly tokensOut?: number | null;
+}
+
+export interface PlanReconciliationResponse {
+  readonly planId: string;
+  readonly sessionId: string;
+  readonly status: string;
+  readonly failureReason?: string | null;
+  readonly updatedAt?: string | null;
+  readonly totalStepCount: number;
+  readonly afterStepIndex: number;
+  readonly steps: readonly PlanStepRecord[];
+}
+
+function isPlanStepRecord(v: unknown): v is PlanStepRecord {
+  if (!v || typeof v !== 'object') return false;
+  const s = v as Record<string, unknown>;
+  return typeof s.stepIndex === 'number' && Number.isFinite(s.stepIndex) &&
+    typeof s.status === 'string';
+}
+
+function isPlanReconciliationResponse(v: unknown): v is PlanReconciliationResponse {
+  if (!v || typeof v !== 'object') return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.planId === 'string' &&
+    typeof r.sessionId === 'string' &&
+    typeof r.status === 'string' &&
+    typeof r.totalStepCount === 'number' &&
+    typeof r.afterStepIndex === 'number' &&
+    Array.isArray(r.steps) &&
+    r.steps.every(isPlanStepRecord)
+  );
+}
+
+export interface ReconcileOptions {
+  readonly afterStepIndex?: number;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * `GET /api/plans/{planId}/reconcile?afterStepIndex=N` — durable plan
+ * status plus any step records whose index exceeds the caller's cursor.
+ * Returns `null` when the plan is unknown or belongs to another subject
+ * (both collapse to 404 server-side, which is expected on cross-tab races).
+ */
+export async function reconcilePlan(
+  planId: string,
+  options: ReconcileOptions = {},
+): Promise<PlanReconciliationResponse | null> {
+  if (!planId) {
+    throw new Error('reconcilePlan requires a non-empty planId.');
+  }
+  const base = resolveApiUrl(`/api/plans/${encode(planId)}/reconcile`);
+  let url = base;
+  if (options.afterStepIndex !== undefined && Number.isFinite(options.afterStepIndex)) {
+    const value = String(Math.max(-1, Math.trunc(options.afterStepIndex)));
+    url = `${base}?afterStepIndex=${value}`;
+  }
+
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal: options.signal,
+  });
+
+  if (res.status === 404 || res.status === 403) return null;
+  if (!res.ok) {
+    throw new Error(`Plan reconcile failed with HTTP ${res.status}`);
+  }
+
+  const data: unknown = await res.json();
+  if (!isPlanReconciliationResponse(data)) {
+    throw new Error('Plan reconcile returned a malformed payload.');
+  }
+  return data;
+}

--- a/src/RetailPulse.Web/src/services/planReconciler.ts
+++ b/src/RetailPulse.Web/src/services/planReconciler.ts
@@ -1,0 +1,123 @@
+import type { PlanStepRecord } from './executionControlApi';
+
+/**
+ * Deterministic client-side merge of a client-rendered step list with the
+ * durable step records returned by `/api/plans/{planId}/reconcile` after
+ * a real-time reconnect (issue #92).
+ *
+ * Contract:
+ * - Steps are keyed by `stepIndex` (stable, monotonic on the backend).
+ * - Duplicate `stepIndex` values collapse to a single entry — the
+ *   authoritative record is the one whose status is FURTHER along the
+ *   lifecycle (`pending` → `running` → terminal). Once a step is in a
+ *   terminal state (`succeeded` / `failed` / `cancelled` / `skipped`) it
+ *   is never overwritten by a non-terminal update, so a late-arriving
+ *   streaming event cannot regress a completed step.
+ * - The returned array is sorted ascending by `stepIndex`, has no gaps
+ *   removed (gaps are the caller's signal that MORE steps are still
+ *   incoming from streaming), and never contains duplicates.
+ *
+ * Pure function so overlap/no-duplicate/no-gap behavior can be asserted
+ * without a running SignalR connection.
+ */
+
+/** Ordered lifecycle used to decide which record "wins" on overlap. */
+const LIFECYCLE_ORDER: Readonly<Record<string, number>> = Object.freeze({
+  pending: 0,
+  queued: 0,
+  running: 1,
+  in_progress: 1,
+  waiting_approval: 1,
+  awaiting_approval: 1,
+  approved: 1,
+  suspended: 1,
+  succeeded: 2,
+  completed: 2,
+  failed: 2,
+  cancelled: 2,
+  canceled: 2,
+  skipped: 2,
+});
+
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  'succeeded',
+  'completed',
+  'failed',
+  'cancelled',
+  'canceled',
+  'skipped',
+]);
+
+function normaliseStatus(status: string | null | undefined): string {
+  return (status ?? '').trim().toLowerCase();
+}
+
+export function isTerminalStatus(status: string | null | undefined): boolean {
+  return TERMINAL_STATUSES.has(normaliseStatus(status));
+}
+
+function lifecycleWeight(status: string | null | undefined): number {
+  const key = normaliseStatus(status);
+  const weight = LIFECYCLE_ORDER[key];
+  return weight ?? 0;
+}
+
+/**
+ * Merges an already-rendered list with a batch of reconciled records.
+ * Duplicate `stepIndex` values are resolved deterministically:
+ *  1. If the rendered record is already terminal, it wins (monotonicity).
+ *  2. Otherwise, whichever record has the higher lifecycle weight wins.
+ *  3. On a tie, the reconciled record wins so refreshed detail/duration
+ *     from the durable store overrides a stale streamed placeholder.
+ */
+export function reconcilePlanSteps<T extends PlanStepRecord>(
+  rendered: readonly T[],
+  reconciled: readonly T[],
+): T[] {
+  const merged = new Map<number, T>();
+
+  for (const record of rendered) {
+    if (!Number.isFinite(record.stepIndex)) continue;
+    merged.set(record.stepIndex, record);
+  }
+
+  for (const incoming of reconciled) {
+    if (!Number.isFinite(incoming.stepIndex)) continue;
+    const existing = merged.get(incoming.stepIndex);
+    if (!existing) {
+      merged.set(incoming.stepIndex, incoming);
+      continue;
+    }
+
+    // Terminal-state monotonicity: never regress a completed step.
+    if (isTerminalStatus(existing.status) && !isTerminalStatus(incoming.status)) {
+      continue;
+    }
+
+    const existingWeight = lifecycleWeight(existing.status);
+    const incomingWeight = lifecycleWeight(incoming.status);
+    if (incomingWeight >= existingWeight) {
+      merged.set(incoming.stepIndex, incoming);
+    }
+  }
+
+  return [...merged.values()].sort((a, b) => a.stepIndex - b.stepIndex);
+}
+
+/**
+ * Convenience helper for the reconcile-after-reconnect path: given the
+ * current rendered index and a reconcile response, returns the new merged
+ * step list AND the next cursor (the max stepIndex now known). Callers
+ * pass the cursor back on the next reconcile call so the endpoint only
+ * returns rows the client has not yet rendered.
+ */
+export function applyReconciliation<T extends PlanStepRecord>(
+  rendered: readonly T[],
+  reconciled: readonly T[],
+): { steps: T[]; nextAfterStepIndex: number } {
+  const merged = reconcilePlanSteps(rendered, reconciled);
+  const nextAfterStepIndex = merged.length === 0
+    ? -1
+    : merged.reduce((max, s) => (s.stepIndex > max ? s.stepIndex : max), -1);
+  return { steps: merged, nextAfterStepIndex };
+}

--- a/src/RetailPulse.Web/src/services/reconnectBackoff.ts
+++ b/src/RetailPulse.Web/src/services/reconnectBackoff.ts
@@ -1,0 +1,99 @@
+/**
+ * Reconnect backoff schedule for real-time channels (issue #92).
+ *
+ * Pure function so the schedule is deterministic and unit-testable without
+ * standing up a SignalR connection. The caller (SignalR's `IRetryPolicy` or
+ * a bespoke reconnect loop) supplies the previous retry count; we return
+ * either the delay in milliseconds before the next attempt, or `null` to
+ * signal the retry budget is exhausted and the channel should transition to
+ * a terminal disconnected state.
+ *
+ * We intentionally cap both the per-attempt delay (`maxDelayMs`) and the
+ * total attempt count (`maxAttempts`) so a persistently unhealthy channel
+ * never spins forever and never grows an unbounded delay that hides the
+ * real problem from the user.
+ */
+
+export interface ReconnectBackoffOptions {
+  /** Delay in ms before the FIRST reconnect attempt (previousRetryCount === 0). */
+  readonly initialDelayMs: number;
+  /** Ceiling for any single delay after exponential growth. */
+  readonly maxDelayMs: number;
+  /** Exponential base. Typical value: 2. */
+  readonly multiplier: number;
+  /**
+   * Hard cap on retry attempts. When `previousRetryCount >= maxAttempts`
+   * the function returns `null` so SignalR (or the bespoke loop) transitions
+   * to the terminal disconnected state.
+   */
+  readonly maxAttempts: number;
+  /**
+   * Optional pseudo-random jitter multiplier in `[0, 1)`. When provided we
+   * return `capped * (1 - jitter/2 + rng() * jitter)` so the schedule stays
+   * bounded but avoids thundering-herd reconnects. Callers omit this in
+   * tests to keep the schedule deterministic.
+   */
+  readonly jitter?: number;
+  /** Optional RNG override (0 <= rng() < 1). Defaults to Math.random. */
+  readonly rng?: () => number;
+}
+
+/**
+ * Default channel-resilience schedule, tuned to sit well under the shortest
+ * plausible intermediary idle timeout (~60s corporate proxy) so the user sees
+ * "reconnecting…" quickly, then backs off to avoid hammering the API during a
+ * real outage. Terminal after 8 attempts (~2 minutes elapsed), at which point
+ * the UI surfaces a "disconnected" state.
+ */
+export const DEFAULT_RECONNECT_BACKOFF: ReconnectBackoffOptions = {
+  initialDelayMs: 1_000,
+  maxDelayMs: 30_000,
+  multiplier: 2,
+  maxAttempts: 8,
+};
+
+/**
+ * Computes the delay before the next reconnect attempt, or `null` when the
+ * retry budget is exhausted. `previousRetryCount` matches SignalR's
+ * `RetryContext.previousRetryCount` — 0 means "no attempts yet, decide when
+ * to make the first one."
+ */
+export function computeReconnectDelayMs(
+  previousRetryCount: number,
+  options: ReconnectBackoffOptions = DEFAULT_RECONNECT_BACKOFF,
+): number | null {
+  if (!Number.isFinite(previousRetryCount) || previousRetryCount < 0) {
+    throw new RangeError('previousRetryCount must be a non-negative finite number.');
+  }
+  if (previousRetryCount >= options.maxAttempts) {
+    return null;
+  }
+
+  const raw = options.initialDelayMs * Math.pow(options.multiplier, previousRetryCount);
+  const capped = Math.min(raw, options.maxDelayMs);
+
+  const jitter = options.jitter;
+  if (jitter === undefined || jitter <= 0) {
+    return Math.max(0, Math.round(capped));
+  }
+  const clampedJitter = Math.min(jitter, 1);
+  const rng = options.rng ?? Math.random;
+  const factor = 1 - clampedJitter / 2 + rng() * clampedJitter;
+  return Math.max(0, Math.round(capped * factor));
+}
+
+/**
+ * Materialises the full deterministic schedule (jitter disabled) up to and
+ * including the terminal `null` marker. Useful for tests and diagnostics.
+ */
+export function buildReconnectSchedule(
+  options: ReconnectBackoffOptions = DEFAULT_RECONNECT_BACKOFF,
+): readonly (number | null)[] {
+  const schedule: (number | null)[] = [];
+  for (let attempt = 0; attempt < options.maxAttempts; attempt++) {
+    const delay = computeReconnectDelayMs(attempt, { ...options, jitter: 0 });
+    schedule.push(delay);
+  }
+  schedule.push(null);
+  return schedule;
+}

--- a/src/RetailPulse.Web/src/services/telemetryHub.ts
+++ b/src/RetailPulse.Web/src/services/telemetryHub.ts
@@ -134,7 +134,11 @@ function reattachManagedHandlers(): void {
  * state.
  */
 class ExponentialReconnectPolicy implements signalR.IRetryPolicy {
-  constructor(private readonly options: ReconnectBackoffOptions) {}
+  private readonly options: ReconnectBackoffOptions;
+
+  constructor(options: ReconnectBackoffOptions) {
+    this.options = options;
+  }
 
   nextRetryDelayInMilliseconds(retryContext: signalR.RetryContext): number | null {
     return computeReconnectDelayMs(retryContext.previousRetryCount, this.options);

--- a/src/RetailPulse.Web/src/services/telemetryHub.ts
+++ b/src/RetailPulse.Web/src/services/telemetryHub.ts
@@ -2,6 +2,11 @@ import * as signalR from '@microsoft/signalr';
 import type { AgentSpan } from '../types';
 import { resolveTelemetryHubUrl } from '../config/telemetryHubUrl';
 import { getHubAccessToken } from '../auth/tokenService';
+import {
+  computeReconnectDelayMs,
+  DEFAULT_RECONNECT_BACKOFF,
+  type ReconnectBackoffOptions,
+} from './reconnectBackoff';
 
 const HUB_URL = resolveTelemetryHubUrl();
 
@@ -9,6 +14,44 @@ let connection: signalR.HubConnection | null = null;
 let startPromise: Promise<void> | null = null;
 const joinedSessions = new Set<string>();
 const progressListeners = new Set<(data: ProgressEvent) => void>();
+
+/**
+ * Application-level connection status surfaced to the UI (issue #92).
+ *
+ * - `connecting`: initial handshake in flight (or a manual restart).
+ * - `connected`: hub is up and application-level events are flowing.
+ * - `reconnecting`: transport dropped; SignalR is retrying per the backoff
+ *   schedule in {@link reconnectBackoff}.
+ * - `disconnected`: retry budget exhausted OR the app explicitly stopped
+ *   the hub. Terminal state — the user must retry (or reload) to recover.
+ */
+export type HubConnectionStatus =
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'disconnected';
+
+export interface HubHeartbeatEvent {
+  readonly timestamp: string;
+  readonly intervalMs?: number;
+}
+
+let currentStatus: HubConnectionStatus = 'disconnected';
+let lastHeartbeatAt: number | null = null;
+const statusListeners = new Set<(status: HubConnectionStatus) => void>();
+const heartbeatListeners = new Set<(event: HubHeartbeatEvent) => void>();
+
+function setStatus(next: HubConnectionStatus): void {
+  if (currentStatus === next) return;
+  currentStatus = next;
+  statusListeners.forEach((listener) => {
+    try {
+      listener(next);
+    } catch (err) {
+      if (import.meta.env.DEV) console.error('Hub status listener threw:', err);
+    }
+  });
+}
 
 export interface ProgressEvent {
   sessionId: string;
@@ -84,10 +127,25 @@ function reattachManagedHandlers(): void {
   }
 }
 
+/**
+ * SignalR retry policy backed by the shared exponential backoff schedule
+ * (issue #92). Returning `null` transitions the connection to Disconnected,
+ * which fires `onclose` and lets the UI render a terminal "disconnected"
+ * state.
+ */
+class ExponentialReconnectPolicy implements signalR.IRetryPolicy {
+  constructor(private readonly options: ReconnectBackoffOptions) {}
+
+  nextRetryDelayInMilliseconds(retryContext: signalR.RetryContext): number | null {
+    return computeReconnectDelayMs(retryContext.previousRetryCount, this.options);
+  }
+}
+
 export function connectTelemetryHub(
   onSpan: (span: AgentSpan) => void,
   onConnected?: () => void,
   onDisconnected?: () => void,
+  backoffOptions: ReconnectBackoffOptions = DEFAULT_RECONNECT_BACKOFF,
 ): signalR.HubConnection {
   // If we already have a connection that isn't disconnected, reuse it
   if (connection && connection.state !== signalR.HubConnectionState.Disconnected) {
@@ -101,6 +159,8 @@ export function connectTelemetryHub(
     return connection;
   }
 
+  setStatus('connecting');
+
   connection = new signalR.HubConnectionBuilder()
     .withUrl(HUB_URL, {
       // Bearer token for the hub handshake. WebSocket handshakes can't set an
@@ -108,7 +168,7 @@ export function connectTelemetryHub(
       // which the API honours ONLY for /hubs. Returns '' locally (no token needed).
       accessTokenFactory: getHubAccessToken,
     })
-    .withAutomaticReconnect()
+    .withAutomaticReconnect(new ExponentialReconnectPolicy(backoffOptions))
     .build();
 
   connection.on('SpanReceived', (span: AgentSpan) => {
@@ -127,15 +187,39 @@ export function connectTelemetryHub(
     }
   });
 
+  // Application-level heartbeat emitted by HubHeartbeatBackgroundService on
+  // both /hubs/telemetry and /hubs/streaming (issue #92). We record the
+  // arrival time so the UI can flag a stalled channel even while SignalR
+  // still reports Connected (e.g. a proxy silently swallowing frames).
+  connection.on('heartbeat', (event: HubHeartbeatEvent) => {
+    lastHeartbeatAt = Date.now();
+    heartbeatListeners.forEach((listener) => {
+      try {
+        listener(event);
+      } catch (err) {
+        if (import.meta.env.DEV) console.error('Hub heartbeat listener threw:', err);
+      }
+    });
+  });
+
+  connection.onreconnecting(() => {
+    setStatus('reconnecting');
+  });
+
   // Re-join any sessions on reconnect — SignalR groups don't survive reconnects.
   connection.onreconnected(() => {
+    setStatus('connected');
     onConnected?.();
     joinPendingSessions();
   });
-  connection.onclose(() => onDisconnected?.());
+  connection.onclose(() => {
+    setStatus('disconnected');
+    onDisconnected?.();
+  });
 
   startPromise = connection.start()
     .then(() => {
+      setStatus('connected');
       onConnected?.();
       joinPendingSessions();
     })
@@ -143,6 +227,7 @@ export function connectTelemetryHub(
       if (import.meta.env.DEV) {
         console.error('SignalR connection error:', err);
       }
+      setStatus('disconnected');
       onDisconnected?.();
     });
 
@@ -152,6 +237,13 @@ export function connectTelemetryHub(
 /**
  * Joins all queued sessions on the current connection.
  * Called after initial connect and on every reconnect.
+ *
+ * Reconnect security note (issue #92): we deliberately re-invoke
+ * `JoinSession` only for sessionIds this client previously joined via
+ * {@link joinTelemetrySession}. Server payloads never influence this set,
+ * so a hostile server message cannot trick the client into rejoining a
+ * foreign group. The hub side also enforces subject ownership on every
+ * join and rejoin (`ISessionOwnershipRegistry`).
  */
 function joinPendingSessions(): void {
   joinedSessions.forEach(sid => {
@@ -204,4 +296,60 @@ export async function disconnectTelemetryHub(): Promise<void> {
   }
   connection = null;
   joinedSessions.clear();
+  setStatus('disconnected');
+}
+
+/**
+ * Subscribe to hub connection-status transitions surfaced to the UI. The
+ * listener fires the CURRENT status immediately so the caller renders the
+ * right badge on mount without probing internals.
+ */
+export function onHubConnectionStatus(
+  listener: (status: HubConnectionStatus) => void,
+): () => void {
+  statusListeners.add(listener);
+  try {
+    listener(currentStatus);
+  } catch (err) {
+    if (import.meta.env.DEV) console.error('Hub status listener threw:', err);
+  }
+  return () => { statusListeners.delete(listener); };
+}
+
+/**
+ * Subscribe to the application-level `heartbeat` event emitted by the
+ * backend hub heartbeat service. Callers can use this to detect a stalled
+ * hub even while SignalR still reports Connected.
+ */
+export function onHubHeartbeat(
+  listener: (event: HubHeartbeatEvent) => void,
+): () => void {
+  heartbeatListeners.add(listener);
+  return () => { heartbeatListeners.delete(listener); };
+}
+
+export function getHubConnectionStatus(): HubConnectionStatus {
+  return currentStatus;
+}
+
+export function getLastHubHeartbeatAt(): number | null {
+  return lastHeartbeatAt;
+}
+
+/**
+ * Test-only reset for module-level state. Guarded so it never runs in a
+ * production bundle. Vitest sets `import.meta.env.MODE === 'test'`.
+ */
+export function __resetTelemetryHubForTests(): void {
+  if (import.meta.env.MODE !== 'test') {
+    throw new Error('__resetTelemetryHubForTests is a vitest-only helper.');
+  }
+  connection = null;
+  startPromise = null;
+  joinedSessions.clear();
+  progressListeners.clear();
+  statusListeners.clear();
+  heartbeatListeners.clear();
+  lastHeartbeatAt = null;
+  currentStatus = 'disconnected';
 }

--- a/src/RetailPulse.Web/src/state/planReducer.ts
+++ b/src/RetailPulse.Web/src/state/planReducer.ts
@@ -145,6 +145,18 @@ export type PlanAction =
   | { type: 'CLARIFICATION_RESOLVED'; planId: string; requestId: string }
   | { type: 'PLAN_FINAL'; planId: string; reply: string; terminalReason?: string | null }
   | { type: 'CONNECTION_STATUS'; connected: boolean }
+  | {
+      // Reconciled delta after a hub reconnect (issue #92): merges any
+      // durable step records the client did not render while offline into
+      // the active plan without regressing terminal steps and refreshes
+      // the plan header from the durable snapshot.
+      type: 'STEPS_RECONCILED';
+      planId: string;
+      steps: readonly PlanStep[];
+      status?: PlanStatus;
+      updatedAt?: string;
+      failureReason?: string | null;
+    }
   | { type: 'ELAPSED_TICK'; now: number }
   | { type: 'CLOSE_ACTIVE' }
   | { type: 'HISTORY_LOADING' }
@@ -477,6 +489,58 @@ export function planReducer(state: PlanAppState, action: PlanAction): PlanAppSta
       return {
         ...state,
         active: { ...state.active, connectionLost: !action.connected },
+      };
+    }
+
+    case 'STEPS_RECONCILED': {
+      if (!state.active || state.active.planId !== action.planId) return state;
+      // Terminal-monotonic merge, keyed by stepIndex. A step already terminal
+      // in the rendered state is NEVER overwritten by a non-terminal record
+      // — that would let a stale streamed placeholder regress a completed
+      // step during reconnect reconciliation. Non-terminal existing steps
+      // are always replaced by the incoming record so refreshed durable
+      // detail (final result / durationMs / tokens) supersedes the stream
+      // placeholder.
+      const byIndex = new Map<number, PlanStep>();
+      for (const existing of state.active.steps) {
+        byIndex.set(existing.stepIndex, existing);
+      }
+      for (const incoming of action.steps) {
+        if (!Number.isFinite(incoming.stepIndex)) continue;
+        const existing = byIndex.get(incoming.stepIndex);
+        if (!existing) {
+          byIndex.set(incoming.stepIndex, incoming);
+          continue;
+        }
+        if (isStepTerminal(existing.status) && !isStepTerminal(incoming.status)) {
+          continue;
+        }
+        byIndex.set(incoming.stepIndex, incoming);
+      }
+      const mergedSteps = [...byIndex.values()].sort(
+        (a, b) => a.stepIndex - b.stepIndex,
+      );
+
+      const nextStatus = action.status ?? state.active.status;
+      const wasRunning = isPlanRunning(state.active.status);
+      const stillRunning = isPlanRunning(nextStatus);
+      const finishedAt = wasRunning && !stillRunning && !state.active.finishedAt
+        ? Date.now()
+        : state.active.finishedAt;
+
+      return {
+        ...state,
+        active: {
+          ...state.active,
+          steps: mergedSteps,
+          status: nextStatus,
+          updatedAt: action.updatedAt ?? state.active.updatedAt,
+          failureReason:
+            action.failureReason !== undefined
+              ? action.failureReason
+              : state.active.failureReason,
+          finishedAt,
+        },
       };
     }
 

--- a/src/RetailPulse.Web/src/state/usePlanController.ts
+++ b/src/RetailPulse.Web/src/state/usePlanController.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import type { ActivePlanState, PlanAppState } from './planReducer';
-import { initialPlanState, isPlanRunning, planReducer } from './planReducer';
+import { initialPlanState, isPlanRunning, isStepTerminal, planReducer } from './planReducer';
 import type {
   PlanClarificationPrompt,
   PlanFinalResponseEvent,
@@ -9,6 +9,8 @@ import type {
   PlanReviewProposal,
   PlanReviewResolvedEvent,
   PlanReviewStep,
+  PlanStatus,
+  PlanStep,
   PlanStepStatus,
 } from '../types';
 import {
@@ -21,6 +23,10 @@ import {
   parseClarificationPrompt,
   parseReviewProposal,
 } from '../services/planApi';
+import {
+  reconcilePlan,
+  type PlanStepRecord,
+} from '../services/executionControlApi';
 
 /**
  * React binding for the plan reducer. Owns hydration, review/clarification
@@ -85,6 +91,71 @@ function selectHydratedStatus(current: PlanStepStatus, incoming: PlanStepStatus)
   return STEP_STATUS_ORDER[incoming] >= STEP_STATUS_ORDER[current] ? incoming : current;
 }
 
+// ── Reconcile-after-reconnect helpers (issue #92) ──────────────────────────
+// The reconcile endpoint returns records with the same shape as
+// PlanStepRecordDto (see RetailPulse.Contracts/Persistence/PlanDtos.cs), but
+// the FE wire type marks every non-key field as optional so an older/lax
+// backend response cannot desync the compiler. Coerce to the reducer's
+// authoritative PlanStep with strict fallbacks so a malformed record never
+// leaks `undefined` into rendered UI or overwrites a rendered step with
+// blank fields.
+
+const VALID_STEP_STATUSES: readonly PlanStepStatus[] = [
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+  'timed_out',
+  'skipped',
+  'unusable',
+];
+
+const VALID_PLAN_STATUSES: readonly PlanStatus[] = [
+  'draft',
+  'awaiting_review',
+  'awaiting_clarification',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+  'unusable',
+];
+
+function coerceStepStatus(raw: string | null | undefined): PlanStepStatus {
+  const trimmed = (raw ?? '').trim();
+  return (VALID_STEP_STATUSES as readonly string[]).includes(trimmed)
+    ? (trimmed as PlanStepStatus)
+    : 'pending';
+}
+
+function coercePlanStatus(raw: string | null | undefined): PlanStatus | undefined {
+  const trimmed = (raw ?? '').trim();
+  return (VALID_PLAN_STATUSES as readonly string[]).includes(trimmed)
+    ? (trimmed as PlanStatus)
+    : undefined;
+}
+
+function mapRecordToPlanStep(record: PlanStepRecord, planId: string): PlanStep {
+  return {
+    stepId: record.stepId ?? '',
+    planId: record.planId ?? planId,
+    stepIndex: record.stepIndex,
+    specialistKey: record.specialistKey ?? '',
+    intent: record.intent ?? '',
+    action: record.action ?? '',
+    status: coerceStepStatus(record.status),
+    result: record.result ?? null,
+    error: record.error ?? null,
+    inputTokens: record.inputTokens ?? null,
+    outputTokens: record.outputTokens ?? null,
+    totalTokens: record.totalTokens ?? null,
+    durationMs: record.durationMs ?? null,
+    startedAt: record.startedAt ?? null,
+    completedAt: record.completedAt ?? null,
+  };
+}
+
 function normalizeReviewProposal(raw: unknown, planId: string): PlanReviewProposal | null {
   if (!raw || typeof raw !== 'object') return null;
   const value = raw as Record<string, unknown>;
@@ -130,6 +201,56 @@ export function usePlanController(options: UsePlanControllerOptions): PlanContro
   // Connection status flows into the reducer for the "connection lost" banner.
   useEffect(() => {
     dispatch({ type: 'CONNECTION_STATUS', connected: options.connection.connected });
+  }, [options.connection.connected]);
+
+  // Reconcile durable plan state after a reconnect (issue #92). Fires only
+  // on the false → true edge so a first-mount connect (no prior drop) does
+  // not trigger a needless reconcile. The endpoint returns steps with
+  // `stepIndex > afterStepIndex`, so the cursor is the highest KNOWN-terminal
+  // step index — any non-terminal step gets refreshed with the durable
+  // record. The reducer applies terminal-monotonic merge so a stream
+  // placeholder cannot regress a completed step.
+  const previousConnectedRef = useRef(options.connection.connected);
+  useEffect(() => {
+    const wasConnected = previousConnectedRef.current;
+    const nowConnected = options.connection.connected;
+    previousConnectedRef.current = nowConnected;
+    if (wasConnected || !nowConnected) return;
+
+    const active = activeRef.current;
+    if (!active) return;
+    if (!isPlanRunning(active.status)) return;
+
+    let cursor = -1;
+    for (const step of active.steps) {
+      if (isStepTerminal(step.status) && step.stepIndex > cursor) {
+        cursor = step.stepIndex;
+      }
+    }
+    const planId = active.planId;
+
+    void reconcilePlan(planId, { afterStepIndex: cursor })
+      .then(response => {
+        if (!response) return;
+        const currentActive = activeRef.current;
+        if (!currentActive || currentActive.planId !== planId) return;
+        const mappedSteps = response.steps.map(record =>
+          mapRecordToPlanStep(record, planId),
+        );
+        dispatch({
+          type: 'STEPS_RECONCILED',
+          planId,
+          steps: mappedSteps,
+          status: coercePlanStatus(response.status),
+          updatedAt: response.updatedAt ?? undefined,
+          failureReason: response.failureReason ?? null,
+        });
+      })
+      .catch(err => {
+        if (import.meta.env.DEV) {
+          console.error('Plan reconcile after reconnect failed:', err);
+        }
+      });
   }, [options.connection.connected]);
 
   // Wire SignalR events to reducer actions.

--- a/tests/RetailPulse.Tests/Configuration/RealtimeResilienceConfigurationTests.cs
+++ b/tests/RetailPulse.Tests/Configuration/RealtimeResilienceConfigurationTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Hubs;
+
+namespace RetailPulse.Tests.Configuration;
+
+/// <summary>
+/// Backend contract for issue #92: RealtimeResilience + ChatTimeout config
+/// bind through the standard <see cref="IOptions{TOptions}"/> pattern, defaults
+/// preserve the pre-#92 single-shot behavior, and the plan ceiling is
+/// distinct so long-running plans don't force us to globally raise 90s.
+/// </summary>
+public sealed class RealtimeResilienceConfigurationTests
+{
+    private static IServiceProvider BuildServices(Dictionary<string, string?> settings)
+    {
+        IConfiguration configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.Configure<RealtimeResilienceOptions>(
+            configuration.GetSection(RealtimeResilienceOptions.SectionName));
+        services.Configure<ChatTimeoutOptions>(
+            configuration.GetSection(ChatTimeoutOptions.SectionName));
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Defaults_PreserveSingleShot90s_AndProvideDistinctPlanCeiling()
+    {
+        IServiceProvider sp = BuildServices([]);
+
+        ChatTimeoutOptions timeouts = sp.GetRequiredService<IOptions<ChatTimeoutOptions>>().Value;
+
+        timeouts.SingleShot.Should().Be(TimeSpan.FromSeconds(90),
+            "the default single-shot ceiling must match the pre-#92 hard-coded value");
+        timeouts.Plan.Should().BeGreaterThan(timeouts.SingleShot,
+            "the plan ceiling exists so long-running plans don't have to widen the fast-path wall");
+    }
+
+    [Fact]
+    public void Defaults_ProvideConservativeHeartbeat_AndSafeClientTimeoutRatio()
+    {
+        IServiceProvider sp = BuildServices([]);
+
+        RealtimeResilienceOptions opts = sp.GetRequiredService<IOptions<RealtimeResilienceOptions>>().Value;
+
+        opts.KeepAliveInterval.Should().BeLessThanOrEqualTo(TimeSpan.FromSeconds(15),
+            "keepalive must stay under the shortest plausible intermediary idle timeout");
+        opts.ApplicationHeartbeatInterval.Should().BeLessThanOrEqualTo(TimeSpan.FromSeconds(15));
+        opts.ApplicationHeartbeatEnabled.Should().BeTrue();
+        opts.IsClientTimeoutSafe.Should().BeTrue(
+            "SignalR guidance is ClientTimeoutInterval >= 2x KeepAliveInterval");
+    }
+
+    [Fact]
+    public void ConfigSection_Binds_OverridingDefaults()
+    {
+        IServiceProvider sp = BuildServices(new Dictionary<string, string?>
+        {
+            ["RealtimeResilience:KeepAliveInterval"] = "00:00:10",
+            ["RealtimeResilience:ClientTimeoutInterval"] = "00:00:25",
+            ["RealtimeResilience:HandshakeTimeout"] = "00:00:12",
+            ["RealtimeResilience:ApplicationHeartbeatInterval"] = "00:00:11",
+            ["RealtimeResilience:ApplicationHeartbeatEnabled"] = "false",
+            ["ChatTimeout:SingleShot"] = "00:01:00",
+            ["ChatTimeout:Plan"] = "00:04:00",
+        });
+
+        RealtimeResilienceOptions rt = sp.GetRequiredService<IOptions<RealtimeResilienceOptions>>().Value;
+        rt.KeepAliveInterval.Should().Be(TimeSpan.FromSeconds(10));
+        rt.ClientTimeoutInterval.Should().Be(TimeSpan.FromSeconds(25));
+        rt.HandshakeTimeout.Should().Be(TimeSpan.FromSeconds(12));
+        rt.ApplicationHeartbeatInterval.Should().Be(TimeSpan.FromSeconds(11));
+        rt.ApplicationHeartbeatEnabled.Should().BeFalse();
+
+        ChatTimeoutOptions timeouts = sp.GetRequiredService<IOptions<ChatTimeoutOptions>>().Value;
+        timeouts.SingleShot.Should().Be(TimeSpan.FromMinutes(1));
+        timeouts.Plan.Should().Be(TimeSpan.FromMinutes(4));
+        timeouts.Plan.Should().BeGreaterThan(timeouts.SingleShot,
+            "the two ceilings must remain distinct even under operator override");
+    }
+}

--- a/tests/RetailPulse.Tests/Endpoints/ExecutionControlEndpointsTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/ExecutionControlEndpointsTests.cs
@@ -1,0 +1,333 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Threading.RateLimiting;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Api.Security.Anonymous;
+using RetailPulse.Contracts.Persistence;
+
+namespace RetailPulse.Tests.Endpoints;
+
+/// <summary>
+/// HTTP contract for issue #92's user-initiated execution control surface:
+/// cancel + reconcile. Covers:
+/// <list type="bullet">
+///   <item>Cancel actually triggers cancellation on the registered CTS and
+///     an in-flight fake tool ceases its work (not merely HTTP 204).</item>
+///   <item>Cross-subject cancels collapse to 404 so live sessions/plans
+///     cannot be probed.</item>
+///   <item>Reconcile filters cross-subject reads to 404 and honours
+///     <c>afterStepIndex</c>.</item>
+/// </list>
+/// </summary>
+public sealed class ExecutionControlEndpointsTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    [Fact]
+    public async Task CancelChat_Owner_TriggersCancellation_OnInFlightTool()
+    {
+        await using ControlHost host = await ControlHost.CreateAsync(new StubAuthConfig
+        {
+            Subject = "alice-oid",
+        });
+
+        using var cts = new CancellationTokenSource();
+        using IDisposable handle = host.Registry.Register(
+            ExecutionCancellationRegistry.ChatScope, "session-1", "alice-oid", cts);
+
+        int toolIterations = 0;
+        bool toolCancelled = false;
+
+        Task toolTask = Task.Run(async () =>
+        {
+            try
+            {
+                while (true)
+                {
+                    cts.Token.ThrowIfCancellationRequested();
+                    Interlocked.Increment(ref toolIterations);
+                    await Task.Delay(10, cts.Token);
+                }
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                toolCancelled = true;
+            }
+        });
+
+        await Task.Delay(50);
+        int beforeCount = Volatile.Read(ref toolIterations);
+        beforeCount.Should().BeGreaterThan(0);
+
+        HttpResponseMessage response = await host.Client.PostAsync("/api/chat/session-1/cancel", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await toolTask.WaitAsync(TimeSpan.FromSeconds(2));
+        toolCancelled.Should().BeTrue("cancellation must reach the fake tool, not just return HTTP");
+
+        int settledCount = Volatile.Read(ref toolIterations);
+        await Task.Delay(80);
+        Volatile.Read(ref toolIterations).Should().Be(settledCount,
+            "the tool loop must stop iterating after cancel arrives");
+    }
+
+    [Fact]
+    public async Task CancelChat_ForeignSubject_ReturnsNotFound_AndDoesNotCancel()
+    {
+        await using ControlHost host = await ControlHost.CreateAsync(new StubAuthConfig
+        {
+            Subject = "attacker-oid",
+        });
+
+        using var cts = new CancellationTokenSource();
+        using IDisposable handle = host.Registry.Register(
+            ExecutionCancellationRegistry.ChatScope, "victim-session", "victim-oid", cts);
+
+        HttpResponseMessage response = await host.Client.PostAsync("/api/chat/victim-session/cancel", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        cts.IsCancellationRequested.Should().BeFalse(
+            "a foreign subject must never cancel another user's in-flight run");
+    }
+
+    [Fact]
+    public async Task CancelPlan_AnonymousCaller_IsRefused()
+    {
+        await using ControlHost host = await ControlHost.CreateAsync(new StubAuthConfig
+        {
+            AsAnonymousProvider = true,
+            Subject = "anon-sub-1",
+        });
+
+        HttpResponseMessage response = await host.Client.PostAsync("/api/plans/some-plan/cancel", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString().Should().Be("plan_cancel_unavailable");
+    }
+
+    [Fact]
+    public async Task ReconcilePlan_Owner_ReturnsStepsAfterCursor()
+    {
+        await using ControlHost host = await ControlHost.CreateAsync(new StubAuthConfig
+        {
+            Subject = "alice-oid",
+        });
+
+        host.PlanStore.Seed("alice-oid", new PlanDetailDto(
+            PlanId: "plan-1",
+            SessionId: "s-1",
+            TenantId: "Contoso",
+            Request: "multi-step",
+            Status: PlanStatus.Running,
+            DetectedIntents: ["a", "b"],
+            FailureReason: null,
+            TotalInputTokens: null,
+            TotalOutputTokens: null,
+            TotalTokens: null,
+            TotalDurationMs: null,
+            CreatedAt: DateTimeOffset.UtcNow,
+            UpdatedAt: DateTimeOffset.UtcNow,
+            Steps:
+            [
+                new PlanStepRecordDto("s0", "plan-1", 0, "kA", "iA", "act0", PlanStepStatus.Completed, "r0", null, 1, 2, 3, 5, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+                new PlanStepRecordDto("s1", "plan-1", 1, "kB", "iB", "act1", PlanStepStatus.Completed, "r1", null, 1, 2, 3, 5, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+                new PlanStepRecordDto("s2", "plan-1", 2, "kC", "iC", "act2", PlanStepStatus.Running, null, null, 0, 0, 0, 0, DateTimeOffset.UtcNow, null),
+            ]));
+
+        HttpResponseMessage response = await host.Client.GetAsync("/api/plans/plan-1/reconcile?afterStepIndex=1");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("planId").GetString().Should().Be("plan-1");
+        doc.RootElement.GetProperty("status").GetString().Should().Be(PlanStatus.Running);
+        doc.RootElement.GetProperty("afterStepIndex").GetInt32().Should().Be(1);
+        doc.RootElement.GetProperty("totalStepCount").GetInt32().Should().Be(3);
+
+        JsonElement steps = doc.RootElement.GetProperty("steps");
+        steps.GetArrayLength().Should().Be(1, "only steps with index > 1 should be returned");
+        steps[0].GetProperty("stepIndex").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ReconcilePlan_CrossSubject_Returns404()
+    {
+        await using ControlHost host = await ControlHost.CreateAsync(new StubAuthConfig
+        {
+            Subject = "attacker-oid",
+        });
+
+        host.PlanStore.Seed("victim-oid", new PlanDetailDto(
+            PlanId: "plan-victim",
+            SessionId: "s-v",
+            TenantId: "Contoso",
+            Request: "victim",
+            Status: PlanStatus.Completed,
+            DetectedIntents: [],
+            FailureReason: null,
+            TotalInputTokens: null,
+            TotalOutputTokens: null,
+            TotalTokens: null,
+            TotalDurationMs: null,
+            CreatedAt: DateTimeOffset.UtcNow,
+            UpdatedAt: DateTimeOffset.UtcNow,
+            Steps: []));
+
+        HttpResponseMessage response = await host.Client.GetAsync("/api/plans/plan-victim/reconcile");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ReconcilePlan_AnonymousCaller_IsRefused()
+    {
+        await using ControlHost host = await ControlHost.CreateAsync(new StubAuthConfig
+        {
+            AsAnonymousProvider = true,
+            Subject = "anon-sub-2",
+        });
+
+        HttpResponseMessage response = await host.Client.GetAsync("/api/plans/anything/reconcile");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString().Should().Be("plan_reconcile_unavailable");
+    }
+
+    private sealed class ControlHost : IAsyncDisposable
+    {
+        public required WebApplication App { get; init; }
+        public required HttpClient Client { get; init; }
+        public required IExecutionCancellationRegistry Registry { get; init; }
+        public required InMemoryPlanStoreForReconcile PlanStore { get; init; }
+
+        public static async Task<ControlHost> CreateAsync(StubAuthConfig auth)
+        {
+            WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
+            builder.WebHost.UseTestServer();
+            builder.Logging.ClearProviders();
+
+            builder.Services.AddSingleton(auth);
+            builder.Services
+                .AddAuthentication("Test")
+                .AddScheme<AuthenticationSchemeOptions, StubAuthHandler>("Test", _ => { });
+            builder.Services.AddAuthorization();
+            builder.Services.AddRateLimiter(options =>
+            {
+                options.AddPolicy("relaxed", _ => RateLimitPartition.GetNoLimiter("all"));
+                options.AddPolicy("moderate", _ => RateLimitPartition.GetNoLimiter("all"));
+            });
+
+            var registry = new ExecutionCancellationRegistry();
+            var planStore = new InMemoryPlanStoreForReconcile();
+            builder.Services.AddSingleton<IExecutionCancellationRegistry>(registry);
+            builder.Services.AddSingleton<IPlanStore>(planStore);
+
+            WebApplication app = builder.Build();
+            app.UseAuthentication();
+            app.UseAuthorization();
+            app.UseRateLimiter();
+            app.MapExecutionControlEndpoints();
+            app.MapPlanReconciliationEndpoint();
+            await app.StartAsync();
+
+            return new ControlHost
+            {
+                App = app,
+                Client = app.GetTestClient(),
+                Registry = registry,
+                PlanStore = planStore,
+            };
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await App.DisposeAsync();
+        }
+    }
+
+    private sealed class StubAuthConfig
+    {
+        public bool AsAnonymousProvider { get; init; }
+        public string Subject { get; init; } = "tester-oid";
+    }
+
+    private sealed class StubAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        StubAuthConfig cfg) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            List<Claim> claims;
+            if (cfg.AsAnonymousProvider)
+            {
+                claims =
+                [
+                    new Claim(AnonymousCapabilityPolicy.ProviderClaimType, AnonymousCapabilityPolicy.ProviderName),
+                    new Claim("sub", cfg.Subject),
+                ];
+            }
+            else
+            {
+                claims = [new Claim("oid", cfg.Subject)];
+            }
+
+            var identity = new ClaimsIdentity(claims, "Test");
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), "Test");
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+
+    private sealed class InMemoryPlanStoreForReconcile : IPlanStore
+    {
+        private readonly Dictionary<string, Dictionary<string, PlanDetailDto>> _byOwner
+            = new(StringComparer.Ordinal);
+
+        public void Seed(string owner, PlanDetailDto detail)
+        {
+            if (!_byOwner.TryGetValue(owner, out Dictionary<string, PlanDetailDto>? bucket))
+            {
+                bucket = new(StringComparer.Ordinal);
+                _byOwner[owner] = bucket;
+            }
+            bucket[detail.PlanId] = detail;
+        }
+
+        public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
+
+        public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default)
+            => _byOwner.TryGetValue(subject, out Dictionary<string, PlanDetailDto>? bucket)
+                && bucket.TryGetValue(planId, out PlanDetailDto? detail)
+                    ? Task.FromResult<PlanDetailDto?>(detail)
+                    : Task.FromResult<PlanDetailDto?>(null);
+
+        public Task<bool> DeletePlanAsync(string subject, string planId, CancellationToken ct = default)
+            => Task.FromResult(false);
+
+        public Task<PlanCleanupResult> PurgeExpiredAsync(DateTimeOffset olderThan, CancellationToken ct = default)
+            => Task.FromResult(new PlanCleanupResult(0, 0));
+    }
+}

--- a/tests/RetailPulse.Tests/Endpoints/ExecutionControlEndpointsTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/ExecutionControlEndpointsTests.cs
@@ -54,7 +54,7 @@ public sealed class ExecutionControlEndpointsTests
         int toolIterations = 0;
         bool toolCancelled = false;
 
-        Task toolTask = Task.Run(async () =>
+        var toolTask = Task.Run(async () =>
         {
             try
             {
@@ -276,20 +276,12 @@ public sealed class ExecutionControlEndpointsTests
     {
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            List<Claim> claims;
-            if (cfg.AsAnonymousProvider)
-            {
-                claims =
-                [
+            List<Claim> claims = cfg.AsAnonymousProvider
+                ? [
                     new Claim(AnonymousCapabilityPolicy.ProviderClaimType, AnonymousCapabilityPolicy.ProviderName),
                     new Claim("sub", cfg.Subject),
-                ];
-            }
-            else
-            {
-                claims = [new Claim("oid", cfg.Subject)];
-            }
-
+                ]
+                : [new Claim("oid", cfg.Subject)];
             var identity = new ClaimsIdentity(claims, "Test");
             var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), "Test");
             return Task.FromResult(AuthenticateResult.Success(ticket));

--- a/tests/RetailPulse.Tests/Hubs/ExecutionCancellationRegistryTests.cs
+++ b/tests/RetailPulse.Tests/Hubs/ExecutionCancellationRegistryTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using RetailPulse.Api.Hubs;
+
+namespace RetailPulse.Tests.Hubs;
+
+/// <summary>
+/// Behavioural contract for issue #92's cancellation surface. Proves the
+/// registry:
+/// <list type="bullet">
+///   <item>Refuses cancellation from a subject that didn't register.</item>
+///   <item>Actually cancels the underlying <see cref="CancellationTokenSource"/>
+///     (not just returns "success").</item>
+///   <item>Ends an in-flight tool invocation via the same CTS — the tool
+///     stops looping / awaiting after the cancel arrives, not merely that
+///     HTTP returned.</item>
+/// </list>
+/// </summary>
+public sealed class ExecutionCancellationRegistryTests
+{
+    [Fact]
+    public void TryCancel_UnknownKey_ReturnsNotFound()
+    {
+        var registry = new ExecutionCancellationRegistry();
+        registry.TryCancel(ExecutionCancellationRegistry.ChatScope, "session-x", "owner").Should().Be(ExecutionCancelResult.NotFound);
+    }
+
+    [Fact]
+    public void TryCancel_ForeignSubject_ReturnsForbidden_AndDoesNotCancel()
+    {
+        var registry = new ExecutionCancellationRegistry();
+        using var cts = new CancellationTokenSource();
+        using IDisposable handle = registry.Register(
+            ExecutionCancellationRegistry.ChatScope, "session-A", "owner-A", cts);
+
+        ExecutionCancelResult result = registry.TryCancel(
+            ExecutionCancellationRegistry.ChatScope, "session-A", "attacker-B");
+
+        result.Should().Be(ExecutionCancelResult.Forbidden);
+        cts.IsCancellationRequested.Should().BeFalse(
+            "a foreign subject must never trigger cancellation on someone else's run");
+    }
+
+    [Fact]
+    public void TryCancel_Owner_ActuallyCancels_UnderlyingCts()
+    {
+        var registry = new ExecutionCancellationRegistry();
+        using var cts = new CancellationTokenSource();
+        using IDisposable handle = registry.Register(
+            ExecutionCancellationRegistry.ChatScope, "session-Z", "owner-Z", cts);
+
+        ExecutionCancelResult result = registry.TryCancel(
+            ExecutionCancellationRegistry.ChatScope, "session-Z", "owner-Z");
+
+        result.Should().Be(ExecutionCancelResult.Cancelled);
+        cts.IsCancellationRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Dispose_DeregistersEntry()
+    {
+        var registry = new ExecutionCancellationRegistry();
+        using var cts = new CancellationTokenSource();
+        IDisposable handle = registry.Register(
+            ExecutionCancellationRegistry.PlanScope, "plan-1", "owner", cts);
+
+        registry.OwnerOf(ExecutionCancellationRegistry.PlanScope, "plan-1").Should().Be("owner");
+        handle.Dispose();
+        registry.OwnerOf(ExecutionCancellationRegistry.PlanScope, "plan-1").Should().BeNull();
+
+        registry.TryCancel(ExecutionCancellationRegistry.PlanScope, "plan-1", "owner")
+            .Should().Be(ExecutionCancelResult.NotFound);
+    }
+
+    /// <summary>
+    /// Proof of end-to-end propagation: an in-flight "tool" invocation that
+    /// awaits on the CTS token STOPS its work when the cancel endpoint fires.
+    /// Simulates a specialist that's mid-tool-call — the token flows through
+    /// the request pipeline and reaches the tool, so the tool observes the
+    /// cancellation and its loop terminates. Asserting the loop count, not
+    /// just that the task completed, matches the issue's "assert tool
+    /// invocation ceases" requirement.
+    /// </summary>
+    [Fact]
+    public async Task InFlightToolInvocation_ObservesCancellation_AndCeasesWork()
+    {
+        var registry = new ExecutionCancellationRegistry();
+        using var cts = new CancellationTokenSource();
+        using IDisposable handle = registry.Register(
+            ExecutionCancellationRegistry.PlanScope, "plan-inflight", "owner", cts);
+
+        int loopIterations = 0;
+        bool observedCancellation = false;
+
+        Task toolTask = Task.Run(async () =>
+        {
+            try
+            {
+                while (true)
+                {
+                    cts.Token.ThrowIfCancellationRequested();
+                    Interlocked.Increment(ref loopIterations);
+                    await Task.Delay(10, cts.Token).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                observedCancellation = true;
+            }
+        });
+
+        // Let the "tool" run a few iterations.
+        await Task.Delay(60);
+        int before = Volatile.Read(ref loopIterations);
+        before.Should().BeGreaterThan(0);
+
+        // Simulate POST /api/plans/{id}/cancel by the owning subject.
+        ExecutionCancelResult result = registry.TryCancel(
+            ExecutionCancellationRegistry.PlanScope, "plan-inflight", "owner");
+        result.Should().Be(ExecutionCancelResult.Cancelled);
+
+        // The tool loop must actually stop — assert BOTH termination AND
+        // that the iteration count freezes (proving the tool ceased its
+        // work, not merely that the outer HTTP response returned).
+        await toolTask.WaitAsync(TimeSpan.FromSeconds(2));
+        observedCancellation.Should().BeTrue(
+            "the in-flight tool invocation must observe cancellation via the shared CTS token");
+
+        int after = Volatile.Read(ref loopIterations);
+        await Task.Delay(80);
+        int later = Volatile.Read(ref loopIterations);
+        later.Should().Be(after,
+            "the tool loop must actually stop iterating after cancellation, not just return HTTP");
+    }
+}

--- a/tests/RetailPulse.Tests/Hubs/ExecutionCancellationRegistryTests.cs
+++ b/tests/RetailPulse.Tests/Hubs/ExecutionCancellationRegistryTests.cs
@@ -91,7 +91,7 @@ public sealed class ExecutionCancellationRegistryTests
         int loopIterations = 0;
         bool observedCancellation = false;
 
-        Task toolTask = Task.Run(async () =>
+        var toolTask = Task.Run(async () =>
         {
             try
             {

--- a/tests/RetailPulse.Tests/Hubs/HubHeartbeatBackgroundServiceTests.cs
+++ b/tests/RetailPulse.Tests/Hubs/HubHeartbeatBackgroundServiceTests.cs
@@ -30,7 +30,7 @@ public sealed class HubHeartbeatBackgroundServiceTests
         (Mock<IHubContext<TelemetryHub>> telemetry, Mock<IClientProxy> telemetryProxy) = NewHub<TelemetryHub>();
         (Mock<IHubContext<StreamingHub>> streaming, Mock<IClientProxy> streamingProxy) = NewHub<StreamingHub>();
 
-        var options = Options.Create(new RealtimeResilienceOptions
+        IOptions<RealtimeResilienceOptions> options = Options.Create(new RealtimeResilienceOptions
         {
             KeepAliveInterval = TimeSpan.FromSeconds(15),
             ClientTimeoutInterval = TimeSpan.FromSeconds(30),
@@ -61,10 +61,10 @@ public sealed class HubHeartbeatBackgroundServiceTests
     [Fact]
     public async Task ExecuteAsync_EmitsAtConfiguredInterval()
     {
-        (Mock<IHubContext<TelemetryHub>> telemetry, Mock<IClientProxy> telemetryProxy) = NewHub<TelemetryHub>();
-        (Mock<IHubContext<StreamingHub>> streaming, Mock<IClientProxy> streamingProxy) = NewHub<StreamingHub>();
+        (Mock<IHubContext<TelemetryHub>> telemetry, _) = NewHub<TelemetryHub>();
+        (Mock<IHubContext<StreamingHub>> streaming, _) = NewHub<StreamingHub>();
 
-        var options = Options.Create(new RealtimeResilienceOptions
+        IOptions<RealtimeResilienceOptions> options = Options.Create(new RealtimeResilienceOptions
         {
             ApplicationHeartbeatInterval = TimeSpan.FromMilliseconds(40),
             ApplicationHeartbeatEnabled = true,
@@ -97,7 +97,7 @@ public sealed class HubHeartbeatBackgroundServiceTests
         (Mock<IHubContext<TelemetryHub>> telemetry, Mock<IClientProxy> telemetryProxy) = NewHub<TelemetryHub>();
         (Mock<IHubContext<StreamingHub>> streaming, Mock<IClientProxy> streamingProxy) = NewHub<StreamingHub>();
 
-        var options = Options.Create(new RealtimeResilienceOptions
+        IOptions<RealtimeResilienceOptions> options = Options.Create(new RealtimeResilienceOptions
         {
             ApplicationHeartbeatInterval = TimeSpan.FromMilliseconds(20),
             ApplicationHeartbeatEnabled = false,

--- a/tests/RetailPulse.Tests/Hubs/HubHeartbeatBackgroundServiceTests.cs
+++ b/tests/RetailPulse.Tests/Hubs/HubHeartbeatBackgroundServiceTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Hubs;
+
+namespace RetailPulse.Tests.Hubs;
+
+/// <summary>
+/// Backend contract for issue #92: an application-level heartbeat is emitted on
+/// both hubs at the configured cadence, and the emitter honours the
+/// configuration binding rather than a private hard-coded default.
+/// </summary>
+public sealed class HubHeartbeatBackgroundServiceTests
+{
+    private static (Mock<IHubContext<T>> Hub, Mock<IClientProxy> Proxy) NewHub<T>() where T : Hub
+    {
+        var proxy = new Mock<IClientProxy>();
+        var clients = new Mock<IHubClients>();
+        clients.SetupGet(c => c.All).Returns(proxy.Object);
+        var hub = new Mock<IHubContext<T>>();
+        hub.SetupGet(h => h.Clients).Returns(clients.Object);
+        return (hub, proxy);
+    }
+
+    [Fact]
+    public async Task EmitOnce_SendsHeartbeat_ToBothHubs()
+    {
+        (Mock<IHubContext<TelemetryHub>> telemetry, Mock<IClientProxy> telemetryProxy) = NewHub<TelemetryHub>();
+        (Mock<IHubContext<StreamingHub>> streaming, Mock<IClientProxy> streamingProxy) = NewHub<StreamingHub>();
+
+        var options = Options.Create(new RealtimeResilienceOptions
+        {
+            KeepAliveInterval = TimeSpan.FromSeconds(15),
+            ClientTimeoutInterval = TimeSpan.FromSeconds(30),
+            ApplicationHeartbeatInterval = TimeSpan.FromMilliseconds(50),
+            ApplicationHeartbeatEnabled = true,
+        });
+
+        var svc = new HubHeartbeatBackgroundService(
+            telemetry.Object,
+            streaming.Object,
+            options,
+            TimeProvider.System,
+            NullLogger<HubHeartbeatBackgroundService>.Instance);
+
+        await svc.EmitOnceAsync(CancellationToken.None);
+
+        telemetryProxy.Verify(p => p.SendCoreAsync(
+            HubHeartbeatBackgroundService.EventName,
+            It.IsAny<object[]>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        streamingProxy.Verify(p => p.SendCoreAsync(
+            HubHeartbeatBackgroundService.EventName,
+            It.IsAny<object[]>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        svc.EmittedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmitsAtConfiguredInterval()
+    {
+        (Mock<IHubContext<TelemetryHub>> telemetry, Mock<IClientProxy> telemetryProxy) = NewHub<TelemetryHub>();
+        (Mock<IHubContext<StreamingHub>> streaming, Mock<IClientProxy> streamingProxy) = NewHub<StreamingHub>();
+
+        var options = Options.Create(new RealtimeResilienceOptions
+        {
+            ApplicationHeartbeatInterval = TimeSpan.FromMilliseconds(40),
+            ApplicationHeartbeatEnabled = true,
+        });
+
+        var svc = new HubHeartbeatBackgroundService(
+            telemetry.Object,
+            streaming.Object,
+            options,
+            TimeProvider.System,
+            NullLogger<HubHeartbeatBackgroundService>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await svc.StartAsync(cts.Token);
+
+        // Wait a real interval so the PeriodicTimer fires several times.
+        await Task.Delay(TimeSpan.FromMilliseconds(250));
+
+        cts.Cancel();
+        await svc.StopAsync(CancellationToken.None);
+
+        svc.EmittedCount.Should().BeGreaterThanOrEqualTo(3,
+            "the emitter should tick at the configured cadence, not a hard-coded default");
+        svc.Interval.Should().Be(TimeSpan.FromMilliseconds(40));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DisabledByConfig_DoesNotEmit()
+    {
+        (Mock<IHubContext<TelemetryHub>> telemetry, Mock<IClientProxy> telemetryProxy) = NewHub<TelemetryHub>();
+        (Mock<IHubContext<StreamingHub>> streaming, Mock<IClientProxy> streamingProxy) = NewHub<StreamingHub>();
+
+        var options = Options.Create(new RealtimeResilienceOptions
+        {
+            ApplicationHeartbeatInterval = TimeSpan.FromMilliseconds(20),
+            ApplicationHeartbeatEnabled = false,
+        });
+
+        var svc = new HubHeartbeatBackgroundService(
+            telemetry.Object,
+            streaming.Object,
+            options,
+            TimeProvider.System,
+            NullLogger<HubHeartbeatBackgroundService>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await svc.StartAsync(cts.Token);
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+        await svc.StopAsync(CancellationToken.None);
+
+        svc.EmittedCount.Should().Be(0);
+        telemetryProxy.Verify(p => p.SendCoreAsync(
+            It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/RetailPulse.Tests/Security/AnonymousHubOwnershipTests.cs
+++ b/tests/RetailPulse.Tests/Security/AnonymousHubOwnershipTests.cs
@@ -3,22 +3,18 @@ using FluentAssertions;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
 using RetailPulse.Api.Hubs;
-using RetailPulse.Api.Security.Anonymous;
 
 namespace RetailPulse.Tests.Security;
 
 /// <summary>
-/// Sprint 1 mandated simplification: the SignalR hubs are NO LONGER part of the anonymous surface.
-/// A valid anonymous token is denied (403) on BOTH hubs at both the negotiate and connection
-/// endpoints — proven by the deny-by-default guard in
-/// <see cref="AnonymousAuthenticationTests"/> and by the compiled endpoint-graph policy in
-/// <see cref="EndpointAuthorizationCoverageTests"/>. Because anonymous callers can never reach a
-/// hub method, the former anonymous hub session-ownership expectations are intentionally gone.
+/// Hub session-ownership guardrails. As of issue #92 the ownership registry is
+/// consulted for BOTH anonymous and authenticated callers so a hostile client
+/// that reconnects and attempts to rejoin another subject's session group is
+/// refused. First-writer-wins for a server-minted sessionId; every subsequent
+/// join (including reconnects) must match the recorded owner.
 ///
-/// What remains here is a guardrail proving the mandate's other half: <b>Entra hub behaviour is
-/// unchanged.</b> An Entra caller keeps its original (unbound) semantics on the real
-/// <see cref="TelemetryHub"/>, so the scope reduction for anonymous did not regress the
-/// authenticated real-time surface.
+/// <para>Card subscriptions remain deny-by-default for anonymous callers — the
+/// card/approval surface is not part of the anonymous scope.</para>
 /// </summary>
 public sealed class AnonymousHubOwnershipTests
 {
@@ -38,17 +34,23 @@ public sealed class AnonymousHubOwnershipTests
     }
 
     [Fact]
-    public async Task TelemetryHub_EntraCaller_IsUnbound_AndCanJoinAnySession()
+    public async Task TelemetryHub_EntraCaller_FirstJoin_ClaimsOwnership()
     {
         var registry = new SessionOwnershipRegistry();
         const string sessionId = "some-session";
 
-        // Entra behaviour is unchanged by the anonymous scope reduction — no ownership binding is
-        // enforced and the caller is added to the requested group as before.
+        // Ownership is now enforced for authenticated callers too (issue #92).
+        // The first Entra join for a fresh sessionId claims ownership and
+        // succeeds; a subsequent rejoin by the same subject also succeeds.
         (TelemetryHub entraHub, Mock<IGroupManager> entraGroups) = NewTelemetryHub(registry, Entra("entra-oid-1"), "conn-E");
         await entraHub.JoinSession(sessionId);
-        entraGroups.Verify(g => g.AddToGroupAsync("conn-E", sessionId, It.IsAny<CancellationToken>()), Times.Once,
-            "Entra callers retain their original hub semantics");
+        entraGroups.Verify(g => g.AddToGroupAsync("conn-E", sessionId, It.IsAny<CancellationToken>()), Times.Once);
+
+        // Rejoin from the same subject is allowed.
+        await entraHub.JoinSession(sessionId);
+        entraGroups.Verify(g => g.AddToGroupAsync("conn-E", sessionId, It.IsAny<CancellationToken>()), Times.Exactly(2));
+
+        registry.OwnerOf(sessionId).Should().Be("entra-oid-1");
     }
 
     [Fact]

--- a/tests/RetailPulse.Tests/Security/HubForeignRejoinTests.cs
+++ b/tests/RetailPulse.Tests/Security/HubForeignRejoinTests.cs
@@ -1,0 +1,161 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using RetailPulse.Api.Hubs;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Security guardrail for issue #92: a hostile client must NOT be able to
+/// rejoin another subject's session group after a reconnect. Ownership is
+/// enforced for BOTH authenticated and anonymous callers on the telemetry AND
+/// the streaming hub, and the same registry is consulted by both — a rejoin
+/// with a foreign sessionId is refused with <see cref="HubException"/>.
+/// </summary>
+public sealed class HubForeignRejoinTests
+{
+    private static ClaimsPrincipal Entra(string oid) =>
+        new(new ClaimsIdentity([new Claim("oid", oid)], authenticationType: "EntraTest"));
+
+    private static ClaimsPrincipal Anonymous(string sub)
+    {
+        // Mirror the Anonymous provider shape (see AnonymousCapabilityPolicy):
+        // an authenticated identity with only the "sub" claim.
+        var identity = new ClaimsIdentity(
+            [
+                new Claim("sub", sub),
+                new Claim("provider", "Anonymous"),
+            ],
+            authenticationType: "Anonymous");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static Mock<HubCallerContext> Ctx(ClaimsPrincipal user, string connectionId)
+    {
+        var ctx = new Mock<HubCallerContext>();
+        ctx.SetupGet(c => c.User).Returns(user);
+        ctx.SetupGet(c => c.ConnectionId).Returns(connectionId);
+        return ctx;
+    }
+
+    private static Mock<IGroupManager> Groups()
+    {
+        var groups = new Mock<IGroupManager>();
+        groups.Setup(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        return groups;
+    }
+
+    [Fact]
+    public async Task TelemetryHub_AuthenticatedAttacker_ForeignSession_IsRefused()
+    {
+        var registry = new SessionOwnershipRegistry();
+        const string victimSession = "victim-session-123";
+
+        // Victim (Entra "oid-A") legitimately joins their session first.
+        var victimHub = new TelemetryHub(registry)
+        {
+            Context = Ctx(Entra("oid-A"), "victim-conn").Object,
+            Groups = Groups().Object,
+        };
+        await victimHub.JoinSession(victimSession);
+
+        // Attacker (Entra "oid-B") reconnects and attempts to rejoin the
+        // victim's session id. Must be refused with HubException.
+        Mock<IGroupManager> attackerGroups = Groups();
+        var attackerHub = new TelemetryHub(registry)
+        {
+            Context = Ctx(Entra("oid-B"), "attacker-conn").Object,
+            Groups = attackerGroups.Object,
+        };
+
+        Func<Task> act = () => attackerHub.JoinSession(victimSession);
+        await act.Should().ThrowAsync<HubException>();
+
+        attackerGroups.Verify(
+            g => g.AddToGroupAsync("attacker-conn", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "attacker must never be added to any group when the join is refused");
+        registry.OwnerOf(victimSession).Should().Be("oid-A");
+    }
+
+    [Fact]
+    public async Task StreamingHub_AuthenticatedAttacker_ForeignSession_IsRefused()
+    {
+        var registry = new SessionOwnershipRegistry();
+        const string victimSession = "victim-stream-abc";
+
+        var victimHub = new StreamingHub(registry)
+        {
+            Context = Ctx(Entra("oid-A"), "victim-conn").Object,
+            Groups = Groups().Object,
+        };
+        await victimHub.JoinSession(victimSession);
+
+        Mock<IGroupManager> attackerGroups = Groups();
+        var attackerHub = new StreamingHub(registry)
+        {
+            Context = Ctx(Entra("oid-B"), "attacker-conn").Object,
+            Groups = attackerGroups.Object,
+        };
+
+        Func<Task> act = () => attackerHub.JoinSession(victimSession);
+        await act.Should().ThrowAsync<HubException>();
+
+        attackerGroups.Verify(
+            g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TelemetryHub_AnonymousHardening_Preserved()
+    {
+        var registry = new SessionOwnershipRegistry();
+        const string victimSession = "anon-victim";
+
+        var victimHub = new TelemetryHub(registry)
+        {
+            Context = Ctx(Anonymous("anon-sub-A"), "victim-conn").Object,
+            Groups = Groups().Object,
+        };
+        await victimHub.JoinSession(victimSession);
+
+        var attackerHub = new TelemetryHub(registry)
+        {
+            Context = Ctx(Anonymous("anon-sub-B"), "attacker-conn").Object,
+            Groups = Groups().Object,
+        };
+
+        Func<Task> act = () => attackerHub.JoinSession(victimSession);
+        await act.Should().ThrowAsync<HubException>();
+    }
+
+    [Fact]
+    public async Task TelemetryHub_LegitimateReconnect_ByOwner_Succeeds()
+    {
+        var registry = new SessionOwnershipRegistry();
+        const string sessionId = "owned-session";
+
+        Mock<IGroupManager> firstGroups = Groups();
+        var firstConnect = new TelemetryHub(registry)
+        {
+            Context = Ctx(Entra("oid-owner"), "conn-1").Object,
+            Groups = firstGroups.Object,
+        };
+        await firstConnect.JoinSession(sessionId);
+
+        // Reconnect: fresh connection id, same subject.
+        Mock<IGroupManager> reconnectGroups = Groups();
+        var reconnect = new TelemetryHub(registry)
+        {
+            Context = Ctx(Entra("oid-owner"), "conn-2").Object,
+            Groups = reconnectGroups.Object,
+        };
+        await reconnect.JoinSession(sessionId);
+
+        reconnectGroups.Verify(
+            g => g.AddToGroupAsync("conn-2", sessionId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
Closes #92

## Summary
- add configurable SignalR keepalive and observable application heartbeats on telemetry and streaming hubs
- separate the 90-second single-shot ceiling from the configurable long-running plan ceiling
- add subject-scoped cancellation and plan reconciliation while preserving session ownership enforcement
- add bounded reconnect, visible connection state, secure resubscription, timeout retry/abandon, and cancel UX

## Security and correctness
- hub join and reconnect enforce `ISessionOwnershipRegistry` for authenticated and anonymous callers
- hostile foreign-session rejoin is rejected in telemetry and streaming hub tests
- cancellation tests assert the in-flight tool loop stops advancing after cancellation, not merely that the HTTP request returns
- reconciliation deduplicates plan steps and does not regress terminal state

## Coordination
- `ChatPanel.tsx` and `telemetryHub.ts`, shared with #96, received minimal resilience-only changes; no plan-view refactor was included
- no #108 content-pack, tenant configuration, or seeding files were touched

## Validation
- full backend suite: 3,178 passed, 9 live-service skips
- targeted resilience/security suite: 23 passed
- `dotnet format RetailPulse.slnx --verify-no-changes`: passed
- frontend Vitest and build validation are CI-only because dependencies are intentionally not installed locally

## Deferred deployed verification
Local execution cannot reproduce intermediary idle behavior. Multi-minute idle survival through APIM is **not claimed as locally verified** and remains a deployed-environment verification item. The procedure and expected observations are documented in `docs/resilience-operations.md`.