### PR TITLE
Frontend: starting tasks sourced from the active content pack (#109)

### DIFF
--- a/packs/default/starting-tasks.yaml
+++ b/packs/default/starting-tasks.yaml
@@ -1,67 +1,133 @@
-# Curated starting prompts for the default (Apex Retail Group) pack.
+# Curated starting tasks for the default (Apex Retail Group) pack.
+#
 # Every category and prompt matches the frontend PROMPT_CATEGORIES in
-# src/RetailPulse.Web/src/constants/prompts.ts so a downstream endpoint
-# that projects these into the PromptLibrary preserves the current
-# welcome-state and library behaviour exactly.
+# src/RetailPulse.Web/src/constants/prompts.ts so the endpoint projection
+# preserves the current welcome-state and library behaviour exactly. On
+# the default pack `name` is intentionally set equal to `prompt` so the
+# prompt-acceptance sweep (which matches on the verbatim prompt text)
+# continues to pass without modification.
+#
+# Fictional packs (halcyon-pet-supply, prairiehearth-craft-supply)
+# demonstrate short, scannable `name` labels that submit a fully-formed
+# `prompt` string — the design pattern issue #109 unlocks.
 
 categories:
   - id: general
     label: "General Retail"
     emoji: "📊"
-    prompts:
-      - "Compare depletion trends across all regions for this quarter"
-      - "Which brands are growing fastest year-over-year across the portfolio?"
-      - "Show me field sentiment for our top 3 brands in the Southeast"
+    order: 1
+    tasks:
+      - name: "Compare depletion trends across all regions for this quarter"
+        prompt: "Compare depletion trends across all regions for this quarter"
+        capability: { kind: prose }
+      - name: "Which brands are growing fastest year-over-year across the portfolio?"
+        prompt: "Which brands are growing fastest year-over-year across the portfolio?"
+        capability: { kind: prose }
+      - name: "Show me field sentiment for our top 3 brands in the Southeast"
+        prompt: "Show me field sentiment for our top 3 brands in the Southeast"
+        capability: { kind: prose }
 
   - id: grocery
     label: "Grocery"
     emoji: "🛒"
-    prompts:
-      - "How are FreshMart depletions trending in the Northeast this quarter?"
-      - "Compare Harvest Table vs FreshMart sell-through rates by region"
-      - "What is the field sentiment for Harvest Table Meal Kits in the Midwest?"
+    order: 2
+    tasks:
+      - name: "How are FreshMart depletions trending in the Northeast this quarter?"
+        prompt: "How are FreshMart depletions trending in the Northeast this quarter?"
+        capability: { kind: prose }
+      - name: "Compare Harvest Table vs FreshMart sell-through rates by region"
+        prompt: "Compare Harvest Table vs FreshMart sell-through rates by region"
+        capability: { kind: prose }
+      - name: "What is the field sentiment for Harvest Table Meal Kits in the Midwest?"
+        prompt: "What is the field sentiment for Harvest Table Meal Kits in the Midwest?"
+        capability: { kind: prose }
 
   - id: qsr
     label: "Quick-Serve Restaurants"
     emoji: "🍔"
-    prompts:
-      - "How is Apex Grill performing in the Southwest this quarter?"
-      - "Compare Coastline Tacos vs Apex Grill depletions across all regions"
-      - "What is the field sentiment for Coastline Tacos in the West Coast?"
+    order: 3
+    tasks:
+      - name: "How is Apex Grill performing in the Southwest this quarter?"
+        prompt: "How is Apex Grill performing in the Southwest this quarter?"
+        capability: { kind: prose }
+      - name: "Compare Coastline Tacos vs Apex Grill depletions across all regions"
+        prompt: "Compare Coastline Tacos vs Apex Grill depletions across all regions"
+        capability: { kind: chart, chartType: groupedBar }
+      - name: "What is the field sentiment for Coastline Tacos in the West Coast?"
+        prompt: "What is the field sentiment for Coastline Tacos in the West Coast?"
+        capability: { kind: prose }
 
   - id: home-improvement
     label: "Home Improvement"
     emoji: "🏠"
-    prompts:
-      - "Show me Pinnacle Hardware depletion stats in the Midwest for Q1"
-      - "How is Summit Outdoor performing in the Southeast vs West Coast?"
-      - "What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest?"
+    order: 4
+    tasks:
+      - name: "Show me Pinnacle Hardware depletion stats in the Midwest for Q1"
+        prompt: "Show me Pinnacle Hardware depletion stats in the Midwest for Q1"
+        capability: { kind: prose }
+      - name: "How is Summit Outdoor performing in the Southeast vs West Coast?"
+        prompt: "How is Summit Outdoor performing in the Southeast vs West Coast?"
+        capability: { kind: prose }
+      - name: "What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest?"
+        prompt: "What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest?"
+        capability: { kind: prose }
 
   - id: office-supply
     label: "Office Supply"
     emoji: "📎"
-    prompts:
-      - "How are ClearDesk depletions trending in the Northeast this quarter?"
-      - "Compare ClearDesk Technology vs Paper Products sell-through by region"
-      - "What is the field sentiment for ClearDesk in the Southeast?"
+    order: 5
+    tasks:
+      - name: "How are ClearDesk depletions trending in the Northeast this quarter?"
+        prompt: "How are ClearDesk depletions trending in the Northeast this quarter?"
+        capability: { kind: prose }
+      - name: "Compare ClearDesk Technology vs Paper Products sell-through by region"
+        prompt: "Compare ClearDesk Technology vs Paper Products sell-through by region"
+        capability: { kind: prose }
+      - name: "What is the field sentiment for ClearDesk in the Southeast?"
+        prompt: "What is the field sentiment for ClearDesk in the Southeast?"
+        capability: { kind: prose }
 
   - id: furniture
     label: "Furniture"
     emoji: "🛋️"
-    prompts:
-      - "Show me Urban Living depletion trends across all regions this quarter"
-      - "Compare Foundry Home vs Urban Living performance in the West Coast"
-      - "What is the field sentiment for Urban Living in the Pacific Northwest?"
+    order: 6
+    tasks:
+      - name: "Show me Urban Living depletion trends across all regions this quarter"
+        prompt: "Show me Urban Living depletion trends across all regions this quarter"
+        capability: { kind: prose }
+      - name: "Compare Foundry Home vs Urban Living performance in the West Coast"
+        prompt: "Compare Foundry Home vs Urban Living performance in the West Coast"
+        capability: { kind: prose }
+      - name: "What is the field sentiment for Urban Living in the Pacific Northwest?"
+        prompt: "What is the field sentiment for Urban Living in the Pacific Northwest?"
+        capability: { kind: prose }
 
   - id: charts
     label: "Charts"
     emoji: "📈"
-    prompts:
-      - "Create a line chart showing Sierra Gold Tequila depletion trends across all regions"
-      - "Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast"
-      - "Create a pie chart showing market share breakdown for our grocery brands nationally"
-      - "Show a grouped bar chart comparing FreshMart and Harvest Table across all regions"
-      - "Create a donut chart of Apex Grill variant mix in the Southwest"
-      - "Show a horizontal bar chart ranking all brands by depletion growth rate"
-      - "Create a table showing depletion stats for all home improvement brands by region"
-      - "Show a gauge chart for Pinnacle Hardware inventory health in the Midwest"
+    order: 7
+    tasks:
+      - name: "Create a line chart showing Sierra Gold Tequila depletion trends across all regions"
+        prompt: "Create a line chart showing Sierra Gold Tequila depletion trends across all regions"
+        capability: { kind: chart, chartType: line }
+      - name: "Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast"
+        prompt: "Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast"
+        capability: { kind: chart, chartType: bar }
+      - name: "Create a pie chart showing market share breakdown for our grocery brands nationally"
+        prompt: "Create a pie chart showing market share breakdown for our grocery brands nationally"
+        capability: { kind: chart, chartType: pie }
+      - name: "Show a grouped bar chart comparing FreshMart and Harvest Table across all regions"
+        prompt: "Show a grouped bar chart comparing FreshMart and Harvest Table across all regions"
+        capability: { kind: chart, chartType: groupedBar }
+      - name: "Create a donut chart of Apex Grill variant mix in the Southwest"
+        prompt: "Create a donut chart of Apex Grill variant mix in the Southwest"
+        capability: { kind: chart, chartType: donut }
+      - name: "Show a horizontal bar chart ranking all brands by depletion growth rate"
+        prompt: "Show a horizontal bar chart ranking all brands by depletion growth rate"
+        capability: { kind: chart, chartType: horizontalBar }
+      - name: "Create a table showing depletion stats for all home improvement brands by region"
+        prompt: "Create a table showing depletion stats for all home improvement brands by region"
+        capability: { kind: chart, chartType: table }
+      - name: "Show a gauge chart for Pinnacle Hardware inventory health in the Midwest"
+        prompt: "Show a gauge chart for Pinnacle Hardware inventory health in the Midwest"
+        capability: { kind: chart, chartType: gauge }

--- a/packs/halcyon-pet-supply/starting-tasks.yaml
+++ b/packs/halcyon-pet-supply/starting-tasks.yaml
@@ -1,41 +1,85 @@
-# Curated starting prompts for Halcyon Pet Supply.
+# Curated starting tasks for Halcyon Pet Supply.
+#
+# Fictional pack. Short display `name` values pair with fully-formed
+# `prompt` strings so a demo can click a concise button and get a rich,
+# specific submitted question. Explicit category and task ordering keeps
+# the panel deterministic regardless of authoring order.
+
 categories:
   - id: nutrition
     label: "Nutrition Planning"
     emoji: "🥣"
-    prompts:
-      - "How is Meadowbowl Nutrition auto-ship depletion trending in the Sunbelt this quarter?"
-      - "Compare grain-inclusive vs grain-free share for Riverstone Feline across all regions"
-      - "Show a life-stage transition forecast for puppy → adult across the Great Lakes"
+    order: 1
+    tasks:
+      - name: "Auto-ship depletion trend"
+        prompt: "How is Meadowbowl Nutrition auto-ship depletion trending in the Sunbelt this quarter?"
+        order: 1
+        capability: { kind: prose }
+      - name: "Grain-inclusive vs grain-free share"
+        prompt: "Compare grain-inclusive vs grain-free share for Riverstone Feline across all regions"
+        order: 2
+        capability: { kind: chart, chartType: bar }
+      - name: "Life-stage transition forecast"
+        prompt: "Show a life-stage transition forecast for puppy → adult across the Great Lakes"
+        order: 3
+        capability: { kind: plan, planPath: multi-step-forecast }
 
   - id: adoption
     label: "Adoption Partnerships"
     emoji: "🐾"
-    prompts:
-      - "Summarize shelter-partner sentiment for adoption events in Mountain Corridor"
-      - "What is the foster-network feedback on starter-kit follow-through in Pacific Metro?"
-      - "Which regions are seeing a drop in adoption-day traffic quality?"
+    order: 2
+    tasks:
+      - name: "Shelter partner sentiment"
+        prompt: "Summarize shelter-partner sentiment for adoption events in Mountain Corridor"
+        capability: { kind: prose }
+      - name: "Foster starter-kit feedback"
+        prompt: "What is the foster-network feedback on starter-kit follow-through in Pacific Metro?"
+        capability: { kind: prose }
+      - name: "Adoption-day traffic risks"
+        prompt: "Which regions are seeing a drop in adoption-day traffic quality?"
+        capability: { kind: prose }
 
   - id: grooming
     label: "Grooming Bar"
     emoji: "🛁"
-    prompts:
-      - "Show grooming appointment utilization for neighborhood stores in the Sunbelt"
-      - "Where are we losing de-shed slot bookings the most this month?"
-      - "Predict this week's stockout risk for grooming shampoo in the Great Lakes"
+    order: 3
+    tasks:
+      - name: "Grooming appointment utilization"
+        prompt: "Show grooming appointment utilization for neighborhood stores in the Sunbelt"
+        capability: { kind: chart, chartType: bar }
+      - name: "De-shed slot booking loss"
+        prompt: "Where are we losing de-shed slot bookings the most this month?"
+        capability: { kind: prose }
+      - name: "Shampoo stockout risk"
+        prompt: "Predict this week's stockout risk for grooming shampoo in the Great Lakes"
+        capability: { kind: plan, planPath: stockout-risk }
 
   - id: wellness-margin
     label: "Wellness Margin"
     emoji: "💚"
-    prompts:
-      - "Show margin drivers for Nimbus Pet Wellness across the portfolio"
-      - "What is the joint-care bundle margin trend over the last four quarters?"
-      - "Detect any margin risks in the wellness category this quarter"
+    order: 4
+    tasks:
+      - name: "Nimbus margin drivers"
+        prompt: "Show margin drivers for Nimbus Pet Wellness across the portfolio"
+        capability: { kind: chart, chartType: horizontalBar }
+      - name: "Joint-care bundle trend"
+        prompt: "What is the joint-care bundle margin trend over the last four quarters?"
+        capability: { kind: chart, chartType: line }
+      - name: "Wellness margin risk scan"
+        prompt: "Detect any margin risks in the wellness category this quarter"
+        capability: { kind: prose }
 
   - id: storefront
     label: "Storefront Planogram"
     emoji: "🏬"
-    prompts:
-      - "Optimize the wellness bay adjacency to the grooming waiting area"
-      - "Show the enrichment endcap rotation for Timberpaw Chews in the Sunbelt"
-      - "How should we lay out small-animal SKUs given Skylark's variant mix?"
+    order: 5
+    tasks:
+      - name: "Wellness bay adjacency"
+        prompt: "Optimize the wellness bay adjacency to the grooming waiting area"
+        capability: { kind: plan, planPath: planogram-adjacency }
+      - name: "Timberpaw endcap rotation"
+        prompt: "Show the enrichment endcap rotation for Timberpaw Chews in the Sunbelt"
+        capability: { kind: prose }
+      - name: "Skylark small-animal layout"
+        prompt: "How should we lay out small-animal SKUs given Skylark's variant mix?"
+        capability: { kind: prose }

--- a/packs/prairiehearth-craft-supply/starting-tasks.yaml
+++ b/packs/prairiehearth-craft-supply/starting-tasks.yaml
@@ -1,41 +1,81 @@
-# Curated starting prompts for Prairiehearth Craft Supply.
+# Curated starting tasks for Prairiehearth Craft Supply.
+#
+# Fictional pack. Short display `name` values pair with fully-formed
+# `prompt` strings, with explicit ordering per scenario so the panel
+# leads with the highest-impact task in every category.
+
 categories:
   - id: fibre-pipeline
     label: "Fibre Pipeline"
     emoji: "🧶"
-    prompts:
-      - "Show cooperative-supplier shipment health for Wovenwheel Fibre in the Prairie Belt"
-      - "Where are Loomshire warp-stock dye lots at risk this month?"
-      - "Summarize supply disruptions across the fibre category in Foothills stores"
+    order: 1
+    tasks:
+      - name: "Wovenwheel shipment health"
+        prompt: "Show cooperative-supplier shipment health for Wovenwheel Fibre in the Prairie Belt"
+        capability: { kind: chart, chartType: line }
+      - name: "Loomshire dye-lot risk"
+        prompt: "Where are Loomshire warp-stock dye lots at risk this month?"
+        capability: { kind: prose }
+      - name: "Foothills supply disruption scan"
+        prompt: "Summarize supply disruptions across the fibre category in Foothills stores"
+        capability: { kind: prose }
 
   - id: workshop-programming
     label: "Workshop Programming"
     emoji: "🎨"
-    prompts:
-      - "Forecast autumn fibre workshop enrollment in Lakes & Rivers"
-      - "Compare winter paper journaling class attach for Pinemark kits across regions"
-      - "Identify demand risks for spring plein-air paint series in Coastal Cottages"
+    order: 2
+    tasks:
+      - name: "Autumn fibre enrollment forecast"
+        prompt: "Forecast autumn fibre workshop enrollment in Lakes & Rivers"
+        capability: { kind: plan, planPath: enrollment-forecast }
+      - name: "Winter journaling attach"
+        prompt: "Compare winter paper journaling class attach for Pinemark kits across regions"
+        capability: { kind: chart, chartType: bar }
+      - name: "Spring plein-air demand risk"
+        prompt: "Identify demand risks for spring plein-air paint series in Coastal Cottages"
+        capability: { kind: prose }
 
   - id: kit-assortment
     label: "Kit Assortment"
     emoji: "🪚"
-    prompts:
-      - "Rebalance beginner endcap adjacency to the workshop-signup counter"
-      - "Show the Ridgeline Woodcraft project-bay rotation for the Foothills"
-      - "How should we lay out Marketstead beading given the summer festival calendar?"
+    order: 3
+    tasks:
+      - name: "Beginner endcap adjacency"
+        prompt: "Rebalance beginner endcap adjacency to the workshop-signup counter"
+        capability: { kind: plan, planPath: planogram-adjacency }
+      - name: "Ridgeline project-bay rotation"
+        prompt: "Show the Ridgeline Woodcraft project-bay rotation for the Foothills"
+        capability: { kind: prose }
+      - name: "Marketstead beading layout"
+        prompt: "How should we lay out Marketstead beading given the summer festival calendar?"
+        capability: { kind: prose }
 
   - id: community-signals
     label: "Community Signals"
     emoji: "🫱🏽‍🫲🏼"
-    prompts:
-      - "Summarize maker-circle sentiment for kit accessibility this quarter"
-      - "What are regional guilds saying about workshop pricing in the Prairie Belt?"
-      - "Which community event booths are outperforming their region's baseline?"
+    order: 4
+    tasks:
+      - name: "Maker-circle sentiment"
+        prompt: "Summarize maker-circle sentiment for kit accessibility this quarter"
+        capability: { kind: prose }
+      - name: "Guild pricing feedback"
+        prompt: "What are regional guilds saying about workshop pricing in the Prairie Belt?"
+        capability: { kind: prose }
+      - name: "Event booth outperformers"
+        prompt: "Which community event booths are outperforming their region's baseline?"
+        capability: { kind: chart, chartType: bar }
 
   - id: maker-margin
     label: "Maker Margin"
     emoji: "📐"
-    prompts:
-      - "Show margin drivers for Auroralight Paint kits"
-      - "What is the workshop-seat contribution trend for advanced joinery?"
-      - "Detect margin risks across the paper category in Foothills"
+    order: 5
+    tasks:
+      - name: "Auroralight margin drivers"
+        prompt: "Show margin drivers for Auroralight Paint kits"
+        capability: { kind: chart, chartType: horizontalBar }
+      - name: "Advanced joinery seat contribution"
+        prompt: "What is the workshop-seat contribution trend for advanced joinery?"
+        capability: { kind: chart, chartType: line }
+      - name: "Paper category margin risks"
+        prompt: "Detect margin risks across the paper category in Foothills"
+        capability: { kind: prose }

--- a/src/RetailPulse.Api/Endpoints/PackEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/PackEndpoints.cs
@@ -49,7 +49,20 @@ public static class PackEndpoints
                 Id: c.Id,
                 Label: c.Label,
                 Emoji: c.Emoji,
-                Prompts: c.Prompts))];
+                Order: c.Order,
+                // The legacy Prompts list is retained for clients that have
+                // not yet moved to the structured Tasks projection.
+                Prompts: c.Prompts,
+                Tasks: [.. c.Tasks.Select(t => new PackStartingTaskItem(
+                    Name: t.Name,
+                    Prompt: t.Prompt,
+                    Order: t.Order,
+                    Capability: t.Capability is null
+                        ? null
+                        : new PackStartingTaskCapabilityResponse(
+                            Kind: t.Capability.Kind,
+                            ChartType: t.Capability.ChartType,
+                            PlanPath: t.Capability.PlanPath)))]))];
 
             return Results.Ok(new PackStartingTasksResponse(
                 PackKey: pack.Name,
@@ -90,4 +103,17 @@ public sealed record PackStartingTaskResponse(
     string Id,
     string Label,
     string Emoji,
-    IReadOnlyList<string> Prompts);
+    int? Order,
+    IReadOnlyList<string> Prompts,
+    IReadOnlyList<PackStartingTaskItem> Tasks);
+
+public sealed record PackStartingTaskItem(
+    string Name,
+    string Prompt,
+    int? Order,
+    PackStartingTaskCapabilityResponse? Capability);
+
+public sealed record PackStartingTaskCapabilityResponse(
+    string Kind,
+    string? ChartType,
+    string? PlanPath);

--- a/src/RetailPulse.Api/Packs/PackLoader.cs
+++ b/src/RetailPulse.Api/Packs/PackLoader.cs
@@ -480,7 +480,7 @@ public sealed partial class PackLoader
         }
 
         var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var categories = new List<PackStartingTaskCategory>();
+        var withOrder = new List<(int SourceIndex, PackStartingTaskCategory Category)>();
         for (int i = 0; i < doc.Categories.Count; i++)
         {
             PackStartingTaskCategory cat = doc.Categories[i];
@@ -506,17 +506,161 @@ public sealed partial class PackLoader
                     $"starting-tasks category '{cat.Id}' is missing 'label'.",
                     "pack.starting-tasks.label-missing"));
             }
-            if (cat.Prompts is null || cat.Prompts.Count == 0)
-            {
-                issues.Add(new PackValidationIssue(packName, label,
-                    $"starting-tasks category '{cat.Id}' has no prompts.",
-                    "pack.starting-tasks.prompts-empty"));
-            }
 
-            categories.Add(cat);
+            PackStartingTaskCategory normalized = NormalizeCategoryTasks(packName, label, cat, issues);
+            withOrder.Add((i, normalized));
         }
 
-        return categories;
+        // Issue #109 — explicit ordering. Category-level `order:` places a
+        // category at the requested position; ties break on source-array
+        // index so an author who leaves the field off entirely still gets
+        // deterministic behavior.
+        return [.. withOrder
+            .OrderBy(x => x.Category.Order ?? int.MaxValue)
+            .ThenBy(x => x.SourceIndex)
+            .Select(x => x.Category)];
+    }
+
+    private static PackStartingTaskCategory NormalizeCategoryTasks(
+        string packName,
+        string label,
+        PackStartingTaskCategory cat,
+        List<PackValidationIssue> issues)
+    {
+        List<PackStartingTask> declaredTasks = cat.Tasks ?? [];
+        List<string> legacyPrompts = cat.Prompts ?? [];
+
+        if (declaredTasks.Count == 0 && legacyPrompts.Count == 0)
+        {
+            issues.Add(new PackValidationIssue(packName, label,
+                $"starting-tasks category '{cat.Id}' has no tasks. Declare 'tasks:' (preferred) or the legacy 'prompts:' list.",
+                "pack.starting-tasks.tasks-empty"));
+            return cat;
+        }
+
+        var effective = new List<PackStartingTask>();
+        if (declaredTasks.Count > 0)
+        {
+            // Structured tasks are the source of truth when declared — they
+            // carry strictly more information (display name + capability)
+            // than the legacy prompt-string list.
+            for (int t = 0; t < declaredTasks.Count; t++)
+            {
+                PackStartingTask task = declaredTasks[t];
+                string taskLabel = $"{label}.tasks[{t}]";
+
+                if (string.IsNullOrWhiteSpace(task.Prompt))
+                {
+                    issues.Add(new PackValidationIssue(packName, taskLabel,
+                        $"starting-tasks category '{cat.Id}' task[{t}] is missing 'prompt'.",
+                        "pack.starting-tasks.task-prompt-missing"));
+                    continue;
+                }
+                if (string.IsNullOrWhiteSpace(task.Name))
+                {
+                    issues.Add(new PackValidationIssue(packName, taskLabel,
+                        $"starting-tasks category '{cat.Id}' task[{t}] is missing 'name'.",
+                        "pack.starting-tasks.task-name-missing"));
+                    continue;
+                }
+
+                if (task.Capability is not null)
+                {
+                    ValidateCapability(packName, taskLabel, cat.Id, t, task.Capability, issues);
+                }
+
+                effective.Add(task);
+            }
+        }
+        else
+        {
+            // Legacy shape: each prompt string becomes a task where the
+            // display name equals the submitted prompt. Preserves pre-#109
+            // behavior verbatim for packs that have not been re-authored.
+            for (int p = 0; p < legacyPrompts.Count; p++)
+            {
+                string prompt = legacyPrompts[p];
+                if (string.IsNullOrWhiteSpace(prompt))
+                {
+                    issues.Add(new PackValidationIssue(packName, $"{label}.prompts[{p}]",
+                        $"starting-tasks category '{cat.Id}' prompt[{p}] is empty.",
+                        "pack.starting-tasks.legacy-prompt-empty"));
+                    continue;
+                }
+                effective.Add(new PackStartingTask { Name = prompt, Prompt = prompt });
+            }
+        }
+
+        if (effective.Count == 0)
+        {
+            issues.Add(new PackValidationIssue(packName, label,
+                $"starting-tasks category '{cat.Id}' has no valid tasks after normalization.",
+                "pack.starting-tasks.tasks-empty"));
+        }
+
+        List<PackStartingTask> sorted = [.. effective
+            .Select((task, idx) => (task, idx))
+            .OrderBy(x => x.task.Order ?? int.MaxValue)
+            .ThenBy(x => x.idx)
+            .Select(x => x.task)];
+
+        return new PackStartingTaskCategory
+        {
+            Id = cat.Id,
+            Label = cat.Label,
+            Emoji = cat.Emoji,
+            Order = cat.Order,
+            Tasks = sorted,
+            // The derived Prompts list keeps the legacy shape available so
+            // clients still on the old contract keep working; the ordered
+            // Tasks list is the primary surface.
+            Prompts = [.. sorted.Select(t => t.Prompt)],
+        };
+    }
+
+    private static readonly HashSet<string> _validCapabilityKinds = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "prose",
+        "chart",
+        "plan",
+    };
+
+    private static void ValidateCapability(
+        string packName,
+        string taskLabel,
+        string categoryId,
+        int taskIndex,
+        PackStartingTaskCapability capability,
+        List<PackValidationIssue> issues)
+    {
+        if (string.IsNullOrWhiteSpace(capability.Kind))
+        {
+            issues.Add(new PackValidationIssue(packName, taskLabel,
+                $"starting-tasks category '{categoryId}' task[{taskIndex}] capability is missing 'kind'.",
+                "pack.starting-tasks.capability-kind-missing"));
+            return;
+        }
+        if (!_validCapabilityKinds.Contains(capability.Kind))
+        {
+            issues.Add(new PackValidationIssue(packName, taskLabel,
+                $"starting-tasks category '{categoryId}' task[{taskIndex}] capability kind '{capability.Kind}' is not one of prose|chart|plan.",
+                "pack.starting-tasks.capability-kind-unknown"));
+            return;
+        }
+        if (capability.Kind.Equals("chart", StringComparison.OrdinalIgnoreCase)
+            && string.IsNullOrWhiteSpace(capability.ChartType))
+        {
+            issues.Add(new PackValidationIssue(packName, taskLabel,
+                $"starting-tasks category '{categoryId}' task[{taskIndex}] capability kind='chart' requires a 'chartType'.",
+                "pack.starting-tasks.capability-chart-type-missing"));
+        }
+        if (capability.Kind.Equals("plan", StringComparison.OrdinalIgnoreCase)
+            && string.IsNullOrWhiteSpace(capability.PlanPath))
+        {
+            issues.Add(new PackValidationIssue(packName, taskLabel,
+                $"starting-tasks category '{categoryId}' task[{taskIndex}] capability kind='plan' requires a 'planPath'.",
+                "pack.starting-tasks.capability-plan-path-missing"));
+        }
     }
 
     private static IReadOnlyList<PackKnowledgeDocument> LoadKnowledgeDocuments(

--- a/src/RetailPulse.Api/Packs/PackStartingTasks.cs
+++ b/src/RetailPulse.Api/Packs/PackStartingTasks.cs
@@ -11,9 +11,13 @@ public sealed class PackStartingTasksDocument
 }
 
 /// <summary>
-/// One category of curated starting prompts. Mirrors the shape the
-/// existing web PromptLibrary consumes so a downstream endpoint can
-/// project this straight into the client without reshaping.
+/// One category of curated starting prompts. Issue #109 adds structured
+/// <see cref="Tasks"/> (display name + submitted prompt + optional
+/// capability metadata) alongside the legacy <see cref="Prompts"/> list
+/// so a scenario can showcase specific behavior — a chart type or a
+/// multi-step plan path — deliberately. Older packs that only declare
+/// <see cref="Prompts"/> keep loading unchanged: the loader synthesizes
+/// tasks from prompt strings and the frontend receives the same shape.
 /// </summary>
 public sealed class PackStartingTaskCategory
 {
@@ -27,6 +31,82 @@ public sealed class PackStartingTaskCategory
     /// <summary>Emoji icon shown in the PromptLibrary chip.</summary>
     public string Emoji { get; init; } = "";
 
-    /// <summary>Ordered list of prompt strings shown in the category.</summary>
+    /// <summary>
+    /// Optional explicit ordering. Categories with a lower <see cref="Order"/>
+    /// value render first; ties break on source-array position so an author
+    /// can leave the field off entirely and get deterministic behavior.
+    /// </summary>
+    public int? Order { get; init; }
+
+    /// <summary>
+    /// Structured tasks for this category. When declared, this list is the
+    /// source of truth and <see cref="Prompts"/> is derived from it. When
+    /// omitted, the loader synthesizes tasks from the legacy string list so
+    /// existing packs keep working without change.
+    /// </summary>
+    public List<PackStartingTask> Tasks { get; init; } = [];
+
+    /// <summary>
+    /// Legacy list of prompt strings. Retained so packs authored before
+    /// issue #109 keep loading verbatim. On load, the flattened
+    /// <see cref="Tasks"/> list drives every downstream consumer.
+    /// </summary>
     public List<string> Prompts { get; init; } = [];
+}
+
+/// <summary>
+/// One curated starting task in a category. Distinguishes the display
+/// name shown to the user from the prompt string that is actually
+/// submitted to the chat backend so a short, scannable label can invoke
+/// a fully-formed question.
+/// </summary>
+public sealed class PackStartingTask
+{
+    /// <summary>Short display name shown on the suggestion button.</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>Verbatim prompt text submitted to the chat backend.</summary>
+    public string Prompt { get; init; } = "";
+
+    /// <summary>
+    /// Optional explicit ordering. Tasks with a lower <see cref="Order"/>
+    /// value render first within their category; ties break on source-array
+    /// position.
+    /// </summary>
+    public int? Order { get; init; }
+
+    /// <summary>
+    /// Optional declarative capability the task showcases. Purely
+    /// descriptive metadata — never changes execution behavior. Used by
+    /// the frontend to expose <c>data-capability-*</c> attributes so a
+    /// scenario can pin which chart type or plan path a task exercises.
+    /// </summary>
+    public PackStartingTaskCapability? Capability { get; init; }
+}
+
+/// <summary>
+/// Declarative capability metadata attached to a starting task.
+/// </summary>
+public sealed class PackStartingTaskCapability
+{
+    /// <summary>
+    /// Capability family the task showcases. Accepted values (case-
+    /// insensitive): <c>prose</c>, <c>chart</c>, <c>plan</c>. The loader
+    /// rejects any other value so a typo cannot silently ship.
+    /// </summary>
+    public string Kind { get; init; } = "";
+
+    /// <summary>
+    /// Chart type the task expects to render. Required when
+    /// <see cref="Kind"/> is <c>chart</c>. Free-form so pack authors can
+    /// name any chart the render pipeline supports.
+    /// </summary>
+    public string? ChartType { get; init; }
+
+    /// <summary>
+    /// Plan path identifier the task expects to exercise. Required when
+    /// <see cref="Kind"/> is <c>plan</c>. Free-form so pack authors can
+    /// name any orchestration path the platform supports.
+    /// </summary>
+    public string? PlanPath { get; init; }
 }

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
@@ -481,3 +481,103 @@ describe('ChatPanel', () => {
     expect(await screen.findByText(/awaiting reviewer input/i)).toBeInTheDocument();
   });
 });
+
+describe('ChatPanel — issue #109 pack-sourced starting tasks', () => {
+  it('renders the empty state when the active pack has no starting tasks', () => {
+    render(
+      <FluentProvider theme={teamsDarkTheme}>
+        <ChatPanel promptCategories={[]} />
+      </FluentProvider>,
+    );
+
+    expect(screen.getByTestId('welcome-prompt-empty')).toBeInTheDocument();
+    // Category chip row is suppressed so an "All" chip doesn't linger.
+    expect(screen.queryByRole('button', { name: /🏪 All/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the task display name on the button but submits the full prompt text', async () => {
+    const user = userEvent.setup();
+    sendMessageMock.mockResolvedValue({
+      kind: 'complete',
+      response: { reply: 'ok', sessionId: 'sess-name', spans: [], totalDurationMs: 10 },
+    });
+
+    render(
+      <FluentProvider theme={teamsDarkTheme}>
+        <ChatPanel
+          promptCategories={[
+            {
+              id: 'pack',
+              label: 'Pack',
+              emoji: '🎁',
+              tasks: [
+                {
+                  name: 'Depletion trend',
+                  prompt: 'How is Meadowbowl Nutrition auto-ship depletion trending in the Sunbelt this quarter?',
+                  capability: { kind: 'chart', chartType: 'line' },
+                },
+              ],
+              prompts: [
+                'How is Meadowbowl Nutrition auto-ship depletion trending in the Sunbelt this quarter?',
+              ],
+            },
+          ]}
+        />
+      </FluentProvider>,
+    );
+
+    const btn = screen.getByRole('button', { name: 'Depletion trend' });
+    expect(btn.textContent).toContain('Depletion trend');
+    expect(btn.textContent).not.toContain('Meadowbowl');
+    expect(btn.getAttribute('data-capability-kind')).toBe('chart');
+    expect(btn.getAttribute('data-capability-chart-type')).toBe('line');
+
+    await user.click(btn);
+
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1));
+    expect(sendMessageMock.mock.calls[0][0]).toMatchObject({
+      message: 'How is Meadowbowl Nutrition auto-ship depletion trending in the Sunbelt this quarter?',
+    });
+  });
+
+  it('re-renders welcome chips when the active pack projection swaps in a new categories list', () => {
+    const initial = [
+      {
+        id: 'pack-a',
+        label: 'Pack A',
+        emoji: '🅰️',
+        tasks: [{ name: 'A-task', prompt: 'a-prompt' }],
+        prompts: ['a-prompt'],
+      },
+    ];
+    const swapped = [
+      {
+        id: 'pack-b',
+        label: 'Pack B',
+        emoji: '🅱️',
+        tasks: [{ name: 'B-task', prompt: 'b-prompt' }],
+        prompts: ['b-prompt'],
+      },
+    ];
+
+    const { rerender } = render(
+      <FluentProvider theme={teamsDarkTheme}>
+        <ChatPanel promptCategories={initial} />
+      </FluentProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: /🅰️ Pack A/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'A-task' })).toBeInTheDocument();
+
+    rerender(
+      <FluentProvider theme={teamsDarkTheme}>
+        <ChatPanel promptCategories={swapped} />
+      </FluentProvider>,
+    );
+
+    expect(screen.queryByRole('button', { name: /🅰️ Pack A/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'A-task' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /🅱️ Pack B/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'B-task' })).toBeInTheDocument();
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/PromptLibrary.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/PromptLibrary.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
 import { PromptLibrary } from '../components/PromptLibrary';
-import { PROMPT_CATEGORIES } from '../constants/prompts';
+import { PROMPT_CATEGORIES, type PromptCategory } from '../constants/prompts';
 
 function renderLibrary(props: Partial<React.ComponentProps<typeof PromptLibrary>> = {}) {
   const onSelect = props.onSelect ?? vi.fn();
@@ -117,5 +117,176 @@ describe('PromptLibrary', () => {
   it('disables the trigger when disabled', () => {
     renderLibrary({ disabled: true });
     expect(screen.getByRole('button', { name: /Prompt ideas/i })).toBeDisabled();
+  });
+});
+
+describe('PromptLibrary — issue #109 task shape', () => {
+  function packCategories(): PromptCategory[] {
+    return [
+      {
+        id: 'pack-cat',
+        label: 'Pack Category',
+        emoji: '🎁',
+        order: 1,
+        tasks: [
+          {
+            name: 'Short label A',
+            prompt: 'Fully formed question about brand X in region Y',
+            capability: { kind: 'chart', chartType: 'line' },
+          },
+          {
+            name: 'Short label B',
+            prompt: 'Another fully formed question submitted to the backend',
+            capability: { kind: 'plan', planPath: 'planogram-adjacency' },
+          },
+        ],
+        prompts: [
+          'Fully formed question about brand X in region Y',
+          'Another fully formed question submitted to the backend',
+        ],
+      },
+    ];
+  }
+
+  it('renders the display name on the button and submits the full prompt string', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <FluentProvider theme={teamsDarkTheme}>
+        <PromptLibrary categories={packCategories()} onSelect={onSelect} />
+      </FluentProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
+    const heading = await screen.findByText('Prompt library', { selector: 'h2' });
+    const surface = heading.closest('[role="dialog"]') as HTMLElement;
+
+    const shortLabel = await within(surface).findByRole('button', { name: 'Short label A', hidden: true });
+    expect(shortLabel.textContent?.trim()).toBe('Short label A');
+
+    await user.click(shortLabel);
+
+    expect(onSelect).toHaveBeenCalledWith('Fully formed question about brand X in region Y');
+  });
+
+  it('exposes capability metadata as data-capability-* attributes so downstream tooling can key on it', async () => {
+    const user = userEvent.setup();
+    render(
+      <FluentProvider theme={teamsDarkTheme}>
+        <PromptLibrary categories={packCategories()} onSelect={() => {}} />
+      </FluentProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
+    await screen.findByText('Prompt library', { selector: 'h2' });
+
+    const items = await waitFor(() => {
+      const els = document.querySelectorAll('[data-testid="prompt-library-item"]');
+      if (els.length !== 2) throw new Error(`expected 2 items, saw ${els.length}`);
+      return Array.from(els) as HTMLButtonElement[];
+    });
+
+    expect(items[0].getAttribute('data-capability-kind')).toBe('chart');
+    expect(items[0].getAttribute('data-capability-chart-type')).toBe('line');
+    expect(items[1].getAttribute('data-capability-kind')).toBe('plan');
+    expect(items[1].getAttribute('data-capability-plan-path')).toBe('planogram-adjacency');
+  });
+
+  it('respects explicit task-level ordering when rendering within a category', async () => {
+    const user = userEvent.setup();
+    const categories: PromptCategory[] = [
+      {
+        id: 'ord',
+        label: 'Ordering',
+        emoji: '🔀',
+        tasks: [
+          { name: 'Delta', prompt: 'p-delta', order: 3 },
+          { name: 'Alpha', prompt: 'p-alpha', order: 1 },
+          { name: 'Bravo', prompt: 'p-bravo', order: 2 },
+        ],
+        // The prompts array intentionally mirrors task.prompt order for
+        // legacy consumers; the DOM order comes from tasks.
+        prompts: ['p-delta', 'p-alpha', 'p-bravo'],
+      },
+    ];
+    render(
+      <FluentProvider theme={teamsDarkTheme}>
+        <PromptLibrary categories={categories} onSelect={() => {}} />
+      </FluentProvider>,
+    );
+    await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
+    await screen.findByText('Prompt library', { selector: 'h2' });
+
+    // The component renders tasks in the array order it received them, so
+    // the ordering contract lives at the pack normalization boundary and is
+    // reflected verbatim in the DOM. This test proves the DOM does not
+    // silently re-sort.
+    const items = await waitFor(() => {
+      const els = document.querySelectorAll('[data-testid="prompt-library-item"]');
+      if (els.length !== 3) throw new Error(`expected 3 items, saw ${els.length}`);
+      return Array.from(els) as HTMLButtonElement[];
+    });
+    expect(items.map((el) => el.textContent?.trim())).toEqual(['Delta', 'Alpha', 'Bravo']);
+  });
+
+  it('renders an accessible empty state when no categories are supplied', async () => {
+    const user = userEvent.setup();
+    render(
+      <FluentProvider theme={teamsDarkTheme}>
+        <PromptLibrary categories={[]} onSelect={() => {}} />
+      </FluentProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
+    await screen.findByText('Prompt library', { selector: 'h2' });
+
+    const empty = await waitFor(() => {
+      const el = document.querySelector('[data-testid="prompt-library-empty"]');
+      if (!el) throw new Error('empty state not mounted');
+      return el as HTMLElement;
+    });
+
+    expect(empty).toHaveAttribute('role', 'status');
+    expect(empty.textContent).toMatch(/no starting tasks/i);
+
+    // The category chip row is hidden when there are no categories so a
+    // stray "All" chip does not linger next to the empty state.
+    expect(document.querySelector('[data-testid="prompt-library-categories"]')).toBeNull();
+  });
+
+  it('supports pack-switching by re-rendering with a fresh categories prop', async () => {
+    const user = userEvent.setup();
+    const initial = packCategories();
+    const { rerender } = render(
+      <FluentProvider theme={teamsDarkTheme}>
+        <PromptLibrary categories={initial} onSelect={() => {}} />
+      </FluentProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Prompt ideas/i }));
+    await screen.findByText('Prompt library', { selector: 'h2' });
+    expect(document.querySelector('[data-testid="prompt-library-category-pack-cat"]')).not.toBeNull();
+
+    // Simulate the Dashboard swapping in a second pack's categories after
+    // /api/pack/starting-tasks resolves for a different Packs:Active setting.
+    const swapped: PromptCategory[] = [
+      {
+        id: 'swap-cat',
+        label: 'Swapped Category',
+        emoji: '🔁',
+        tasks: [{ name: 'Swap task', prompt: 'swap-prompt' }],
+        prompts: ['swap-prompt'],
+      },
+    ];
+    rerender(
+      <FluentProvider theme={teamsDarkTheme}>
+        <PromptLibrary categories={swapped} onSelect={() => {}} />
+      </FluentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="prompt-library-category-swap-cat"]')).not.toBeNull();
+      expect(document.querySelector('[data-testid="prompt-library-category-pack-cat"]')).toBeNull();
+    });
   });
 });

--- a/src/RetailPulse.Web/src/__tests__/packApi.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/packApi.test.ts
@@ -196,4 +196,140 @@ describe('packApi.fetchStartingTasks', () => {
 
     await expect(fetchStartingTasks()).rejects.toThrow(/500/);
   });
+
+  it('parses the issue #109 tasks[] shape and preserves display name + submitted prompt + capability', async () => {
+    const payload = {
+      packKey: 'halcyon-pet-supply',
+      categories: [
+        {
+          id: 'nutrition',
+          label: 'Nutrition',
+          emoji: '🥣',
+          order: 1,
+          tasks: [
+            {
+              name: 'Auto-ship depletion trend',
+              prompt: 'How is Meadowbowl Nutrition auto-ship depletion trending in the Sunbelt this quarter?',
+              order: 1,
+              capability: { kind: 'prose' },
+            },
+            {
+              name: 'Grain-inclusive vs grain-free share',
+              prompt: 'Compare grain-inclusive vs grain-free share for Riverstone Feline across all regions',
+              order: 2,
+              capability: { kind: 'chart', chartType: 'bar' },
+            },
+            {
+              name: 'Life-stage forecast',
+              prompt: 'Show a life-stage transition forecast for puppy → adult across the Great Lakes',
+              order: 3,
+              capability: { kind: 'plan', planPath: 'multi-step-forecast' },
+            },
+          ],
+        },
+      ],
+    };
+
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse(payload)) as unknown as typeof fetch;
+
+    const tasks = await fetchStartingTasks();
+    expect(tasks.categories).toHaveLength(1);
+
+    const cat = tasks.categories[0];
+    expect(cat.order).toBe(1);
+    expect(cat.tasks).toHaveLength(3);
+    expect(cat.tasks[0].name).toBe('Auto-ship depletion trend');
+    expect(cat.tasks[0].prompt).toContain('Meadowbowl Nutrition');
+    expect(cat.tasks[0].capability).toEqual({ kind: 'prose' });
+    expect(cat.tasks[1].capability).toEqual({ kind: 'chart', chartType: 'bar' });
+    expect(cat.tasks[2].capability).toEqual({ kind: 'plan', planPath: 'multi-step-forecast' });
+
+    // Derived `prompts` array preserves submitted-prompt order for the
+    // legacy shape consumers.
+    expect(cat.prompts).toEqual(cat.tasks.map((t) => t.prompt));
+  });
+
+  it('sorts categories and tasks by their explicit `order` regardless of source-array position', async () => {
+    const payload = {
+      packKey: 'ordering',
+      categories: [
+        {
+          id: 'second-in-yaml',
+          label: 'Second in YAML',
+          emoji: 'b',
+          order: 1,
+          tasks: [
+            { name: 'Late task', prompt: 'p-late', order: 5 },
+            { name: 'Early task', prompt: 'p-early', order: 1 },
+          ],
+        },
+        {
+          id: 'first-in-yaml',
+          label: 'First in YAML',
+          emoji: 'a',
+          order: 10,
+          tasks: [{ name: 'Solo', prompt: 'p-solo' }],
+        },
+      ],
+    };
+
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse(payload)) as unknown as typeof fetch;
+
+    const tasks = await fetchStartingTasks();
+    expect(tasks.categories.map((c) => c.id)).toEqual(['second-in-yaml', 'first-in-yaml']);
+    expect(tasks.categories[0].tasks.map((t) => t.name)).toEqual(['Early task', 'Late task']);
+  });
+
+  it('prefers structured tasks[] over legacy prompts[] when both are present', async () => {
+    const payload = {
+      packKey: 'both',
+      categories: [
+        {
+          id: 'mixed',
+          label: 'Mixed',
+          emoji: 'm',
+          tasks: [{ name: 'From tasks', prompt: 'submitted-tasks-prompt' }],
+          prompts: ['legacy-prompt-should-be-ignored'],
+        },
+      ],
+    };
+
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse(payload)) as unknown as typeof fetch;
+
+    const tasks = await fetchStartingTasks();
+    expect(tasks.categories[0].tasks).toHaveLength(1);
+    expect(tasks.categories[0].tasks[0].name).toBe('From tasks');
+    expect(tasks.categories[0].tasks[0].prompt).toBe('submitted-tasks-prompt');
+    expect(tasks.categories[0].prompts).toEqual(['submitted-tasks-prompt']);
+  });
+
+  it('drops malformed tasks (missing name or prompt) and unknown capability kinds', async () => {
+    const payload = {
+      packKey: 'broken',
+      categories: [
+        {
+          id: 'mostly-fine',
+          label: 'Mostly Fine',
+          emoji: 'x',
+          tasks: [
+            { name: 'Good', prompt: 'good-prompt', capability: { kind: 'chart', chartType: 'line' } },
+            { name: '', prompt: 'no-name' },
+            { name: 'No prompt', prompt: '' },
+            { name: 'Unknown kind', prompt: 'weird', capability: { kind: 'sorcery' } },
+          ],
+        },
+      ],
+    };
+
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse(payload)) as unknown as typeof fetch;
+
+    const tasks = await fetchStartingTasks();
+    expect(tasks.categories[0].tasks).toHaveLength(2);
+    expect(tasks.categories[0].tasks[0].name).toBe('Good');
+    expect(tasks.categories[0].tasks[0].capability).toEqual({ kind: 'chart', chartType: 'line' });
+    // The 'Unknown kind' task survives because name+prompt are valid, but its
+    // capability is dropped (defensive normalization at the JSON boundary).
+    expect(tasks.categories[0].tasks[1].name).toBe('Unknown kind');
+    expect(tasks.categories[0].tasks[1].capability).toBeUndefined();
+  });
 });

--- a/src/RetailPulse.Web/src/__tests__/useActivePack.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/useActivePack.test.tsx
@@ -112,4 +112,48 @@ describe('useActivePack', () => {
     expect(result.current.pack?.key).toBe('halcyon-pet-supply');
     expect(result.current.categories).toBe(PROMPT_CATEGORIES);
   });
+
+  it('propagates structured tasks (name + prompt + capability) from the pack projection to the ready state', async () => {
+    const payload = {
+      packKey: 'halcyon-pet-supply',
+      categories: [
+        {
+          id: 'planning',
+          label: 'Planning',
+          emoji: 'map',
+          order: 1,
+          tasks: [
+            {
+              name: 'Multi-step forecast',
+              prompt: 'Build a multi-step demand forecast for auto-ship kibble',
+              order: 1,
+              capability: { kind: 'plan', planPath: 'multi-step-forecast' },
+            },
+            {
+              name: 'Adjacency chart',
+              prompt: 'Compare planogram adjacency lift across the Sunbelt',
+              order: 2,
+              capability: { kind: 'chart', chartType: 'bar' },
+            },
+          ],
+        },
+      ],
+    };
+
+    globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/api/pack')) return Promise.resolve(jsonResponse(packPayload()));
+      if (url.endsWith('/api/pack/starting-tasks')) return Promise.resolve(jsonResponse(payload));
+      return Promise.resolve(new Response(null, { status: 404 }));
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useActivePack());
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    const cats = result.current.categories;
+    expect(cats.map((c) => c.id)).toEqual(['planning']);
+    expect(cats[0].tasks.map((t) => t.name)).toEqual(['Multi-step forecast', 'Adjacency chart']);
+    expect(cats[0].tasks[0].capability).toEqual({ kind: 'plan', planPath: 'multi-step-forecast' });
+    expect(cats[0].tasks[1].capability).toEqual({ kind: 'chart', chartType: 'bar' });
+  });
 });

--- a/src/RetailPulse.Web/src/components/ChatPanel.tsx
+++ b/src/RetailPulse.Web/src/components/ChatPanel.tsx
@@ -353,6 +353,17 @@ const useChatStyles = makeStyles({
       transform: 'none',
     },
   },
+  suggestedEmpty: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '6px',
+    padding: '24px 16px',
+    textAlign: 'center',
+    color: 'var(--color-text-muted)',
+    fontSize: '13px',
+    lineHeight: '1.5',
+  },
   message: {
     display: 'flex',
     gap: '12px',
@@ -767,6 +778,9 @@ export function ChatPanel({
     ? promptCategories.filter(c => c.id === selectedCategory)
     : promptCategories;
 
+  const totalVisibleTasks = visiblePrompts.reduce((n, c) => n + c.tasks.length, 0);
+  const hasAnyTasks = promptCategories.some((c) => c.tasks.length > 0);
+
   return (
     <div className={styles.panel}>
       <div className={styles.messages}>
@@ -783,37 +797,71 @@ export function ChatPanel({
               Ask me about sales performance, inventory trends, or customer insights across your retail portfolio.
             </Text>
             <div className={styles.suggestedQueries}>
-              <div className={styles.categoryChips}>
-                <button
-                  className={`${styles.categoryChip} ${selectedCategory === null ? styles.categoryChipActive : ''}`}
-                  onClick={() => setSelectedCategory(null)}
-                >
-                  🏪 All
-                </button>
-                {promptCategories.map((cat) => (
-                  <button
-                    key={cat.id}
-                    className={`${styles.categoryChip} ${selectedCategory === cat.id ? styles.categoryChipActive : ''}`}
-                    onClick={() => setSelectedCategory(cat.id)}
-                  >
-                    {cat.emoji} {cat.label}
-                  </button>
-                ))}
-              </div>
-              <div className={styles.promptGrid}>
-                {visiblePrompts.map((cat) =>
-                  (selectedCategory ? cat.prompts : cat.prompts.slice(0, 1)).map((prompt, i) => (
+              {hasAnyTasks ? (
+                <>
+                  <div className={styles.categoryChips} role="group" aria-label="Suggested prompt categories">
                     <button
-                      key={`${cat.id}-${i}`}
-                      className={styles.suggestedQuery}
-                      onClick={() => handleSuggestedClick(prompt)}
-                      disabled={loading}
+                      className={`${styles.categoryChip} ${selectedCategory === null ? styles.categoryChipActive : ''}`}
+                      aria-pressed={selectedCategory === null}
+                      onClick={() => setSelectedCategory(null)}
                     >
-                      <span>{cat.emoji}</span> {prompt}
+                      🏪 All
                     </button>
-                  ))
-                )}
-              </div>
+                    {promptCategories.map((cat) => (
+                      <button
+                        key={cat.id}
+                        className={`${styles.categoryChip} ${selectedCategory === cat.id ? styles.categoryChipActive : ''}`}
+                        aria-pressed={selectedCategory === cat.id}
+                        onClick={() => setSelectedCategory(cat.id)}
+                      >
+                        {cat.emoji} {cat.label}
+                      </button>
+                    ))}
+                  </div>
+                  <div className={styles.promptGrid} data-testid="welcome-prompt-grid">
+                    {totalVisibleTasks === 0 ? (
+                      <div
+                        className={styles.suggestedEmpty}
+                        role="status"
+                        data-testid="welcome-prompt-empty"
+                      >
+                        No starting tasks in this category.
+                      </div>
+                    ) : (
+                      visiblePrompts.map((cat) =>
+                        (selectedCategory ? cat.tasks : cat.tasks.slice(0, 1)).map((task, i) => (
+                          <button
+                            key={`${cat.id}-${i}`}
+                            className={styles.suggestedQuery}
+                            data-testid="welcome-prompt-item"
+                            data-prompt-category={cat.id}
+                            data-prompt-index={i}
+                            data-prompt-text={task.prompt}
+                            data-capability-kind={task.capability?.kind ?? ''}
+                            data-capability-chart-type={task.capability?.chartType ?? ''}
+                            data-capability-plan-path={task.capability?.planPath ?? ''}
+                            aria-label={task.name}
+                            onClick={() => handleSuggestedClick(task.prompt)}
+                            disabled={loading}
+                          >
+                            <span>{cat.emoji}</span> {task.name}
+                          </button>
+                        ))
+                      )
+                    )}
+                  </div>
+                </>
+              ) : (
+                <div
+                  className={styles.suggestedEmpty}
+                  role="status"
+                  data-testid="welcome-prompt-empty"
+                >
+                  <span aria-hidden="true">✨</span>
+                  <Text>No starting tasks are defined for the active scenario.</Text>
+                  <Text>Ask a question directly in the composer to get started.</Text>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/src/RetailPulse.Web/src/components/PromptLibrary.tsx
+++ b/src/RetailPulse.Web/src/components/PromptLibrary.tsx
@@ -8,7 +8,7 @@ import {
   makeStyles,
 } from '@fluentui/react-components';
 import { Lightbulb24Regular } from '@fluentui/react-icons';
-import type { PromptCategory } from '../constants/prompts';
+import type { PromptCategory, StartingTask } from '../constants/prompts';
 
 interface PromptLibraryProps {
   categories: ReadonlyArray<PromptCategory>;
@@ -128,12 +128,26 @@ const useStyles = makeStyles({
       cursor: 'not-allowed',
     },
   },
+  emptyState: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '6px',
+    padding: '28px 16px',
+    textAlign: 'center',
+    color: 'var(--color-text-muted)',
+    fontSize: '13px',
+    lineHeight: '1.5',
+  },
 });
 
 /**
  * Always-available, discoverable prompt library rendered as a popover next to
- * the composer. Reuses the shared PROMPT_CATEGORIES source and the caller's safe
- * send behavior so a selected prompt is dispatched exactly like a welcome chip.
+ * the composer. Consumes `PromptCategory`s from either the built-in defaults
+ * or the active content pack (issue #109) and the caller's safe send behavior
+ * so a selected task's submitted prompt is dispatched exactly like a welcome
+ * chip. Each button displays `task.name` and submits `task.prompt`, so short
+ * scannable labels can invoke fully-formed questions.
  */
 export function PromptLibrary({ categories, onSelect, disabled }: PromptLibraryProps) {
   const styles = useStyles();
@@ -145,11 +159,16 @@ export function PromptLibrary({ categories, onSelect, disabled }: PromptLibraryP
     : categories;
 
   const handlePromptClick = useCallback(
-    (prompt: string) => {
-      onSelect(prompt);
+    (task: StartingTask) => {
+      onSelect(task.prompt);
       setOpen(false);
     },
     [onSelect],
+  );
+
+  const totalVisibleTasks = visibleCategories.reduce(
+    (n, c) => n + c.tasks.length,
+    0,
   );
 
   return (
@@ -182,53 +201,72 @@ export function PromptLibrary({ categories, onSelect, disabled }: PromptLibraryP
               Browse a category and pick a prompt to send.
             </Text>
           </div>
-          <div className={styles.categoryChips} role="group" aria-label="Prompt categories" data-testid="prompt-library-categories">
-            <button
-              type="button"
-              className={`${styles.categoryChip} ${selectedCategory === null ? styles.categoryChipActive : ''}`}
-              aria-pressed={selectedCategory === null}
-              data-testid="prompt-library-category-all"
-              onClick={() => setSelectedCategory(null)}
-            >
-              🏪 All
-            </button>
-            {categories.map((cat) => (
+          {categories.length > 0 && (
+            <div className={styles.categoryChips} role="group" aria-label="Prompt categories" data-testid="prompt-library-categories">
               <button
-                key={cat.id}
                 type="button"
-                className={`${styles.categoryChip} ${selectedCategory === cat.id ? styles.categoryChipActive : ''}`}
-                aria-pressed={selectedCategory === cat.id}
-                data-testid={`prompt-library-category-${cat.id}`}
-                onClick={() => setSelectedCategory(cat.id)}
+                className={`${styles.categoryChip} ${selectedCategory === null ? styles.categoryChipActive : ''}`}
+                aria-pressed={selectedCategory === null}
+                data-testid="prompt-library-category-all"
+                onClick={() => setSelectedCategory(null)}
               >
-                {cat.emoji} {cat.label}
+                🏪 All
               </button>
-            ))}
-          </div>
+              {categories.map((cat) => (
+                <button
+                  key={cat.id}
+                  type="button"
+                  className={`${styles.categoryChip} ${selectedCategory === cat.id ? styles.categoryChipActive : ''}`}
+                  aria-pressed={selectedCategory === cat.id}
+                  data-testid={`prompt-library-category-${cat.id}`}
+                  onClick={() => setSelectedCategory(cat.id)}
+                >
+                  {cat.emoji} {cat.label}
+                </button>
+              ))}
+            </div>
+          )}
           <div className={styles.promptList} data-testid="prompt-library-list">
-            {visibleCategories.map((cat) => (
-              <div key={cat.id} className={styles.promptGroup} data-testid={`prompt-library-group-${cat.id}`}>
-                {!selectedCategory && (
-                  <Text className={styles.groupLabel}>
-                    {cat.emoji} {cat.label}
-                  </Text>
-                )}
-                {cat.prompts.map((prompt, i) => (
-                  <button
-                    key={`${cat.id}-${i}`}
-                    type="button"
-                    className={styles.promptButton}
-                    data-testid="prompt-library-item"
-                    data-prompt-category={cat.id}
-                    data-prompt-index={i}
-                    onClick={() => handlePromptClick(prompt)}
-                    disabled={disabled}
-                  >
-                    {prompt}
-                  </button>
-                ))}
+            {totalVisibleTasks === 0 ? (
+              <div
+                className={styles.emptyState}
+                role="status"
+                data-testid="prompt-library-empty"
+              >
+                <span aria-hidden="true">✨</span>
+                <Text>No starting tasks are defined for the active scenario.</Text>
+                <Text>Ask a question directly in the composer to get started.</Text>
               </div>
-            ))}
+            ) : (
+              visibleCategories.map((cat) => (
+                <div key={cat.id} className={styles.promptGroup} data-testid={`prompt-library-group-${cat.id}`}>
+                  {!selectedCategory && (
+                    <Text className={styles.groupLabel}>
+                      {cat.emoji} {cat.label}
+                    </Text>
+                  )}
+                  {cat.tasks.map((task, i) => (
+                    <button
+                      key={`${cat.id}-${i}`}
+                      type="button"
+                      className={styles.promptButton}
+                      data-testid="prompt-library-item"
+                      data-prompt-category={cat.id}
+                      data-prompt-index={i}
+                      data-prompt-text={task.prompt}
+                      data-capability-kind={task.capability?.kind ?? ''}
+                      data-capability-chart-type={task.capability?.chartType ?? ''}
+                      data-capability-plan-path={task.capability?.planPath ?? ''}
+                      aria-label={task.name}
+                      onClick={() => handlePromptClick(task)}
+                      disabled={disabled}
+                    >
+                      {task.name}
+                    </button>
+                  ))}
+                </div>
+              ))
+            )}
           </div>
         </div>
       </PopoverSurface>

--- a/src/RetailPulse.Web/src/constants/prompts.ts
+++ b/src/RetailPulse.Web/src/constants/prompts.ts
@@ -4,89 +4,136 @@
  * Both the empty New Chat welcome state and the always-available prompt-library
  * popover consume these definitions, so the prompt text and categories are never
  * duplicated. Update prompts here and every surface stays in sync.
+ *
+ * Issue #109 introduces a richer per-task shape (display `name` vs submitted
+ * `prompt`, optional `capability` metadata) sourced from the active content
+ * pack. This module retains the built-in defaults as a synchronous fallback
+ * so the welcome grid paints on first render before `/api/pack/starting-tasks`
+ * resolves, and to keep the existing prompt-acceptance sweep grounded in a
+ * stable set of prompt strings. Each fallback task's `name` is intentionally
+ * set equal to its `prompt` so the manifest and DOM contracts (which match on
+ * verbatim prompt text) continue to hold.
  */
+
+/**
+ * Declarative capability metadata attached to a starting task. Purely
+ * descriptive — never changes execution behavior. Consumed by the UI to
+ * project `data-capability-*` attributes on the button.
+ */
+export interface StartingTaskCapability {
+  readonly kind: 'prose' | 'chart' | 'plan';
+  readonly chartType?: string;
+  readonly planPath?: string;
+}
+
+/**
+ * One curated starting task in a category. Distinguishes the short display
+ * `name` shown to the user from the fully-formed `prompt` string actually
+ * submitted to the chat backend.
+ */
+export interface StartingTask {
+  /** Short display label shown on the suggestion button. */
+  readonly name: string;
+  /** Verbatim prompt text submitted to the chat backend. */
+  readonly prompt: string;
+  /**
+   * Optional explicit ordering. Tasks with a lower `order` render first
+   * within their category; ties break on source-array position.
+   */
+  readonly order?: number;
+  /** Optional declarative capability the task showcases. */
+  readonly capability?: StartingTaskCapability;
+}
 
 export interface PromptCategory {
   id: string;
   label: string;
   emoji: string;
+  /**
+   * Optional explicit ordering. Categories with a lower `order` render first.
+   * Ties break on source-array position so packs that leave the field off
+   * still render deterministically.
+   */
+  order?: number;
+  /**
+   * Structured tasks — the primary rendering surface introduced by issue #109.
+   * `prompts` is derived from this list for backward compatibility with the
+   * prompt-acceptance manifest.
+   */
+  tasks: readonly StartingTask[];
+  /** Legacy list of submitted prompt strings; derived from `tasks`. */
   prompts: string[];
 }
 
+/**
+ * Build a category where each display `name` equals its submitted `prompt`.
+ * The synchronous fallback preserves the pre-#109 UI text exactly and keeps
+ * the prompt-acceptance manifest and DOM sweep grounded in the same strings.
+ */
+function mirrorCategory(
+  id: string,
+  label: string,
+  emoji: string,
+  order: number,
+  prompts: readonly (readonly [string, StartingTaskCapability])[],
+): PromptCategory {
+  const tasks: StartingTask[] = prompts.map(([prompt, capability]) => ({
+    name: prompt,
+    prompt,
+    capability,
+  }));
+  return {
+    id,
+    label,
+    emoji,
+    order,
+    tasks,
+    prompts: tasks.map((t) => t.prompt),
+  };
+}
+
+const PROSE: StartingTaskCapability = { kind: 'prose' };
+const CHART = (chartType: string): StartingTaskCapability => ({ kind: 'chart', chartType });
+
 export const PROMPT_CATEGORIES: ReadonlyArray<PromptCategory> = [
-  {
-    id: 'general',
-    label: 'General Retail',
-    emoji: '📊',
-    prompts: [
-      'Compare depletion trends across all regions for this quarter',
-      'Which brands are growing fastest year-over-year across the portfolio?',
-      'Show me field sentiment for our top 3 brands in the Southeast',
-    ],
-  },
-  {
-    id: 'grocery',
-    label: 'Grocery',
-    emoji: '🛒',
-    prompts: [
-      'How are FreshMart depletions trending in the Northeast this quarter?',
-      'Compare Harvest Table vs FreshMart sell-through rates by region',
-      'What is the field sentiment for Harvest Table Meal Kits in the Midwest?',
-    ],
-  },
-  {
-    id: 'qsr',
-    label: 'Quick-Serve Restaurants',
-    emoji: '🍔',
-    prompts: [
-      'How is Apex Grill performing in the Southwest this quarter?',
-      'Compare Coastline Tacos vs Apex Grill depletions across all regions',
-      'What is the field sentiment for Coastline Tacos in the West Coast?',
-    ],
-  },
-  {
-    id: 'home-improvement',
-    label: 'Home Improvement',
-    emoji: '🏠',
-    prompts: [
-      'Show me Pinnacle Hardware depletion stats in the Midwest for Q1',
-      'How is Summit Outdoor performing in the Southeast vs West Coast?',
-      'What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest?',
-    ],
-  },
-  {
-    id: 'office-supply',
-    label: 'Office Supply',
-    emoji: '📎',
-    prompts: [
-      'How are ClearDesk depletions trending in the Northeast this quarter?',
-      'Compare ClearDesk Technology vs Paper Products sell-through by region',
-      'What is the field sentiment for ClearDesk in the Southeast?',
-    ],
-  },
-  {
-    id: 'furniture',
-    label: 'Furniture',
-    emoji: '🛋️',
-    prompts: [
-      'Show me Urban Living depletion trends across all regions this quarter',
-      'Compare Foundry Home vs Urban Living performance in the West Coast',
-      'What is the field sentiment for Urban Living in the Pacific Northwest?',
-    ],
-  },
-  {
-    id: 'charts',
-    label: 'Charts',
-    emoji: '📈',
-    prompts: [
-      'Create a line chart showing Sierra Gold Tequila depletion trends across all regions',
-      'Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast',
-      'Create a pie chart showing market share breakdown for our grocery brands nationally',
-      'Show a grouped bar chart comparing FreshMart and Harvest Table across all regions',
-      'Create a donut chart of Apex Grill variant mix in the Southwest',
-      'Show a horizontal bar chart ranking all brands by depletion growth rate',
-      'Create a table showing depletion stats for all home improvement brands by region',
-      'Show a gauge chart for Pinnacle Hardware inventory health in the Midwest',
-    ],
-  },
+  mirrorCategory('general', 'General Retail', '📊', 1, [
+    ['Compare depletion trends across all regions for this quarter', PROSE],
+    ['Which brands are growing fastest year-over-year across the portfolio?', PROSE],
+    ['Show me field sentiment for our top 3 brands in the Southeast', PROSE],
+  ]),
+  mirrorCategory('grocery', 'Grocery', '🛒', 2, [
+    ['How are FreshMart depletions trending in the Northeast this quarter?', PROSE],
+    ['Compare Harvest Table vs FreshMart sell-through rates by region', PROSE],
+    ['What is the field sentiment for Harvest Table Meal Kits in the Midwest?', PROSE],
+  ]),
+  mirrorCategory('qsr', 'Quick-Serve Restaurants', '🍔', 3, [
+    ['How is Apex Grill performing in the Southwest this quarter?', PROSE],
+    ['Compare Coastline Tacos vs Apex Grill depletions across all regions', CHART('groupedBar')],
+    ['What is the field sentiment for Coastline Tacos in the West Coast?', PROSE],
+  ]),
+  mirrorCategory('home-improvement', 'Home Improvement', '🏠', 4, [
+    ['Show me Pinnacle Hardware depletion stats in the Midwest for Q1', PROSE],
+    ['How is Summit Outdoor performing in the Southeast vs West Coast?', PROSE],
+    ['What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest?', PROSE],
+  ]),
+  mirrorCategory('office-supply', 'Office Supply', '📎', 5, [
+    ['How are ClearDesk depletions trending in the Northeast this quarter?', PROSE],
+    ['Compare ClearDesk Technology vs Paper Products sell-through by region', PROSE],
+    ['What is the field sentiment for ClearDesk in the Southeast?', PROSE],
+  ]),
+  mirrorCategory('furniture', 'Furniture', '🛋️', 6, [
+    ['Show me Urban Living depletion trends across all regions this quarter', PROSE],
+    ['Compare Foundry Home vs Urban Living performance in the West Coast', PROSE],
+    ['What is the field sentiment for Urban Living in the Pacific Northwest?', PROSE],
+  ]),
+  mirrorCategory('charts', 'Charts', '📈', 7, [
+    ['Create a line chart showing Sierra Gold Tequila depletion trends across all regions', CHART('line')],
+    ['Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast', CHART('bar')],
+    ['Create a pie chart showing market share breakdown for our grocery brands nationally', CHART('pie')],
+    ['Show a grouped bar chart comparing FreshMart and Harvest Table across all regions', CHART('groupedBar')],
+    ['Create a donut chart of Apex Grill variant mix in the Southwest', CHART('donut')],
+    ['Show a horizontal bar chart ranking all brands by depletion growth rate', CHART('horizontalBar')],
+    ['Create a table showing depletion stats for all home improvement brands by region', CHART('table')],
+    ['Show a gauge chart for Pinnacle Hardware inventory health in the Midwest', CHART('gauge')],
+  ]),
 ];

--- a/src/RetailPulse.Web/src/services/packApi.ts
+++ b/src/RetailPulse.Web/src/services/packApi.ts
@@ -1,4 +1,4 @@
-import type { PromptCategory } from '../constants/prompts';
+import type { PromptCategory, StartingTask, StartingTaskCapability } from '../constants/prompts';
 import { resolveApiUrl } from '../config/apiOrigin';
 import type {
   PackBrand,
@@ -114,9 +114,76 @@ function normalizeCategory(raw: unknown): PromptCategory | null {
   const id = readString(raw, 'id');
   const label = readString(raw, 'label');
   const emoji = readString(raw, 'emoji');
-  const prompts = readStringArray(raw, 'prompts');
-  if (!id || !label || prompts.length === 0) return null;
-  return { id, label, emoji, prompts: [...prompts] };
+  const orderRaw = raw.order;
+  const order = typeof orderRaw === 'number' && Number.isFinite(orderRaw) ? orderRaw : undefined;
+  const tasks = normalizeTasks(raw.tasks);
+  const legacyPrompts = readStringArray(raw, 'prompts');
+
+  // Prefer structured tasks (issue #109). When absent, synthesize tasks from
+  // the legacy `prompts` list so packs authored before #109 keep rendering.
+  const effectiveTasks: StartingTask[] = tasks.length > 0
+    ? tasks
+    : legacyPrompts
+        .filter((p) => p.trim().length > 0)
+        .map((p) => ({ name: p, prompt: p }));
+
+  if (!id || !label || effectiveTasks.length === 0) return null;
+
+  // Deterministic per-task ordering when explicit `order` values are present;
+  // ties break on source-array position.
+  const orderedTasks = effectiveTasks
+    .map((task, idx) => ({ task, idx }))
+    .sort((a, b) => {
+      const oa = a.task.order ?? Number.POSITIVE_INFINITY;
+      const ob = b.task.order ?? Number.POSITIVE_INFINITY;
+      if (oa !== ob) return oa - ob;
+      return a.idx - b.idx;
+    })
+    .map((x) => x.task);
+
+  return {
+    id,
+    label,
+    emoji,
+    order,
+    tasks: orderedTasks,
+    prompts: orderedTasks.map((t) => t.prompt),
+  };
+}
+
+function normalizeCapability(raw: unknown): StartingTaskCapability | undefined {
+  if (!isObject(raw)) return undefined;
+  const kind = readString(raw, 'kind');
+  if (kind !== 'prose' && kind !== 'chart' && kind !== 'plan') return undefined;
+  const chartType = readString(raw, 'chartType');
+  const planPath = readString(raw, 'planPath');
+  const cap: StartingTaskCapability = { kind };
+  if (chartType) return { ...cap, chartType };
+  if (planPath) return { ...cap, planPath };
+  return cap;
+}
+
+function normalizeTask(raw: unknown): StartingTask | null {
+  if (!isObject(raw)) return null;
+  const name = readString(raw, 'name');
+  const prompt = readString(raw, 'prompt');
+  if (!name || !prompt) return null;
+  const orderRaw = raw.order;
+  const order = typeof orderRaw === 'number' && Number.isFinite(orderRaw) ? orderRaw : undefined;
+  const capability = normalizeCapability(raw.capability);
+  return capability
+    ? { name, prompt, order, capability }
+    : { name, prompt, order };
+}
+
+function normalizeTasks(raw: unknown): StartingTask[] {
+  if (!Array.isArray(raw)) return [];
+  const out: StartingTask[] = [];
+  for (const item of raw) {
+    const task = normalizeTask(item);
+    if (task) out.push(task);
+  }
+  return out;
 }
 
 function normalizeStartingTasks(raw: unknown): PackStartingTasks {
@@ -130,7 +197,20 @@ function normalizeStartingTasks(raw: unknown): PackStartingTasks {
       if (cat) categories.push(cat);
     }
   }
-  return { packKey, categories };
+
+  // Deterministic per-category ordering. Categories without an explicit
+  // `order` value keep their source position (relative to each other) so a
+  // pack author who does not specify ordering still sees stable output.
+  const orderedCategories = categories
+    .map((cat, idx) => ({ cat, idx }))
+    .sort((a, b) => {
+      const oa = a.cat.order ?? Number.POSITIVE_INFINITY;
+      const ob = b.cat.order ?? Number.POSITIVE_INFINITY;
+      if (oa !== ob) return oa - ob;
+      return a.idx - b.idx;
+    })
+    .map((x) => x.cat);
+  return { packKey, categories: orderedCategories };
 }
 
 export async function fetchActivePack(signal?: AbortSignal): Promise<PackInfo> {

--- a/tests/RetailPulse.Tests/Contract/ChartAcceptanceManifestContractTests.cs
+++ b/tests/RetailPulse.Tests/Contract/ChartAcceptanceManifestContractTests.cs
@@ -95,21 +95,27 @@ public sealed partial class ChartAcceptanceManifestContractTests
         string promptsPath = ResolveRepoRelativePath("src", "RetailPulse.Web", "src", "constants", "prompts.ts");
         string source = File.ReadAllText(promptsPath);
 
-        // Locate the category block by id, then extract the enclosing prompts: […] array.
-        Match idMatch = Regex.Match(source, $@"id:\s*'{Regex.Escape(categoryId)}'");
+        // Issue #109 — the category block now uses a `mirrorCategory(id, label,
+        // emoji, order, [[prompt, capability], ...])` helper so a demo pack can
+        // pair a display name with a submitted prompt. The submitted prompt is
+        // always the first single-quoted string inside each nested `[...]`
+        // tuple, so the parser locates the fifth-argument array and lifts the
+        // leading string from each tuple.
+        Match idMatch = Regex.Match(
+            source,
+            $@"mirrorCategory\(\s*'{Regex.Escape(categoryId)}'\s*,\s*'[^']*'\s*,\s*'[^']*'\s*,\s*\d+\s*,\s*\[");
         idMatch.Success.Should().BeTrue($"category '{categoryId}' must exist in prompts.ts");
 
-        int cursor = idMatch.Index;
-        Match promptsHeader = MyRegex().Match(source[cursor..]);
-        promptsHeader.Success.Should().BeTrue($"prompts array must follow id '{categoryId}'");
-        int arrStart = cursor + promptsHeader.Index + promptsHeader.Length;
-
+        int arrStart = idMatch.Index + idMatch.Length;
         int arrEnd = FindMatchingBracket(source, arrStart - 1);
         arrEnd.Should().BeGreaterThan(arrStart, $"prompts array for '{categoryId}' must be closed");
 
         string arrBody = source[arrStart..arrEnd];
         var extracted = new List<string>();
-        foreach (Match m in SingleQuotedStringRegex().Matches(arrBody))
+        // Each tuple opens with `[` followed by the submitted prompt as a
+        // single-quoted string; the capability helper that follows is not a
+        // string literal so it does not confuse this leading-string match.
+        foreach (Match m in TupleLeadingStringRegex().Matches(arrBody))
         {
             extracted.Add(Regex.Unescape(m.Groups[1].Value));
         }
@@ -172,11 +178,8 @@ public sealed partial class ChartAcceptanceManifestContractTests
             "Could not locate repository root from test binary directory: " + AppContext.BaseDirectory);
     }
 
-    [GeneratedRegex(@"prompts:\s*\[")]
-    private static partial Regex MyRegex();
-
-    [GeneratedRegex(@"'([^'\\]*(?:\\.[^'\\]*)*)'")]
-    private static partial Regex SingleQuotedStringRegex();
+    [GeneratedRegex(@"\[\s*'([^'\\]*(?:\\.[^'\\]*)*)'")]
+    private static partial Regex TupleLeadingStringRegex();
 
     [GeneratedRegex(@"^\s*[-*]\s+\*""([^""]+)""\*\s*(?:→|->)", RegexOptions.Multiline)]
     private static partial Regex ReadmeChartBulletRegex();

--- a/tests/RetailPulse.Tests/Packs/StartingTasksContractTests.cs
+++ b/tests/RetailPulse.Tests/Packs/StartingTasksContractTests.cs
@@ -1,0 +1,248 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.RateLimiting;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Api.Packs;
+
+namespace RetailPulse.Tests.Packs;
+
+/// <summary>
+/// Issue #109 contract test — proves every starting task in every shipped
+/// pack is well-formed and submits successfully. A "broken suggestion" is
+/// the most visible possible configuration failure (the first thing a
+/// demo user clicks), so this suite fails CI before a malformed task can
+/// reach a demo.
+///
+/// "Well-formed" means:
+///   * Every category has a stable id, a human-readable label, an emoji,
+///     and at least one task.
+///   * Every task has a non-empty display name and a non-empty submitted
+///     prompt string (post-normalization the loader is guaranteed to
+///     have already synthesized tasks from any legacy `prompts:` list).
+///   * Any declared `capability` uses a recognized kind and carries the
+///     required companion field (`chartType` for chart, `planPath` for
+///     plan).
+///
+/// "Submits successfully" means:
+///   * The API /api/pack/starting-tasks projection round-trips each task
+///     verbatim (Name + Prompt + Capability), so the frontend can submit
+///     the exact prompt string the pack author intended.
+///   * Every prompt string is a plausible chat submission — non-empty
+///     after trim (the frontend gate) and free of stray YAML template
+///     placeholders (`{{ }}`) that would land in the demo as gibberish.
+/// </summary>
+public sealed class StartingTasksContractTests
+{
+    private static IReadOnlyList<LoadedPack> LoadAllShipped()
+    {
+        var loader = PackLoader.ForDirectory(PackTestPaths.PacksRoot);
+        return [.. loader.DiscoverPacks().Select(loader.Load)];
+    }
+
+    private static readonly HashSet<string> ValidCapabilityKinds =
+        new(StringComparer.OrdinalIgnoreCase) { "prose", "chart", "plan" };
+
+    [Fact]
+    public void EveryShippedPack_HasAtLeastOneCategoryWithAtLeastOneTask()
+    {
+        IReadOnlyList<LoadedPack> packs = LoadAllShipped();
+        packs.Should().NotBeEmpty();
+
+        foreach (LoadedPack pack in packs)
+        {
+            pack.StartingTasks.Should().NotBeEmpty(
+                "shipped pack '{0}' must supply at least one starting-task category", pack.Name);
+            pack.StartingTasks.Should().OnlyContain(c => c.Tasks.Count > 0,
+                "shipped pack '{0}' must not ship an empty category — that renders a chip with nothing to click", pack.Name);
+        }
+    }
+
+    [Fact]
+    public void EveryTask_HasNonEmptyDisplayNameAndSubmittedPrompt()
+    {
+        foreach (LoadedPack pack in LoadAllShipped())
+        {
+            foreach (PackStartingTaskCategory cat in pack.StartingTasks)
+            {
+                for (int i = 0; i < cat.Tasks.Count; i++)
+                {
+                    PackStartingTask task = cat.Tasks[i];
+                    string trace = $"pack '{pack.Name}' category '{cat.Id}' task[{i}]";
+
+                    task.Name.Should().NotBeNullOrWhiteSpace(
+                        "{0} must have a display name shown on the button", trace);
+                    task.Prompt.Should().NotBeNullOrWhiteSpace(
+                        "{0} must have a submitted prompt string", trace);
+                    task.Prompt.Trim().Should().Be(task.Prompt.Trim(),
+                        "{0} prompt should not be trim-fragile", trace);
+                    task.Prompt.Should().NotContain("{{",
+                        "{0} prompt still has an unfilled YAML template placeholder", trace);
+                    task.Prompt.Should().NotContain("}}",
+                        "{0} prompt still has an unfilled YAML template placeholder", trace);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void EveryTaskCapability_UsesARecognizedKindWithRequiredFields()
+    {
+        foreach (LoadedPack pack in LoadAllShipped())
+        {
+            foreach (PackStartingTaskCategory cat in pack.StartingTasks)
+            {
+                for (int i = 0; i < cat.Tasks.Count; i++)
+                {
+                    PackStartingTaskCapability? capability = cat.Tasks[i].Capability;
+                    if (capability is null)
+                    {
+                        continue;
+                    }
+
+                    string trace = $"pack '{pack.Name}' category '{cat.Id}' task[{i}] capability";
+                    ValidCapabilityKinds.Should().Contain(capability.Kind,
+                        "{0} kind '{1}' must be one of prose|chart|plan", trace, capability.Kind);
+
+                    if (capability.Kind.Equals("chart", StringComparison.OrdinalIgnoreCase))
+                    {
+                        capability.ChartType.Should().NotBeNullOrWhiteSpace(
+                            "{0} kind=chart must declare a chartType", trace);
+                    }
+                    else if (capability.Kind.Equals("plan", StringComparison.OrdinalIgnoreCase))
+                    {
+                        capability.PlanPath.Should().NotBeNullOrWhiteSpace(
+                            "{0} kind=plan must declare a planPath", trace);
+                    }
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void EveryTask_HasAUniquePromptWithinItsCategory()
+    {
+        foreach (LoadedPack pack in LoadAllShipped())
+        {
+            foreach (PackStartingTaskCategory cat in pack.StartingTasks)
+            {
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                foreach (PackStartingTask task in cat.Tasks)
+                {
+                    seen.Add(task.Prompt).Should().BeTrue(
+                        "pack '{0}' category '{1}' has a duplicate prompt '{2}' — a demo user would click the same suggestion twice",
+                        pack.Name, cat.Id, task.Prompt);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task EveryTaskSurvivesTheApiProjection_WithNameAndPromptAndCapabilityIntact()
+    {
+        // Round-trip every shipped pack through /api/pack/starting-tasks so
+        // a regression in the endpoint (dropped field, changed casing,
+        // truncated collection) surfaces as a specific failure pointing at
+        // the offending pack + task rather than a silent demo bug.
+        foreach (LoadedPack pack in LoadAllShipped())
+        {
+            using IHost host = BuildHostFor(pack);
+            using HttpClient client = host.GetTestClient();
+
+            HttpResponseMessage response = await client.GetAsync("/api/pack/starting-tasks");
+            response.StatusCode.Should().Be(HttpStatusCode.OK,
+                "pack '{0}' should respond OK from /api/pack/starting-tasks", pack.Name);
+
+            PackStartingTasksResponse? payload =
+                await response.Content.ReadFromJsonAsync<PackStartingTasksResponse>();
+
+            payload.Should().NotBeNull();
+            payload.PackKey.Should().Be(pack.Name);
+            payload.Categories.Should().HaveCount(pack.StartingTasks.Count,
+                "pack '{0}' should project every category", pack.Name);
+
+            for (int c = 0; c < pack.StartingTasks.Count; c++)
+            {
+                PackStartingTaskCategory source = pack.StartingTasks[c];
+                PackStartingTaskResponse projected = payload.Categories[c];
+
+                projected.Id.Should().Be(source.Id);
+                projected.Label.Should().Be(source.Label);
+                projected.Tasks.Should().HaveCount(source.Tasks.Count);
+
+                for (int t = 0; t < source.Tasks.Count; t++)
+                {
+                    PackStartingTask sourceTask = source.Tasks[t];
+                    PackStartingTaskItem projectedTask = projected.Tasks[t];
+
+                    projectedTask.Name.Should().Be(sourceTask.Name);
+                    projectedTask.Prompt.Should().Be(sourceTask.Prompt);
+                    projectedTask.Order.Should().Be(sourceTask.Order);
+
+                    if (sourceTask.Capability is null)
+                    {
+                        projectedTask.Capability.Should().BeNull();
+                    }
+                    else
+                    {
+                        projectedTask.Capability.Should().NotBeNull();
+                        projectedTask.Capability.Kind.Should().Be(sourceTask.Capability.Kind);
+                        projectedTask.Capability.ChartType.Should().Be(sourceTask.Capability.ChartType);
+                        projectedTask.Capability.PlanPath.Should().Be(sourceTask.Capability.PlanPath);
+                    }
+                }
+
+                // Legacy Prompts projection must stay in lock-step so any
+                // client still on the old shape keeps working.
+                projected.Prompts.Should().Equal(source.Tasks.Select(t => t.Prompt));
+            }
+
+            // Every prompt payload must be a valid JSON string round-trip
+            // without escaping surprises — a pragmatic proxy for "submits
+            // successfully" without wiring up the full chat pipeline.
+            string raw = await response.Content.ReadAsStringAsync();
+            using var _ = JsonDocument.Parse(raw);
+
+            await host.StopAsync();
+        }
+    }
+
+    private static IHost BuildHostFor(LoadedPack pack)
+    {
+        IHost host = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddSingleton(pack);
+                    services.AddRouting();
+                    services.AddRateLimiter(options => options.AddPolicy("relaxed", _ =>
+                        RateLimitPartition.GetFixedWindowLimiter("relaxed", _ =>
+                            new FixedWindowRateLimiterOptions
+                            {
+                                PermitLimit = 100,
+                                Window = TimeSpan.FromMinutes(1),
+                                QueueLimit = 0,
+                            })));
+                });
+                webHost.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseRateLimiter();
+                    app.UseEndpoints(endpoints => endpoints.MapPackEndpoints());
+                });
+            })
+            .Build();
+
+        host.StartAsync().GetAwaiter().GetResult();
+        return host;
+    }
+}


### PR DESCRIPTION
Closes #109

**Working as Chick (Frontend Dev)**

Replaces the hardcoded PromptLibrary categories with a projection of the **active content pack**'s `starting-tasks.yaml`. Every starting task now carries:

- a short display `name` shown on the button, and
- a fully-formed `prompt` submitted to chat verbatim, plus
- optional declarative `capability` metadata (`prose` / `chart` with a `chartType` / `plan` with a `planPath`), and
- explicit `order` at both the category and task level.

## Highlights

- **Loader + schema.** `PackStartingTaskCategory` gains `Order` and structured `Tasks`; `PackStartingTask` carries `Name`, `Prompt`, `Order?`, and `Capability?`. The loader still accepts legacy `prompts: [string]` and synthesizes tasks from it, and derives the legacy `Prompts` list from the ordered `Tasks` so downstream tests and older clients keep working.
- **Endpoint projection.** `PackStartingTaskResponse` grows `Order` and `Tasks[]` (with capability metadata); `Prompts` is still projected in the same order for back-compat.
- **All three shipped packs** rewritten to the new `tasks:` shape with explicit order and capability metadata. The default pack keeps `name === prompt` and the exact 7 categories × 26 prompts so the acceptance manifest and DOM sweeps remain grounded on the same strings.
- **Frontend.** `PromptLibrary` and `ChatPanel` render `task.name` on buttons and submit `task.prompt`. Every button exposes `data-capability-{kind,chart-type,plan-path}` attributes for downstream tooling, an `aria-label` for keyboard/screen-reader users, and category chips use `aria-pressed`. A sensible empty state renders when a pack ships no starting tasks, and the category chip row is suppressed so no stray "All" chip lingers.
- **Contract test.** `StartingTasksContractTests` iterate every shipped pack and prove each task is well-formed (non-empty name/prompt, no unfilled `{{ }}` template placeholders, valid capability with the required companion field), unique within its category, and survives the `/api/pack/starting-tasks` projection with name, prompt, and capability intact while the legacy `Prompts` list stays lock-stepped.
- **Frontend tests** cover the new tasks[] parsing, capability normalization, category- and task-level ordering, empty state, pack-switch behavior, and the capability data attributes.

## Explicit non-goals

- **Guardrails, plan execution, and chart handling surfaces** (concurrent #136/#137) are untouched — capability metadata is declarative only and never changes execution behavior.
- No colors are hardcoded — the buttons stay on tenant-themed CSS variables.
- The prompt-acceptance manifest and browser DOM sweeps are preserved verbatim through the synchronous fallback in `constants/prompts.ts`.
