### PR TITLE
Fix P0 plan broadcast isolation and completion regressions

### DIFF
--- a/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
@@ -45,16 +45,31 @@ namespace RetailPulse.Api.Approval;
 ///     conversation-export, and session-turn writes fire; the final response
 ///     is persisted onto the plan record's <c>FailureReason</c> column
 ///     (which now doubles as <c>FinalReply</c> for review-driven turns) and
-///     broadcast over the SignalR hub as <c>plan_final_response</c>. Plan
-///     status transitions to <c>Completed</c> / <c>Failed</c>.</item>
+///     broadcast over the SignalR hub as <c>plan_final_response</c> to the
+///     <b>owning session's group only</b> (never <c>Clients.All</c>) — see
+///     <see cref="SendToOwningSessionAsync"/>. Plan status transitions to
+///     <c>Completed</c> / <c>Failed</c>.</item>
 ///   <item>Reject with cap remaining → the replanner produces a revised step
 ///     list, a new plan-review row + checkpoint open for round N+1, and a
-///     <c>plan_review_next_round</c> hub event fires so the reviewer UI can
-///     surface the new request id.</item>
+///     <c>plan_review_next_round</c> hub event fires against the owning
+///     session group so the reviewer UI can surface the new request id
+///     without leaking to any other connected client.</item>
 ///   <item>Terminal without execution → plan status transitions to
 ///     <c>Failed</c> with the terminal reason; the failure reply is persisted
-///     and broadcast.</item>
+///     and broadcast to the owning session group.</item>
 /// </list>
+///
+/// <para>
+/// <b>Broadcast scoping (#141).</b> Every SignalR event this service emits
+/// carries subject-identifying content (<c>subject</c>, <c>reply</c>,
+/// <c>charts</c>) and MUST be delivered only to the plan's owning session
+/// group. Missing / whitespace session identity fails closed: the broadcast
+/// is suppressed with a warning, never falling back to
+/// <c>Clients.All</c>. The client-side <see cref="TelemetryHub.JoinSession"/>
+/// binding — gated by <see cref="ISessionOwnershipRegistry"/> — is the sole
+/// route by which a connection joins the group, so this delivery contract
+/// composes with the existing hostile-rejoin protection (#92).
+/// </para>
 ///
 /// <para>
 /// The completion service is idempotent: if the plan is already Completed or
@@ -186,7 +201,7 @@ public sealed class PlanReviewCompletionService
             case PlanReviewContinuationKind.Terminal:
                 await FinaliseAsFailedAsync(planStore, plan, state.Subject,
                     $"{continuation.TerminalReason}: {continuation.FailureMessage}", sp, ct);
-                await BroadcastFinalAsync(sp, plan.PlanId, state.Subject,
+                await BroadcastFinalAsync(sp, plan.PlanId, state.Subject, state.SessionId,
                     BuildTerminalReply(continuation.TerminalReason), continuation.TerminalReason);
                 return PlanReviewCompletionResult.TerminatedWithoutExecution(
                     continuation.TerminalReason,
@@ -206,7 +221,7 @@ public sealed class PlanReviewCompletionService
                         string msg = replanned?.UnusableReason ?? "planner unavailable";
                         await FinaliseAsFailedAsync(planStore, plan, state.Subject,
                             $"{PlanReviewTerminalReason.ReplanExhausted}: {msg}", sp, ct);
-                        await BroadcastFinalAsync(sp, plan.PlanId, state.Subject,
+                        await BroadcastFinalAsync(sp, plan.PlanId, state.Subject, state.SessionId,
                             BuildTerminalReply(PlanReviewTerminalReason.ReplanExhausted),
                             PlanReviewTerminalReason.ReplanExhausted);
                         return PlanReviewCompletionResult.TerminatedWithoutExecution(
@@ -243,15 +258,18 @@ public sealed class PlanReviewCompletionService
 
                     // Broadcast that a new review round is waiting.
                     IHubContext<TelemetryHub>? hub = sp.GetService<IHubContext<TelemetryHub>>();
-                    if (hub is not null)
-                    {
-                        await hub.Clients.All.SendAsync("plan_review_next_round", new
+                    // Session-scoped delivery (#141): the next-round event
+                    // reveals the plan id and reviewer request id of another
+                    // subject's in-flight plan and MUST NOT reach other
+                    // clients. Route it through the owning session's group;
+                    // fail closed on missing identity.
+                    await SendToOwningSessionAsync(
+                        hub, state.SessionId, "plan_review_next_round", new
                         {
                             planId = state.PlanId,
                             requestId = nextHandle.RequestId,
                             round = nextHandle.RoundNumber,
                         }, ct);
-                    }
 
                     return PlanReviewCompletionResult.SuspendedForNextRound(
                         nextHandle.RequestId, nextHandle.RoundNumber);
@@ -289,22 +307,35 @@ public sealed class PlanReviewCompletionService
             await FinaliseAsFailedAsync(planStore, plan, state.Subject,
                 $"{clarification.TerminalReason}: reviewer did not provide a usable answer.",
                 sp, ct);
-            await BroadcastFinalAsync(sp, plan.PlanId, state.Subject,
+            await BroadcastFinalAsync(sp, plan.PlanId, state.Subject, state.SessionId,
                 BuildTerminalReply(clarification.TerminalReason), clarification.TerminalReason);
             return PlanReviewCompletionResult.TerminatedWithoutExecution(
                 clarification.TerminalReason, "no usable clarification answer");
         }
 
         // Substitute the answer as the paused step's Result, then execute the
-        // remaining steps starting from PausedAtStepIndex + 1.
+        // remaining steps AFTER the paused step.
+        //
+        // Index-rebase note (#141): the executor stores <c>state.Steps</c>
+        // rebased to start at the pause — see PlanExecutor.SuspendForClarificationAsync
+        // which writes <c>execution.Plan.Steps.Skip(stepIndex)</c>. Element 0
+        // of <c>state.Steps</c> IS the paused (CLARIFY) step; elements 1..N
+        // are the post-pause specialists that still need to run.
+        //
+        // The previous implementation indexed <c>state.Steps</c> with
+        // <c>state.PausedAtStepIndex</c> — the ORIGINAL plan index — so on any
+        // plan that paused past index 0 it (a) recorded the wrong step as the
+        // "answer" transcript and (b) skipped the first post-pause specialist
+        // entirely. Rebase against element 0 instead, and take the true
+        // remaining as <c>Skip(1)</c>. The persisted
+        // <see cref="PlanReviewCompletedStep.StepIndex"/> keeps the original
+        // index so downstream numbering is unchanged.
         int pauseIndex = state.PausedAtStepIndex ?? 0;
         List<PlanReviewCompletedStep> priorCompleted =
             [.. state.CompletedSteps ?? []];
 
-        // The paused step itself becomes an "answer" step with the answer as
-        // its transcript so the accumulated context reads coherently.
-        PlanReviewStepDto paused = pauseIndex < state.Steps.Count
-            ? state.Steps[pauseIndex]
+        PlanReviewStepDto paused = state.Steps.Count > 0
+            ? state.Steps[0]
             : new PlanReviewStepDto
             {
                 SpecialistKey = "clarification",
@@ -325,7 +356,7 @@ public sealed class PlanReviewCompletionService
         });
 
         IReadOnlyList<PlanReviewStepDto> remaining =
-            [.. state.Steps.Skip(pauseIndex + 1)];
+            [.. state.Steps.Skip(1)];
         return await ExecuteApprovedPlanAsync(
             sp, planStore, plan, state,
             remaining,
@@ -463,7 +494,8 @@ public sealed class PlanReviewCompletionService
         // Chat-turn parity — mirror the trio the single-specialist branch fires.
         await ApplyChatTurnParityAsync(sp, plan, state, filtered, outcome, ct);
 
-        await BroadcastFinalAsync(sp, plan.PlanId, state.Subject, filtered, terminalReason, planCharts);
+        await BroadcastFinalAsync(sp, plan.PlanId, state.Subject, state.SessionId,
+            filtered, terminalReason, planCharts);
 
         return PlanReviewCompletionResult.Executed(filtered, outcome, planCharts);
     }
@@ -687,28 +719,68 @@ public sealed class PlanReviewCompletionService
         }
     }
 
-    private static async Task BroadcastFinalAsync(
-        IServiceProvider sp, string planId, string subject, string reply, string terminalReason,
+    private async Task BroadcastFinalAsync(
+        IServiceProvider sp, string planId, string subject, string? sessionId,
+        string reply, string terminalReason,
         IReadOnlyList<ChartSpec>? charts = null)
     {
         IHubContext<TelemetryHub>? hub = sp.GetService<IHubContext<TelemetryHub>>();
-        if (hub is null) return;
-        await hub.Clients.All.SendAsync("plan_final_response", new
+        // Session-scoped delivery (#141): the plan_final_response payload
+        // carries subject-identifying content — subject id, the full reply
+        // text, and any specialist chart data — so it MUST be delivered to
+        // the owning session's group only. See <see cref="SendToOwningSessionAsync"/>
+        // for the fail-closed semantics on missing session identity.
+        //
+        // Charts flattened in specialist order — matches the
+        // ChatResponse.Charts contract on the fast path so the client
+        // renders identical charts regardless of whether the plan was
+        // executed immediately or resumed via the review surface. Null
+        // or empty means the specialists produced no charts on this
+        // turn. Non-terminal (early replan / clarification) broadcasts
+        // don't reach this method — those go via plan_review_next_round
+        // instead.
+        await SendToOwningSessionAsync(
+            hub, sessionId, "plan_final_response", new
+            {
+                planId,
+                subject,
+                reply,
+                terminalReason,
+                charts = charts is { Count: > 0 } ? charts : null,
+            });
+    }
+
+    /// <summary>
+    /// Session-scoped SignalR delivery for plan-path events (#141). Sends the
+    /// payload to <c>Clients.Group(sessionId)</c> — the same group the
+    /// <see cref="TelemetryHub.JoinSession"/> ownership gate populates — so
+    /// only the plan's owning subject receives it. A null/whitespace
+    /// <paramref name="sessionId"/> fails closed: the send is suppressed with
+    /// a warning and the caller MUST NOT fall back to <c>Clients.All</c> or
+    /// any other broadcast surface. That matches the existing session-scoped
+    /// telemetry model (see <c>ISessionOwnershipRegistry</c>, issue #92) and
+    /// contains any regression that lets a plan record land without a
+    /// session id.
+    /// </summary>
+    private async Task SendToOwningSessionAsync(
+        IHubContext<TelemetryHub>? hub,
+        string? sessionId,
+        string method,
+        object payload,
+        CancellationToken ct = default)
+    {
+        if (hub is null)
         {
-            planId,
-            subject,
-            reply,
-            terminalReason,
-            // Charts flattened in specialist order — matches the
-            // ChatResponse.Charts contract on the fast path so the client
-            // renders identical charts regardless of whether the plan was
-            // executed immediately or resumed via the review surface. Null
-            // or empty means the specialists produced no charts on this
-            // turn. Non-terminal (early replan / clarification) broadcasts
-            // don't reach this method — those go via
-            // plan_review_next_round instead.
-            charts = charts is { Count: > 0 } ? charts : null,
-        });
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            _logger.LogWarning(
+                "Plan-path SignalR event {Method} suppressed: session identity is missing on the resolved plan; refusing to broadcast to Clients.All to avoid cross-session leak.",
+                method);
+            return;
+        }
+        await hub.Clients.Group(sessionId).SendAsync(method, payload, ct);
     }
 }
 

--- a/src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs
@@ -74,6 +74,7 @@ public static class PlanReviewEndpoints
             HttpContext http,
             [FromServices] PlanReviewCompletionService? completion,
             [FromServices] GuardrailsMiddleware guardrails,
+            [FromServices] ILoggerFactory loggerFactory,
             CancellationToken ct) =>
         {
             if (RefuseAnonymous(http, out IResult? refusal))
@@ -206,7 +207,26 @@ public static class PlanReviewEndpoints
                 round = row.Context.RoundNumber,
             };
 
-            await hubContext.Clients.All.SendAsync("plan_review_resolved", responseDto, ct);
+            // Session-scoped delivery (#141): the plan_review_resolved event
+            // carries the plan id, reviewer comment, and terminal reason for a
+            // subject-owned plan, so it MUST reach only the owning session's
+            // group — never Clients.All. Missing / whitespace session id
+            // fails closed (suppress + log) so a regression that lets a plan
+            // review land without a session id cannot silently widen delivery.
+            // Aligns with the plan_final_response and plan_review_next_round
+            // paths in PlanReviewCompletionService.
+            string? reviewSessionId = row.Context.SessionId;
+            if (string.IsNullOrWhiteSpace(reviewSessionId))
+            {
+                loggerFactory.CreateLogger("PlanReviewEndpoints").LogWarning(
+                    "plan_review_resolved suppressed for plan {PlanId} request {RequestId}: session identity missing; refusing to broadcast to Clients.All.",
+                    planId, requestId);
+            }
+            else
+            {
+                await hubContext.Clients.Group(reviewSessionId).SendAsync(
+                    "plan_review_resolved", responseDto, ct);
+            }
 
             // Drive the plan through the resume path so the reviewer's
             // decision produces a real final response (execute the effective

--- a/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/ChatPanel.test.tsx
@@ -419,6 +419,7 @@ describe('ChatPanel', () => {
       removePlanFromHistory: vi.fn().mockResolvedValue(undefined),
       openHistoryPlan: vi.fn().mockResolvedValue(undefined),
       reportStepStatus: vi.fn(),
+      applyFinalResponse: vi.fn(),
     } as unknown as import('../state/usePlanController').PlanController;
     // Point the "active" getter at state.active so PlanView renders.
     Object.defineProperty(planController, 'active', {
@@ -437,6 +438,93 @@ describe('ChatPanel', () => {
 
     // The plan-first bubble shows the plan surface — not the plain reply.
     expect(await screen.findByTestId('plan-view')).toBeInTheDocument();
+  });
+
+  it('plan-first 200 with charts forwards them via applyFinalResponse (#141)', async () => {
+    const user = userEvent.setup();
+    const charts = [
+      {
+        type: 'bar' as const,
+        title: 'Revenue by region',
+        data: [{ legend: 'q1', values: [{ x: 'NE', y: 10 }] }],
+      },
+      {
+        type: 'line' as const,
+        title: 'Weekly trend',
+        data: [{ legend: 'w', values: [{ x: 'w1', y: 5 }] }],
+      },
+    ];
+    sendMessageMock.mockResolvedValue({
+      kind: 'complete',
+      response: {
+        reply: 'aggregate reply with charts',
+        sessionId: 'sess-plan',
+        spans: [],
+        totalDurationMs: 300,
+        routing: {
+          agentKey: 'planner',
+          agentName: 'Plan Orchestrator',
+          intent: 'plan',
+          confidence: 0.5,
+          executionPath: 'plan',
+        },
+        planId: 'plan-142',
+        charts,
+      },
+    });
+
+    const applyFinalResponseSpy = vi.fn();
+    const planController = {
+      state: {
+        active: {
+          planId: 'plan-142',
+          sessionId: 'sess-plan',
+          request: 'compare',
+          status: 'completed' as const,
+          steps: [],
+          detectedIntents: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          elapsedMs: 300,
+          startedAt: Date.now(),
+        },
+        history: [],
+        historyLoading: false,
+      },
+      active: null,
+      startPlan: vi.fn().mockResolvedValue(undefined),
+      hydrate: vi.fn().mockResolvedValue(undefined),
+      approve: vi.fn().mockResolvedValue(undefined),
+      reject: vi.fn().mockResolvedValue(undefined),
+      edit: vi.fn().mockResolvedValue(undefined),
+      clarify: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn(),
+      reloadHistory: vi.fn().mockResolvedValue(undefined),
+      removePlanFromHistory: vi.fn().mockResolvedValue(undefined),
+      openHistoryPlan: vi.fn().mockResolvedValue(undefined),
+      reportStepStatus: vi.fn(),
+      applyFinalResponse: applyFinalResponseSpy,
+    } as unknown as import('../state/usePlanController').PlanController;
+    Object.defineProperty(planController, 'active', {
+      get: () => planController.state.active,
+    });
+
+    renderPanel({ planController, planConnected: true });
+
+    await user.type(screen.getByPlaceholderText(/Ask about retail performance/i), 'compare');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+
+    await waitFor(() => expect(planController.startPlan).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(applyFinalResponseSpy).toHaveBeenCalledTimes(1));
+    // The immediate path pushes reply + charts through the controller so
+    // PlanView renders them exactly like the review-resume path.
+    expect(applyFinalResponseSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        planId: 'plan-142',
+        reply: 'aggregate reply with charts',
+        charts,
+      }),
+    );
   });
 
   it('202 suspended response starts the plan and shows the review bubble', async () => {
@@ -467,6 +555,7 @@ describe('ChatPanel', () => {
       removePlanFromHistory: vi.fn().mockResolvedValue(undefined),
       openHistoryPlan: vi.fn().mockResolvedValue(undefined),
       reportStepStatus: vi.fn(),
+      applyFinalResponse: vi.fn(),
     } as unknown as import('../state/usePlanController').PlanController;
 
     renderPanel({ planController, planConnected: true });

--- a/src/RetailPulse.Web/src/__tests__/PlanView.finalCharts.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/PlanView.finalCharts.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
+
+// Issue #141: PlanView is the surface that must render aggregate charts on
+// both plan paths. The immediate path pipes `ChatResponse.charts` into
+// `finalCharts` via `applyFinalResponse`; the review-resume path pipes
+// `plan_final_response.charts` through the reducer's PLAN_FINAL action.
+// Both land here as `active.finalCharts`, which this suite proves renders
+// through the shared ChartRenderer for every supported ChartType.
+
+vi.mock('../components/ChartRenderer', () => ({
+  default: ({ charts }: { charts: Array<{ type: string; title: string }> }) => (
+    <div data-testid="chart-renderer-mock">
+      {charts.map((c, i) => (
+        <div key={i} data-testid="chart-card" data-chart-type={c.type}>
+          {c.title}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+import { PlanView } from '../components/plan/PlanView';
+import type { ActivePlanState } from '../state/planReducer';
+import type { ChartSpec, ChartType, PlanStep } from '../types';
+
+function step(index: number, status: PlanStep['status']): PlanStep {
+  return {
+    stepId: `s-${index}`,
+    planId: 'p1',
+    stepIndex: index,
+    specialistKey: 'demand-forecasting',
+    intent: 'demand',
+    action: `run step ${index}`,
+    status,
+  };
+}
+
+function makeActive(overrides: Partial<ActivePlanState> = {}): ActivePlanState {
+  return {
+    planId: 'p1',
+    sessionId: 'sess',
+    request: 'demand + promo across regions',
+    status: 'completed',
+    steps: [step(0, 'completed'), step(1, 'completed')],
+    detectedIntents: ['demand', 'promo'],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    elapsedMs: 1234,
+    startedAt: Date.now() - 1234,
+    finishedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+const ALL_CHART_TYPES: readonly ChartType[] = [
+  'line',
+  'bar',
+  'groupedBar',
+  'stackedBar',
+  'horizontalBar',
+  'pie',
+  'donut',
+  'gauge',
+  'table',
+];
+
+function chartSpec(type: ChartType, title: string): ChartSpec {
+  return {
+    type,
+    title,
+    data: [
+      {
+        legend: 'series',
+        values: [
+          { x: 'a', y: 1 },
+          { x: 'b', y: 2 },
+        ],
+      },
+    ],
+  };
+}
+
+function wrap(ui: React.ReactNode) {
+  return <FluentProvider theme={teamsDarkTheme}>{ui}</FluentProvider>;
+}
+
+describe('PlanView aggregate charts (#141)', () => {
+  it('does not render the charts section when finalCharts is absent', () => {
+    render(
+      wrap(
+        <PlanView
+          active={makeActive({ finalReply: 'aggregate', finalCharts: undefined })}
+          connected={true}
+          onApprove={vi.fn()}
+          onReject={vi.fn()}
+          onEdit={vi.fn()}
+          onClarify={vi.fn()}
+        />,
+      ),
+    );
+    expect(screen.queryByTestId('plan-final-charts')).not.toBeInTheDocument();
+  });
+
+  it('does not render the charts section when finalCharts is an empty array', () => {
+    render(
+      wrap(
+        <PlanView
+          active={makeActive({ finalReply: 'aggregate', finalCharts: [] })}
+          connected={true}
+          onApprove={vi.fn()}
+          onReject={vi.fn()}
+          onEdit={vi.fn()}
+          onClarify={vi.fn()}
+        />,
+      ),
+    );
+    expect(screen.queryByTestId('plan-final-charts')).not.toBeInTheDocument();
+  });
+
+  it('renders the charts section with the ChartRenderer when finalCharts is populated', async () => {
+    const charts = [chartSpec('bar', 'Region A'), chartSpec('line', 'Trend')];
+    render(
+      wrap(
+        <PlanView
+          active={makeActive({ finalReply: 'aggregate', finalCharts: charts })}
+          connected={true}
+          onApprove={vi.fn()}
+          onReject={vi.fn()}
+          onEdit={vi.fn()}
+          onClarify={vi.fn()}
+        />,
+      ),
+    );
+
+    const section = await screen.findByTestId('plan-final-charts');
+    expect(section).toHaveAttribute('data-chart-count', '2');
+    await waitFor(() => {
+      expect(screen.getByTestId('chart-renderer-mock')).toBeInTheDocument();
+    });
+    const cards = screen.getAllByTestId('chart-card');
+    expect(cards.map(c => c.getAttribute('data-chart-type'))).toEqual(['bar', 'line']);
+  });
+
+  it('renders every supported ChartType passed via finalCharts (all 9)', async () => {
+    const charts = ALL_CHART_TYPES.map(t => chartSpec(t, `chart-${t}`));
+    render(
+      wrap(
+        <PlanView
+          active={makeActive({ finalReply: 'aggregate', finalCharts: charts })}
+          connected={true}
+          onApprove={vi.fn()}
+          onReject={vi.fn()}
+          onEdit={vi.fn()}
+          onClarify={vi.fn()}
+        />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chart-renderer-mock')).toBeInTheDocument();
+    });
+    const cards = screen.getAllByTestId('chart-card');
+    expect(cards).toHaveLength(ALL_CHART_TYPES.length);
+    expect(cards.map(c => c.getAttribute('data-chart-type'))).toEqual([...ALL_CHART_TYPES]);
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/usePlanController.finalCharts.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/usePlanController.finalCharts.test.tsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+// Issue #141 regression: charts produced by specialists during plan execution
+// must reach the reducer on BOTH plan paths.
+//   - Immediate path: ChatPanel calls `planController.applyFinalResponse` with
+//     the ChatResponse's aggregate `charts`.
+//   - Review-resume path: the backend broadcasts `plan_final_response` (now
+//     session-scoped, see PR for #141 backend commit) with an optional
+//     `charts` field the frontend must forward through PLAN_FINAL.
+// Before the fix the frontend event type, controller handler, and reducer
+// state all discarded `charts`, so the aggregate visualization silently
+// vanished on both paths.
+
+const answerPlanClarificationMock = vi.fn();
+const fetchPlanDetailMock = vi.fn();
+const fetchPlanReviewsMock = vi.fn();
+const decidePlanReviewMock = vi.fn();
+const deletePlanMock = vi.fn();
+const fetchPlansMock = vi.fn();
+
+vi.mock('../services/planApi', () => ({
+  answerPlanClarification: (...args: unknown[]) => answerPlanClarificationMock(...args),
+  fetchPlanDetail: (...args: unknown[]) => fetchPlanDetailMock(...args),
+  fetchPlanReviews: (...args: unknown[]) => fetchPlanReviewsMock(...args),
+  decidePlanReview: (...args: unknown[]) => decidePlanReviewMock(...args),
+  deletePlan: (...args: unknown[]) => deletePlanMock(...args),
+  fetchPlans: (...args: unknown[]) => fetchPlansMock(...args),
+  parseClarificationPrompt: () => null,
+  parseReviewProposal: () => null,
+}));
+
+vi.mock('../services/executionControlApi', () => ({
+  reconcilePlan: vi.fn().mockResolvedValue(null),
+}));
+
+import { usePlanController, type PlanControllerConnection } from '../state/usePlanController';
+import type { ChartSpec, ChartType } from '../types';
+
+type ConnHandler = (payload: unknown) => void;
+
+function makeConnection(): PlanControllerConnection & {
+  emit: (evt: string, payload: unknown) => void;
+} {
+  const handlers = new Map<string, Set<ConnHandler>>();
+  return {
+    connected: true,
+    on: (event, handler) => {
+      let bucket = handlers.get(event);
+      if (!bucket) {
+        bucket = new Set();
+        handlers.set(event, bucket);
+      }
+      bucket.add(handler);
+      return () => {
+        bucket?.delete(handler);
+      };
+    },
+    emit: (event, payload) => {
+      const bucket = handlers.get(event);
+      if (!bucket) return;
+      for (const h of Array.from(bucket)) h(payload);
+    },
+  };
+}
+
+function chartSpec(type: ChartType, title: string): ChartSpec {
+  // Bindable single-series spec — the ChartRenderer's own acceptance suite
+  // covers per-type visual output; here we only care that the spec survives
+  // the controller / reducer boundary intact.
+  return {
+    type,
+    title,
+    data: [
+      {
+        legend: 'series',
+        values: [
+          { x: 'a', y: 1 },
+          { x: 'b', y: 2 },
+          { x: 'c', y: 3 },
+        ],
+      },
+    ],
+  };
+}
+
+const ALL_CHART_TYPES: readonly ChartType[] = [
+  'line',
+  'bar',
+  'groupedBar',
+  'stackedBar',
+  'horizontalBar',
+  'pie',
+  'donut',
+  'gauge',
+  'table',
+];
+
+async function primePlan(planId: string) {
+  fetchPlanDetailMock.mockResolvedValueOnce(null);
+  const connection = makeConnection();
+  const { result } = renderHook(() => usePlanController({ connection }));
+  await act(async () => {
+    await result.current.startPlan({
+      planId,
+      sessionId: 'sess-1',
+      request: 'compare regions and forecast demand',
+    });
+  });
+  return { result, connection };
+}
+
+describe('usePlanController charts on plan_final_response (#141)', () => {
+  beforeEach(() => {
+    fetchPlanDetailMock.mockReset();
+    fetchPlanReviewsMock.mockReset();
+    decidePlanReviewMock.mockReset();
+    answerPlanClarificationMock.mockReset();
+    deletePlanMock.mockReset();
+    fetchPlansMock.mockReset();
+  });
+
+  it('immediate path: applyFinalResponse dispatches reply + charts into finalCharts', async () => {
+    const { result } = await primePlan('p-imm');
+
+    const charts = [chartSpec('bar', 'Regional revenue'), chartSpec('line', 'Weekly trend')];
+
+    act(() => {
+      result.current.applyFinalResponse({
+        planId: 'p-imm',
+        reply: 'here is the aggregate answer',
+        charts,
+      });
+    });
+
+    expect(result.current.active?.finalReply).toBe('here is the aggregate answer');
+    expect(result.current.active?.finalCharts).toEqual(charts);
+    // Chart identity is preserved — the reducer forwards the array by
+    // reference; the immediate path never round-trips through JSON.
+    expect(result.current.active?.finalCharts?.[0]).toBe(charts[0]);
+  });
+
+  it('review-resume path: plan_final_response event with charts hydrates finalCharts', async () => {
+    const { result, connection } = await primePlan('p-rev');
+
+    const charts = [chartSpec('groupedBar', 'Category share'), chartSpec('pie', 'Mix')];
+
+    act(() => {
+      connection.emit('plan_final_response', {
+        planId: 'p-rev',
+        subject: 'user-1',
+        reply: 'reviewed and executed',
+        terminalReason: null,
+        charts,
+      });
+    });
+
+    expect(result.current.active?.finalReply).toBe('reviewed and executed');
+    expect(result.current.active?.finalCharts).toEqual(charts);
+  });
+
+  it('preserves all nine ChartSpec types across the reducer boundary', async () => {
+    const { result, connection } = await primePlan('p-nine');
+
+    const charts = ALL_CHART_TYPES.map(t => chartSpec(t, `chart-${t}`));
+
+    act(() => {
+      connection.emit('plan_final_response', {
+        planId: 'p-nine',
+        reply: 'done',
+        charts,
+      });
+    });
+
+    const rendered = result.current.active?.finalCharts ?? [];
+    expect(rendered.map(c => c.type)).toEqual(ALL_CHART_TYPES);
+    // Every spec's structure survives — title, data, and first datapoint
+    // preserved verbatim so the ChartRenderer sees the same input the
+    // backend broadcast.
+    for (const spec of rendered) {
+      expect(spec.title).toBe(`chart-${spec.type}`);
+      expect(spec.data[0].values[0]).toEqual({ x: 'a', y: 1 });
+    }
+  });
+
+  it('event without charts field does not clear a prior attach', async () => {
+    const { result, connection } = await primePlan('p-preserve');
+
+    const first = [chartSpec('donut', 'Mix')];
+    act(() => {
+      result.current.applyFinalResponse({
+        planId: 'p-preserve',
+        reply: 'first',
+        charts: first,
+      });
+    });
+    expect(result.current.active?.finalCharts).toEqual(first);
+
+    // A subsequent broadcast that carries only reply+terminalReason (no
+    // `charts` field at all) must not blow away the previously attached
+    // chart array — otherwise a benign redelivery would clear the UI.
+    act(() => {
+      connection.emit('plan_final_response', {
+        planId: 'p-preserve',
+        reply: 'first',
+        terminalReason: null,
+      });
+    });
+    expect(result.current.active?.finalCharts).toEqual(first);
+  });
+
+  it('null charts on the broadcast explicitly clears finalCharts', async () => {
+    const { result, connection } = await primePlan('p-null');
+
+    act(() => {
+      result.current.applyFinalResponse({
+        planId: 'p-null',
+        reply: 'first',
+        charts: [chartSpec('bar', 'a')],
+      });
+    });
+    expect(result.current.active?.finalCharts?.length).toBe(1);
+
+    act(() => {
+      connection.emit('plan_final_response', {
+        planId: 'p-null',
+        reply: 'no-charts',
+        charts: null,
+      });
+    });
+    expect(result.current.active?.finalCharts).toBeNull();
+  });
+
+  it('ignores plan_final_response for a different plan', async () => {
+    const { result, connection } = await primePlan('p-a');
+
+    act(() => {
+      connection.emit('plan_final_response', {
+        planId: 'p-b',
+        reply: 'unrelated',
+        charts: [chartSpec('bar', 'other')],
+      });
+    });
+
+    expect(result.current.active?.finalReply).toBeUndefined();
+    expect(result.current.active?.finalCharts).toBeUndefined();
+  });
+});

--- a/src/RetailPulse.Web/src/components/ChatPanel.tsx
+++ b/src/RetailPulse.Web/src/components/ChatPanel.tsx
@@ -639,6 +639,17 @@ export function ChatPanel({
               sessionId: response.sessionId,
               request: trimmed,
             });
+            // Immediate plan-completion path (issue #141): the ChatResponse
+            // already carries the terminal reply and aggregate specialist
+            // charts, and no `plan_final_response` SignalR event fires for
+            // this branch. Route them through the same PLAN_FINAL reducer
+            // action the review-resume path uses so PlanView renders the
+            // final reply and charts on both plan paths identically.
+            planController.applyFinalResponse({
+              planId,
+              reply: response.reply,
+              charts: response.charts ?? null,
+            });
           }
           setMessages(prev => [
             ...prev,

--- a/src/RetailPulse.Web/src/components/plan/PlanView.tsx
+++ b/src/RetailPulse.Web/src/components/plan/PlanView.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { lazy, Suspense, useMemo } from 'react';
 import { Badge, Button, ProgressBar, Text, makeStyles } from '@fluentui/react-components';
 import { Dismiss20Regular } from '@fluentui/react-icons';
 import type { ActivePlanState } from '../../state/planReducer';
@@ -7,6 +7,11 @@ import { PLAN_STATUS_META, formatElapsed, progressCounts } from './statusMeta';
 import { PlanStepRow } from './PlanStepRow';
 import { PlanReviewCard } from './PlanReviewCard';
 import { PlanClarificationCard } from './PlanClarificationCard';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+// Lazy-load the chart renderer to keep the plan surface from pulling Recharts
+// into the initial bundle. Matches how ChatPanel and PlanStepRow load it.
+const ChartRenderer = lazy(() => import('../ChartRenderer'));
 
 /**
  * Top-level plan surface (issue #96). Renders a summary strip (progress,
@@ -301,6 +306,21 @@ export function PlanView({
               Terminal reason: {active.terminalReason}
             </Text>
           )}
+        </div>
+      )}
+
+      {active.finalCharts && active.finalCharts.length > 0 && (
+        <div
+          className={styles.section}
+          data-testid="plan-final-charts"
+          data-chart-count={active.finalCharts.length}
+        >
+          <span className={styles.sectionLabel}>Charts</span>
+          <ErrorBoundary fallback={<div>Chart failed to render.</div>}>
+            <Suspense fallback={<div>Loading charts…</div>}>
+              <ChartRenderer charts={active.finalCharts} />
+            </Suspense>
+          </ErrorBoundary>
         </div>
       )}
     </div>

--- a/src/RetailPulse.Web/src/state/planReducer.ts
+++ b/src/RetailPulse.Web/src/state/planReducer.ts
@@ -1,4 +1,5 @@
 import type {
+  ChartSpec,
   PlanClarificationPrompt,
   PlanDetail,
   PlanReviewProposal,
@@ -65,6 +66,14 @@ export interface ActivePlanState {
   /** Terminal reply text once the plan settles. */
   finalReply?: string;
   terminalReason?: string | null;
+  /**
+   * Aggregate charts attached to the plan's terminal response (issue #141).
+   * Populated on both plan paths: the immediate path forwards
+   * `ChatResponse.charts`, and the review-resume path forwards the
+   * `plan_final_response` event's `charts` payload. Rendered by `PlanView`
+   * near `finalReply` so specialist charts survive the plan boundary.
+   */
+  finalCharts?: ChartSpec[] | null;
 
   /** Set true when the SignalR connection drops mid-plan. */
   connectionLost?: boolean;
@@ -143,7 +152,14 @@ export type PlanAction =
   | { type: 'CLARIFICATION_SUBMITTING'; planId: string; requestId: string }
   | { type: 'CLARIFICATION_SUBMIT_FAILED'; planId: string; requestId: string }
   | { type: 'CLARIFICATION_RESOLVED'; planId: string; requestId: string }
-  | { type: 'PLAN_FINAL'; planId: string; reply: string; terminalReason?: string | null }
+  | {
+      type: 'PLAN_FINAL';
+      planId: string;
+      reply: string;
+      terminalReason?: string | null;
+      /** Aggregate charts attached to the terminal reply. */
+      charts?: ChartSpec[] | null;
+    }
   | { type: 'CONNECTION_STATUS'; connected: boolean }
   | {
       // Reconciled delta after a hub reconnect (issue #92): merges any
@@ -215,6 +231,7 @@ function detailToActive(detail: PlanDetail, base: ActivePlanState | null): Activ
     clarification: base?.clarification,
     finalReply: base?.finalReply,
     terminalReason: base?.terminalReason,
+    finalCharts: base?.finalCharts,
     connectionLost: base?.connectionLost,
     hydrateError: undefined,
   };
@@ -467,6 +484,12 @@ export function planReducer(state: PlanAppState, action: PlanAction): PlanAppSta
             : state.active.status === 'failed' || state.active.status === 'cancelled' || state.active.status === 'unusable'
               ? state.active.status
               : 'completed';
+      // Freshest wins: an explicit chart array on the terminal event overwrites
+      // any prior charts. `undefined` (event carried no chart field at all)
+      // preserves what the reducer already has so a broadcast without charts
+      // never clears a prior attach.
+      const nextFinalCharts =
+        action.charts === undefined ? state.active.finalCharts : action.charts;
       return {
         ...state,
         active: {
@@ -474,6 +497,7 @@ export function planReducer(state: PlanAppState, action: PlanAction): PlanAppSta
           status,
           finalReply: action.reply,
           terminalReason: action.terminalReason ?? null,
+          finalCharts: nextFinalCharts,
           finishedAt: finished,
           review: state.active.review
             ? { ...state.active.review, decisionInFlight: undefined }

--- a/src/RetailPulse.Web/src/state/usePlanController.ts
+++ b/src/RetailPulse.Web/src/state/usePlanController.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import type { ActivePlanState, PlanAppState } from './planReducer';
 import { initialPlanState, isPlanRunning, isStepTerminal, planReducer } from './planReducer';
 import type {
+  ChartSpec,
   PlanClarificationPrompt,
   PlanFinalResponseEvent,
   PlanReviewNextRoundEvent,
@@ -72,6 +73,19 @@ export interface PlanController {
     status: PlanStepStatus,
     specialistKey?: string,
   ): void;
+  /**
+   * Attach the terminal reply + aggregate charts for a plan that completed
+   * synchronously on the immediate path (issue #141). The review-resume
+   * path receives the same shape via the `plan_final_response` SignalR
+   * event; both paths converge on the reducer's `PLAN_FINAL` action so
+   * `PlanView` renders `finalReply` and `finalCharts` identically.
+   */
+  applyFinalResponse(input: {
+    planId: string;
+    reply: string;
+    charts?: ChartSpec[] | null;
+    terminalReason?: string | null;
+  }): void;
 }
 
 const STEP_STATUS_ORDER: Record<PlanStepStatus, number> = {
@@ -345,6 +359,12 @@ export function usePlanController(options: UsePlanControllerOptions): PlanContro
         planId: evt.planId,
         reply: evt.reply,
         terminalReason: evt.terminalReason,
+        // Forward specialist charts on the review-resume path (issue #141).
+        // Preserve the tri-state on the wire — `undefined` (field absent)
+        // preserves any prior attach, `null` explicitly clears, and an
+        // array replaces. The reducer applies the same rule for both plan
+        // paths.
+        charts: evt.charts,
       });
     });
 
@@ -604,6 +624,24 @@ export function usePlanController(options: UsePlanControllerOptions): PlanContro
     [],
   );
 
+  const applyFinalResponse = useCallback(
+    (input: {
+      planId: string;
+      reply: string;
+      charts?: ChartSpec[] | null;
+      terminalReason?: string | null;
+    }) => {
+      dispatch({
+        type: 'PLAN_FINAL',
+        planId: input.planId,
+        reply: input.reply,
+        terminalReason: input.terminalReason,
+        charts: input.charts,
+      });
+    },
+    [],
+  );
+
   return useMemo<PlanController>(
     () => ({
       state,
@@ -619,6 +657,7 @@ export function usePlanController(options: UsePlanControllerOptions): PlanContro
       removePlanFromHistory,
       openHistoryPlan,
       reportStepStatus,
+      applyFinalResponse,
     }),
     [
       state,
@@ -633,6 +672,7 @@ export function usePlanController(options: UsePlanControllerOptions): PlanContro
       removePlanFromHistory,
       openHistoryPlan,
       reportStepStatus,
+      applyFinalResponse,
     ],
   );
 }

--- a/src/RetailPulse.Web/src/types/index.ts
+++ b/src/RetailPulse.Web/src/types/index.ts
@@ -1037,6 +1037,14 @@ export interface PlanFinalResponseEvent {
   subject?: string;
   reply: string;
   terminalReason?: string | null;
+  /**
+   * Optional aggregate charts produced by specialists during plan execution
+   * (issue #141). Populated on the review-resume path by
+   * `PlanReviewCompletionService.BroadcastFinalAsync`. The immediate path
+   * carries the same shape inline on `ChatResponse.charts`, so both plan
+   * paths converge on `ChartSpec[]` for rendering.
+   */
+  charts?: ChartSpec[] | null;
 }
 
 /** 202 Accepted body returned by POST /api/chat when a plan suspends for review. */

--- a/tests/RetailPulse.Tests/Approval/PlanBroadcastScopingTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanBroadcastScopingTests.cs
@@ -1,0 +1,557 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Agents.Planning;
+using RetailPulse.Api.Approval;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Guardrails;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Middleware;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Approval;
+using RetailPulse.Contracts.Guardrails;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Persistence;
+using RetailPulse.Contracts.Routing;
+using RetailPulse.Contracts.Tracing;
+using RetailPulse.Tests.Fixtures;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
+
+namespace RetailPulse.Tests.Approval;
+
+/// <summary>
+/// Adversarial delivery + clarification-resume regression coverage for
+/// issue #141. The plan-completion path used to broadcast
+/// <c>plan_final_response</c>, <c>plan_review_next_round</c>, and
+/// <c>plan_review_resolved</c> via <see cref="IHubClients.All"/>, which
+/// leaked another subject's plan payload — including <c>reply</c> and
+/// <c>charts</c> — to every connected SignalR client.
+///
+/// <para>
+/// This suite pins:
+/// </para>
+/// <list type="bullet">
+///   <item>Two distinct subjects on distinct sessions: subject B receives
+///     zero plan payloads when subject A's plan resolves, and
+///     <see cref="IHubClients.All"/> is never invoked for a plan event.</item>
+///   <item>A resolved plan without an owning session id fails closed —
+///     nothing is broadcast, no fallback to <c>Clients.All</c>.</item>
+///   <item>Mid-plan clarification: the first specialist AFTER the pause
+///     runs on resume — the previous index-rebase bug silently skipped it.</item>
+/// </list>
+///
+/// <para>
+/// The hub fake used here (<see cref="RecordingHub"/>) issues a DISTINCT
+/// proxy per All / Group / Client target so a delivery-scope assertion is
+/// meaningful — the earlier <c>CapturingHub</c> in this project shared one
+/// proxy across <c>All</c> and <c>Group</c>, which would have made this
+/// entire suite vacuous.
+/// </para>
+/// </summary>
+public sealed class PlanBroadcastScopingTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _checkpointDir;
+
+    public PlanBroadcastScopingTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"prv_scope_{Guid.NewGuid():N}.db");
+        _checkpointDir = Path.Combine(Path.GetTempPath(), $"prv_scope_ckpt_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_checkpointDir);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { }
+        try { File.Delete(_dbPath + "-wal"); } catch { }
+        try { File.Delete(_dbPath + "-shm"); } catch { }
+        try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
+    }
+
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    // Adversarial delivery: two subjects on distinct sessions
+
+    [Fact]
+    public async Task Subject_B_on_a_different_session_receives_zero_plan_payloads_when_subject_A_plan_completes()
+    {
+        const string sessionA = "session-A";
+        const string sessionB = "session-B";
+        const string subjectA = "user-A";
+
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, _, RecordingHub hub) = BuildHost();
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(
+            SampleInput(subjectA, sessionA), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        ApprovalRequest row = (await gate.GetPendingAsync(subjectA))
+            .Single(r => r.Context.PlanId == suspend.PlanId);
+        await gate.RespondAsync(row.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult resume = await completion.ResolveAsync(suspend.PlanId, subjectA);
+        resume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+
+        // Owning session group DID receive the final response.
+        hub.GroupSends.Should().ContainKey(sessionA);
+        hub.GroupSends[sessionA].Should().Contain(
+            s => s.Method == "plan_final_response",
+            "the plan's owning session must receive its own final response.");
+
+        // Subject B's group received nothing at all — no plan_final_response,
+        // no plan_review_next_round, no plan_review_resolved.
+        (hub.GroupSends.TryGetValue(sessionB, out List<RecordingHub.SendCall>? bSends) ? bSends : [])
+            .Where(s => IsPlanEvent(s.Method))
+            .Should().BeEmpty(
+                "a second subject on a different session must never receive another subject's plan payload — this is the cross-session leak #141 fixes.");
+
+        // And Clients.All must NOT have been used for any plan event.
+        hub.AllSends
+            .Where(s => IsPlanEvent(s.Method))
+            .Should().BeEmpty(
+                "no plan-path SignalR event may ever go to Clients.All; delivery must be session-scoped or suppressed.");
+
+        await sp.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Final_response_carries_charts_only_to_owning_session_group()
+    {
+        const string sessionA = "session-A";
+        const string subjectA = "user-A";
+        ChartSpec chart = new()
+        {
+            Type = "bar",
+            Title = "leaked?",
+            Data =
+            [
+                new ChartSeries
+                {
+                    Legend = "s",
+                    Values = [new ChartDataPoint { X = "Q1", Y = 10 }],
+                },
+            ],
+        };
+
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, _, RecordingHub hub) =
+            BuildHost(specialistCharts: [chart]);
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(
+            SampleInput(subjectA, sessionA), default);
+        ApprovalRequest row = (await gate.GetPendingAsync(subjectA))
+            .Single(r => r.Context.PlanId == suspend.PlanId);
+        await gate.RespondAsync(row.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult resume = await completion.ResolveAsync(suspend.PlanId, subjectA);
+        resume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+
+        RecordingHub.SendCall final = hub.GroupSends[sessionA]
+            .Single(s => s.Method == "plan_final_response");
+        ExtractCharts(final.Payload)
+            .Should().Contain(c => c.Type == "bar",
+                "review-resume broadcast must still carry Charts alongside the reply so the frontend can render without an extra GET.");
+
+        hub.AllSends.Should().BeEmpty(
+            "Clients.All must not receive plan payloads even when charts are present.");
+
+        await sp.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Missing_session_identity_suppresses_broadcast_and_never_falls_back_to_all()
+    {
+        const string subjectA = "user-A";
+
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, _, RecordingHub hub) = BuildHost();
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(
+            SampleInput(subjectA, sessionId: null), default);
+
+        ApprovalRequest row = (await gate.GetPendingAsync(subjectA))
+            .Single(r => r.Context.PlanId == suspend.PlanId);
+        await gate.RespondAsync(row.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult resume = await completion.ResolveAsync(suspend.PlanId, subjectA);
+        resume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+
+        hub.AllSends
+            .Where(s => IsPlanEvent(s.Method))
+            .Should().BeEmpty(
+                "missing session identity must fail closed — no Clients.All fallback.");
+
+        hub.GroupSends.Values.SelectMany(v => v)
+            .Where(s => IsPlanEvent(s.Method))
+            .Should().BeEmpty(
+                "with no session identity, no plan payload may be delivered at all.");
+
+        await sp.DisposeAsync();
+    }
+
+    // Clarification-resume index bug (#141)
+
+    [Fact]
+    public async Task Clarification_resume_executes_the_post_pause_specialist()
+    {
+        const string sessionA = "session-A";
+        const string subjectA = "user-A";
+
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, ConcurrentQueue<string> invocations,
+            RecordingHub hub) =
+            BuildHost(plannerJson: PlannerJsonWithClarify());
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(
+            SampleInput(subjectA, sessionA), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        ApprovalRequest reviewRow = (await gate.GetPendingAsync(subjectA))
+            .Single(r => r.Context.PlanId == suspend.PlanId
+                      && r.Context.Kind == ApprovalKind.PlanReview);
+        await gate.RespondAsync(reviewRow.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult reviewResume = await completion.ResolveAsync(suspend.PlanId, subjectA);
+        reviewResume.Kind.Should().Be(PlanReviewCompletionKind.SuspendedForClarification);
+
+        int invocationsBeforeAnswer = invocations.Count;
+
+        ApprovalRequest clarRow = (await gate.GetPendingAsync(subjectA))
+            .Single(r => r.Context.Kind == ApprovalKind.Clarification
+                      && r.Context.PlanId == suspend.PlanId);
+        await gate.RespondAsync(clarRow.RequestId, ApprovalDecision.Approved, "ans",
+            JsonSerializer.Serialize(new PlanClarificationAnswer { Answer = "west" }, _json));
+
+        PlanReviewCompletionResult clarResume = await completion.ResolveAsync(suspend.PlanId, subjectA);
+        clarResume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+
+        int invocationsAfterAnswer = invocations.Count;
+        (invocationsAfterAnswer - invocationsBeforeAnswer).Should().BeGreaterThan(0,
+            "the clarification-resume path must execute at least one specialist AFTER the pause.");
+
+        invocations.Should().Contain(s => s.Contains("step-2", StringComparison.Ordinal),
+            "the first specialist after the pause (demand-forecasting, step-2) must run on resume — the index-rebase bug used to skip it silently.");
+
+        clarResume.Reply.Should().Contain("demand-reply",
+            "the post-pause specialist's transcript must appear in the composed reply.");
+
+        hub.GroupSends[sessionA].Should().Contain(s => s.Method == "plan_final_response");
+        hub.AllSends.Where(s => IsPlanEvent(s.Method)).Should().BeEmpty();
+
+        await sp.DisposeAsync();
+    }
+
+    // Support
+
+    private static bool IsPlanEvent(string method) =>
+        method is "plan_final_response"
+              or "plan_review_next_round"
+              or "plan_review_resolved";
+
+    private static IReadOnlyList<ChartSpec>? ExtractCharts(object? payload)
+    {
+        if (payload is null) return null;
+        Type t = payload.GetType();
+        System.Reflection.PropertyInfo? prop = t.GetProperty("charts")
+            ?? t.GetProperty("Charts");
+        return prop is null ? null : prop.GetValue(payload) as IReadOnlyList<ChartSpec>;
+    }
+
+    private static PlanOrchestrationInput SampleInput(string subject, string? sessionId)
+    {
+        ISpecialistAgent scorecard = MakeSpecialist("scorecard", new(), "score-reply", null);
+        ISpecialistAgent demand = MakeSpecialist("demand-forecasting", new(), "demand-reply", null);
+        return new PlanOrchestrationInput
+        {
+            Request = new ChatRequest("multi", SessionId: sessionId),
+            Subject = subject,
+            PrincipalKey = subject,
+            TenantId = "Contoso",
+            Roster = [scorecard, demand],
+            SpecialistLookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["scorecard"] = scorecard,
+                ["demand-forecasting"] = demand,
+            },
+            DetectedIntents = ["scorecard", "demand"],
+            TraceId = "t",
+        };
+    }
+
+    private static string DefaultPlannerJson() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""ORIGINAL_ACTION"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""ORIGINAL_DEMAND_ACTION"" }
+    ] }";
+
+    private static string PlannerJsonWithClarify() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""step-0"" },
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""[[CLARIFY]] Which region?"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""step-2"" }
+    ] }";
+
+    private static ISpecialistAgent MakeSpecialist(
+        string key,
+        ConcurrentQueue<string> invocations,
+        string reply,
+        IReadOnlyList<ChartSpec>? charts)
+    {
+        var m = new Mock<ISpecialistAgent>();
+        m.SetupGet(a => a.Key).Returns(key);
+        m.SetupGet(a => a.DisplayName).Returns(key);
+        m.SetupGet(a => a.Model).Returns("gpt-test");
+        m.SetupGet(a => a.SupportedIntents).Returns([key]);
+        m.Setup(a => a.HandleAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()))
+            .Returns((ChatRequest req, CancellationToken _) =>
+            {
+                invocations.Enqueue(req.Message);
+                List<ChartSpec>? chartList = charts is null ? null : [.. charts];
+                return Task.FromResult(new ChatResponse(
+                    string.IsNullOrEmpty(reply) ? $"{key}-reply" : reply,
+                    req.SessionId ?? "s", [], chartList, 10, new TokenUsage(1, 1, 2)));
+            });
+        return m.Object;
+    }
+
+    private (ServiceProvider Sp, PlanOrchestrator Orchestrator, PlanReviewCompletionServiceTests.InMemoryPlanStore PlanStore,
+        SqliteApprovalGate Gate, ConcurrentQueue<string> Invocations, RecordingHub Hub)
+        BuildHost(
+            string? plannerJson = null,
+            IReadOnlyList<ChartSpec>? specialistCharts = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton(TimeProvider.System);
+
+        SqliteApprovalGate gate = new(_dbPath, NullLogger<SqliteApprovalGate>.Instance,
+            TimeSpan.FromMinutes(30), TimeProvider.System);
+        services.AddSingleton(gate);
+        services.AddSingleton<IApprovalGate>(sp => sp.GetRequiredService<SqliteApprovalGate>());
+
+        services.AddSingleton<ICheckpointStore<JsonElement>>(_ =>
+                new FileSystemJsonCheckpointStore(new DirectoryInfo(_checkpointDir)));
+        services.AddSingleton(sp =>
+        {
+            ICheckpointStore<JsonElement> store = sp.GetRequiredService<ICheckpointStore<JsonElement>>();
+            return Microsoft.Agents.AI.Workflows.CheckpointManager.CreateJson(store, customOptions: null);
+        });
+        services.AddSingleton<PlanReviewCheckpointService>();
+
+        var options = new PlanReviewOptions
+        {
+            Enabled = true,
+            DefaultReviewTimeout = TimeSpan.FromSeconds(30),
+            ClarificationTimeout = TimeSpan.FromSeconds(30),
+            MaxReplanRounds = 1,
+        };
+        services.AddSingleton(Options.Create(options));
+
+        services.AddSingleton<PlanClarifier>();
+        services.AddSingleton<IPlanClarifier>(sp => sp.GetRequiredService<PlanClarifier>());
+        services.AddSingleton<PlanReviewCoordinator>();
+
+        var plans = new PlanReviewCompletionServiceTests.InMemoryPlanStore();
+        services.AddSingleton<IPlanStore>(plans);
+
+        var invocations = new ConcurrentQueue<string>();
+        ISpecialistAgent scorecard = MakeSpecialist("scorecard", invocations, "score-reply", specialistCharts);
+        ISpecialistAgent demand = MakeSpecialist("demand-forecasting", invocations, "demand-reply", specialistCharts);
+        services.AddSingleton(scorecard);
+        services.AddSingleton(demand);
+
+        var persistOpts = new PlanPersistenceOptions();
+        services.AddSingleton(persistOpts);
+        services.AddSingleton(new Api.Models.AgentDefinition
+        {
+            Key = "planner",
+            Name = "Plan-First Orchestrator",
+            Model = "gpt-test",
+            SystemPrompt = "You are the planner.",
+            Temperature = 0.1,
+        });
+        services.AddSingleton(sp => new PlanBuilder(
+            AgentTestFixtures.CreateMockChatClient(plannerJson ?? DefaultPlannerJson()),
+            sp.GetRequiredService<Api.Models.AgentDefinition>(),
+            persistOpts,
+            NullLogger<PlanBuilder>.Instance));
+
+        services.AddSingleton<ICostTracker>(new NoOpCostTracker());
+        services.AddSingleton<ITraceCollector>(new NoOpTraceCollector());
+        services.AddSingleton(sp => new PlanExecutor(
+            sp.GetRequiredService<IPlanStore>(),
+            sp.GetRequiredService<ICostTracker>(),
+            sp.GetRequiredService<ITraceCollector>(),
+            sp.GetRequiredService<PlanPersistenceOptions>(),
+            NullLogger<PlanExecutor>.Instance,
+            sp.GetService<PlanClarifier>(),
+            sp.GetService<PlanReviewCoordinator>()));
+
+        services.AddSingleton(sp => new PlanOrchestrator(
+            sp.GetRequiredService<PlanBuilder>(),
+            sp.GetRequiredService<PlanExecutor>(),
+            sp.GetRequiredService<IPlanStore>(),
+            sp.GetRequiredService<ICostTracker>(),
+            persistOpts,
+            NullLogger<PlanOrchestrator>.Instance,
+            sp.GetService<PlanReviewCoordinator>(),
+            Options.Create(options)));
+
+        services.AddSingleton(new GuardrailsConfig
+        {
+            PiiDetectionEnabled = false,
+            AutoRedactPii = false,
+            ContentSafety = new ContentSafetyConfig { Enabled = false },
+        });
+        services.AddSingleton<ISuspiciousRequestLog, InMemorySuspiciousRequestLog>();
+        services.AddSingleton<ITenantProvider>(new StubTenantProvider());
+        services.AddSingleton<GuardrailsMiddleware>();
+        services.AddSingleton<IAuditLog, InMemoryAuditLog>();
+        services.AddSingleton(_ => new ConversationExporter(
+            Options.Create(new ObservabilityOptions())));
+
+        var hub = new RecordingHub();
+        services.AddSingleton<IHubContext<TelemetryHub>>(hub);
+
+        services.AddSingleton<PlanReviewCompletionService>();
+
+        ServiceProvider sp2 = services.BuildServiceProvider();
+        return (sp2,
+            sp2.GetRequiredService<PlanOrchestrator>(),
+            plans,
+            sp2.GetRequiredService<SqliteApprovalGate>(),
+            invocations,
+            hub);
+    }
+
+    /// <summary>
+    /// A minimal <see cref="IHubContext{THub}"/> fake that gives each
+    /// delivery target its OWN <see cref="IClientProxy"/> and records every
+    /// SendAsync so tests can assert whether a payload landed on
+    /// <c>Clients.All</c>, on a specific <c>Group(name)</c>, or on a
+    /// specific <c>Client(id)</c>. Sharing a single proxy across targets
+    /// would let a broadcast to <c>All</c> pass a test that only asserted
+    /// against a group name and vice-versa — see the tightening called out
+    /// in the #141 design review contract.
+    /// </summary>
+    private sealed class RecordingHub : IHubContext<TelemetryHub>
+    {
+        public List<SendCall> AllSends { get; } = [];
+        public Dictionary<string, List<SendCall>> GroupSends { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, List<SendCall>> ClientSends { get; } = new(StringComparer.Ordinal);
+
+        public IHubClients Clients { get; }
+        public IGroupManager Groups { get; } = new StubGroupManager();
+
+        public RecordingHub()
+        {
+            Clients = new RecordingClients(this);
+        }
+
+        public sealed record SendCall(string Method, object? Payload);
+
+        private sealed class RecordingClients(RecordingHub owner) : IHubClients
+        {
+            public IClientProxy All { get; } = new BucketProxy(owner.AllSends);
+            public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) => new BucketProxy(owner.AllSends);
+            public IClientProxy Client(string connectionId) =>
+                new BucketProxy(owner.ClientSends.TryGetValue(connectionId, out List<SendCall>? list)
+                    ? list
+                    : owner.ClientSends[connectionId] = []);
+            public IClientProxy Clients(IReadOnlyList<string> connectionIds) => new BucketProxy([]);
+            public IClientProxy Group(string groupName) =>
+                new BucketProxy(owner.GroupSends.TryGetValue(groupName, out List<SendCall>? list)
+                    ? list
+                    : owner.GroupSends[groupName] = []);
+            public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) =>
+                new BucketProxy(owner.GroupSends.TryGetValue(groupName, out List<SendCall>? list)
+                    ? list
+                    : owner.GroupSends[groupName] = []);
+            public IClientProxy Groups(IReadOnlyList<string> groupNames) => new BucketProxy([]);
+            public IClientProxy User(string userId) => new BucketProxy([]);
+            public IClientProxy Users(IReadOnlyList<string> userIds) => new BucketProxy([]);
+        }
+
+        private sealed class BucketProxy(List<SendCall> bucket) : IClientProxy
+        {
+            public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+            {
+                lock (bucket)
+                {
+                    bucket.Add(new SendCall(method, args.Length > 0 ? args[0] : null));
+                }
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class StubGroupManager : IGroupManager
+        {
+            public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+    }
+
+    private sealed class NoOpTraceCollector : ITraceCollector
+    {
+        public void CaptureSpan(TraceSpan span) { }
+        public IReadOnlyList<TraceSpan>? GetSpans(string traceId) => null;
+        public TraceSummary? GetSummary(string traceId) => null;
+        public IReadOnlyList<TraceSummary> GetRecentTraces(int count = 20) => [];
+        public StructuredTraceSummary? GetStructuredSummary(string traceId) => null;
+        public IReadOnlyList<ToolUsageStat> GetToolStats(DateTimeOffset since, int top = 10) => [];
+        public int TraceCount => 0;
+        public int Capacity => 100;
+    }
+
+    private sealed class NoOpCostTracker : ICostTracker
+    {
+        public Task TrackUsageAsync(UsageEvent usage, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<CostSummary> GetSummaryAsync(CostPeriod period, CancellationToken ct = default)
+            => Task.FromResult(new CostSummary(0, 0, 0, period));
+        public Task<IReadOnlyList<AgentCostBreakdown>> GetByAgentAsync(CostPeriod period, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<AgentCostBreakdown>>([]);
+        public Task<CostTrend> GetTrendAsync(int days = 7, CancellationToken ct = default)
+            => Task.FromResult(new CostTrend([]));
+    }
+
+    private sealed class StubTenantProvider : ITenantProvider
+    {
+        public TenantConfiguration GetTenant() => new()
+        {
+            Company = "Contoso",
+            Industry = "test",
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- scope plan completion and review SignalR events to the owning session group and fail closed without a session
- preserve charts through immediate and review-resume frontend paths for all supported chart types
- correct clarification resume indexing so the post-pause specialist executes
- add adversarial delivery and regression coverage for all three defects

## Validation
- dotnet format RetailPulse.slnx --verify-no-changes
- dotnet build RetailPulse.slnx -c Debug
- dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj --no-build (3289 passed, 9 skipped)
- independent Publix review verdict: APPROVE

Closes #141