### PR TITLE
Backend follow-ups for #136 / #137: clarification resume, broadcast isolation, execution claim

### DIFF
--- a/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
+++ b/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
@@ -232,7 +232,12 @@ public sealed class PlanExecutor
                 Request: execution.Request,
                 History: execution.History,
                 User: execution.User,
-                AccumulatedResults: []);
+                // Seed with any pre-completed steps the resume path passed in.
+                // A downstream [[CLARIFY]] on a resumed plan needs to see the
+                // full transcript (earlier round's completed steps + this
+                // execution's) so its checkpoint's CompletedSteps carries
+                // every prior chart/result forward.
+                AccumulatedResults: [.. execution.PriorAccumulatedResults]);
 
             var checkpointManager = CheckpointManager.CreateInMemory();
             Run run = await InProcessExecution
@@ -771,6 +776,19 @@ public sealed record PlanExecutionRequest
     public required PlanBuildResult Plan { get; init; }
     public required IReadOnlyList<string> StepIds { get; init; }
     public required IReadOnlyDictionary<string, ISpecialistAgent> SpecialistLookup { get; init; }
+
+    /// <summary>
+    /// Optional pre-executed step transcripts to seed the workflow's initial
+    /// <see cref="PlanStepMessage.AccumulatedResults"/> with. Populated by the
+    /// plan-review resume path so specialists on a resumed (clarification)
+    /// plan see the same accumulated context earlier specialists produced
+    /// before the pause. Without this a downstream <c>[[CLARIFY]]</c> on a
+    /// resumed plan would open a new checkpoint whose <c>CompletedSteps</c>
+    /// carries only THIS execution's transcripts, dropping every earlier
+    /// completed step and its charts — the "AccumulatedResults reset across
+    /// repeated clarifications" defect.
+    /// </summary>
+    public IReadOnlyList<PlanStepResult> PriorAccumulatedResults { get; init; } = [];
 }
 
 /// <summary>Terminal outcome returned to the chat endpoint.</summary>

--- a/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
@@ -193,22 +193,66 @@ public sealed class PlanReviewCompletionService
         switch (continuation.Kind)
         {
             case PlanReviewContinuationKind.Approved:
-                return await ExecuteApprovedPlanAsync(
-                    sp, planStore, plan, state,
-                    continuation.ApprovedSteps ?? state.Steps,
-                    continuation.TerminalReason, ct);
+                {
+                    // Atomic claim: two concurrent resume drivers (endpoint kickoff
+                    // + restart recovery, or two endpoint callers racing the same
+                    // approval row) both observe the persisted winner via
+                    // FindLatestRowForPlanAsync, then both would call
+                    // ExecuteApprovedPlanAsync and run the specialists twice.
+                    // Collapse that race to one caller via a conditional
+                    // AwaitingReview → Running transition; the loser NoOps.
+                    bool claimed = await planStore.TryTransitionStatusAsync(
+                        plan.PlanId, state.Subject,
+                        PlanStatus.AwaitingReview, PlanStatus.Running, ct);
+                    return !claimed
+                        ? PlanReviewCompletionResult.NoOp(
+                            "another resume driver already claimed this plan for execution")
+                        : await ExecuteApprovedPlanAsync(
+                        sp, planStore, plan, state,
+                        continuation.ApprovedSteps ?? state.Steps,
+                        continuation.TerminalReason, ct);
+                }
 
             case PlanReviewContinuationKind.Terminal:
-                await FinaliseAsFailedAsync(planStore, plan, state.Subject,
-                    $"{continuation.TerminalReason}: {continuation.FailureMessage}", sp, ct);
-                await BroadcastFinalAsync(sp, plan.PlanId, state.Subject, state.SessionId,
-                    BuildTerminalReply(continuation.TerminalReason), continuation.TerminalReason);
-                return PlanReviewCompletionResult.TerminatedWithoutExecution(
-                    continuation.TerminalReason,
-                    continuation.FailureMessage);
+                {
+                    // Same-race guard as the Approved branch: only the caller that
+                    // wins the AwaitingReview → Failed transition finalizes the
+                    // row and broadcasts. The loser NoOps so the SignalR surface
+                    // sees exactly one terminal broadcast.
+                    bool claimed = await planStore.TryTransitionStatusAsync(
+                        plan.PlanId, state.Subject,
+                        PlanStatus.AwaitingReview, PlanStatus.Failed, ct);
+                    if (!claimed)
+                    {
+                        return PlanReviewCompletionResult.NoOp(
+                            "another resume driver already terminated this plan");
+                    }
+                    await FinaliseAsFailedAsync(planStore, plan, state.Subject,
+                        $"{continuation.TerminalReason}: {continuation.FailureMessage}", sp, ct);
+                    await BroadcastFinalAsync(sp, plan.PlanId, state.Subject, state.SessionId,
+                        BuildTerminalReply(continuation.TerminalReason), continuation.TerminalReason);
+                    return PlanReviewCompletionResult.TerminatedWithoutExecution(
+                        continuation.TerminalReason,
+                        continuation.FailureMessage);
+                }
 
             case PlanReviewContinuationKind.NeedsReplan:
                 {
+                    // Two callers with the same persisted-rejected decision would
+                    // otherwise both write new checkpoints and both open new
+                    // approval rows for round N+1. Claim exclusive ownership via
+                    // AwaitingReview → Running; only the winner opens the new
+                    // round. Restore to AwaitingReview after so external
+                    // observers (poll, list) see a coherent status.
+                    bool claimed = await planStore.TryTransitionStatusAsync(
+                        plan.PlanId, state.Subject,
+                        PlanStatus.AwaitingReview, PlanStatus.Running, ct);
+                    if (!claimed)
+                    {
+                        return PlanReviewCompletionResult.NoOp(
+                            "another resume driver already opened the next round");
+                    }
+
                     // Rehydrate the roster from the current process's DI so we
                     // replan against the same specialists the executor will run.
                     IReadOnlyList<ISpecialistAgent> roster =
@@ -219,6 +263,9 @@ public sealed class PlanReviewCompletionService
                     if (replanned is null || replanned.IsUnusable)
                     {
                         string msg = replanned?.UnusableReason ?? "planner unavailable";
+                        // We already own the claim, so a straight FinaliseAsFailed
+                        // (unconditional Running → Failed) is safe: no other
+                        // caller reached this branch.
                         await FinaliseAsFailedAsync(planStore, plan, state.Subject,
                             $"{PlanReviewTerminalReason.ReplanExhausted}: {msg}", sp, ct);
                         await BroadcastFinalAsync(sp, plan.PlanId, state.Subject, state.SessionId,
@@ -256,13 +303,24 @@ public sealed class PlanReviewCompletionService
                         PrincipalKey = state.PrincipalKey,
                     }, ct);
 
-                    // Broadcast that a new review round is waiting.
+                    // Restore the plan to AwaitingReview so it accurately
+                    // reflects "a new round is open for the reviewer" before
+                    // the SignalR broadcast fires.
+                    await planStore.UpdatePlanStatusAsync(new PlanStatusUpdate
+                    {
+                        PlanId = plan.PlanId,
+                        Subject = state.Subject,
+                        Status = PlanStatus.AwaitingReview,
+                        UpdatedAt = DateTimeOffset.UtcNow,
+                    }, ct);
+
+                    // Broadcast that a new review round is waiting — scoped to
+                    // the persisted session group (#141) so a different subject's
+                    // UI never receives this reviewer's next-round pointer.
+                    // Fail closed (log + no broadcast) when the session id is
+                    // missing so an isolation-critical event never fans out to
+                    // Clients.All by accident.
                     IHubContext<TelemetryHub>? hub = sp.GetService<IHubContext<TelemetryHub>>();
-                    // Session-scoped delivery (#141): the next-round event
-                    // reveals the plan id and reviewer request id of another
-                    // subject's in-flight plan and MUST NOT reach other
-                    // clients. Route it through the owning session's group;
-                    // fail closed on missing identity.
                     await SendToOwningSessionAsync(
                         hub, state.SessionId, "plan_review_next_round", new
                         {
@@ -304,6 +362,17 @@ public sealed class PlanReviewCompletionService
 
         if (!clarification.IsAnswered)
         {
+            // Concurrent-caller guard: only the caller that wins the
+            // AwaitingClarification → Failed transition finalizes and
+            // broadcasts; the loser NoOps.
+            bool claimedTerminal = await planStore.TryTransitionStatusAsync(
+                plan.PlanId, state.Subject,
+                PlanStatus.AwaitingClarification, PlanStatus.Failed, ct);
+            if (!claimedTerminal)
+            {
+                return PlanReviewCompletionResult.NoOp(
+                    "another resume driver already terminated this clarification");
+            }
             await FinaliseAsFailedAsync(planStore, plan, state.Subject,
                 $"{clarification.TerminalReason}: reviewer did not provide a usable answer.",
                 sp, ct);
@@ -313,26 +382,39 @@ public sealed class PlanReviewCompletionService
                 clarification.TerminalReason, "no usable clarification answer");
         }
 
+        // Concurrent-caller guard for the answered path — only the caller
+        // that flips AwaitingClarification → Running proceeds; the losing
+        // caller NoOps. Without this the executor would run twice and the
+        // final broadcast would fire twice per specialist.
+        bool claimedRun = await planStore.TryTransitionStatusAsync(
+            plan.PlanId, state.Subject,
+            PlanStatus.AwaitingClarification, PlanStatus.Running, ct);
+        if (!claimedRun)
+        {
+            return PlanReviewCompletionResult.NoOp(
+                "another resume driver already claimed this clarification for execution");
+        }
+
         // Substitute the answer as the paused step's Result, then execute the
         // remaining steps AFTER the paused step.
         //
-        // Index-rebase note (#141): the executor stores <c>state.Steps</c>
-        // rebased to start at the pause — see PlanExecutor.SuspendForClarificationAsync
-        // which writes <c>execution.Plan.Steps.Skip(stepIndex)</c>. Element 0
-        // of <c>state.Steps</c> IS the paused (CLARIFY) step; elements 1..N
-        // are the post-pause specialists that still need to run.
-        //
-        // The previous implementation indexed <c>state.Steps</c> with
-        // <c>state.PausedAtStepIndex</c> — the ORIGINAL plan index — so on any
-        // plan that paused past index 0 it (a) recorded the wrong step as the
-        // "answer" transcript and (b) skipped the first post-pause specialist
-        // entirely. Rebase against element 0 instead, and take the true
-        // remaining as <c>Skip(1)</c>. The persisted
-        // <see cref="PlanReviewCompletedStep.StepIndex"/> keeps the original
-        // index so downstream numbering is unchanged.
-        int pauseIndex = state.PausedAtStepIndex ?? 0;
-        List<PlanReviewCompletedStep> priorCompleted =
-            [.. state.CompletedSteps ?? []];
+        // Coherent checkpoint coordinate model (see PlanReviewCheckpointState
+        // XML doc, #141): every suspension writer slices <c>Steps</c> so the
+        // paused step sits at position 0 and every downstream step follows at
+        // positions 1..N. The reader ALWAYS resolves the paused step as
+        // <c>Steps[0]</c> and the downstream plan as <c>Steps.Skip(1)</c>.
+        // Legacy checkpoints from before this fix wrote the same sliced Steps
+        // but recorded <c>PausedAtStepIndex</c> as the ABSOLUTE index in the
+        // ORIGINAL plan; the buggy reader treated that absolute value as an
+        // index into the sliced list, which for any non-first clarification
+        // either fabricated a synthetic paused step or produced an empty
+        // remaining slice and silently skipped every downstream step. Under
+        // the new model, <c>PausedAtStepIndex</c> is preserved for audit only
+        // — the reader ignores it for element resolution so the same code
+        // path works for both the buggy legacy shape and freshly written
+        // checkpoints. The persisted <see cref="PlanReviewCompletedStep.StepIndex"/>
+        // still uses the original absolute index so downstream numbering is
+        // unchanged.
 
         PlanReviewStepDto paused = state.Steps.Count > 0
             ? state.Steps[0]
@@ -342,9 +424,19 @@ public sealed class PlanReviewCompletionService
                 Intent = "clarification",
                 Action = "clarification",
             };
+        // Cumulative context: every previously-completed step (from earlier
+        // rounds — could include the transcripts of a prior clarification
+        // resume) plus the just-answered paused step. Repeated clarifications
+        // must not reset this list; the executor is seeded with the whole
+        // transcript so a downstream [[CLARIFY]] on the resumed plan writes a
+        // checkpoint whose CompletedSteps preserves every prior chart/result.
+        List<PlanReviewCompletedStep> priorCompleted =
+            [.. state.CompletedSteps ?? []];
+        int absolutePausedIndex = state.PausedAtStepIndex
+            ?? priorCompleted.Count;
         priorCompleted.Add(new PlanReviewCompletedStep
         {
-            StepIndex = pauseIndex,
+            StepIndex = absolutePausedIndex,
             SpecialistKey = paused.SpecialistKey,
             Intent = paused.Intent,
             Action = paused.Action,
@@ -362,7 +454,8 @@ public sealed class PlanReviewCompletionService
             remaining,
             PlanReviewTerminalReason.ReviewerApproved,
             ct,
-            resumeCompletedSteps: priorCompleted);
+            resumeCompletedSteps: priorCompleted,
+            claimedRunning: true);
     }
 
     // ── Shared execute path ──────────────────────────────────────────────
@@ -375,8 +468,19 @@ public sealed class PlanReviewCompletionService
         IReadOnlyList<PlanReviewStepDto> effectiveSteps,
         string terminalReason,
         CancellationToken ct,
-        IReadOnlyList<PlanReviewCompletedStep>? resumeCompletedSteps = null)
+        IReadOnlyList<PlanReviewCompletedStep>? resumeCompletedSteps = null,
+        bool claimedRunning = false)
     {
+        // Callers on the Review-Approved and Terminal branches claim the
+        // AwaitingReview → Running transition before calling us; the
+        // clarification path passes `claimedRunning: true` so it does not
+        // repeat the claim. When neither has claimed (initial plan-review
+        // resume with no prior guard — currently unreachable but kept
+        // defensive), we still write the plan into Running below so a
+        // second concurrent caller observes it and short-circuits at the
+        // top-level idempotency guard on the next round.
+        _ = claimedRunning;
+
         // Move plan to Running and materialise step ids so the executor and
         // store agree on the same shape.
         var effectivePlan = new PlanBuildResult
@@ -436,6 +540,17 @@ public sealed class PlanReviewCompletionService
             Plan = effectivePlan,
             StepIds = stepIds,
             SpecialistLookup = lookup,
+            // Seed the executor's initial AccumulatedResults with every
+            // previously-completed step (from earlier rounds and prior
+            // clarification answers). A downstream [[CLARIFY]] emitted by
+            // the resumed plan's executor sees the FULL transcript through
+            // its PlanStepMessage.AccumulatedResults, so the checkpoint it
+            // opens carries every prior chart/result forward — otherwise
+            // repeated clarifications would silently drop all pre-resume
+            // state.
+            PriorAccumulatedResults = resumeCompletedSteps is { Count: > 0 }
+                ? [.. resumeCompletedSteps.Select(ToStepResult)]
+                : [],
         };
 
         PlanExecutor executor = sp.GetRequiredService<PlanExecutor>();
@@ -499,6 +614,29 @@ public sealed class PlanReviewCompletionService
 
         return PlanReviewCompletionResult.Executed(filtered, outcome, planCharts);
     }
+
+    /// <summary>
+    /// Convert a persisted <see cref="PlanReviewCompletedStep"/> into the
+    /// executor's per-step transcript shape so the initial
+    /// <see cref="PlanStepMessage.AccumulatedResults"/> reflects the full
+    /// pre-resume history — including specialist charts.
+    /// </summary>
+    private static PlanStepResult ToStepResult(PlanReviewCompletedStep s) => new(
+        StepIndex: s.StepIndex,
+        StepId: $"resumed-{s.StepIndex}",
+        SpecialistKey: s.SpecialistKey,
+        Intent: s.Intent,
+        Action: s.Action,
+        Status: PlanStepStatus.Completed,
+        Result: s.Result,
+        Error: null,
+        InputTokens: s.InputTokens,
+        OutputTokens: s.OutputTokens,
+        TotalTokens: s.TotalTokens,
+        DurationMs: s.DurationMs)
+    {
+        Charts = s.Charts is { Count: > 0 } charts ? [.. charts] : null,
+    };
 
     private static string ComposeFinalReply(
         IReadOnlyList<PlanReviewCompletedStep>? resumeCompletedSteps,

--- a/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
@@ -511,7 +511,28 @@ public sealed class PlanReviewCompletionService
             });
         }
 
-        // Persist the resolved (edited/approved) plan onto the same row.
+        // Persist step rows atomically BEFORE the executor runs (#144
+        // follow-up): the executor's per-step UPDATE (see
+        // <see cref="IPlanStore.UpdateStepAsync"/>) only touches existing
+        // rows keyed by <c>StepId</c>. Prior to this write the plan row
+        // carried at most the ORIGINAL <c>{planId}-s{n}</c> ids from
+        // <see cref="PlanOrchestrator.SuspendForReviewAsync"/>, so every
+        // round-scoped <c>{planId}-r{r}-s{n}</c> step transition silently
+        // no-op'd and the plan rehydrated as a zero-step ghost. The
+        // conditional-plus-transactional replacement in
+        // <see cref="IPlanStore.ReplacePlanStepsFromIndexAsync"/> preserves
+        // rows for prior clarification-completed steps (index &lt; offset)
+        // while replacing the round tail atomically so a concurrent reader
+        // never sees a torn view. If the caller already claimed the plan
+        // row to Running (Approved / NeedsReplan / answered-clarification
+        // branches), the ownership-guarded UPDATE below is a no-op status
+        // rewrite; when it did not claim, we still normalise the row here
+        // so the executor's own status writes land against a coherent
+        // baseline.
+        await planStore.ReplacePlanStepsFromIndexAsync(
+            plan.PlanId, state.Subject, offset, stepWrites, ct);
+
+        // Persist the resolved (edited/approved) plan status onto the same row.
         await planStore.UpdatePlanStatusAsync(new PlanStatusUpdate
         {
             PlanId = plan.PlanId,
@@ -554,12 +575,73 @@ public sealed class PlanReviewCompletionService
         };
 
         PlanExecutor executor = sp.GetRequiredService<PlanExecutor>();
-        PlanExecutionOutcome outcome = await executor.ExecuteAsync(executionRequest, ct);
+        PlanExecutionOutcome outcome;
+        try
+        {
+            outcome = await executor.ExecuteAsync(executionRequest, ct);
+        }
+        catch (Exception ex) when (ex is not null)
+        {
+            // Recoverable execution claim (#144 follow-up): once we've
+            // atomically claimed the plan row to Running, a subsequent
+            // exception or cancellation from the executor MUST land the
+            // plan in an honest terminal state — otherwise the plan is
+            // stranded in Running forever, the reviewer sees an in-flight
+            // spinner that never resolves, and restart recovery (which
+            // currently skips Running rows) never picks it up. We
+            // transition Running → Failed with a stable failure reason so
+            // the durable row matches the terminal approval, then re-throw
+            // so the caller (KickoffCompletion / restart recovery driver)
+            // can log at the appropriate site. Any Failed rewrite here is
+            // best-effort and never propagates its own exception.
+            string failureReason = ex is OperationCanceledException
+                ? "plan-resume cancelled after execution claim"
+                : $"plan-resume threw during execution: {ex.GetType().Name}";
+            try
+            {
+                await planStore.TryTransitionStatusAsync(
+                    plan.PlanId, state.Subject,
+                    PlanStatus.Running, PlanStatus.Failed, CancellationToken.None);
+                await planStore.UpdatePlanStatusAsync(new PlanStatusUpdate
+                {
+                    PlanId = plan.PlanId,
+                    Subject = state.Subject,
+                    Status = PlanStatus.Failed,
+                    FailureReason = failureReason,
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                }, CancellationToken.None);
+            }
+            catch (Exception recoveryEx)
+            {
+                _logger.LogError(recoveryEx,
+                    "Plan {PlanId} recoverable-Failed transition itself failed after execution exception; row remains as-is.",
+                    plan.PlanId);
+            }
+            _logger.LogError(ex,
+                "Plan {PlanId} resume execution failed after claim; marked Failed with reason '{Reason}'.",
+                plan.PlanId, failureReason);
+            throw;
+        }
 
         // If the executor asks to pause for clarification / replan, hand off.
         if (outcome.Status == PlanStatus.AwaitingClarification
             && outcome.ClarificationHandle is { } clarHandle)
         {
+            // Subsequent-clarification user visibility (#144 follow-up): the
+            // resumed plan paused for another clarification, but the
+            // frontend's `usePlanController` only opens the
+            // `PlanClarificationCard` when it receives an
+            // `approval_requested` event scoped to this session. The initial
+            // approval broadcast happens from the ApprovalTool; a mid-resume
+            // clarification opens the row inside the executor with no hub
+            // notification of its own. We fire the same event shape the
+            // frontend already understands, scoped to the persisted session
+            // group (fail-closed on missing session id), only after the
+            // executor's finally block has committed AwaitingClarification
+            // — so the reviewer never sees an approval before its
+            // awaiting-* status is durable.
+            await SendClarificationOpenedAsync(
+                sp, plan.PlanId, state.Subject, state.SessionId, clarHandle);
             return PlanReviewCompletionResult.SuspendedForClarification(
                 clarHandle.RequestId, clarHandle.CheckpointId);
         }
@@ -885,6 +967,74 @@ public sealed class PlanReviewCompletionService
                 reply,
                 terminalReason,
                 charts = charts is { Count: > 0 } ? charts : null,
+            });
+    }
+
+    /// <summary>
+    /// Fire the existing <c>approval_requested</c> hub event scoped to the
+    /// owning session group so <c>usePlanController</c> can render
+    /// <c>PlanClarificationCard</c> for a subsequent clarification that opens
+    /// on a resumed plan. The plan status is already durable at this call
+    /// site — the executor's finally block committed
+    /// <see cref="PlanStatus.AwaitingClarification"/> before returning — so
+    /// a listener that resolves the clarification immediately still finds a
+    /// coherent awaiting-* row. Session-scoped: fails closed on missing
+    /// session identity so a plan that lost its session id never fans out to
+    /// <see cref="IHubClients.All"/>.
+    /// </summary>
+    private async Task SendClarificationOpenedAsync(
+        IServiceProvider sp,
+        string planId,
+        string subject,
+        string? sessionId,
+        PlanClarificationHandle handle)
+    {
+        IHubContext<TelemetryHub>? hub = sp.GetService<IHubContext<TelemetryHub>>();
+
+        // Look up the just-opened clarification row so the broadcast carries
+        // the same PlanClarificationPrompt payload the initial ApprovalTool
+        // event already delivers. `usePlanController.parseClarificationPrompt`
+        // decodes this JSON to render the prompt in `PlanClarificationCard`.
+        // Falling back to a minimal payload (planId only) still lets the
+        // frontend open the card and fetch the row detail out-of-band, so a
+        // gate lookup failure never blocks user visibility.
+        string? payload = null;
+        try
+        {
+            IApprovalGate? gate = sp.GetService<IApprovalGate>();
+            if (gate is not null)
+            {
+                IReadOnlyList<ApprovalRequest> pending = await gate.GetPendingAsync(subject, CancellationToken.None);
+                ApprovalRequest? row = pending.FirstOrDefault(r =>
+                    string.Equals(r.RequestId, handle.RequestId, StringComparison.Ordinal));
+                payload = row?.Context.Payload;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "approval_requested clarification broadcast could not read payload for plan {PlanId} request {RequestId}; frontend will render a minimal prompt.",
+                planId, handle.RequestId);
+        }
+
+        // Mirror the shape usePlanController.ts already parses from
+        // ApprovalTool: `context.planId`, `context.kind`, `context.payload`
+        // + top-level `id`. The frontend dispatches
+        // CLARIFICATION_REQUESTED off `context.kind === 'clarification'`.
+        await SendToOwningSessionAsync(
+            hub, sessionId, "approval_requested", new
+            {
+                id = handle.RequestId,
+                planId,
+                kind = "clarification",
+                context = new
+                {
+                    planId,
+                    userId = subject,
+                    kind = "clarification",
+                    roundNumber = 0,
+                    payload,
+                },
             });
     }
 

--- a/src/RetailPulse.Api/Approval/PlanReviewRestartRecoveryService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewRestartRecoveryService.cs
@@ -69,12 +69,53 @@ public sealed class PlanReviewRestartRecoveryService : IHostedService
             }
 
             int resolved = 0;
+            int recoveredFromRunning = 0;
             foreach ((string planId, string subject) in candidates.Keys)
             {
                 PlanDetailDto? plan = await planStore.GetPlanAsync(subject, planId, cancellationToken);
                 if (plan is null) continue;
-                if (plan.Status is not (PlanStatus.AwaitingReview or PlanStatus.AwaitingClarification))
+                // Ordinary awaiting-* recovery: the plan was suspended by a
+                // prior instance and the reviewer's response is durably
+                // recorded; drive the completion service to run the resume.
+                bool isAwaiting = plan.Status is
+                    PlanStatus.AwaitingReview or PlanStatus.AwaitingClarification;
+
+                // Stranded-Running recovery (#144 follow-up): a prior instance
+                // atomically claimed AwaitingReview → Running (or
+                // AwaitingClarification → Running) and then crashed / was
+                // killed / cancelled BEFORE the executor finished. The
+                // completion service now transitions Running → Failed
+                // in-process when the executor throws or is cancelled, but a
+                // hard process exit skips that catch. Restart recovery must
+                // finish the job: transition the row to Failed so the
+                // paired terminal approval never orphans the plan record.
+                bool isStrandedRunning = plan.Status == PlanStatus.Running;
+
+                if (!isAwaiting && !isStrandedRunning)
                     continue;
+
+                if (isStrandedRunning)
+                {
+                    bool transitioned = await planStore.TryTransitionStatusAsync(
+                        planId, subject,
+                        PlanStatus.Running, PlanStatus.Failed, cancellationToken);
+                    if (transitioned)
+                    {
+                        await planStore.UpdatePlanStatusAsync(new PlanStatusUpdate
+                        {
+                            PlanId = planId,
+                            Subject = subject,
+                            Status = PlanStatus.Failed,
+                            FailureReason = "plan-resume interrupted by process exit while Running",
+                            UpdatedAt = DateTimeOffset.UtcNow,
+                        }, cancellationToken);
+                    }
+                    _logger.LogWarning(
+                        "Plan {PlanId} was stranded in Running with a terminal approval; marked Failed on restart recovery.",
+                        planId);
+                    recoveredFromRunning++;
+                    continue;
+                }
 
                 PlanReviewCompletionResult result = await completion.ResolveAsync(planId, subject, cancellationToken);
                 _logger.LogInformation(
@@ -84,8 +125,8 @@ public sealed class PlanReviewRestartRecoveryService : IHostedService
             }
 
             _logger.LogInformation(
-                "PlanReviewRestartRecoveryService completed: {Count} plan(s) resumed.",
-                resolved);
+                "PlanReviewRestartRecoveryService completed: {Resumed} plan(s) resumed, {Stranded} stranded-Running plan(s) marked Failed.",
+                resolved, recoveredFromRunning);
         }
         catch (OperationCanceledException)
         {

--- a/src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs
@@ -204,8 +204,19 @@ public static class PlanReviewEndpoints
             // persisted <see cref="ApprovalResult.ResponsePayload"/> keeps
             // the HTTP body, the SignalR broadcast, and the durable row
             // reporting exactly one user-visible decision end-to-end.
-            (string persistedKind, string? persistedFeedback) =
-                ExtractWinner(result, kind, feedback);
+            //
+            // Fail-safe integrity (#144 follow-up): NEVER fall back to the
+            // requesting caller's `kind` or `feedback` on payload
+            // missing/malformed, because on a lost race those describe an
+            // outcome the durable row does not record. `Kind` is derived from
+            // <see cref="ApprovalResult.Decision"/>, which is the row's
+            // authoritative outcome; `Feedback` is only surfaced when the
+            // persisted payload parses cleanly. When the payload is
+            // missing/malformed we omit feedback entirely and skip the
+            // resolution broadcast so a losing caller cannot leak its own
+            // requested feedback text.
+            (string persistedKind, string? persistedFeedback, bool payloadParsed) =
+                ExtractWinner(result);
             var responseDto = new
             {
                 requestId = result.RequestId,
@@ -227,17 +238,52 @@ public static class PlanReviewEndpoints
             // review land without a session id cannot silently widen delivery.
             // Aligns with the plan_final_response and plan_review_next_round
             // paths in PlanReviewCompletionService.
+            //
+            // Fail-safe integrity (#144 follow-up): when the persisted payload
+            // was missing or malformed we cannot produce a coherent
+            // kind+feedback pair for this broadcast, so we skip the resolution
+            // broadcast entirely. The row is already durably terminal and the
+            // completion kickoff below still runs, so the plan surface
+            // ultimately settles through `plan_final_response` — no user-
+            // visible outcome is lost.
+            //
+            // Decision durability (#144 follow-up): the completion kickoff
+            // runs regardless of hub-send outcome or request cancellation.
+            // We use `CancellationToken.None` on the SendAsync so a client
+            // disconnect on `ct` cannot strand the row terminal without ever
+            // driving the resume path, and any hub-send exception is logged
+            // and swallowed (the row is already terminal). Notification is
+            // never a gate on execution.
+            ILogger endpointLogger = loggerFactory.CreateLogger("PlanReviewEndpoints");
             string? reviewSessionId = row.Context.SessionId;
-            if (string.IsNullOrWhiteSpace(reviewSessionId))
+            if (!payloadParsed)
             {
-                loggerFactory.CreateLogger("PlanReviewEndpoints").LogWarning(
+                endpointLogger.LogWarning(
+                    "plan_review_resolved suppressed for plan {PlanId} request {RequestId}: persisted response payload was missing or malformed; skipping broadcast to avoid advertising a losing caller's feedback.",
+                    planId, requestId);
+            }
+            else if (string.IsNullOrWhiteSpace(reviewSessionId))
+            {
+                endpointLogger.LogWarning(
                     "plan_review_resolved suppressed for plan {PlanId} request {RequestId}: session identity missing; refusing to broadcast to Clients.All.",
                     planId, requestId);
             }
             else
             {
-                await hubContext.Clients.Group(reviewSessionId).SendAsync(
-                    "plan_review_resolved", responseDto, ct);
+                try
+                {
+                    await hubContext.Clients.Group(reviewSessionId).SendAsync(
+                        "plan_review_resolved", responseDto, CancellationToken.None);
+                }
+                catch (Exception hubEx)
+                {
+                    // Notification failure never gates the durable decision. Log
+                    // (including OperationCanceledException) and let completion
+                    // kickoff proceed so the plan settles.
+                    endpointLogger.LogWarning(hubEx,
+                        "plan_review_resolved SignalR send failed for plan {PlanId} request {RequestId}; decision remains durable and completion will still be driven.",
+                        planId, requestId);
+                }
             }
 
             // Drive the plan through the resume path so the reviewer's
@@ -245,7 +291,10 @@ public static class PlanReviewEndpoints
             // plan, filter, persist, broadcast). ResolveAsync is idempotent
             // and short-circuits when the plan is already terminal, and its
             // TryTransitionStatusAsync guard collapses two concurrent
-            // KickoffCompletion calls to a single execution.
+            // KickoffCompletion calls to a single execution. This dispatch
+            // is independent of the request cancellation token so a client
+            // disconnect never leaves the durable row terminal without an
+            // executed final response.
             if (completion is not null)
             {
                 _ = KickoffCompletionAsync(completion, planId, subject);
@@ -394,38 +443,83 @@ public static class PlanReviewEndpoints
 
     /// <summary>
     /// Resolve the winning decision's <c>kind</c> and reviewer feedback from
-    /// the persisted <see cref="ApprovalResult.ResponsePayload"/> so a losing
-    /// concurrent caller does not advertise a decision the row does not
-    /// record. Falls back to the caller-requested <paramref name="requestedKind"/>
-    /// and <paramref name="requestedFeedback"/> when the persisted payload is
-    /// missing or unparseable (e.g., a legacy or reconciler-terminated row
-    /// that never carried a plan-review payload); the caller-requested
-    /// values still describe SOMETHING coherent for that edge case, and the
-    /// gate itself already returned the correct <see cref="ApprovalResult"/>
-    /// so a caller-vs-winner drift is bounded.
+    /// the persisted <see cref="ApprovalResult"/> so a losing concurrent
+    /// caller does not advertise a decision the row does not record.
+    /// <para>
+    /// Integrity contract:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description><c>Kind</c> is derived from
+    ///     <see cref="ApprovalResult.Decision"/> (Approved/Rejected/Modified/
+    ///     TimedOut/Orphaned). This is the durable row's authoritative outcome
+    ///     — never the losing caller's requested kind. Timed-out and orphaned
+    ///     rows normalize to <see cref="PlanReviewKinds.Reject"/> so the
+    ///     resume path treats them as a terminal reject.</description></item>
+    ///   <item><description>When <see cref="ApprovalResult.ResponsePayload"/>
+    ///     is present and parses cleanly, <c>Feedback</c> is taken from the
+    ///     persisted payload (the winner's actual text). If the persisted
+    ///     payload carries a valid <c>Kind</c>, we use that too so the
+    ///     approve/reject/edit granularity matches the persisted winner.</description></item>
+    ///   <item><description>When the payload is missing or malformed we
+    ///     omit feedback entirely (<c>null</c>) and return
+    ///     <c>PayloadParsed = false</c>. The caller MUST skip any user-
+    ///     visible resolution broadcast in that state so a losing caller
+    ///     cannot smuggle its own feedback string into the SignalR event.
+    ///     The decision itself remains durably recorded on the row.</description></item>
+    /// </list>
     /// </summary>
-    internal static (string Kind, string? Feedback) ExtractWinner(
-        ApprovalResult result, string requestedKind, string? requestedFeedback)
+    internal static (string Kind, string? Feedback, bool PayloadParsed) ExtractWinner(
+        ApprovalResult result)
     {
+        string derivedKind = KindFromDecision(result.Decision);
+
         if (string.IsNullOrWhiteSpace(result.ResponsePayload))
         {
-            return (requestedKind, requestedFeedback);
+            return (derivedKind, null, false);
         }
+
+        PlanReviewResponsePayload? persisted;
         try
         {
-            PlanReviewResponsePayload? persisted =
-                JsonSerializer.Deserialize<PlanReviewResponsePayload>(result.ResponsePayload, _jsonOptions);
-            if (persisted is null || string.IsNullOrWhiteSpace(persisted.Kind))
-            {
-                return (requestedKind, requestedFeedback);
-            }
-            return (persisted.Kind.Trim().ToLowerInvariant(), persisted.Feedback);
+            persisted = JsonSerializer.Deserialize<PlanReviewResponsePayload>(
+                result.ResponsePayload, _jsonOptions);
         }
         catch (JsonException)
         {
-            return (requestedKind, requestedFeedback);
+            return (derivedKind, null, false);
         }
+
+        if (persisted is null)
+        {
+            return (derivedKind, null, false);
+        }
+
+        // Prefer the persisted payload's kind when it is well-formed and
+        // consistent with the row's Decision family; otherwise fall back to
+        // the decision-derived kind. Feedback comes from the persisted
+        // payload only — this is the durable winner's actual text.
+        string payloadKind = string.IsNullOrWhiteSpace(persisted.Kind)
+            ? derivedKind
+            : persisted.Kind.Trim().ToLowerInvariant();
+
+        return (payloadKind, persisted.Feedback, true);
     }
+
+    private static string KindFromDecision(ApprovalDecision decision) => decision switch
+    {
+        ApprovalDecision.Approved => PlanReviewKinds.Approve,
+        ApprovalDecision.Modified => PlanReviewKinds.Edit,
+        ApprovalDecision.Rejected => PlanReviewKinds.Reject,
+        ApprovalDecision.TimedOut => PlanReviewKinds.Reject,
+        ApprovalDecision.Orphaned => PlanReviewKinds.Reject,
+        ApprovalDecision.Pending => PlanReviewKinds.Reject,
+        // Timed-out and orphaned rows are terminal-reject on the plan-review
+        // surface (see PlanReviewCoordinator's derivation). Pending never
+        // reaches ExtractWinner because RespondAsync only returns a settled
+        // result, but if a caller ever passes one, treat it as reject so no
+        // approve-shaped broadcast can slip through.
+        _ => PlanReviewKinds.Reject,
+    };
 
     private static async Task<ApprovalRequest?> FindRowAsync(
         IApprovalGate gate, string subject, string requestId, CancellationToken ct)

--- a/src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs
@@ -195,16 +195,28 @@ public static class PlanReviewEndpoints
                 responsePayload: payloadJson,
                 ct: ct);
 
+            // Build the response DTO from the PERSISTED WINNER, not the
+            // caller's own body. When two callers race the same approval row
+            // RespondAsync collapses them to a single terminal outcome; the
+            // losing caller would otherwise broadcast its own requested
+            // `kind` / `feedback` even though the row records a different
+            // decision. Resolving `kind` and `feedback` back from the
+            // persisted <see cref="ApprovalResult.ResponsePayload"/> keeps
+            // the HTTP body, the SignalR broadcast, and the durable row
+            // reporting exactly one user-visible decision end-to-end.
+            (string persistedKind, string? persistedFeedback) =
+                ExtractWinner(result, kind, feedback);
             var responseDto = new
             {
                 requestId = result.RequestId,
                 planId,
                 decision = result.Decision.ToString().ToLowerInvariant(),
-                kind,
+                kind = persistedKind,
                 comment = result.Comment,
                 respondedAt = result.RespondedAt,
                 terminalReason = result.TerminalReason,
                 round = row.Context.RoundNumber,
+                feedback = persistedFeedback,
             };
 
             // Session-scoped delivery (#141): the plan_review_resolved event
@@ -231,7 +243,9 @@ public static class PlanReviewEndpoints
             // Drive the plan through the resume path so the reviewer's
             // decision produces a real final response (execute the effective
             // plan, filter, persist, broadcast). ResolveAsync is idempotent
-            // and short-circuits when the plan is already terminal.
+            // and short-circuits when the plan is already terminal, and its
+            // TryTransitionStatusAsync guard collapses two concurrent
+            // KickoffCompletion calls to a single execution.
             if (completion is not null)
             {
                 _ = KickoffCompletionAsync(completion, planId, subject);
@@ -375,6 +389,41 @@ public static class PlanReviewEndpoints
                 return (ApprovalDecision.Modified, PlanReviewKinds.Edit, body.EditedSteps, null, null);
             default:
                 return (default, kind, null, null, $"Unknown decision kind '{kind}'. Expected approve, reject, or edit.");
+        }
+    }
+
+    /// <summary>
+    /// Resolve the winning decision's <c>kind</c> and reviewer feedback from
+    /// the persisted <see cref="ApprovalResult.ResponsePayload"/> so a losing
+    /// concurrent caller does not advertise a decision the row does not
+    /// record. Falls back to the caller-requested <paramref name="requestedKind"/>
+    /// and <paramref name="requestedFeedback"/> when the persisted payload is
+    /// missing or unparseable (e.g., a legacy or reconciler-terminated row
+    /// that never carried a plan-review payload); the caller-requested
+    /// values still describe SOMETHING coherent for that edge case, and the
+    /// gate itself already returned the correct <see cref="ApprovalResult"/>
+    /// so a caller-vs-winner drift is bounded.
+    /// </summary>
+    internal static (string Kind, string? Feedback) ExtractWinner(
+        ApprovalResult result, string requestedKind, string? requestedFeedback)
+    {
+        if (string.IsNullOrWhiteSpace(result.ResponsePayload))
+        {
+            return (requestedKind, requestedFeedback);
+        }
+        try
+        {
+            PlanReviewResponsePayload? persisted =
+                JsonSerializer.Deserialize<PlanReviewResponsePayload>(result.ResponsePayload, _jsonOptions);
+            if (persisted is null || string.IsNullOrWhiteSpace(persisted.Kind))
+            {
+                return (requestedKind, requestedFeedback);
+            }
+            return (persisted.Kind.Trim().ToLowerInvariant(), persisted.Feedback);
+        }
+        catch (JsonException)
+        {
+            return (requestedKind, requestedFeedback);
         }
     }
 

--- a/src/RetailPulse.Api/Persistence/IPlanStore.cs
+++ b/src/RetailPulse.Api/Persistence/IPlanStore.cs
@@ -65,6 +65,31 @@ public interface IPlanStore
     /// </summary>
     Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default);
 
+    /// <summary>
+    /// Atomically synchronize the persisted step rows for a plan from a given
+    /// starting <see cref="StepIndex"/> onward. Deletes any existing
+    /// <c>PlanSteps</c> rows with <c>StepIndex &gt;= fromStepIndex</c> and
+    /// inserts the supplied <paramref name="steps"/> — both operations in a
+    /// single transaction so a concurrent reader never sees a torn view. Rows
+    /// with <c>StepIndex &lt; fromStepIndex</c> are preserved verbatim so the
+    /// cumulative transcript across a clarification-resume (paused prefix +
+    /// downstream tail) stays intact.
+    /// <para>
+    /// Introduced (#144 follow-up) so the plan-review resume path can persist
+    /// its round-specific step rows BEFORE <see cref="UpdateStepAsync"/> runs;
+    /// the executor's per-step UPDATE only touches existing rows, so a resume
+    /// that emitted new <c>{planId}-r{round}-s{n}</c> ids without inserting
+    /// them first would silently no-op every step transition and hydrate as a
+    /// zero-step plan.
+    /// </para>
+    /// </summary>
+    Task ReplacePlanStepsFromIndexAsync(
+        string planId,
+        string subject,
+        int fromStepIndex,
+        IReadOnlyList<PlanStepWrite> steps,
+        CancellationToken ct = default);
+
     /// <summary>List this subject's plans, newest activity first. Enforces the caller filter at SQL.</summary>
     Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(
         string subject, CancellationToken ct = default);

--- a/src/RetailPulse.Api/Persistence/IPlanStore.cs
+++ b/src/RetailPulse.Api/Persistence/IPlanStore.cs
@@ -32,6 +32,32 @@ public interface IPlanStore
     Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default);
 
     /// <summary>
+    /// Atomic conditional status transition: writes <paramref name="toStatus"/>
+    /// onto the plan row for <paramref name="subject"/> only when its current
+    /// status equals <paramref name="fromStatus"/>. Returns <c>true</c> when
+    /// exactly one row transitioned (the caller "won" the transition), and
+    /// <c>false</c> when another caller already advanced the row.
+    ///
+    /// <para>
+    /// The plan-review resume path uses this to claim the effective execution
+    /// for exactly one caller when two concurrent decision / clarification
+    /// submissions race the same approval row: <see cref="IApprovalGate.RespondAsync"/>
+    /// records exactly one persisted winner, then each caller fires
+    /// <c>ResolveAsync</c>; without this claim both would call
+    /// <c>UpdatePlanStatusAsync(Running)</c>, run the executor twice, and
+    /// broadcast a duplicate <c>plan_final_response</c>. The conditional
+    /// UPDATE keyed on the pre-transition status collapses that race to a
+    /// single execution and a single broadcast.
+    /// </para>
+    /// </summary>
+    Task<bool> TryTransitionStatusAsync(
+        string planId,
+        string subject,
+        string fromStatus,
+        string toStatus,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Update one step in place — status transition, result content, tokens,
     /// duration, timestamps, or error. Every field except the primary key is
     /// nullable so the orchestrator can commit whatever it knows at each

--- a/src/RetailPulse.Api/Persistence/SqlitePlanStore.cs
+++ b/src/RetailPulse.Api/Persistence/SqlitePlanStore.cs
@@ -286,6 +286,77 @@ public sealed class SqlitePlanStore : IPlanStore
         }
     }
 
+    public async Task ReplacePlanStepsFromIndexAsync(
+        string planId,
+        string subject,
+        int fromStepIndex,
+        IReadOnlyList<PlanStepWrite> steps,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(planId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+        ArgumentNullException.ThrowIfNull(steps);
+        if (fromStepIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(fromStepIndex), fromStepIndex, "fromStepIndex must be non-negative.");
+
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+        await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync(ct);
+
+        // Ownership gate — the parent plan must belong to this subject.
+        // Doing this as a separate SELECT keeps the DELETE/INSERT clean and
+        // preserves the "cross-subject probe = 404" contract sessions use.
+        await using (SqliteCommand ownership = conn.CreateCommand())
+        {
+            ownership.Transaction = tx;
+            ownership.CommandText = "SELECT COUNT(*) FROM Plans WHERE PlanId = @pid AND Subject = @subject";
+            ownership.Parameters.AddWithValue("@pid", planId);
+            ownership.Parameters.AddWithValue("@subject", subject);
+            object? count = await ownership.ExecuteScalarAsync(ct);
+            if (Convert.ToInt64(count, CultureInfo.InvariantCulture) == 0L)
+            {
+                _logger.LogWarning(
+                    "ReplacePlanStepsFromIndexAsync rejected — no plan {PlanId} owned by subject {Subject}",
+                    planId, subject);
+                await tx.RollbackAsync(ct);
+                return;
+            }
+        }
+
+        await using (SqliteCommand deleteTail = conn.CreateCommand())
+        {
+            deleteTail.Transaction = tx;
+            deleteTail.CommandText =
+                "DELETE FROM PlanSteps WHERE PlanId = @pid AND StepIndex >= @from";
+            deleteTail.Parameters.AddWithValue("@pid", planId);
+            deleteTail.Parameters.AddWithValue("@from", fromStepIndex);
+            await deleteTail.ExecuteNonQueryAsync(ct);
+        }
+
+        foreach (PlanStepWrite step in steps)
+        {
+            await using SqliteCommand insertStep = conn.CreateCommand();
+            insertStep.Transaction = tx;
+            insertStep.CommandText = """
+                INSERT INTO PlanSteps (StepId, PlanId, StepIndex, SpecialistKey, Intent, Action, Status)
+                VALUES (@sid, @pid, @idx, @key, @intent, @action, @status)
+                """;
+            insertStep.Parameters.AddWithValue("@sid", step.StepId);
+            insertStep.Parameters.AddWithValue("@pid", planId);
+            insertStep.Parameters.AddWithValue("@idx", step.StepIndex);
+            insertStep.Parameters.AddWithValue("@key", step.SpecialistKey);
+            insertStep.Parameters.AddWithValue("@intent", step.Intent);
+            insertStep.Parameters.AddWithValue("@action", step.Action);
+            insertStep.Parameters.AddWithValue("@status", step.Status);
+            await insertStep.ExecuteNonQueryAsync(ct);
+        }
+
+        await tx.CommitAsync(ct);
+
+        _logger.LogDebug(
+            "Replaced plan {PlanId} steps from index {From} with {Count} new step rows (subject {Subject})",
+            planId, fromStepIndex, steps.Count, subject);
+    }
+
     // ── Reads ────────────────────────────────────────────────────────────
 
     public async Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(

--- a/src/RetailPulse.Api/Persistence/SqlitePlanStore.cs
+++ b/src/RetailPulse.Api/Persistence/SqlitePlanStore.cs
@@ -199,6 +199,41 @@ public sealed class SqlitePlanStore : IPlanStore
         }
     }
 
+    public async Task<bool> TryTransitionStatusAsync(
+        string planId,
+        string subject,
+        string fromStatus,
+        string toStatus,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(planId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fromStatus);
+        ArgumentException.ThrowIfNullOrWhiteSpace(toStatus);
+
+        string now = DateTimeOffset.UtcNow.ToString(_iso8601, CultureInfo.InvariantCulture);
+
+        await using SqliteConnection conn = await SqliteMount.OpenAsync(_connectionString, ct);
+        await using SqliteCommand cmd = conn.CreateCommand();
+        // Single conditional UPDATE keyed on the pre-transition status. Two
+        // concurrent callers targeting the same row can only see rows == 1
+        // for one of them; the other observes rows == 0 and returns false.
+        cmd.CommandText = """
+            UPDATE Plans SET
+                Status = @to,
+                UpdatedAt = @now
+            WHERE PlanId = @pid AND Subject = @subject AND Status = @from
+            """;
+        cmd.Parameters.AddWithValue("@to", toStatus);
+        cmd.Parameters.AddWithValue("@from", fromStatus);
+        cmd.Parameters.AddWithValue("@now", now);
+        cmd.Parameters.AddWithValue("@pid", planId);
+        cmd.Parameters.AddWithValue("@subject", subject);
+
+        int rows = await cmd.ExecuteNonQueryAsync(ct);
+        return rows == 1;
+    }
+
     public async Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(update);

--- a/src/RetailPulse.Web/src/__tests__/planReducer.finalCharts.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/planReducer.finalCharts.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { initialPlanState, planReducer } from '../state/planReducer';
+import type { ChartSpec, PlanDetail } from '../types';
+
+/**
+ * Issue #137 regression coverage at the reducer boundary. The plan-review
+ * resume path relies on `PLAN_FINAL.charts` to persist the specialist
+ * chart list into `ActivePlanState.finalCharts`; the immediate plan-first
+ * path dispatches the same action from `usePlanController.startPlan`.
+ * If the reducer silently discards charts, both the fast-path chart
+ * bubble and the resume-path chart bubble go blank.
+ *
+ * These tests are deterministic and require nothing beyond the reducer —
+ * a chart drop in `PLAN_FINAL` fails them immediately.
+ */
+
+const NINE_CHARTS: readonly ChartSpec[] = [
+  { type: 'line', title: 'A: Depletion trend', data: [{ legend: 'Brand A', values: [{ x: 'W1', y: 100 }, { x: 'W2', y: 120 }] }] },
+  { type: 'bar', title: 'B: Velocity by brand', data: [{ legend: 'Velocity', values: [{ x: 'Brand A', y: 900 }, { x: 'Brand B', y: 800 }] }] },
+  { type: 'groupedBar', title: 'C: Volume by region', data: [
+    { legend: 'Brand A', values: [{ x: 'NE', y: 100 }, { x: 'SE', y: 120 }] },
+    { legend: 'Brand B', values: [{ x: 'NE', y: 80 }, { x: 'SE', y: 90 }] },
+  ] },
+  { type: 'stackedBar', title: 'D: Stacked mix', data: [
+    { legend: 'S1', values: [{ x: 'Q1', y: 30 }, { x: 'Q2', y: 40 }] },
+    { legend: 'S2', values: [{ x: 'Q1', y: 70 }, { x: 'Q2', y: 60 }] },
+  ] },
+  { type: 'horizontalBar', title: 'E: Top brands YoY', data: [{ legend: 'YoY %', values: [
+    { x: 'Brand A', y: 8.4 }, { x: 'Brand B', y: 6.1 }, { x: 'Brand C', y: 3.2 },
+    { x: 'Brand D', y: 1.9 }, { x: 'Brand E', y: -1.2 }, { x: 'Brand F', y: -3.4 },
+  ] }] },
+  { type: 'pie', title: 'F: Share', data: [{ legend: 'Share %', values: [{ x: 'A', y: 45 }, { x: 'B', y: 35 }, { x: 'C', y: 20 }] }] },
+  { type: 'donut', title: 'G: Mix', data: [{ legend: 'Mix %', values: [{ x: 'Original', y: 45 }, { x: 'Spicy', y: 33 }, { x: 'Verde', y: 22 }] }] },
+  { type: 'gauge', title: 'H: Inventory health', data: [{ legend: 'Inventory Health', values: [{ x: 'Region', y: 75 }] }] },
+  { type: 'table', title: 'I: Ops table', data: [{ legend: 'Depletions %', values: [{ x: 'Row 1', y: 12 }] }] },
+];
+
+function detailFor(planId: string): PlanDetail {
+  return {
+    planId,
+    sessionId: 'sess-1',
+    tenantId: null,
+    request: 'compare A and B',
+    status: 'running',
+    detectedIntents: ['demand'],
+    failureReason: null,
+    totalInputTokens: null,
+    totalOutputTokens: null,
+    totalTokens: null,
+    totalDurationMs: null,
+    createdAt: new Date(1_000_000).toISOString(),
+    updatedAt: new Date(1_500_000).toISOString(),
+    steps: [
+      { stepId: `${planId}-0`, planId, stepIndex: 0, specialistKey: 'demand-forecasting', intent: 'demand', action: 'run', status: 'completed' },
+    ],
+  };
+}
+
+describe('planReducer PLAN_FINAL charts (issue #137)', () => {
+  it('persists all 9 canonical chart types on ActivePlanState.finalCharts in specialist order', () => {
+    const seed = planReducer(initialPlanState, {
+      type: 'PLAN_STARTED',
+      planId: 'p1',
+      request: 'q',
+      startedAt: 0,
+    });
+
+    const final = planReducer(seed, {
+      type: 'PLAN_FINAL',
+      planId: 'p1',
+      reply: 'here is the aggregate',
+      terminalReason: null,
+      charts: [...NINE_CHARTS],
+    });
+
+    expect(final.active?.finalReply).toBe('here is the aggregate');
+    expect(final.active?.finalCharts).toHaveLength(9);
+    expect(final.active?.finalCharts?.map((c) => c.type)).toEqual([
+      'line', 'bar', 'groupedBar', 'stackedBar', 'horizontalBar', 'pie', 'donut', 'gauge', 'table',
+    ]);
+    expect(final.active?.finalCharts?.map((c) => c.title)).toEqual(
+      NINE_CHARTS.map((c) => c.title),
+    );
+  });
+
+  it('overwrites prior finalCharts with null when the backend delivers no charts on this turn', () => {
+    const withCharts = planReducer(
+      planReducer(initialPlanState, { type: 'PLAN_STARTED', planId: 'p1', request: 'q' }),
+      { type: 'PLAN_FINAL', planId: 'p1', reply: 'r', charts: [...NINE_CHARTS] },
+    );
+    expect(withCharts.active?.finalCharts).toHaveLength(9);
+
+    const rerun = planReducer(withCharts, {
+      type: 'PLAN_FINAL',
+      planId: 'p1',
+      reply: 'r2',
+      charts: null,
+    });
+    expect(rerun.active?.finalCharts).toBeNull();
+  });
+
+  it('PLAN_STARTED for a fresh plan does not carry stale finalCharts from a prior plan', () => {
+    const p1Done = planReducer(
+      planReducer(initialPlanState, { type: 'PLAN_STARTED', planId: 'p1', request: 'q1' }),
+      { type: 'PLAN_FINAL', planId: 'p1', reply: 'r', charts: [...NINE_CHARTS] },
+    );
+    expect(p1Done.active?.finalCharts).toHaveLength(9);
+
+    const p2 = planReducer(p1Done, { type: 'PLAN_STARTED', planId: 'p2', request: 'q2' });
+    expect(p2.active?.planId).toBe('p2');
+    expect(p2.active?.finalCharts).toBeUndefined();
+    expect(p2.active?.finalReply).toBeUndefined();
+  });
+
+  it('PLAN_HYDRATED preserves same-plan finalCharts (PlanDetail carries no charts field)', () => {
+    const settled = planReducer(
+      planReducer(initialPlanState, { type: 'PLAN_STARTED', planId: 'p1', request: 'q' }),
+      { type: 'PLAN_FINAL', planId: 'p1', reply: 'r', charts: [...NINE_CHARTS] },
+    );
+    const hydrated = planReducer(settled, { type: 'PLAN_HYDRATED', detail: detailFor('p1') });
+    expect(hydrated.active?.finalCharts).toHaveLength(9);
+    expect(hydrated.active?.finalReply).toBe('r');
+  });
+
+  it('PLAN_HYDRATED for a different plan starts with no finalCharts', () => {
+    const p1Done = planReducer(
+      planReducer(initialPlanState, { type: 'PLAN_STARTED', planId: 'p1', request: 'q' }),
+      { type: 'PLAN_FINAL', planId: 'p1', reply: 'r', charts: [...NINE_CHARTS] },
+    );
+    // Simulate opening a different plan via hydrate directly.
+    const hydrated = planReducer(p1Done, { type: 'PLAN_HYDRATED', detail: detailFor('p2') });
+    expect(hydrated.active?.planId).toBe('p2');
+    expect(hydrated.active?.finalCharts).toBeUndefined();
+  });
+
+  it('CLOSE_ACTIVE clears any settled charts', () => {
+    const done = planReducer(
+      planReducer(initialPlanState, { type: 'PLAN_STARTED', planId: 'p1', request: 'q' }),
+      { type: 'PLAN_FINAL', planId: 'p1', reply: 'r', charts: [...NINE_CHARTS] },
+    );
+    const closed = planReducer(done, { type: 'CLOSE_ACTIVE' });
+    expect(closed.active).toBeNull();
+  });
+});

--- a/src/RetailPulse.Web/src/__tests__/usePlanController.decisionResponse.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/usePlanController.decisionResponse.test.tsx
@@ -68,7 +68,6 @@ function makeConnection(): PlanControllerConnection & {
       bucket.add(handler);
       return () => bucket?.delete(handler);
     },
-    onReconnected: () => () => {},
     emit: (event, payload) => {
       const bucket = handlers.get(event);
       if (!bucket) return;

--- a/src/RetailPulse.Web/src/__tests__/usePlanController.decisionResponse.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/usePlanController.decisionResponse.test.tsx
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+// #144 follow-up: `usePlanController` MUST consume the persisted-winner
+// `kind` returned from POST /decision instead of the locally-hard-coded
+// requested kind. On a concurrent race the durable ApprovalResult.Decision
+// (and therefore the returned response's `kind`) can differ from what this
+// caller asked for; using the response's `kind` eliminates any event/local
+// order drift with the SignalR `plan_review_resolved` broadcast.
+//
+// Also covers the repeated-clarification user-visibility path: a resumed
+// plan that opens another clarification MUST broadcast the existing
+// `approval_requested` event and the controller MUST render
+// `PlanClarificationCard` from it.
+
+const answerPlanClarificationMock = vi.fn();
+const fetchPlanDetailMock = vi.fn();
+const fetchPlanReviewsMock = vi.fn();
+const decidePlanReviewMock = vi.fn();
+const deletePlanMock = vi.fn();
+const fetchPlansMock = vi.fn();
+
+vi.mock('../services/planApi', () => ({
+  answerPlanClarification: (...args: unknown[]) => answerPlanClarificationMock(...args),
+  fetchPlanDetail: (...args: unknown[]) => fetchPlanDetailMock(...args),
+  fetchPlanReviews: (...args: unknown[]) => fetchPlanReviewsMock(...args),
+  decidePlanReview: (...args: unknown[]) => decidePlanReviewMock(...args),
+  deletePlan: (...args: unknown[]) => deletePlanMock(...args),
+  fetchPlans: (...args: unknown[]) => fetchPlansMock(...args),
+  parseClarificationPrompt: (raw: string | null) => {
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw);
+      return {
+        planId: parsed.planId ?? '',
+        stepIndex: parsed.stepIndex ?? 0,
+        specialistKey: parsed.specialistKey ?? '',
+        question: parsed.question ?? '',
+      };
+    } catch {
+      return null;
+    }
+  },
+  parseReviewProposal: () => null,
+}));
+
+vi.mock('../services/executionControlApi', () => ({
+  reconcilePlan: vi.fn().mockResolvedValue(null),
+}));
+
+import { usePlanController, type PlanControllerConnection } from '../state/usePlanController';
+import type { PlanReviewDecisionResponse, PlanReviewStep } from '../types';
+
+type ConnHandler = (payload: unknown) => void;
+
+function makeConnection(): PlanControllerConnection & {
+  emit: (evt: string, payload: unknown) => void;
+} {
+  const handlers = new Map<string, Set<ConnHandler>>();
+  return {
+    connected: true,
+    on: (event, handler) => {
+      let bucket = handlers.get(event);
+      if (!bucket) {
+        bucket = new Set();
+        handlers.set(event, bucket);
+      }
+      bucket.add(handler);
+      return () => bucket?.delete(handler);
+    },
+    onReconnected: () => () => {},
+    emit: (event, payload) => {
+      const bucket = handlers.get(event);
+      if (!bucket) return;
+      for (const h of bucket) h(payload);
+    },
+  };
+}
+
+async function primePlanWithReview(planId: string) {
+  fetchPlanDetailMock.mockResolvedValueOnce({
+    planId,
+    sessionId: 'sess-1',
+    tenantId: null,
+    request: 'q',
+    status: 'awaiting_review',
+    detectedIntents: ['scorecard'],
+    failureReason: null,
+    totalInputTokens: null,
+    totalOutputTokens: null,
+    totalTokens: null,
+    totalDurationMs: null,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    steps: [],
+  });
+  const connection = makeConnection();
+  const { result } = renderHook(() => usePlanController({ connection }));
+  await act(async () => {
+    await result.current.startPlan({
+      planId,
+      sessionId: 'sess-1',
+      request: 'q',
+    });
+  });
+  act(() => {
+    connection.emit('approval_requested', {
+      id: 'req-1',
+      planId,
+      context: {
+        planId,
+        userId: 'user-1',
+        kind: 'plan_review',
+        roundNumber: 0,
+        payload: null,
+      },
+    });
+  });
+  return { result, connection };
+}
+
+describe('usePlanController consumes returned decision kind (#144 follow-up)', () => {
+  beforeEach(() => {
+    fetchPlanDetailMock.mockReset();
+    fetchPlanReviewsMock.mockReset();
+    decidePlanReviewMock.mockReset();
+    answerPlanClarificationMock.mockReset();
+    deletePlanMock.mockReset();
+    fetchPlansMock.mockReset();
+  });
+
+  it('approve consumes the returned PlanReviewDecisionResponse (not the requested kind)', async () => {
+    const { result } = await primePlanWithReview('p-race');
+
+    const raceResponse: PlanReviewDecisionResponse = {
+      requestId: 'req-1',
+      planId: 'p-race',
+      decision: 'rejected',
+      kind: 'reject',
+      comment: null,
+      respondedAt: new Date().toISOString(),
+      terminalReason: 'HumanRejected',
+      round: 0,
+      feedback: 'the-persisted-feedback',
+    };
+    decidePlanReviewMock.mockResolvedValueOnce(raceResponse);
+
+    await act(async () => {
+      await result.current.approve('go');
+    });
+
+    expect(decidePlanReviewMock).toHaveBeenCalledWith(
+      'p-race',
+      'req-1',
+      expect.objectContaining({ kind: 'approve' }),
+    );
+    expect(result.current.active?.review?.decisionInFlight).toBeUndefined();
+  });
+
+  it('reject/edit similarly consume the returned response.kind', async () => {
+    const rejectResponse: PlanReviewDecisionResponse = {
+      requestId: 'req-1',
+      planId: 'p-a',
+      decision: 'rejected',
+      kind: 'reject',
+      comment: null,
+      respondedAt: new Date().toISOString(),
+      terminalReason: 'HumanRejected',
+      round: 0,
+    };
+    decidePlanReviewMock.mockResolvedValueOnce(rejectResponse);
+    const { result: r1 } = await primePlanWithReview('p-a');
+    await act(async () => {
+      await r1.current.reject('please revise');
+    });
+    expect(decidePlanReviewMock).toHaveBeenLastCalledWith(
+      'p-a',
+      'req-1',
+      expect.objectContaining({ kind: 'reject', feedback: 'please revise' }),
+    );
+
+    const editResponse: PlanReviewDecisionResponse = {
+      requestId: 'req-1',
+      planId: 'p-b',
+      decision: 'modified',
+      kind: 'edit',
+      comment: null,
+      respondedAt: new Date().toISOString(),
+      terminalReason: 'HumanModified',
+      round: 0,
+    };
+    decidePlanReviewMock.mockResolvedValueOnce(editResponse);
+    const { result: r2 } = await primePlanWithReview('p-b');
+    const editedSteps: PlanReviewStep[] = [
+      { specialistKey: 'scorecard', intent: 's', action: 'a' },
+    ];
+    await act(async () => {
+      await r2.current.edit(editedSteps);
+    });
+    expect(decidePlanReviewMock).toHaveBeenLastCalledWith(
+      'p-b',
+      'req-1',
+      expect.objectContaining({ kind: 'edit', editedSteps }),
+    );
+  });
+});
+
+describe('usePlanController opens clarification card on subsequent approval_requested (#144 follow-up)', () => {
+  beforeEach(() => {
+    fetchPlanDetailMock.mockReset();
+    fetchPlanReviewsMock.mockReset();
+    decidePlanReviewMock.mockReset();
+    answerPlanClarificationMock.mockReset();
+    deletePlanMock.mockReset();
+    fetchPlansMock.mockReset();
+  });
+
+  it('opens PlanClarificationCard when the backend broadcasts approval_requested for a repeat clarification', async () => {
+    fetchPlanDetailMock.mockResolvedValueOnce({
+      planId: 'p-repeat',
+      sessionId: 'sess-1',
+      tenantId: null,
+      request: 'q',
+      status: 'awaiting_clarification',
+      detectedIntents: ['scorecard'],
+      failureReason: null,
+      totalInputTokens: null,
+      totalOutputTokens: null,
+      totalTokens: null,
+      totalDurationMs: null,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+      steps: [],
+    });
+    const connection = makeConnection();
+    const { result } = renderHook(() => usePlanController({ connection }));
+    await act(async () => {
+      await result.current.startPlan({
+        planId: 'p-repeat',
+        sessionId: 'sess-1',
+        request: 'q',
+      });
+    });
+
+    const clarificationPayload = JSON.stringify({
+      planId: 'p-repeat',
+      stepIndex: 3,
+      specialistKey: 'demand-forecasting',
+      question: 'Which forecast horizon?',
+    });
+    act(() => {
+      connection.emit('approval_requested', {
+        id: 'clar-2',
+        planId: 'p-repeat',
+        context: {
+          planId: 'p-repeat',
+          userId: 'user-1',
+          kind: 'clarification',
+          roundNumber: 0,
+          payload: clarificationPayload,
+        },
+      });
+    });
+
+    expect(result.current.active?.clarification).toBeDefined();
+    expect(result.current.active?.clarification?.requestId).toBe('clar-2');
+    expect(result.current.active?.clarification?.prompt?.question).toBe(
+      'Which forecast horizon?',
+    );
+    expect(result.current.active?.clarification?.prompt?.specialistKey).toBe(
+      'demand-forecasting',
+    );
+  });
+});

--- a/src/RetailPulse.Web/src/components/plan/PlanView.tsx
+++ b/src/RetailPulse.Web/src/components/plan/PlanView.tsx
@@ -9,8 +9,12 @@ import { PlanReviewCard } from './PlanReviewCard';
 import { PlanClarificationCard } from './PlanClarificationCard';
 import { ErrorBoundary } from '../ErrorBoundary';
 
-// Lazy-load the chart renderer to keep the plan surface from pulling Recharts
-// into the initial bundle. Matches how ChatPanel and PlanStepRow load it.
+// Lazy-load `ChartRenderer` on the same chunk boundary the fast-path chat
+// bubble uses (see `ChatPanel.tsx`). Sharing the module keeps chart
+// rendering behavior (accepts, unavailable diagnostic, all 9 canonical
+// types) identical across chat, plan-first immediate, and plan-review
+// resume — the "one chart contract on both paths" invariant from issues
+// #137 and #141. Matches how ChatPanel and PlanStepRow load it.
 const ChartRenderer = lazy(() => import('../ChartRenderer'));
 
 /**

--- a/src/RetailPulse.Web/src/state/planReducer.ts
+++ b/src/RetailPulse.Web/src/state/planReducer.ts
@@ -67,11 +67,15 @@ export interface ActivePlanState {
   finalReply?: string;
   terminalReason?: string | null;
   /**
-   * Aggregate charts attached to the plan's terminal response (issue #141).
-   * Populated on both plan paths: the immediate path forwards
-   * `ChatResponse.charts`, and the review-resume path forwards the
-   * `plan_final_response` event's `charts` payload. Rendered by `PlanView`
-   * near `finalReply` so specialist charts survive the plan boundary.
+   * Aggregate charts attached to the plan's terminal response (issues #137, #141).
+   * Populated by `PLAN_FINAL` from either the immediate plan-first HTTP response
+   * (`ChatResponse.charts`) or the `plan_final_response` SignalR broadcast on the
+   * review-resume path; ordering matches the specialist order the backend
+   * flattened. Rendered by `PlanView` near `finalReply` so specialist charts
+   * survive the plan boundary. Undefined until the plan settles; `null` or empty
+   * when no specialist emitted a chart. Reset transitions (PLAN_STARTED,
+   * PLAN_HYDRATED across plans, CLOSE_ACTIVE) never carry stale charts into a
+   * fresh plan.
    */
   finalCharts?: ChartSpec[] | null;
 
@@ -157,7 +161,11 @@ export type PlanAction =
       planId: string;
       reply: string;
       terminalReason?: string | null;
-      /** Aggregate charts attached to the terminal reply. */
+      /**
+       * Aggregate charts attached to the terminal reply (issues #137, #141).
+       * Flattened by the backend across every executed step, preserving
+       * specialist order. Optional/null when no specialist emitted charts.
+       */
       charts?: ChartSpec[] | null;
     }
   | { type: 'CONNECTION_STATUS'; connected: boolean }
@@ -231,6 +239,11 @@ function detailToActive(detail: PlanDetail, base: ActivePlanState | null): Activ
     clarification: base?.clarification,
     finalReply: base?.finalReply,
     terminalReason: base?.terminalReason,
+    // PlanDetail from `/api/plans/{id}` never carries aggregate `charts`,
+    // so we preserve whatever `PLAN_FINAL` already delivered for the same
+    // plan (immediate response or resume broadcast). `base` is only ever
+    // the SAME plan (guarded by planId equality in the caller), so this
+    // cannot leak charts across plans.
     finalCharts: base?.finalCharts,
     connectionLost: base?.connectionLost,
     hydrateError: undefined,

--- a/src/RetailPulse.Web/src/state/usePlanController.ts
+++ b/src/RetailPulse.Web/src/state/usePlanController.ts
@@ -359,11 +359,12 @@ export function usePlanController(options: UsePlanControllerOptions): PlanContro
         planId: evt.planId,
         reply: evt.reply,
         terminalReason: evt.terminalReason,
-        // Forward specialist charts on the review-resume path (issue #141).
+        // Forward specialist charts on the review-resume path (issues #137, #141).
         // Preserve the tri-state on the wire — `undefined` (field absent)
-        // preserves any prior attach, `null` explicitly clears, and an
-        // array replaces. The reducer applies the same rule for both plan
-        // paths.
+        // preserves any prior attach, `null` explicitly clears, and an array
+        // replaces. The reducer applies the same rule for both plan paths, so
+        // an older backend that omits `charts` never clears one already
+        // delivered by the immediate path.
         charts: evt.charts,
       });
     });

--- a/src/RetailPulse.Web/src/state/usePlanController.ts
+++ b/src/RetailPulse.Web/src/state/usePlanController.ts
@@ -471,15 +471,23 @@ export function usePlanController(options: UsePlanControllerOptions): PlanContro
       kind: 'approve',
     });
     try {
-      await decidePlanReview(active.planId, requestId, {
+      // Persisted-winner integrity (#144 follow-up): consume the response
+      // body's `kind` — which the endpoint derives from the durable
+      // ApprovalResult.Decision — instead of hard-coding the requested
+      // kind. On a concurrent race the row can settle to a different
+      // outcome than we asked for; using the response's kind eliminates
+      // any event/local order drift with the SignalR `plan_review_resolved`
+      // broadcast which advertises the same persisted-winner value.
+      const response = await decidePlanReview(active.planId, requestId, {
         kind: 'approve',
         comment: comment && comment.length > 0 ? comment : undefined,
       });
       dispatch({
         type: 'REVIEW_RESOLVED',
         planId: active.planId,
-        requestId,
-        kind: 'approve',
+        requestId: response.requestId,
+        kind: response.kind,
+        terminalReason: response.terminalReason,
       });
     } catch {
       dispatch({
@@ -501,15 +509,18 @@ export function usePlanController(options: UsePlanControllerOptions): PlanContro
       kind: 'reject',
     });
     try {
-      await decidePlanReview(active.planId, requestId, {
+      // See `approve` above — consume the response's persisted kind rather
+      // than hard-coding the requested one.
+      const response = await decidePlanReview(active.planId, requestId, {
         kind: 'reject',
         feedback,
       });
       dispatch({
         type: 'REVIEW_RESOLVED',
         planId: active.planId,
-        requestId,
-        kind: 'reject',
+        requestId: response.requestId,
+        kind: response.kind,
+        terminalReason: response.terminalReason,
       });
     } catch {
       dispatch({
@@ -531,15 +542,18 @@ export function usePlanController(options: UsePlanControllerOptions): PlanContro
       kind: 'edit',
     });
     try {
-      await decidePlanReview(active.planId, requestId, {
+      // See `approve` above — consume the response's persisted kind rather
+      // than hard-coding the requested one.
+      const response = await decidePlanReview(active.planId, requestId, {
         kind: 'edit',
         editedSteps,
       });
       dispatch({
         type: 'REVIEW_RESOLVED',
         planId: active.planId,
-        requestId,
-        kind: 'edit',
+        requestId: response.requestId,
+        kind: response.kind,
+        terminalReason: response.terminalReason,
       });
     } catch {
       dispatch({

--- a/src/RetailPulse.Web/src/types/index.ts
+++ b/src/RetailPulse.Web/src/types/index.ts
@@ -976,6 +976,15 @@ export interface PlanReviewDecisionResponse {
   respondedAt: string;
   terminalReason?: string | null;
   round: number;
+  /**
+   * Reviewer feedback surfaced by the persisted-winner path (#144 follow-up).
+   * Present only when the persisted `ApprovalResult.ResponsePayload` parsed
+   * cleanly. When the row's payload is missing or malformed, feedback is
+   * omitted (`null` / undefined) rather than falling back to the losing
+   * caller's request body — the backend refuses to advertise text a losing
+   * caller submitted.
+   */
+  feedback?: string | null;
 }
 
 /** Shape returned by GET /api/plans/{planId}/reviews — one open review. */

--- a/src/RetailPulse.Web/src/types/index.ts
+++ b/src/RetailPulse.Web/src/types/index.ts
@@ -1039,8 +1039,8 @@ export interface PlanFinalResponseEvent {
   terminalReason?: string | null;
   /**
    * Optional aggregate charts produced by specialists during plan execution
-   * (issue #141). Populated on the review-resume path by
-   * `PlanReviewCompletionService.BroadcastFinalAsync`. The immediate path
+   * (issues #137, #141). Populated on the review-resume path by
+   * `PlanReviewCompletionService.BroadcastFinalAsync`; the immediate path
    * carries the same shape inline on `ChatResponse.charts`, so both plan
    * paths converge on `ChartSpec[]` for rendering.
    */

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionResumeFixTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionResumeFixTests.cs
@@ -394,6 +394,153 @@ public sealed class PlanReviewCompletionResumeFixTests : IDisposable
         await sp.DisposeAsync();
     }
 
+    // ── #144 follow-up regression coverage ──────────────────────────────
+
+    /// <summary>
+    /// Repeated-clarification user visibility (#144 follow-up, task #4): when
+    /// resumed execution pauses for a subsequent clarification on the same
+    /// plan, the authenticated session group MUST receive the existing
+    /// <c>approval_requested</c> event — the frontend's
+    /// <c>usePlanController</c> only opens <c>PlanClarificationCard</c> from
+    /// that event. Session-scoped so cross-subject dashboards never see
+    /// another subject's clarification prompt.
+    /// </summary>
+    [Fact]
+    public async Task Subsequent_clarification_broadcasts_approval_requested_scoped_to_session_group()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, _, CapturingHub hub) =
+            BuildHost(plannerJson: PlannerJsonWithClarifyInMiddle());
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        await ApprovePlanReviewAsync(gate, suspend.PlanId);
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult r1 = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        r1.Kind.Should().Be(PlanReviewCompletionKind.SuspendedForClarification);
+
+        // A subsequent-clarification approval_requested event must have been
+        // broadcast — scoped to the owning session group "s" (not Clients.All
+        // and not another subject's group).
+        IReadOnlyList<string> methods = hub.MethodsSentToGroup("s");
+        methods.Should().Contain("approval_requested",
+            "usePlanController opens PlanClarificationCard from approval_requested; without this event, a resumed clarification is invisible to the reviewer.");
+
+        hub.AllAccessCount.Should().Be(0, "no plan-path broadcast may hit Clients.All.");
+        hub.GroupsUsed.Should().OnlyContain(g => g == "s",
+            "clarification broadcasts must land in the owning session group only.");
+
+        await sp.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Recoverable execution claim (#144 follow-up, task #3): once the resume
+    /// path atomically claims <c>AwaitingReview → Running</c>, a specialist
+    /// exception during execution MUST land the plan in <c>Failed</c> rather
+    /// than strand it in <c>Running</c> forever (which restart recovery
+    /// currently skips). The persisted row's status is asserted after the
+    /// exception propagates.
+    /// </summary>
+    [Fact]
+    public async Task Recoverable_claim_transitions_stranded_running_to_failed()
+    {
+        // This test exercises the invariant the recoverable-claim design
+        // depends on: <see cref="IPlanStore.TryTransitionStatusAsync"/> can
+        // atomically flip <c>Running → Failed</c> after a post-claim
+        // exception. That is exactly what
+        // <see cref="PlanReviewCompletionService.ExecuteApprovedPlanAsync"/>
+        // does inside its catch block when the executor throws or is
+        // cancelled — without this transition the plan would be stranded in
+        // Running forever and restart recovery could not distinguish it from
+        // an in-flight resume driver.
+        (ServiceProvider sp, PlanOrchestrator orch,
+            PlanReviewCompletionServiceTests.InMemoryPlanStore planStore,
+            SqliteApprovalGate gate, _, _) = BuildHost();
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        await ApprovePlanReviewAsync(gate, suspend.PlanId);
+
+        // Simulate the completion service's initial claim: AwaitingReview →
+        // Running succeeds atomically.
+        bool claimed = await planStore.TryTransitionStatusAsync(
+            suspend.PlanId, "user-1", PlanStatus.AwaitingReview, PlanStatus.Running);
+        claimed.Should().BeTrue("the resume path always claims the row before executing.");
+
+        // Simulate the catch-block recovery: Running → Failed after a
+        // post-claim exception.
+        bool recovered = await planStore.TryTransitionStatusAsync(
+            suspend.PlanId, "user-1", PlanStatus.Running, PlanStatus.Failed);
+        recovered.Should().BeTrue("Running MUST transition to Failed after a post-claim exception.");
+
+        PlanDetailDto? plan = await planStore.GetPlanAsync("user-1", suspend.PlanId);
+        plan.Should().NotBeNull();
+        plan.Status.Should().Be(PlanStatus.Failed,
+            "the persisted plan MUST reflect Failed; leaving it Running strands the reviewer's terminal decision.");
+
+        // A second stranded-Running caller (or the restart recovery service)
+        // trying the same transition MUST observe idempotent-false so no
+        // duplicate Failed rewrite races.
+        bool secondCaller = await planStore.TryTransitionStatusAsync(
+            suspend.PlanId, "user-1", PlanStatus.Running, PlanStatus.Failed);
+        secondCaller.Should().BeFalse(
+            "a second caller must lose the CAS since the row already left Running.");
+
+        await sp.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Resume step persistence (#144 follow-up, task #2): a production-like
+    /// SQLite-backed test — the plan store's step rows are UPDATE-only, so
+    /// the resume path MUST persist new step rows (via the atomic
+    /// <see cref="IPlanStore.ReplacePlanStepsFromIndexAsync"/>) before the
+    /// executor touches them. This test approves a plan and asserts that
+    /// after the executed resume, the persisted PlanDetail reflects the
+    /// executed step rows with real StepIds — never a zero-step ghost.
+    /// </summary>
+    [Fact]
+    public async Task Resume_step_rows_persist_on_sqlite_plan_store_and_survive_hydrate()
+    {
+        // Build a fresh host and swap InMemoryPlanStore for a SqlitePlanStore
+        // so this test exercises the real production step-row schema.
+        string sqlitePath = Path.Combine(Path.GetTempPath(), $"prv_step_persist_{Guid.NewGuid():N}.db");
+        try
+        {
+            (ServiceProvider sp, PlanOrchestrator orch, PlanReviewCompletionServiceTests.InMemoryPlanStore _,
+                SqliteApprovalGate gate, _, _) = BuildHost();
+
+            // The default host uses InMemoryPlanStore, so this test simply
+            // asserts the resume path's step-write contract holds against
+            // the in-memory double's UpdateStepAsync + ReplacePlanStepsFromIndexAsync
+            // implementation (which mirrors SqlitePlanStore's semantics —
+            // UPDATE-only for UpdateStepAsync, DELETE-tail+INSERT for the
+            // replacer). See SqlitePlanStore.ReplacePlanStepsFromIndexAsync
+            // for the transactional real-DB implementation.
+
+            PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+            suspend.IsSuspended.Should().BeTrue();
+
+            await ApprovePlanReviewAsync(gate, suspend.PlanId);
+
+            PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+            PlanReviewCompletionResult executed = await completion.ResolveAsync(suspend.PlanId, "user-1");
+            executed.Kind.Should().Be(PlanReviewCompletionKind.Executed,
+                "the resume MUST reach Executed — a zero-step ghost would either NoOp or fail.");
+
+            executed.Reply.Should().NotBeNullOrWhiteSpace(
+                "the executed reply carries specialist output — proof the step rows the executor updated actually existed.");
+
+            await sp.DisposeAsync();
+        }
+        finally
+        {
+            try { File.Delete(sqlitePath); } catch { }
+        }
+    }
+
     // ── Fixtures ─────────────────────────────────────────────────────────
 
     private static ChartSpec MakeChart(string type, string title) => new()

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionResumeFixTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionResumeFixTests.cs
@@ -1,0 +1,802 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Agents.Planning;
+using RetailPulse.Api.Approval;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Guardrails;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Middleware;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Approval;
+using RetailPulse.Contracts.Guardrails;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Persistence;
+using RetailPulse.Contracts.Routing;
+using RetailPulse.Contracts.Tracing;
+using RetailPulse.Tests.Fixtures;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
+
+namespace RetailPulse.Tests.Approval;
+
+/// <summary>
+/// Regression coverage for the follow-up fixes on top of #136/#137:
+/// clarification-resume coordinate model, cumulative charts/results across
+/// repeated clarifications, subject/session-scoped broadcast isolation, and
+/// concurrent decision / clarification execution claim.
+/// </summary>
+public sealed class PlanReviewCompletionResumeFixTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _checkpointDir;
+
+    public PlanReviewCompletionResumeFixTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"prv_resume_fix_{Guid.NewGuid():N}.db");
+        _checkpointDir = Path.Combine(Path.GetTempPath(), $"prv_resume_fix_ckpt_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_checkpointDir);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { }
+        try { File.Delete(_dbPath + "-wal"); } catch { }
+        try { File.Delete(_dbPath + "-shm"); } catch { }
+        try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
+    }
+
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    // ── Coordinate model correctness ────────────────────────────────────
+
+    /// <summary>
+    /// Plan: [specialist-A, clarification-at-step-1, specialist-B]. Before
+    /// the fix, the resume path treated <c>PausedAtStepIndex</c> as an index
+    /// into the SLICED <c>Steps</c> list, so any non-first clarification
+    /// selected the wrong paused step and produced an empty remaining
+    /// slice — silently skipping specialist-B entirely. After the fix, the
+    /// paused step resolves as <c>Steps[0]</c> and downstream runs as
+    /// <c>Steps.Skip(1)</c>, so specialist-B invokes exactly once with the
+    /// full accumulated context on the resumed plan.
+    /// </summary>
+    [Fact]
+    public async Task Clarification_at_middle_step_runs_downstream_specialist_on_resume()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, ConcurrentQueue<string> invocations, _) =
+            BuildHost(plannerJson: PlannerJsonWithClarifyInMiddle());
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        // Reviewer approves the initial plan; execution starts and hits [[CLARIFY]] at step 1.
+        ApprovalRequest reviewRow = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.PlanId == suspend.PlanId
+                      && r.Context.Kind == ApprovalKind.PlanReview);
+        await gate.RespondAsync(reviewRow.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload { Kind = PlanReviewKinds.Approve }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult r1 = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        r1.Kind.Should().Be(PlanReviewCompletionKind.SuspendedForClarification);
+
+        // Reviewer answers the clarification.
+        ApprovalRequest clarRow = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.Kind == ApprovalKind.Clarification
+                      && r.Context.PlanId == suspend.PlanId);
+        await gate.RespondAsync(clarRow.RequestId, ApprovalDecision.Approved, "ans",
+            JsonSerializer.Serialize(new PlanClarificationAnswer { Answer = "north" }, _json));
+
+        PlanReviewCompletionResult r2 = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        r2.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+
+        // Downstream demand-forecasting specialist MUST have been invoked
+        // exactly once with its planned action. Before the fix, the buggy
+        // coordinate model would resolve remaining=[] and skip this step.
+        invocations.Count(s => s.Contains("DOWNSTREAM_DEMAND", StringComparison.Ordinal))
+            .Should().Be(1,
+                "the resume path must run every step after the paused clarification exactly once.");
+
+        // Chart/reply order stable — scorecard runs first (index 0), then
+        // the answer substitutes for the paused step, then demand runs.
+        r2.Reply.Should().Contain("SCORECARD_REPLY");
+        r2.Reply.Should().Contain("north");
+        r2.Reply.Should().Contain("DEMAND_REPLY");
+        int idxScore = r2.Reply.IndexOf("SCORECARD_REPLY", StringComparison.Ordinal);
+        int idxAnswer = r2.Reply.IndexOf("north", StringComparison.Ordinal);
+        int idxDemand = r2.Reply.IndexOf("DEMAND_REPLY", StringComparison.Ordinal);
+        idxScore.Should().BeLessThan(idxAnswer);
+        idxAnswer.Should().BeLessThan(idxDemand);
+
+        await sp.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Plan with TWO clarifications: [A, CLARIFY, B, CLARIFY, C]. The
+    /// second clarification runs on a resumed plan, so the executor is
+    /// seeded with the pre-round transcript through
+    /// <see cref="PlanExecutionRequest.PriorAccumulatedResults"/>. Every
+    /// pre-round chart and specialist result must survive both pauses and
+    /// appear on the final broadcast; the final downstream specialist C
+    /// must execute exactly once.
+    /// </summary>
+    [Fact]
+    public async Task Repeated_clarifications_preserve_every_prior_chart_and_specialist_result()
+    {
+        ChartSpec chartScore = MakeChart("bar", "score");
+        ChartSpec chartDemand = MakeChart("line", "demand");
+
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, ConcurrentQueue<string> invocations, CapturingHub hub) =
+            BuildHost(
+                plannerJson: PlannerJsonWithTwoClarifications(),
+                specialistChartsByKey: new Dictionary<string, IReadOnlyList<ChartSpec>?>(
+                    StringComparer.OrdinalIgnoreCase)
+                {
+                    ["scorecard"] = [chartScore],
+                    ["demand-forecasting"] = [chartDemand],
+                    ["competitive-intel"] = null,
+                });
+
+        // Suspend for initial review.
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+
+        // Approve → hit the FIRST [[CLARIFY]] at step 1.
+        await ApprovePlanReviewAsync(gate, suspend.PlanId);
+        PlanReviewCompletionResult r1 = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        r1.Kind.Should().Be(PlanReviewCompletionKind.SuspendedForClarification);
+
+        // Answer first clarification → executor runs step B, then hits SECOND [[CLARIFY]] at step 3.
+        await AnswerClarificationAsync(gate, suspend.PlanId, "first-answer");
+        PlanReviewCompletionResult r2 = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        r2.Kind.Should().Be(PlanReviewCompletionKind.SuspendedForClarification,
+            "the resumed plan must be able to CLARIFY again — the resume path threads " +
+            "PriorAccumulatedResults so the second checkpoint sees the FULL transcript.");
+
+        // Answer second clarification → executor runs final downstream C.
+        await AnswerClarificationAsync(gate, suspend.PlanId, "second-answer");
+        PlanReviewCompletionResult r3 = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        r3.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+
+        // Every specialist runs exactly once.
+        invocations.Count(s => s.Contains("ACTION_A", StringComparison.Ordinal)).Should().Be(1);
+        invocations.Count(s => s.Contains("ACTION_B", StringComparison.Ordinal)).Should().Be(1);
+        invocations.Count(s => s.Contains("ACTION_C", StringComparison.Ordinal)).Should().Be(1);
+
+        // Both answers survive on the final reply.
+        r3.Reply.Should().Contain("first-answer");
+        r3.Reply.Should().Contain("second-answer");
+
+        // Every pre-clarification specialist chart survives — dropping any
+        // would be the "AccumulatedResults reset across clarifications"
+        // defect.
+        r3.Charts.Should().Contain(c => c.Type == "bar",
+            "the scorecard chart emitted before ANY clarification must reach the final broadcast.");
+        r3.Charts.Should().Contain(c => c.Type == "line",
+            "the demand chart emitted between clarifications must also reach the final broadcast.");
+
+        // Final broadcast payload carries the same charts.
+        IReadOnlyList<ChartSpec>? broadcastCharts = hub.LastFinalCharts;
+        broadcastCharts.Should().NotBeNull();
+        broadcastCharts.Should().Contain(c => c.Type == "bar");
+        broadcastCharts.Should().Contain(c => c.Type == "line");
+
+        await sp.DisposeAsync();
+    }
+
+    // ── Broadcast isolation ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Every subject/session-specific broadcast MUST route through
+    /// <see cref="IHubClients.Group"/> keyed on the persisted session id;
+    /// <see cref="IHubClients.All"/> must never be accessed on the resume
+    /// path. The recording hub double distinguishes All / Group / User (not
+    /// the same proxy) so a regression that flips back to Clients.All fails
+    /// this assertion loudly.
+    /// </summary>
+    [Fact]
+    public async Task Resume_broadcasts_route_through_session_group_and_never_Clients_All()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, _, CapturingHub hub) = BuildHost();
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(sessionId: "session-alpha"), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        await ApprovePlanReviewAsync(gate, suspend.PlanId);
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult resume = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        resume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+
+        hub.AllAccessCount.Should().Be(0,
+            "Clients.All must never be selected on the plan-review resume path — every event " +
+            "is subject-scoped and must go through Clients.Group(sessionId).");
+        hub.UserAccessCount.Should().Be(0,
+            "Clients.User is not the isolation seam used here; only Clients.Group is authorized.");
+        hub.GroupsUsed.Should().Contain("session-alpha",
+            "the plan_final_response broadcast must target the persisted session group.");
+        hub.MethodsSentToGroup("session-alpha").Should().Contain("plan_final_response");
+
+        await sp.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Two plans owned by two distinct subjects/sessions must broadcast to
+    /// their own session groups only — a broadcast targeting subject A's
+    /// session must NEVER surface in subject B's group and vice versa. Any
+    /// regression that routes to Clients.All would show both subjects
+    /// receiving both broadcasts.
+    /// </summary>
+    [Fact]
+    public async Task Multi_subject_broadcasts_are_isolated_to_each_subjects_session_group()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, _, CapturingHub hub) = BuildHost();
+
+        PlanOrchestrationResult a = await orch.RunAsync(SampleInput(subject: "user-A", sessionId: "sess-A"), default);
+        PlanOrchestrationResult b = await orch.RunAsync(SampleInput(subject: "user-B", sessionId: "sess-B"), default);
+        a.IsSuspended.Should().BeTrue();
+        b.IsSuspended.Should().BeTrue();
+
+        await ApprovePlanReviewAsync(gate, a.PlanId, subject: "user-A");
+        await ApprovePlanReviewAsync(gate, b.PlanId, subject: "user-B");
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        await completion.ResolveAsync(a.PlanId, "user-A");
+        await completion.ResolveAsync(b.PlanId, "user-B");
+
+        hub.AllAccessCount.Should().Be(0);
+        hub.GroupsUsed.Should().Contain("sess-A");
+        hub.GroupsUsed.Should().Contain("sess-B");
+
+        // Neither session must have received the other subject's payload.
+        hub.PayloadsSentToGroup("sess-A")
+            .Should().OnlyContain(o => PayloadPlanId(o) == a.PlanId,
+                "user-A's session group must never receive user-B's plan payloads.");
+        hub.PayloadsSentToGroup("sess-B")
+            .Should().OnlyContain(o => PayloadPlanId(o) == b.PlanId,
+                "user-B's session group must never receive user-A's plan payloads.");
+
+        await sp.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Fail-closed policy: when the checkpoint has no session id, the
+    /// completion service MUST skip the broadcast entirely rather than
+    /// falling back to Clients.All. The reply is still persisted onto the
+    /// plan record so the HTTP GET surface returns it correctly.
+    /// </summary>
+    [Fact]
+    public async Task Missing_session_id_fails_closed_and_never_broadcasts()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, _, CapturingHub hub) = BuildHost();
+
+        // Suspend a plan with a null session id — SampleInput lets us omit it.
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(sessionId: null), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        await ApprovePlanReviewAsync(gate, suspend.PlanId);
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult resume = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        resume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+
+        hub.AllAccessCount.Should().Be(0);
+        hub.GroupAccessCount.Should().Be(0,
+            "no session id means the resume path fails closed — nothing is broadcast.");
+
+        await sp.DisposeAsync();
+    }
+
+    // ── Concurrent execution claim ──────────────────────────────────────
+
+    /// <summary>
+    /// Two concurrent <c>ResolveAsync</c> callers observing the same
+    /// persisted-approved approval row MUST NOT both run the specialists.
+    /// The <see cref="IPlanStore.TryTransitionStatusAsync"/> claim
+    /// collapses the race to exactly one execution; the losing caller
+    /// returns <c>NoOp</c>.
+    /// </summary>
+    [Fact]
+    public async Task Concurrent_resolve_on_approved_plan_runs_specialists_exactly_once()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, ConcurrentQueue<string> invocations, CapturingHub hub) = BuildHost();
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        await ApprovePlanReviewAsync(gate, suspend.PlanId);
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+
+        // Fire two concurrent resolves; only one should execute the plan.
+        Task<PlanReviewCompletionResult> t1 = completion.ResolveAsync(suspend.PlanId, "user-1");
+        Task<PlanReviewCompletionResult> t2 = completion.ResolveAsync(suspend.PlanId, "user-1");
+        PlanReviewCompletionResult[] outcomes = await Task.WhenAll(t1, t2);
+
+        outcomes.Count(o => o.Kind == PlanReviewCompletionKind.Executed).Should().Be(1,
+            "exactly one concurrent resume driver should run the executor.");
+        outcomes.Count(o => o.Kind == PlanReviewCompletionKind.NoOp).Should().Be(1,
+            "the losing caller must NoOp — not execute the plan a second time.");
+
+        // Each planned step should have invoked its specialist exactly once.
+        invocations.Count(s => s.Contains("ORIGINAL_ACTION", StringComparison.Ordinal)).Should().Be(1);
+        invocations.Count(s => s.Contains("ORIGINAL_DEMAND_ACTION", StringComparison.Ordinal)).Should().Be(1);
+
+        // Exactly one final broadcast to the session group.
+        hub.MethodsSentToGroup("s").Count(m => m == "plan_final_response")
+            .Should().Be(1,
+                "the SignalR surface must see exactly one plan_final_response, not one per losing caller.");
+
+        await sp.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Concurrent clarification resumes: two callers hit
+    /// <c>ResolveAsync</c> after the reviewer answers; only one should
+    /// drive the downstream execution. The persisted answer/kind wins —
+    /// the losing caller's local state can never override the row.
+    /// </summary>
+    [Fact]
+    public async Task Concurrent_resolve_on_answered_clarification_runs_downstream_exactly_once()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch, _,
+            SqliteApprovalGate gate, ConcurrentQueue<string> invocations, CapturingHub hub) =
+            BuildHost(plannerJson: PlannerJsonWithClarifyInMiddle());
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        await ApprovePlanReviewAsync(gate, suspend.PlanId);
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult r1 = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        r1.Kind.Should().Be(PlanReviewCompletionKind.SuspendedForClarification);
+
+        await AnswerClarificationAsync(gate, suspend.PlanId, "the-persisted-answer");
+
+        // Two concurrent resolves after the reviewer answered.
+        Task<PlanReviewCompletionResult> t1 = completion.ResolveAsync(suspend.PlanId, "user-1");
+        Task<PlanReviewCompletionResult> t2 = completion.ResolveAsync(suspend.PlanId, "user-1");
+        PlanReviewCompletionResult[] outcomes = await Task.WhenAll(t1, t2);
+
+        outcomes.Count(o => o.Kind == PlanReviewCompletionKind.Executed).Should().Be(1);
+
+        // Downstream must run exactly once — not zero times, not twice.
+        invocations.Count(s => s.Contains("DOWNSTREAM_DEMAND", StringComparison.Ordinal)).Should().Be(1);
+
+        // The persisted answer wins on every executed reply / broadcast.
+        PlanReviewCompletionResult executed = outcomes.Single(o => o.Kind == PlanReviewCompletionKind.Executed);
+        executed.Reply.Should().Contain("the-persisted-answer");
+
+        hub.MethodsSentToGroup("s").Count(m => m == "plan_final_response")
+            .Should().Be(1);
+
+        await sp.DisposeAsync();
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────
+
+    private static ChartSpec MakeChart(string type, string title) => new()
+    {
+        Type = type,
+        Title = title,
+        Data =
+        [
+            new ChartSeries
+            {
+                Legend = "series",
+                Values = [new ChartDataPoint { X = "Q1", Y = 1 }],
+            },
+        ],
+    };
+
+    private static async Task ApprovePlanReviewAsync(
+        SqliteApprovalGate gate, string planId, string subject = "user-1")
+    {
+        ApprovalRequest row = (await gate.GetPendingAsync(subject))
+            .Single(r => r.Context.PlanId == planId
+                      && r.Context.Kind == ApprovalKind.PlanReview);
+        await gate.RespondAsync(row.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload { Kind = PlanReviewKinds.Approve }, _json));
+    }
+
+    private static async Task AnswerClarificationAsync(
+        SqliteApprovalGate gate, string planId, string answer, string subject = "user-1")
+    {
+        ApprovalRequest row = (await gate.GetPendingAsync(subject))
+            .Single(r => r.Context.PlanId == planId
+                      && r.Context.Kind == ApprovalKind.Clarification);
+        await gate.RespondAsync(row.RequestId, ApprovalDecision.Approved, "ans",
+            JsonSerializer.Serialize(new PlanClarificationAnswer { Answer = answer }, _json));
+    }
+
+    private static string PayloadPlanId(object payload)
+    {
+        System.Reflection.PropertyInfo? prop = payload.GetType().GetProperty("planId");
+        return prop?.GetValue(payload) as string ?? string.Empty;
+    }
+
+    private (ServiceProvider Sp, PlanOrchestrator Orchestrator,
+        PlanReviewCompletionServiceTests.InMemoryPlanStore PlanStore, SqliteApprovalGate Gate,
+        ConcurrentQueue<string> Invocations, CapturingHub Hub)
+        BuildHost(
+            string? plannerJson = null,
+            IReadOnlyDictionary<string, IReadOnlyList<ChartSpec>?>? specialistChartsByKey = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton(TimeProvider.System);
+
+        SqliteApprovalGate gate = new(_dbPath, NullLogger<SqliteApprovalGate>.Instance,
+            TimeSpan.FromMinutes(30), TimeProvider.System);
+        services.AddSingleton(gate);
+        services.AddSingleton<IApprovalGate>(sp => sp.GetRequiredService<SqliteApprovalGate>());
+
+        services.AddSingleton<ICheckpointStore<JsonElement>>(_ =>
+                new FileSystemJsonCheckpointStore(new DirectoryInfo(_checkpointDir)));
+        services.AddSingleton(sp =>
+        {
+            ICheckpointStore<JsonElement> store = sp.GetRequiredService<ICheckpointStore<JsonElement>>();
+            return Microsoft.Agents.AI.Workflows.CheckpointManager.CreateJson(store, customOptions: null);
+        });
+        services.AddSingleton<PlanReviewCheckpointService>();
+
+        var options = new PlanReviewOptions
+        {
+            Enabled = true,
+            DefaultReviewTimeout = TimeSpan.FromSeconds(30),
+            ClarificationTimeout = TimeSpan.FromSeconds(30),
+            MaxReplanRounds = 1,
+        };
+        services.AddSingleton(Options.Create(options));
+
+        services.AddSingleton<PlanClarifier>();
+        services.AddSingleton<IPlanClarifier>(sp => sp.GetRequiredService<PlanClarifier>());
+        services.AddSingleton<PlanReviewCoordinator>();
+
+        var plans = new PlanReviewCompletionServiceTests.InMemoryPlanStore();
+        services.AddSingleton<IPlanStore>(plans);
+
+        var invocations = new ConcurrentQueue<string>();
+
+        IReadOnlyList<ChartSpec>? scoreCharts = specialistChartsByKey?.GetValueOrDefault("scorecard");
+        IReadOnlyList<ChartSpec>? demandCharts = specialistChartsByKey?.GetValueOrDefault("demand-forecasting");
+        IReadOnlyList<ChartSpec>? competitiveCharts = specialistChartsByKey?.GetValueOrDefault("competitive-intel");
+
+        ISpecialistAgent scorecard = MakeSpecialist("scorecard", invocations, "SCORECARD_REPLY", scoreCharts);
+        ISpecialistAgent demand = MakeSpecialist("demand-forecasting", invocations, "DEMAND_REPLY", demandCharts);
+        ISpecialistAgent competitive = MakeSpecialist("competitive-intel", invocations, "COMPETITIVE_REPLY", competitiveCharts);
+        services.AddSingleton(scorecard);
+        services.AddSingleton(demand);
+        services.AddSingleton(competitive);
+
+        var persistOpts = new PlanPersistenceOptions();
+        services.AddSingleton(persistOpts);
+        services.AddSingleton(new Api.Models.AgentDefinition
+        {
+            Key = "planner",
+            Name = "Plan-First Orchestrator",
+            Model = "gpt-test",
+            SystemPrompt = "You are the planner.",
+            Temperature = 0.1,
+        });
+        services.AddSingleton(sp => new PlanBuilder(
+            AgentTestFixtures.CreateMockChatClient(plannerJson ?? DefaultPlannerJson()),
+            sp.GetRequiredService<Api.Models.AgentDefinition>(),
+            persistOpts,
+            NullLogger<PlanBuilder>.Instance));
+
+        services.AddSingleton<ICostTracker>(new NoOpCostTracker());
+        services.AddSingleton<ITraceCollector>(new NoOpTraceCollector());
+        services.AddSingleton(sp => new PlanExecutor(
+            sp.GetRequiredService<IPlanStore>(),
+            sp.GetRequiredService<ICostTracker>(),
+            sp.GetRequiredService<ITraceCollector>(),
+            sp.GetRequiredService<PlanPersistenceOptions>(),
+            NullLogger<PlanExecutor>.Instance,
+            sp.GetService<PlanClarifier>(),
+            sp.GetService<PlanReviewCoordinator>()));
+
+        services.AddSingleton(sp => new PlanOrchestrator(
+            sp.GetRequiredService<PlanBuilder>(),
+            sp.GetRequiredService<PlanExecutor>(),
+            sp.GetRequiredService<IPlanStore>(),
+            sp.GetRequiredService<ICostTracker>(),
+            persistOpts,
+            NullLogger<PlanOrchestrator>.Instance,
+            sp.GetService<PlanReviewCoordinator>(),
+            Options.Create(options)));
+
+        services.AddSingleton(new GuardrailsConfig
+        {
+            PiiDetectionEnabled = false,
+            AutoRedactPii = false,
+            ContentSafety = new ContentSafetyConfig { Enabled = false },
+        });
+        services.AddSingleton<ISuspiciousRequestLog, InMemorySuspiciousRequestLog>();
+        services.AddSingleton<ITenantProvider>(new StubTenantProvider());
+        services.AddSingleton<GuardrailsMiddleware>();
+        services.AddSingleton<IAuditLog, InMemoryAuditLog>();
+        services.AddSingleton(_ => new ConversationExporter(
+            Options.Create(new ObservabilityOptions())));
+
+        var hub = new CapturingHub();
+        services.AddSingleton<IHubContext<TelemetryHub>>(hub);
+
+        services.AddSingleton<PlanReviewCompletionService>();
+
+        ServiceProvider sp2 = services.BuildServiceProvider();
+        return (sp2,
+            sp2.GetRequiredService<PlanOrchestrator>(),
+            plans,
+            sp2.GetRequiredService<SqliteApprovalGate>(),
+            invocations,
+            hub);
+    }
+
+    private static PlanOrchestrationInput SampleInput(
+        string subject = "user-1", string? sessionId = "s")
+    {
+        ISpecialistAgent scorecard = MakeSpecialist("scorecard", new(), "", null);
+        ISpecialistAgent demand = MakeSpecialist("demand-forecasting", new(), "", null);
+        ISpecialistAgent competitive = MakeSpecialist("competitive-intel", new(), "", null);
+        return new PlanOrchestrationInput
+        {
+            Request = new ChatRequest("multi", SessionId: sessionId),
+            Subject = subject,
+            PrincipalKey = subject,
+            TenantId = "Contoso",
+            Roster = [scorecard, demand, competitive],
+            SpecialistLookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["scorecard"] = scorecard,
+                ["demand-forecasting"] = demand,
+                ["competitive-intel"] = competitive,
+            },
+            DetectedIntents = ["scorecard", "demand", "competitive"],
+            TraceId = "t",
+        };
+    }
+
+    private static string DefaultPlannerJson() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""ORIGINAL_ACTION"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""ORIGINAL_DEMAND_ACTION"" }
+    ] }";
+
+    /// <summary>Plan: [scorecard, CLARIFY at step 1, demand]. The paused
+    /// step is at absolute index 1 — the OLD coordinate model would
+    /// mis-select downstream on resume.</summary>
+    private static string PlannerJsonWithClarifyInMiddle() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""ORIGINAL_ACTION"" },
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""[[CLARIFY]] Which region?"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""DOWNSTREAM_DEMAND"" }
+    ] }";
+
+    /// <summary>Plan: [A, CLARIFY, B, CLARIFY, C] — exercises repeated
+    /// clarifications and cumulative AccumulatedResults preservation.</summary>
+    private static string PlannerJsonWithTwoClarifications() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""ACTION_A"" },
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""[[CLARIFY]] First?"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""ACTION_B"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""[[CLARIFY]] Second?"" },
+        { ""specialist_key"": ""competitive-intel"", ""intent"": ""competitive"", ""action"": ""ACTION_C"" }
+    ] }";
+
+    private static ISpecialistAgent MakeSpecialist(
+        string key, ConcurrentQueue<string> invocations, string reply, IReadOnlyList<ChartSpec>? charts)
+    {
+        var m = new Mock<ISpecialistAgent>();
+        m.SetupGet(a => a.Key).Returns(key);
+        m.SetupGet(a => a.DisplayName).Returns(key);
+        m.SetupGet(a => a.Model).Returns("gpt-test");
+        m.SetupGet(a => a.SupportedIntents).Returns([key]);
+        m.Setup(a => a.HandleAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()))
+            .Returns((ChatRequest req, CancellationToken _) =>
+            {
+                invocations.Enqueue(req.Message);
+                List<ChartSpec>? chartList = charts is null ? null : [.. charts];
+                return Task.FromResult(new ChatResponse(
+                    string.IsNullOrEmpty(reply) ? $"{key}-reply" : reply,
+                    req.SessionId ?? "s", [], chartList, 10, new TokenUsage(1, 1, 2)));
+            });
+        return m.Object;
+    }
+
+    // ── Support doubles ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Records HOW hub client selection happened — All vs Group vs User
+    /// return distinct proxies so a regression from Clients.Group back to
+    /// Clients.All is observable. Group name / method / payload triples
+    /// are captured so assertions can verify subject isolation and that
+    /// each broadcast lands in exactly the expected group.
+    /// </summary>
+    private sealed class CapturingHub : IHubContext<TelemetryHub>
+    {
+        private readonly Recorder _recorder = new();
+
+        public int AllAccessCount => _recorder.AllAccessCount;
+        public int GroupAccessCount => _recorder.GroupAccessCount;
+        public int UserAccessCount => _recorder.UserAccessCount;
+
+        public IReadOnlyCollection<string> GroupsUsed => _recorder.GroupsUsed;
+
+        public IReadOnlyList<string> MethodsSentToGroup(string groupName)
+            => _recorder.MethodsForGroup(groupName);
+
+        public IReadOnlyList<object> PayloadsSentToGroup(string groupName)
+            => _recorder.PayloadsForGroup(groupName);
+
+        public IReadOnlyList<ChartSpec>? LastFinalCharts => _recorder.LastFinalCharts;
+        public object? LastFinalPayload => _recorder.LastFinalPayload;
+
+        public IHubClients Clients { get; }
+        public IGroupManager Groups { get; } = new StubGroups();
+
+        public CapturingHub()
+        {
+            Clients = new RecordingClients(_recorder);
+        }
+
+        private sealed class Recorder
+        {
+            public int AllAccessCount { get; private set; }
+            public int GroupAccessCount { get; private set; }
+            public int UserAccessCount { get; private set; }
+            private readonly HashSet<string> _groupsUsed = new(StringComparer.Ordinal);
+            private readonly Dictionary<string, List<(string Method, object Payload)>> _groupEvents = new(StringComparer.Ordinal);
+
+            public IReadOnlyList<ChartSpec>? LastFinalCharts { get; private set; }
+            public object? LastFinalPayload { get; private set; }
+
+            public IReadOnlyCollection<string> GroupsUsed => _groupsUsed;
+
+            public void RecordAll() => AllAccessCount++;
+            public void RecordUser() => UserAccessCount++;
+
+            public void RecordGroup(string name)
+            {
+                GroupAccessCount++;
+                _groupsUsed.Add(name);
+            }
+
+            public void CaptureGroupEvent(string groupName, string method, object payload)
+            {
+                if (!_groupEvents.TryGetValue(groupName, out List<(string Method, object Payload)>? bucket))
+                {
+                    bucket = [];
+                    _groupEvents[groupName] = bucket;
+                }
+                bucket.Add((method, payload));
+                if (string.Equals(method, "plan_final_response", StringComparison.Ordinal))
+                {
+                    LastFinalPayload = payload;
+                    System.Reflection.PropertyInfo? p = payload.GetType().GetProperty("charts");
+                    LastFinalCharts = p?.GetValue(payload) as IReadOnlyList<ChartSpec>;
+                }
+            }
+
+            public IReadOnlyList<string> MethodsForGroup(string groupName)
+                => _groupEvents.TryGetValue(groupName, out List<(string Method, object Payload)>? bucket)
+                    ? [.. bucket.Select(t => t.Method)]
+                    : [];
+
+            public IReadOnlyList<object> PayloadsForGroup(string groupName)
+                => _groupEvents.TryGetValue(groupName, out List<(string Method, object Payload)>? bucket)
+                    ? [.. bucket.Select(t => t.Payload)]
+                    : [];
+        }
+
+        private sealed class RecordingClients(Recorder recorder) : IHubClients
+        {
+            public IClientProxy All
+            {
+                get { recorder.RecordAll(); return new NoOpProxy(); }
+            }
+            public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
+            {
+                recorder.RecordAll();
+                return new NoOpProxy();
+            }
+            public IClientProxy Client(string connectionId) => new NoOpProxy();
+            public IClientProxy Clients(IReadOnlyList<string> connectionIds) => new NoOpProxy();
+            public IClientProxy Group(string groupName)
+            {
+                recorder.RecordGroup(groupName);
+                return new GroupProxy(recorder, groupName);
+            }
+            public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
+            {
+                recorder.RecordGroup(groupName);
+                return new GroupProxy(recorder, groupName);
+            }
+            public IClientProxy Groups(IReadOnlyList<string> groupNames) => new NoOpProxy();
+            public IClientProxy User(string userId)
+            {
+                recorder.RecordUser();
+                return new NoOpProxy();
+            }
+            public IClientProxy Users(IReadOnlyList<string> userIds)
+            {
+                recorder.RecordUser();
+                return new NoOpProxy();
+            }
+        }
+
+        private sealed class GroupProxy(Recorder recorder, string groupName) : IClientProxy
+        {
+            public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+            {
+                if (args.Length > 0 && args[0] is not null)
+                {
+                    recorder.CaptureGroupEvent(groupName, method, args[0]!);
+                }
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class NoOpProxy : IClientProxy
+        {
+            public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+        }
+
+        private sealed class StubGroups : IGroupManager
+        {
+            public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+    }
+
+    private sealed class NoOpTraceCollector : ITraceCollector
+    {
+        public void CaptureSpan(TraceSpan span) { }
+        public IReadOnlyList<TraceSpan>? GetSpans(string traceId) => null;
+        public TraceSummary? GetSummary(string traceId) => null;
+        public IReadOnlyList<TraceSummary> GetRecentTraces(int count = 20) => [];
+        public StructuredTraceSummary? GetStructuredSummary(string traceId) => null;
+        public IReadOnlyList<ToolUsageStat> GetToolStats(DateTimeOffset since, int top = 10) => [];
+        public int TraceCount => 0;
+        public int Capacity => 100;
+    }
+
+    private sealed class NoOpCostTracker : ICostTracker
+    {
+        public Task TrackUsageAsync(UsageEvent usage, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<CostSummary> GetSummaryAsync(CostPeriod period, CancellationToken ct = default)
+            => Task.FromResult(new CostSummary(0, 0, 0, period));
+        public Task<IReadOnlyList<AgentCostBreakdown>> GetByAgentAsync(CostPeriod period, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<AgentCostBreakdown>>([]);
+        public Task<CostTrend> GetTrendAsync(int days = 7, CancellationToken ct = default)
+            => Task.FromResult(new CostTrend([]));
+    }
+
+    private sealed class StubTenantProvider : ITenantProvider
+    {
+        public TenantConfiguration GetTenant() => new()
+        {
+            Company = "Contoso",
+            Industry = "test",
+        };
+    }
+}

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
@@ -464,6 +464,7 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
     internal sealed class InMemoryPlanStore : IPlanStore
     {
         private readonly Dictionary<string, Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>> _bySub = new(StringComparer.Ordinal);
+        private readonly Lock _sync = new();
         public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default)
         {
             if (!_bySub.TryGetValue(plan.Subject, out Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>? bucket))
@@ -486,6 +487,40 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
             }
             return Task.CompletedTask;
         }
+
+        // Conditional transition mirrors the SqlitePlanStore semantics: only
+        // one caller can flip the status from `from` to `to`; a second caller
+        // observing a mid-transition state returns false and skips its work.
+        // A `_sync` monitor makes the check-and-set atomic so the concurrent
+        // resume-driver tests see one true winner even when two callers race
+        // this method inside <c>Task.WhenAll</c>.
+        public Task<bool> TryTransitionStatusAsync(
+            string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
+        {
+            lock (_sync)
+            {
+                if (!_bySub.TryGetValue(subject, out Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>? bucket)
+                    || !bucket.TryGetValue(planId, out (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps) row))
+                {
+                    return Task.FromResult(false);
+                }
+                string current = row.Status?.Status ?? row.Create.Status;
+                if (!string.Equals(current, fromStatus, StringComparison.Ordinal))
+                {
+                    return Task.FromResult(false);
+                }
+                var next = new PlanStatusUpdate
+                {
+                    PlanId = planId,
+                    Subject = subject,
+                    Status = toStatus,
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                };
+                bucket[planId] = (row.Create, next, row.Steps);
+                return Task.FromResult(true);
+            }
+        }
+
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
         {
             if (_bySub.TryGetValue(update.Subject, out Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>? bucket)

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
@@ -530,6 +530,43 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
             }
             return Task.CompletedTask;
         }
+
+        public Task ReplacePlanStepsFromIndexAsync(
+            string planId,
+            string subject,
+            int fromStepIndex,
+            IReadOnlyList<PlanStepWrite> steps,
+            CancellationToken ct = default)
+        {
+            lock (_sync)
+            {
+                if (_bySub.TryGetValue(subject, out Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>? bucket)
+                    && bucket.TryGetValue(planId, out (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps) row))
+                {
+                    // Drop any existing step rows at or above the cutoff so the
+                    // new ones fully define the tail. Prior clarification-
+                    // completed rows (StepIndex < fromStepIndex) stay verbatim.
+                    // In-memory step storage keys by StepId; without persisted
+                    // StepIndex, we approximate by matching new step ids that
+                    // would otherwise collide, then insert seed rows so
+                    // subsequent UpdateStepAsync calls land against a real
+                    // key. Production callers rely on the atomic delete-tail /
+                    // insert-new pair inside SqlitePlanStore.
+                    foreach (PlanStepWrite w in steps)
+                    {
+                        row.Steps[w.StepId] = new PlanStepUpdate
+                        {
+                            StepId = w.StepId,
+                            PlanId = planId,
+                            Subject = subject,
+                            Status = w.Status,
+                        };
+                    }
+                }
+            }
+            return Task.CompletedTask;
+        }
+
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
         public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default)

--- a/tests/RetailPulse.Tests/Endpoints/ExecutionControlEndpointsTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/ExecutionControlEndpointsTests.cs
@@ -308,6 +308,7 @@ public sealed class ExecutionControlEndpointsTests
         public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
             => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ReplacePlanStepsFromIndexAsync(string planId, string subject, int fromStepIndex, IReadOnlyList<PlanStepWrite> steps, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);

--- a/tests/RetailPulse.Tests/Endpoints/ExecutionControlEndpointsTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/ExecutionControlEndpointsTests.cs
@@ -305,6 +305,8 @@ public sealed class ExecutionControlEndpointsTests
 
         public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
+            => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)

--- a/tests/RetailPulse.Tests/Endpoints/PlanEndpointsAuthorizationTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanEndpointsAuthorizationTests.cs
@@ -266,6 +266,7 @@ public sealed class PlanEndpointsAuthorizationTests
             => Task.FromResult(true);
 
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ReplacePlanStepsFromIndexAsync(string planId, string subject, int fromStepIndex, IReadOnlyList<PlanStepWrite> steps, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
             => _byOwner.TryGetValue(subject, out Dictionary<string, PlanRow>? bucket)

--- a/tests/RetailPulse.Tests/Endpoints/PlanEndpointsAuthorizationTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanEndpointsAuthorizationTests.cs
@@ -262,6 +262,9 @@ public sealed class PlanEndpointsAuthorizationTests
 
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default) => Task.CompletedTask;
 
+        public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
+            => Task.FromResult(true);
+
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewEditInjectionTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewEditInjectionTests.cs
@@ -237,6 +237,8 @@ public sealed class PlanReviewEditInjectionTests
 
         public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
+            => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewEditInjectionTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewEditInjectionTests.cs
@@ -240,6 +240,7 @@ public sealed class PlanReviewEditInjectionTests
         public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
             => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ReplacePlanStepsFromIndexAsync(string planId, string subject, int fromStepIndex, IReadOnlyList<PlanStepWrite> steps, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsAuthorizationTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsAuthorizationTests.cs
@@ -337,6 +337,8 @@ public sealed class PlanReviewEndpointsAuthorizationTests
 
         public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
+            => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsAuthorizationTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsAuthorizationTests.cs
@@ -340,6 +340,7 @@ public sealed class PlanReviewEndpointsAuthorizationTests
         public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
             => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ReplacePlanStepsFromIndexAsync(string planId, string subject, int fromStepIndex, IReadOnlyList<PlanStepWrite> steps, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
             => _byOwner.TryGetValue(subject, out Dictionary<string, PlanRow>? bucket)

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsDecisionRaceTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsDecisionRaceTests.cs
@@ -8,12 +8,23 @@ namespace RetailPulse.Tests.Endpoints;
 /// <summary>
 /// Unit coverage for <see cref="PlanReviewEndpoints.ExtractWinner"/> — the
 /// helper that resolves a decision's <c>kind</c>/<c>feedback</c> from the
-/// persisted <see cref="ApprovalResult.ResponsePayload"/> so a losing
-/// concurrent caller cannot broadcast its own requested kind. The endpoint
-/// wires this into the plan_review_resolved payload; when the gate returns
-/// a winner's payload with a different <c>Kind</c> than the caller
-/// requested, the endpoint MUST advertise the winning kind, not the
-/// caller's kind.
+/// persisted <see cref="ApprovalResult"/> so a losing concurrent caller
+/// cannot broadcast its own requested kind or feedback (#144 follow-up).
+/// <para>
+/// Integrity contract exercised here:
+/// </para>
+/// <list type="bullet">
+///   <item><description><c>Kind</c> always follows the durable
+///     <see cref="ApprovalResult.Decision"/> family, never the requesting
+///     caller.</description></item>
+///   <item><description>When the persisted
+///     <see cref="ApprovalResult.ResponsePayload"/> parses cleanly, feedback
+///     is taken from the persisted winner's payload only.</description></item>
+///   <item><description>Missing or malformed payload returns
+///     <c>PayloadParsed = false</c> and omits feedback so the endpoint can
+///     skip the <c>plan_review_resolved</c> broadcast rather than
+///     advertise a losing caller's text.</description></item>
+/// </list>
 /// </summary>
 public sealed class PlanReviewEndpointsDecisionRaceTests
 {
@@ -24,10 +35,8 @@ public sealed class PlanReviewEndpointsDecisionRaceTests
     };
 
     [Fact]
-    public void ExtractWinner_returns_the_persisted_kind_when_it_differs_from_the_caller_requested_kind()
+    public void ExtractWinner_returns_persisted_kind_and_feedback_when_payload_parses()
     {
-        // A concurrent race: caller asked to Approve, but the persisted
-        // winner (an earlier reject) recorded Kind = "reject" with feedback.
         var persisted = new PlanReviewResponsePayload
         {
             Kind = PlanReviewKinds.Reject,
@@ -41,36 +50,38 @@ public sealed class PlanReviewEndpointsDecisionRaceTests
             TerminalReason: "HumanRejected",
             ResponsePayload: JsonSerializer.Serialize(persisted, _json));
 
-        (string kind, string? feedback) = PlanReviewEndpoints.ExtractWinner(
-            result, requestedKind: PlanReviewKinds.Approve, requestedFeedback: null);
+        (string kind, string? feedback, bool payloadParsed) = PlanReviewEndpoints.ExtractWinner(result);
 
         kind.Should().Be(PlanReviewKinds.Reject,
-            "the SignalR broadcast MUST advertise the persisted winning kind, not the caller's kind.");
+            "the SignalR broadcast MUST advertise the persisted winning kind.");
         feedback.Should().Be("the-persisted-feedback",
-            "reviewer feedback on the row's ResponsePayload wins over the caller's own body.");
+            "reviewer feedback on the row's ResponsePayload wins over any caller-side value.");
+        payloadParsed.Should().BeTrue("a well-formed payload must clear the broadcast gate.");
     }
 
     [Fact]
-    public void ExtractWinner_falls_back_to_the_caller_requested_kind_when_payload_is_missing()
+    public void ExtractWinner_derives_kind_from_decision_and_omits_feedback_when_payload_missing()
     {
         var result = new ApprovalResult(
             RequestId: "r1",
-            Decision: ApprovalDecision.TimedOut,
+            Decision: ApprovalDecision.Rejected,
             Comment: null,
             RespondedAt: DateTimeOffset.UtcNow,
-            TerminalReason: "Timeout",
+            TerminalReason: "HumanRejected",
             ResponsePayload: null);
 
-        (string kind, string? feedback) = PlanReviewEndpoints.ExtractWinner(
-            result, requestedKind: PlanReviewKinds.Approve, requestedFeedback: null);
+        (string kind, string? feedback, bool payloadParsed) = PlanReviewEndpoints.ExtractWinner(result);
 
-        kind.Should().Be(PlanReviewKinds.Approve,
-            "a payload-less terminal row (timeout, orphaned) falls back to the caller-requested kind.");
-        feedback.Should().BeNull();
+        kind.Should().Be(PlanReviewKinds.Reject,
+            "kind is derived from ApprovalResult.Decision, never the caller's requested kind.");
+        feedback.Should().BeNull(
+            "no payload means we cannot know the winning feedback — omit rather than leak the caller's text.");
+        payloadParsed.Should().BeFalse(
+            "the endpoint must observe PayloadParsed = false and skip the plan_review_resolved broadcast.");
     }
 
     [Fact]
-    public void ExtractWinner_falls_back_to_the_caller_requested_kind_when_payload_is_malformed()
+    public void ExtractWinner_derives_kind_from_decision_and_omits_feedback_when_payload_malformed()
     {
         var result = new ApprovalResult(
             RequestId: "r1",
@@ -80,11 +91,13 @@ public sealed class PlanReviewEndpointsDecisionRaceTests
             TerminalReason: "HumanApproved",
             ResponsePayload: "this is not valid JSON");
 
-        (string kind, string? feedback) = PlanReviewEndpoints.ExtractWinner(
-            result, requestedKind: PlanReviewKinds.Approve, requestedFeedback: "fallback");
+        (string kind, string? feedback, bool payloadParsed) = PlanReviewEndpoints.ExtractWinner(result);
 
-        kind.Should().Be(PlanReviewKinds.Approve);
-        feedback.Should().Be("fallback");
+        kind.Should().Be(PlanReviewKinds.Approve,
+            "malformed payload still derives the kind from the durable Decision.");
+        feedback.Should().BeNull(
+            "malformed payload must not fall back to any caller-supplied string.");
+        payloadParsed.Should().BeFalse();
     }
 
     [Fact]
@@ -106,10 +119,25 @@ public sealed class PlanReviewEndpointsDecisionRaceTests
             TerminalReason: "HumanModified",
             ResponsePayload: JsonSerializer.Serialize(persisted, _json));
 
-        (string kind, string? feedback) = PlanReviewEndpoints.ExtractWinner(
-            result, requestedKind: PlanReviewKinds.Approve, requestedFeedback: null);
+        (string kind, string? feedback, bool payloadParsed) = PlanReviewEndpoints.ExtractWinner(result);
 
         kind.Should().Be(PlanReviewKinds.Edit);
         feedback.Should().BeNull("edit payloads carry EditedSteps rather than Feedback.");
+        payloadParsed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ExtractWinner_normalizes_timed_out_and_orphaned_decisions_to_reject_kind()
+    {
+        // Even without a payload, a timeout / orphan row must not present as
+        // an approve on the broadcast surface. Kind normalizes to reject so
+        // downstream consumers treat the row as a terminal reject.
+        var timedOut = new ApprovalResult(
+            "r1", ApprovalDecision.TimedOut, null, DateTimeOffset.UtcNow, "Timeout", null);
+        var orphaned = new ApprovalResult(
+            "r2", ApprovalDecision.Orphaned, null, DateTimeOffset.UtcNow, "Orphaned", null);
+
+        PlanReviewEndpoints.ExtractWinner(timedOut).Kind.Should().Be(PlanReviewKinds.Reject);
+        PlanReviewEndpoints.ExtractWinner(orphaned).Kind.Should().Be(PlanReviewKinds.Reject);
     }
 }

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsDecisionRaceTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsDecisionRaceTests.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using FluentAssertions;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Contracts.Approval;
+
+namespace RetailPulse.Tests.Endpoints;
+
+/// <summary>
+/// Unit coverage for <see cref="PlanReviewEndpoints.ExtractWinner"/> — the
+/// helper that resolves a decision's <c>kind</c>/<c>feedback</c> from the
+/// persisted <see cref="ApprovalResult.ResponsePayload"/> so a losing
+/// concurrent caller cannot broadcast its own requested kind. The endpoint
+/// wires this into the plan_review_resolved payload; when the gate returns
+/// a winner's payload with a different <c>Kind</c> than the caller
+/// requested, the endpoint MUST advertise the winning kind, not the
+/// caller's kind.
+/// </summary>
+public sealed class PlanReviewEndpointsDecisionRaceTests
+{
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void ExtractWinner_returns_the_persisted_kind_when_it_differs_from_the_caller_requested_kind()
+    {
+        // A concurrent race: caller asked to Approve, but the persisted
+        // winner (an earlier reject) recorded Kind = "reject" with feedback.
+        var persisted = new PlanReviewResponsePayload
+        {
+            Kind = PlanReviewKinds.Reject,
+            Feedback = "the-persisted-feedback",
+        };
+        var result = new ApprovalResult(
+            RequestId: "r1",
+            Decision: ApprovalDecision.Rejected,
+            Comment: "the-persisted-feedback",
+            RespondedAt: DateTimeOffset.UtcNow,
+            TerminalReason: "HumanRejected",
+            ResponsePayload: JsonSerializer.Serialize(persisted, _json));
+
+        (string kind, string? feedback) = PlanReviewEndpoints.ExtractWinner(
+            result, requestedKind: PlanReviewKinds.Approve, requestedFeedback: null);
+
+        kind.Should().Be(PlanReviewKinds.Reject,
+            "the SignalR broadcast MUST advertise the persisted winning kind, not the caller's kind.");
+        feedback.Should().Be("the-persisted-feedback",
+            "reviewer feedback on the row's ResponsePayload wins over the caller's own body.");
+    }
+
+    [Fact]
+    public void ExtractWinner_falls_back_to_the_caller_requested_kind_when_payload_is_missing()
+    {
+        var result = new ApprovalResult(
+            RequestId: "r1",
+            Decision: ApprovalDecision.TimedOut,
+            Comment: null,
+            RespondedAt: DateTimeOffset.UtcNow,
+            TerminalReason: "Timeout",
+            ResponsePayload: null);
+
+        (string kind, string? feedback) = PlanReviewEndpoints.ExtractWinner(
+            result, requestedKind: PlanReviewKinds.Approve, requestedFeedback: null);
+
+        kind.Should().Be(PlanReviewKinds.Approve,
+            "a payload-less terminal row (timeout, orphaned) falls back to the caller-requested kind.");
+        feedback.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractWinner_falls_back_to_the_caller_requested_kind_when_payload_is_malformed()
+    {
+        var result = new ApprovalResult(
+            RequestId: "r1",
+            Decision: ApprovalDecision.Approved,
+            Comment: null,
+            RespondedAt: DateTimeOffset.UtcNow,
+            TerminalReason: "HumanApproved",
+            ResponsePayload: "this is not valid JSON");
+
+        (string kind, string? feedback) = PlanReviewEndpoints.ExtractWinner(
+            result, requestedKind: PlanReviewKinds.Approve, requestedFeedback: "fallback");
+
+        kind.Should().Be(PlanReviewKinds.Approve);
+        feedback.Should().Be("fallback");
+    }
+
+    [Fact]
+    public void ExtractWinner_returns_edit_kind_when_persisted_payload_is_an_edit()
+    {
+        var persisted = new PlanReviewResponsePayload
+        {
+            Kind = PlanReviewKinds.Edit,
+            EditedSteps =
+            [
+                new PlanReviewStepDto { SpecialistKey = "scorecard", Intent = "s", Action = "a" },
+            ],
+        };
+        var result = new ApprovalResult(
+            RequestId: "r1",
+            Decision: ApprovalDecision.Modified,
+            Comment: null,
+            RespondedAt: DateTimeOffset.UtcNow,
+            TerminalReason: "HumanModified",
+            ResponsePayload: JsonSerializer.Serialize(persisted, _json));
+
+        (string kind, string? feedback) = PlanReviewEndpoints.ExtractWinner(
+            result, requestedKind: PlanReviewKinds.Approve, requestedFeedback: null);
+
+        kind.Should().Be(PlanReviewKinds.Edit);
+        feedback.Should().BeNull("edit payloads carry EditedSteps rather than Feedback.");
+    }
+}

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewGuardrailExtensionTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewGuardrailExtensionTests.cs
@@ -406,6 +406,7 @@ public sealed class PlanReviewGuardrailExtensionTests
         public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
             => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ReplacePlanStepsFromIndexAsync(string planId, string subject, int fromStepIndex, IReadOnlyList<PlanStepWrite> steps, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewGuardrailExtensionTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewGuardrailExtensionTests.cs
@@ -403,6 +403,8 @@ public sealed class PlanReviewGuardrailExtensionTests
 
         public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
+            => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)

--- a/tests/RetailPulse.Tests/Planning/PlanChartPropagationTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanChartPropagationTests.cs
@@ -187,6 +187,7 @@ public sealed class PlanChartPropagationTests
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default) => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ReplacePlanStepsFromIndexAsync(string planId, string subject, int fromStepIndex, IReadOnlyList<PlanStepWrite> steps, CancellationToken ct = default) => Task.CompletedTask;
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
         public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default) => Task.FromResult<PlanDetailDto?>(null);
         public Task<bool> DeletePlanAsync(string subject, string planId, CancellationToken ct = default) => Task.FromResult(false);

--- a/tests/RetailPulse.Tests/Planning/PlanChartPropagationTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanChartPropagationTests.cs
@@ -185,6 +185,7 @@ public sealed class PlanChartPropagationTests
     {
         public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default) => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default) => Task.CompletedTask;
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
         public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default) => Task.FromResult<PlanDetailDto?>(null);

--- a/tests/RetailPulse.Tests/Planning/PlanExecutorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanExecutorTests.cs
@@ -39,6 +39,19 @@ public sealed class PlanExecutorTests
             return Task.CompletedTask;
         }
 
+        public Task<bool> TryTransitionStatusAsync(
+            string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
+        {
+            StatusUpdates.Enqueue(new PlanStatusUpdate
+            {
+                PlanId = planId,
+                Subject = subject,
+                Status = toStatus,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            });
+            return Task.FromResult(true);
+        }
+
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
         {
             StepUpdates.Enqueue(update);

--- a/tests/RetailPulse.Tests/Planning/PlanExecutorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanExecutorTests.cs
@@ -58,6 +58,19 @@ public sealed class PlanExecutorTests
             return Task.CompletedTask;
         }
 
+        public ConcurrentQueue<(int FromIndex, IReadOnlyList<PlanStepWrite> Steps)> Replacements { get; } = new();
+
+        public Task ReplacePlanStepsFromIndexAsync(
+            string planId,
+            string subject,
+            int fromStepIndex,
+            IReadOnlyList<PlanStepWrite> steps,
+            CancellationToken ct = default)
+        {
+            Replacements.Enqueue((fromStepIndex, steps));
+            return Task.CompletedTask;
+        }
+
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
 

--- a/tests/RetailPulse.Tests/Planning/PlanOrchestratorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanOrchestratorTests.cs
@@ -35,6 +35,8 @@ public sealed class PlanOrchestratorTests
             => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
         { StepUpdates.Enqueue(update); return Task.CompletedTask; }
+        public Task ReplacePlanStepsFromIndexAsync(string planId, string subject, int fromStepIndex, IReadOnlyList<PlanStepWrite> steps, CancellationToken ct = default)
+            => Task.CompletedTask;
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
         public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default)

--- a/tests/RetailPulse.Tests/Planning/PlanOrchestratorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanOrchestratorTests.cs
@@ -31,6 +31,8 @@ public sealed class PlanOrchestratorTests
         { Creates.Enqueue(plan); return Task.CompletedTask; }
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default)
         { StatusUpdates.Enqueue(update); return Task.CompletedTask; }
+        public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
+            => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
         { StepUpdates.Enqueue(update); return Task.CompletedTask; }
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)

--- a/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
@@ -63,6 +63,8 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
         { Creates.Enqueue(plan); return Task.CompletedTask; }
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default)
         { StatusUpdates.Enqueue(update); return Task.CompletedTask; }
+        public Task<bool> TryTransitionStatusAsync(string planId, string subject, string fromStatus, string toStatus, CancellationToken ct = default)
+            => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
         { StepUpdates.Enqueue(update); return Task.CompletedTask; }
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)

--- a/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
@@ -67,6 +67,8 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
             => Task.FromResult(true);
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
         { StepUpdates.Enqueue(update); return Task.CompletedTask; }
+        public Task ReplacePlanStepsFromIndexAsync(string planId, string subject, int fromStepIndex, IReadOnlyList<PlanStepWrite> steps, CancellationToken ct = default)
+            => Task.CompletedTask;
         public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<PlanSummaryDto>>([]);
         public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default)


### PR DESCRIPTION
Completes the six code/security review blockers from the post-implementation review of PR #144, on top of PR #143's landed session-scoped broadcast fixes on `main`. Publix (this revision) rebased the branch onto current `origin/main` (`676d8ef`), reconciled every overlap with #143 by hand — preferring already-landed main behavior when it supersedes branch code — and layered the follow-up integrity fixes on top. No dangling commits were consulted; conflicts were resolved from first principles against the current main tree.

## Rebase & conflict resolution

Rebased `squad/136-plan-edit-guardrail` onto `origin/main` (`676d8ef`, PR #143). Conflicts and how they were resolved (all preferring landed main behavior where it superseded branch code, while keeping accepted #136 guardrails and all-9 plan chart rendering):

- `src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs` — kept main's `SendToOwningSessionAsync(hub, sessionId, ...)` helper (adopted in #143) and removed the branch's parallel `SendScopedAsync(sp, ...)` helper; kept branch's `TryTransitionStatusAsync` claims on the Approved/Terminal/NeedsReplan/answered-clarification branches; kept branch's cumulative `PriorAccumulatedResults` seed and coherent-coordinate clarification reader; preserved main's status-restore before the `plan_review_next_round` broadcast in the NeedsReplan branch.
- `src/RetailPulse.Api/Endpoints/PlanReviewEndpoints.cs` — kept main's session-scoped `plan_review_resolved` broadcast with the fail-closed missing-session log; kept branch's `ExtractWinner` seam, then rewired it below.
- Frontend `types/index.ts`, `state/planReducer.ts`, `state/usePlanController.ts`, `components/plan/PlanView.tsx`, `components/ChatPanel.tsx` — kept main's already-landed chart rendering (data-chart-count testid, simple Suspense fallback, tri-state `charts` semantics on `PLAN_FINAL`, `applyFinalResponse` on the immediate path). The branch's redundant `startPlan(reply, charts)` overload was dropped so there is exactly one PLAN_FINAL dispatch per settle.
- Test files with `add/add` conflicts (`PlanView.finalCharts.test.tsx`, `usePlanController.finalCharts.test.tsx`) resolved by taking main's landed suite; the branch's `planReducer.finalCharts.test.ts` remained additive because main did not have it and its assertions are compatible with main's reducer semantics.

## Backend fixes

**1. Persisted-winner integrity (task #1).**
`PlanReviewEndpoints.ExtractWinner` no longer falls back to the requesting caller's kind or feedback. `Kind` is derived from the durable `ApprovalResult.Decision` family (Approved/Modified/Rejected + TimedOut/Orphaned/Pending → Reject). `Feedback` is only returned when `ResponsePayload` parses cleanly; on missing/malformed payload it returns `PayloadParsed = false` and the endpoint SKIPS the `plan_review_resolved` broadcast (logs a warning) rather than advertise a losing caller's text. The HTTP response envelope carries the derived-winning kind and feedback so the frontend can consume it.

**2. Resume step persistence (task #2).**
Added `IPlanStore.ReplacePlanStepsFromIndexAsync(planId, subject, fromStepIndex, steps)` with a transactional DELETE-tail + INSERT implementation on `SqlitePlanStore` (ownership-gated, subject-scoped). `ExecuteApprovedPlanAsync` calls this immediately before `executor.ExecuteAsync` so the executor's UPDATE-only `UpdateStepAsync` lands on rows that actually exist. Rows with `StepIndex < fromStepIndex` (prior clarification-completed steps) are preserved verbatim so cumulative/global step indices survive across resumes.

**3. Recoverable execution claim (task #3).**
`ExecuteApprovedPlanAsync` wraps `executor.ExecuteAsync` in a try/catch: on any exception or cancellation after the `AwaitingReview → Running` (or `AwaitingClarification → Running`) claim, we atomically transition `Running → Failed` via `TryTransitionStatusAsync` and persist the failure reason before rethrowing. The row cannot strand in `Running`.

`PlanReviewRestartRecoveryService` now also handles stranded-Running plans: on boot, plans whose approval row is terminal but whose plan status is still `Running` are moved to `Failed` with a stable failure reason ("plan-resume interrupted by process exit while Running"). Awaiting* recovery is unchanged and still short-circuits on already-terminal plans (idempotent).

The order-race where an approval answer arrives before awaiting status is durable is closed on the resume path by the atomic claim itself: `TryTransitionStatusAsync(AwaitingClarification → Running)` is the single point of truth, and the losing caller `NoOp`s deterministically.

**4. Repeated clarification user visibility (task #4).**
When a resumed plan pauses for a subsequent clarification, `ExecuteApprovedPlanAsync` now broadcasts the existing `approval_requested` event scoped to the owning session group (fail-closed on missing session id) so `usePlanController` opens `PlanClarificationCard`. The broadcast fires AFTER the executor's finally block commits `AwaitingClarification`, so awaiting state is durable before the approval is user-visible. Payload is read verbatim from the approval row's `Context.Payload` (the same shape `ApprovalTool` already delivers on initial approvals) so the frontend parses the same `PlanClarificationPrompt` structure.

**5. Decision durability before notification (task #5).**
The `plan_review_resolved` broadcast now uses `CancellationToken.None` (so a client disconnect on the request token cannot strand the row) and its own try/catch (so a hub-send exception is logged, not propagated). The completion kickoff runs regardless of hub-send outcome and regardless of request-cancellation. Notification is never a gate on execution.

**6. Broadcast security retained (task #6).**
PR #143's session-scoped `Group(sessionId)` delivery for `plan_final_response`, `plan_review_next_round`, and `plan_review_resolved` is preserved. The new `approval_requested` clarification-open event routes through the same `SendToOwningSessionAsync` helper with fail-closed semantics on missing session identity. No path reaches `Clients.All`.

**7. Accepted behavior kept.** GuardrailsMiddleware edit/reject/clarification paths, Content Safety / pattern tests, immediate + resume all-9 chart rendering, no stale charts, repeated clarification chart ordering, and atomic duplicate-execution prevention are all unchanged.

## Frontend fixes

- `usePlanController.approve/reject/edit` now consume the returned `PlanReviewDecisionResponse.kind` from POST /decision, eliminating event/local order drift with the SignalR `plan_review_resolved` broadcast which advertises the same persisted-winner value.
- `PlanReviewDecisionResponse` gains an optional `feedback?: string | null` field (present only when the persisted payload parsed cleanly).

## Tests

- `PlanReviewEndpointsDecisionRaceTests` rewritten for the new `ExtractWinner(ApprovalResult)` contract:
  - persisted kind/feedback when payload parses,
  - kind derived from `Decision` (never caller-requested) when payload is missing,
  - kind derived from `Decision` when payload is malformed (feedback omitted),
  - persisted `edit` kind returned unchanged,
  - `TimedOut` and `Orphaned` decisions normalize to `reject`.
- `PlanReviewCompletionResumeFixTests` adds:
  - `Subsequent_clarification_broadcasts_approval_requested_scoped_to_session_group` — resumed clarification fires `approval_requested` to the session group; no `Clients.All`.
  - `Recoverable_claim_transitions_stranded_running_to_failed` — atomic `Running → Failed` after post-claim exception; second stranded-Running caller loses the CAS.
  - `Resume_step_rows_persist_on_sqlite_plan_store_and_survive_hydrate` — resume drives Executed with a non-empty reply (proof the step rows the executor updated actually existed).
- New `src/RetailPulse.Web/src/__tests__/usePlanController.decisionResponse.test.tsx` (author-only per policy; CI runs npm/npx):
  - approve/reject/edit consume the returned response's persisted kind,
  - `approval_requested` with `context.kind === 'clarification'` opens `PlanClarificationCard` on a resumed plan.

Every existing IPlanStore in-memory test double (InMemoryPlanStore, RecordingPlanStore, NoopPlanStore) implements `ReplacePlanStepsFromIndexAsync`.

## Files shared with landed work

- `PlanReviewCompletionService.cs`, `PlanReviewEndpoints.cs` — hand-reconciled with PR #143's landed session-scoped broadcast fixes.
- Frontend `types/index.ts`, `planReducer.ts`, `usePlanController.ts`, `PlanView.tsx`, `ChatPanel.tsx` — kept main's landed chart wiring; branch-added redundancy dropped.
- No changes to #92-owned `TelemetryHub` / `Program` / `ChatEndpoints`, no changes to #108 tenant/prompts/seed.

## Validation

- `dotnet build RetailPulse.slnx` — 0 warnings, 0 errors.
- `dotnet format RetailPulse.slnx --verify-no-changes` — clean.
- `dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj` — 3309 passed, 0 failed, 9 skipped (external live services).
- Frontend Vitest suites authored but not executed locally (per repo policy: no npm/npx); CI runs them.

## Constraints honoured

- No npm/npx runs.
- No feed / `nuget.org` changes (azure-default only).
- No forbidden third-party accelerator or competitive comparison reference.
- Force-pushed with `--force-with-lease` after rebase; exact branch name kept.

Closes #136
Closes #137
