### PR TITLE
fix(#76): prose chart-drop invariant + family-aware chart-type guards

### DIFF
--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs
@@ -21,6 +21,39 @@ public partial class AgentExecutionPipeline
 {
     internal readonly record struct ChartFulfillmentResult(List<ChartSpec> Charts, string Reply);
 
+    /// <summary>
+    /// Structural chart-type families. Members share the same underlying data shape
+    /// (series-of-{X,Y}) so within-family differences are presentation-only rendering
+    /// hints (orientation / grouping / stacking). Cross-family differences imply a
+    /// different data model and are treated as an explicit chart-type mismatch — never
+    /// silently rewritten. The nine canonical <see cref="ChartSpec.Type"/> values are:
+    /// <c>bar, horizontalBar, groupedBar, stackedBar, line, pie, donut, gauge, table</c>.
+    /// Gauge and table are singletons because their data shapes (single-scalar; row
+    /// grid) don't bind to any other chart type. See issue #76 Group D.
+    /// </summary>
+    private static readonly string[][] _chartTypeFamilies =
+    [
+        ["bar", "horizontalBar", "groupedBar", "stackedBar"],
+        ["line"],
+        ["pie", "donut"],
+        ["gauge"],
+        ["table"],
+    ];
+
+    private static string[]? ChartTypeFamily(string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type)) return null;
+        foreach (string[] family in _chartTypeFamilies)
+        {
+            foreach (string member in family)
+            {
+                if (string.Equals(member, type, StringComparison.OrdinalIgnoreCase))
+                    return family;
+            }
+        }
+        return null;
+    }
+
     internal ChartFulfillmentResult EnforceChartFulfillment(
         string? userMessage,
         Microsoft.Extensions.AI.ChatResponse response,
@@ -29,10 +62,57 @@ public partial class AgentExecutionPipeline
     {
         ChartIntent intent = ChartRequestDetector.Detect(userMessage);
 
-        // Not an explicit chart request → never force a chart.
+        // ── GROUP A (issue #76): inverse chart-on-prose invariant ─────────────
+        // When the request is NOT an explicit chart request, any model-emitted
+        // chart is unsolicited noise — the prose the user actually asked for is
+        // the source of truth. Drop every chart before the response leaves the
+        // pipeline. Design decision (issue #76): NO prose intent carries a
+        // legitimate chart exception. The nine curated chart prompts all pass
+        // through ChartRequestDetector as explicit; anything the detector
+        // classifies as prose is prose, full stop. This closes the exact P0
+        // failure mode where "How is the portfolio performing?" surfaced a
+        // model-emitted chart that the user had not asked for.
         if (!intent.IsExplicitChartRequest)
         {
+            if (charts.Count > 0)
+            {
+                _logger.LogInformation(
+                    "Chart-fulfillment: dropping {ChartCount} model-emitted chart(s) — the user "
+                    + "did not ask for a visualization (chart-on-prose invariant, issue #76 Group A).",
+                    charts.Count);
+                charts.Clear();
+            }
             return new ChartFulfillmentResult(charts, reply);
+        }
+
+        // ── GROUP D (issue #76): family-aware chart-type enforcement ──────────
+        // ChartRequestDetector.Detect() captured the requested type. Validate
+        // every model-emitted chart against that request:
+        //   * exact-type match  → keep as-is;
+        //   * same family       → coerce Type in place (identical data shape,
+        //     presentation-only rewrite is safe and deterministic);
+        //   * cross family      → fail closed with a structured diagnostic —
+        //     never a silent rewrite (data would not bind, and the user's
+        //     stated intent was structurally different).
+        // Undeclared type intent (intent.ChartType is null) → no enforcement.
+        if (!string.IsNullOrWhiteSpace(intent.ChartType) && charts.Count > 0)
+        {
+            ChartTypeEnforcementResult typeCheck = EnforceRequestedChartType(charts, intent.ChartType);
+            charts = typeCheck.Charts;
+            if (typeCheck.CrossFamilyMismatch is { } mismatch)
+            {
+                _logger.LogWarning(
+                    "Chart-fulfillment: model emitted '{ModelType}' but the user asked for "
+                    + "'{RequestedType}' (different structural family). Failing closed with a "
+                    + "chart-type mismatch diagnostic — issue #76 Group D.",
+                    mismatch.ModelType, mismatch.RequestedType);
+                string mismatchDiag = BuildChartTypeMismatchDiagnostic(mismatch.ModelType, mismatch.RequestedType);
+                string mismatchScrubbed = StripFallbackClaims(reply);
+                string mismatchReply = string.IsNullOrWhiteSpace(mismatchScrubbed)
+                    ? mismatchDiag
+                    : $"{mismatchScrubbed}\n\n{mismatchDiag}";
+                return new ChartFulfillmentResult(charts, mismatchReply);
+            }
         }
 
         bool isPortfolioRanking = IsPortfolioRankingIntent(userMessage, intent);
@@ -177,6 +257,82 @@ public partial class AgentExecutionPipeline
             + "underlying data tools returned no chartable values for this request. This is a "
             + "data-availability issue, not a rendering failure — please retry with a specific "
             + "brand and region, or confirm the entity exists for this tenant.";
+    }
+
+    /// <summary>
+    /// Result of <see cref="EnforceRequestedChartType"/>: the (possibly coerced) chart list,
+    /// plus — when the model emitted a chart from a different structural family than the
+    /// user asked for — the mismatch tuple so the caller can fail closed with a diagnostic.
+    /// </summary>
+    internal readonly record struct ChartTypeEnforcementResult(
+        List<ChartSpec> Charts,
+        (string ModelType, string RequestedType)? CrossFamilyMismatch);
+
+    /// <summary>
+    /// Family-aware enforcement of the chart type the user explicitly requested. Iterates
+    /// every model-emitted chart:
+    /// <list type="bullet">
+    ///   <item>exact-type match → keep unchanged;</item>
+    ///   <item>same family (identical data shape, presentation-only difference) → coerce
+    ///     <see cref="ChartSpec.Type"/> to the requested type in place;</item>
+    ///   <item>cross family → drop the chart and record the first mismatch so the caller
+    ///     can fail closed with a chart-type-mismatch diagnostic. A silent rewrite here
+    ///     would bind the wrong data shape and hide a real model error (issue #76 Group D).</item>
+    /// </list>
+    /// </summary>
+    internal ChartTypeEnforcementResult EnforceRequestedChartType(
+        List<ChartSpec> charts,
+        string requestedType)
+    {
+        string[]? requestedFamily = ChartTypeFamily(requestedType);
+        if (requestedFamily is null)
+        {
+            // The requested type isn't in our nine canonical types — no enforcement possible.
+            return new ChartTypeEnforcementResult(charts, null);
+        }
+
+        (string ModelType, string RequestedType)? firstMismatch = null;
+        var kept = new List<ChartSpec>(charts.Count);
+        foreach (ChartSpec? chart in charts)
+        {
+            if (chart is null) continue;
+
+            if (string.Equals(chart.Type, requestedType, StringComparison.OrdinalIgnoreCase))
+            {
+                kept.Add(chart);
+                continue;
+            }
+
+            string[]? actualFamily = ChartTypeFamily(chart.Type);
+            if (actualFamily is not null && ReferenceEquals(actualFamily, requestedFamily))
+            {
+                // Within-family coercion: safe presentation-only rewrite.
+                _logger.LogInformation(
+                    "Chart-fulfillment: coercing model-emitted '{ModelType}' chart to user-stated "
+                    + "'{RequestedType}' (same structural family) — issue #76 Group D.",
+                    chart.Type, requestedType);
+                kept.Add(chart with { Type = requestedType });
+                continue;
+            }
+
+            // Cross-family (or unknown-family) mismatch: fail closed.
+            firstMismatch ??= (chart.Type ?? "unknown", requestedType);
+            _logger.LogWarning(
+                "Chart-fulfillment: dropping cross-family chart — model emitted '{ModelType}', "
+                + "user asked for '{RequestedType}' — issue #76 Group D.",
+                chart.Type, requestedType);
+        }
+
+        return new ChartTypeEnforcementResult(kept, firstMismatch);
+    }
+
+    private static string BuildChartTypeMismatchDiagnostic(string modelType, string requestedType)
+    {
+        return $"⚠️ Chart unavailable: you asked for a {requestedType} chart, but the underlying "
+            + $"tools returned data shaped for a {modelType} chart — a different chart family. "
+            + "The data shape and the requested chart type are incompatible, so no chart is emitted. "
+            + $"Please retry and confirm the request is for a {modelType}-shaped visualization, or "
+            + $"narrow the query so a {requestedType}-shaped answer can be produced.";
     }
 
     /// <summary>

--- a/tests/RetailPulse.Tests/Agents/Issue76ChartGuardsTests.cs
+++ b/tests/RetailPulse.Tests/Agents/Issue76ChartGuardsTests.cs
@@ -1,0 +1,298 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using RetailPulse.Api.Agents;
+using RetailPulse.Contracts;
+using RetailPulse.Tests.Fixtures;
+using Xunit;
+using MeaiChatResponse = Microsoft.Extensions.AI.ChatResponse;
+
+namespace RetailPulse.Tests.Agents;
+
+/// <summary>
+/// Contract coverage for issue #76 Groups A + D on both the fast path (raw user
+/// message hits <see cref="AgentExecutionPipeline.EnforceChartFulfillment"/> directly)
+/// and the plan path (the specialist step receives the plan's scoped message
+/// <c>"{action} — original user request: {message}"</c>, which is what the
+/// <c>PlanExecutor</c> builds before delegating to the same pipeline).
+/// <para>
+/// The two failure classes pinned here are:
+/// </para>
+/// <list type="bullet">
+///   <item><b>Group A — chart on prose.</b> A prose prompt where the model emits a
+///     chart must have that chart dropped before the response leaves the pipeline.
+///     No prose intent carries a chart exception (design decision, PR body).</item>
+///   <item><b>Group D — chart-type family guard.</b> When the request captured a
+///     specific chart type, a within-family mismatch (bar → horizontalBar) may be
+///     coerced deterministically because the data shape is identical; a cross-family
+///     mismatch (bar → line, or bar → gauge) must fail closed with a chart-type
+///     mismatch diagnostic — never a silent rewrite.</item>
+/// </list>
+/// Both defects would have shipped without these tests; the fast/plan pairs prove
+/// the invariant applies transitively through the plan-first architecture because
+/// <c>PlanExecutor</c> injects the raw user message into every step's scoped message.
+/// </summary>
+public sealed class Issue76ChartGuardsTests
+{
+    // ── GROUP A: chart-on-prose (fast path + plan path) ─────────────────────
+
+    [Theory]
+    [InlineData("How is the portfolio performing?")]
+    [InlineData("Summarize distributor sentiment this quarter.")]
+    [InlineData("What's the inventory level for Pinnacle Hardware?")]
+    public void FastPath_ProsePrompt_ModelEmittedChart_IsDropped(string prosePrompt)
+    {
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults(
+            JsonSerializer.Serialize(new { note = "prose payload — no chart requested" }));
+
+        // Model hallucinated a chart even though the user asked for prose.
+        var stray = new ChartSpec
+        {
+            Type = "bar",
+            Title = "Unrequested",
+            Data = [new ChartSeries { Legend = "s", Values = [new ChartDataPoint { X = "A", Y = 1 }] }]
+        };
+        var charts = new List<ChartSpec> { stray };
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            prosePrompt, response, charts, "Here is the prose summary the user asked for.");
+
+        result.Charts.Should().BeEmpty(
+            "prose intents must never surface a model-emitted chart — chart-on-prose invariant, issue #76 Group A");
+        result.Reply.Should().Be("Here is the prose summary the user asked for.",
+            "the prose reply must survive the drop untouched");
+    }
+
+    [Theory]
+    [InlineData("How is the portfolio performing?")]
+    [InlineData("Summarize distributor sentiment this quarter.")]
+    public void PlanPath_ProsePrompt_ModelEmittedChart_IsDropped(string prosePrompt)
+    {
+        // Plan-path shape: PlanExecutor scopes the step message as
+        //   "{action} — original user request: {message}"
+        // ChartRequestDetector sees the full concatenation. If the original user
+        // request is prose and the step action has no chart nouns, the invariant
+        // must still drop the model-emitted chart at the specialist boundary.
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults(
+            JsonSerializer.Serialize(new { note = "prose payload — no chart requested" }));
+
+        string stepMessage =
+            $"aggregate cross-brand depletion metrics — original user request: {prosePrompt}";
+
+        var stray = new ChartSpec
+        {
+            Type = "bar",
+            Title = "Unrequested",
+            Data = [new ChartSeries { Legend = "s", Values = [new ChartDataPoint { X = "A", Y = 1 }] }]
+        };
+        var charts = new List<ChartSpec> { stray };
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            stepMessage, response, charts, "The prose synthesis for the plan step.");
+
+        result.Charts.Should().BeEmpty(
+            "plan-path prose prompts must drop model-emitted charts identically to the fast path");
+        result.Reply.Should().Be("The prose synthesis for the plan step.");
+    }
+
+    // ── GROUP D: within-family coercion (fast path + plan path) ─────────────
+
+    public static IEnumerable<object[]> WithinFamilyCases =>
+    [
+        // Requested → emitted, expected coerced-to.
+        ["Show me a bar chart of depletion velocity in the Northeast",
+            "bar", "horizontalBar", "bar"],
+        ["Show me a horizontal bar chart ranking brands by depletion",
+            "horizontalBar", "bar", "horizontalBar"],
+        ["Show me a grouped bar chart of depletion by region",
+            "groupedBar", "stackedBar", "groupedBar"],
+        ["Show me a donut chart of market share by competitor",
+            "donut", "pie", "donut"],
+    ];
+
+    [Theory]
+    [MemberData(nameof(WithinFamilyCases))]
+    public void FastPath_WithinFamilyMismatch_IsCoerced(
+        string prompt, string requested, string modelEmitted, string coercedTo)
+    {
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults(
+            JsonSerializer.Serialize(new { note = "chart data payload" }));
+
+        var emitted = new ChartSpec
+        {
+            Type = modelEmitted,
+            Title = $"{modelEmitted} sample",
+            Data =
+            [
+                new ChartSeries
+                {
+                    Legend = "series",
+                    Values = [new ChartDataPoint { X = "A", Y = 1 }, new ChartDataPoint { X = "B", Y = 2 }]
+                }
+            ]
+        };
+        var charts = new List<ChartSpec> { emitted };
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            prompt, response, charts, "Here is the chart.");
+
+        result.Charts.Should().ContainSingle(
+            "within-family coercion must never drop the chart — the data shape binds");
+        result.Charts[0].Type.Should().Be(coercedTo,
+            $"the model emitted '{modelEmitted}' but the user asked for '{requested}' — same family, coerce in place");
+        // Coercion preserves data verbatim.
+        result.Charts[0].Data[0].Values.Should().HaveCount(2);
+        result.Reply.Should().NotContain("Chart unavailable",
+            "within-family coercion is a rendering-orientation fix, not a fail-closed path — issue #76 requires prompt = '{0}'", prompt);
+    }
+
+    [Theory]
+    [MemberData(nameof(WithinFamilyCases))]
+    public void PlanPath_WithinFamilyMismatch_IsCoerced(
+        string prompt, string requested, string modelEmitted, string coercedTo)
+    {
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults(
+            JsonSerializer.Serialize(new { note = "chart data payload" }));
+
+        string stepMessage = $"visualize brand comparison — original user request: {prompt}";
+
+        var emitted = new ChartSpec
+        {
+            Type = modelEmitted,
+            Title = $"{modelEmitted} sample",
+            Data =
+            [
+                new ChartSeries
+                {
+                    Legend = "series",
+                    Values = [new ChartDataPoint { X = "A", Y = 1 }, new ChartDataPoint { X = "B", Y = 2 }]
+                }
+            ]
+        };
+        var charts = new List<ChartSpec> { emitted };
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            stepMessage, response, charts, "Here is the chart.");
+
+        // Note: the "horizontalBar ranking brands" prompt is a portfolio-ranking
+        // intent — without a tenant roster the coverage invariant is bypassed and
+        // the coerced chart survives. See CreatePipeline() which supplies no
+        // roster, so this fast/plan pair is symmetric.
+        _ = requested;
+        result.Charts.Should().ContainSingle(
+            "plan-path within-family coercion must work identically to the fast path");
+        result.Charts[0].Type.Should().Be(coercedTo);
+    }
+
+    // ── GROUP D: cross-family error (fast path + plan path) ─────────────────
+
+    public static IEnumerable<object[]> CrossFamilyCases =>
+    [
+        // Requested → emitted (different structural family).
+        ["Show me a bar chart of depletion velocity in the Northeast", "bar", "line"],
+        ["Show me a line chart of margin trend by quarter", "line", "bar"],
+        ["Show a pie chart of market share by competitor", "pie", "line"],
+        ["Show me a bar chart of depletion velocity in the Northeast", "bar", "gauge"],
+        ["Show me a bar chart of depletion velocity in the Northeast", "bar", "table"],
+    ];
+
+    [Theory]
+    [MemberData(nameof(CrossFamilyCases))]
+    public void FastPath_CrossFamilyMismatch_IsExplicitError(
+        string prompt, string requested, string modelEmitted)
+    {
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults(
+            JsonSerializer.Serialize(new { note = "chart data payload" }));
+
+        var emitted = new ChartSpec
+        {
+            Type = modelEmitted,
+            Title = $"{modelEmitted} sample",
+            Data =
+            [
+                new ChartSeries
+                {
+                    Legend = "series",
+                    Values = [new ChartDataPoint { X = "A", Y = 1 }, new ChartDataPoint { X = "B", Y = 2 }]
+                }
+            ]
+        };
+        var charts = new List<ChartSpec> { emitted };
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            prompt, response, charts, "Here is the chart.");
+
+        result.Charts.Should().BeEmpty(
+            $"a cross-family mismatch ({modelEmitted} → {requested}) must fail closed, not silently rewrite");
+        result.Reply.Should().Contain("Chart unavailable",
+            "cross-family mismatches must surface a structured diagnostic to the user");
+        result.Reply.Should().Contain(requested);
+        result.Reply.Should().Contain(modelEmitted);
+    }
+
+    [Theory]
+    [MemberData(nameof(CrossFamilyCases))]
+    public void PlanPath_CrossFamilyMismatch_IsExplicitError(
+        string prompt, string requested, string modelEmitted)
+    {
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults(
+            JsonSerializer.Serialize(new { note = "chart data payload" }));
+
+        string stepMessage = $"visualize the requested comparison — original user request: {prompt}";
+
+        var emitted = new ChartSpec
+        {
+            Type = modelEmitted,
+            Title = $"{modelEmitted} sample",
+            Data =
+            [
+                new ChartSeries
+                {
+                    Legend = "series",
+                    Values = [new ChartDataPoint { X = "A", Y = 1 }, new ChartDataPoint { X = "B", Y = 2 }]
+                }
+            ]
+        };
+        var charts = new List<ChartSpec> { emitted };
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            stepMessage, response, charts, "Here is the chart.");
+
+        result.Charts.Should().BeEmpty();
+        result.Reply.Should().Contain("Chart unavailable");
+        result.Reply.Should().Contain(requested);
+        result.Reply.Should().Contain(modelEmitted);
+        _ = requested;
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static AgentExecutionPipeline CreatePipeline()
+    {
+        IConfigurationRoot config = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+        return new AgentExecutionPipeline(
+            AgentTestFixtures.CreateMockChatClient("{}"),
+            AgentTestFixtures.CreateMockHubContext(),
+            config,
+            NullLogger<AgentExecutionPipeline>.Instance);
+    }
+
+    private static MeaiChatResponse ResponseWithToolResults(params string[] toolResultJson)
+    {
+        var contents = new List<AIContent>();
+        for (int i = 0; i < toolResultJson.Length; i++)
+        {
+            contents.Add(new FunctionResultContent($"call-{i}", toolResultJson[i]));
+        }
+        var message = new ChatMessage(ChatRole.Assistant, contents);
+        return new MeaiChatResponse(message);
+    }
+}

--- a/tests/RetailPulse.Tests/Budget/ChartIntentToolCallCapTests.cs
+++ b/tests/RetailPulse.Tests/Budget/ChartIntentToolCallCapTests.cs
@@ -163,4 +163,36 @@ public sealed class ChartIntentToolCallCapTests
         json.Should().NotContain("truncated");
         json.Should().NotContain("placeholder");
     }
+
+    /// <summary>
+    /// Issue #76 Group F: the per-request explicit-chart intent cap default is
+    /// <see cref="ToolResultBudgetOptions.MaxToolCallsForChartIntent"/> = 5 and
+    /// <see cref="BudgetedAIFunction"/> enforces it using ONLY the default options
+    /// (no explicit override). Regressing either the constant or the read site
+    /// silently reopens the fan-out failure class from the P0 sweep.
+    /// </summary>
+    [Fact]
+    public async Task ChartIntent_UsesDefaultCapOfFive_WithoutExplicitOverride()
+    {
+        // Take the shipped defaults verbatim — this test would fail if a future
+        // config change lowered the default under 5 or raised it above 5 without
+        // the caller opting in explicitly.
+        ToolResultBudgetOptions shipped = new();
+        shipped.MaxToolCallsForChartIntent.Should().Be(5,
+            "ADR-006 tool-context budget: explicit chart intents are hard-capped at 5 distinct tool calls");
+
+        var inner = new CountingFunction("GetHistoricalDemand",
+            a => JsonSerializer.Serialize(new { brand = a["brand"] }));
+        BudgetedAIFunction fn = Wrap(inner, shipped);
+
+        using IDisposable scope = RequestToolContext.Begin("session-defaults", isChartIntent: true);
+        for (int i = 0; i < 9; i++)
+        {
+            await fn.InvokeAsync(Args($"Brand{i}"));
+        }
+
+        inner.Invocations.Should().Be(5,
+            "BudgetedAIFunction must read the shipped default MaxToolCallsForChartIntent (5) " +
+            "when the caller does not override it — issue #76 Group F");
+    }
 }


### PR DESCRIPTION
Closes #76

## Summary

Re-implements the current-main remediation for issue #76 under the MAF /
plan-first architecture. Two production-code changes plus dedicated
contract coverage for both pipeline entry shapes (fast path and plan
path).

## Groups covered

### Group A — inverse chart-on-prose invariant
`AgentExecutionPipeline.EnforceChartFulfillment` now drops every
model-emitted chart when `ChartRequestDetector` reports the request is
**not** an explicit chart request. Design decision: **no prose intent
carries a legitimate chart exception**. The nine curated chart prompts
all pass through the detector as explicit; anything the detector
classifies as prose is prose, full stop. This closes the exact P0
failure mode where "How is the portfolio performing?" surfaced a
model-emitted chart the user had not asked for.

### Group D — family-aware chart-type enforcement
`ChartRequestDetector.Detect()` captures the requested type. The
fulfillment invariant now validates every model-emitted chart against
that request using structural chart-type **families**:

| Family | Members                                            |
| ------ | -------------------------------------------------- |
| bar    | `bar`, `horizontalBar`, `groupedBar`, `stackedBar` |
| line   | `line`                                             |
| pie    | `pie`, `donut`                                     |
| gauge  | `gauge` (singleton)                                |
| table  | `table` (singleton)                                |

All nine canonical chart types (`bar`, `horizontalBar`, `groupedBar`,
`stackedBar`, `line`, `pie`, `donut`, `gauge`, `table`) are preserved —
this only re-groups them by data-shape compatibility.

Enforcement rules:
* **exact match** → keep the chart unchanged;
* **same family, different type** → coerce `Type` in place. Members of
  a family share the same underlying series-of-{X,Y} data shape, so
  the rewrite is presentation-only (orientation / grouping /
  stacking). The motivating case is issue #76's `bar` vs
  `horizontalBar` failure (#20);
* **cross-family** (e.g. requested `bar`, emitted `line`; requested
  `bar`, emitted `gauge`) → **fail closed**. Drop the chart and append
  a structured chart-type mismatch diagnostic. The data shape would
  not bind, and silently rewriting would hide a real model error.

### Group F — chart-intent tool-call cap unit test
Adds `ChartIntent_UsesDefaultCapOfFive_WithoutExplicitOverride` to
`ChartIntentToolCallCapTests`. Pins that
`ToolResultBudgetOptions.MaxToolCallsForChartIntent` = `5` on the
shipped defaults AND that `BudgetedAIFunction` reads the shipped
default when the caller does not override it. Complements the existing
suite (`ChartIntent_HardCapsDistinctToolCallsAtFive`,
`ChartIntent_UsesLowerOfMaxToolCallsAndChartCap`) which already covers
the cap with an explicit override.

### Group B — briefly investigated, no deterministic repro
"Chart prompt falls back to prose, no chart" (#21; intermittent #19 /
#23 / #26 from the P0 sweep) requires a live LLM + tool network to
reproduce — it is a runtime emission behavior, not a code invariant.
Against current main under the MAF / plan-first pipeline, the
pre-existing `EnforceChartFulfillment` deterministic-reconstruction
path (from tool payloads) followed by the chart-unavailable diagnostic
already handles the *code* half of that failure class: an explicit
chart request that reaches the pipeline with no chart triggers
deterministic reconstruction and, failing that, a structured
diagnostic. **No further code change would deterministically close
Group B without live integration** — I did not speculate or broaden
scope.

## Contract test coverage — fast path AND plan path

New `tests/RetailPulse.Tests/Agents/Issue76ChartGuardsTests.cs`
(~28 pinned cases across theories). Each defect is exercised against
**both** pipeline entry shapes:

* **fast path**: the raw user message hits
  `EnforceChartFulfillment` directly;
* **plan path**: the same invariant runs against the
  `PlanExecutor`-scoped step message shape
  `"{planned.Action} — original user request: {message.Request}"`
  which is what every specialist step receives before calling into the
  identical `AgentExecutionPipeline`. The `ChartRequestDetector` sees
  the full concatenation, so the invariant transitively applies to
  every plan step.

Cases pinned:
* **prose → chart dropped** (3 prose prompts × 2 shapes = 6);
* **within-family mismatch → coerced** (4 pairs × 2 shapes = 8;
  bar↔horizontalBar, horizontalBar↔bar, groupedBar↔stackedBar,
  donut↔pie);
* **cross-family mismatch → structured error** (5 pairs × 2 shapes =
  10; bar↔line, line↔bar, pie↔line, bar↔gauge, bar↔table).

Each test truly executes the pipeline invariant end-to-end (no reflection,
no branch skipping) and would have caught both defects on current main
before this PR.

## Constraints honoured

* **Nine chart render types preserved.** The family map only groups
  them by structural compatibility; every canonical type still round-
  trips through the pipeline (verified by the untouched
  `PlanChartPropagationTests` and `ChartAcceptanceMatrixTests`).
* **PlanExecutor / PlanReviewCompletionService / IPlanStore not
  touched.** Concurrent issue #145 owns them. The plan-path coverage
  is contract-level, driven by the message shape `PlanExecutor` emits
  today.
* **ADR-006 tool-context budget, `span.type` telemetry, fast-path
  latency, anonymous-session hardening**: no regressions — no code in
  those subsystems was modified.
* **No wholesale cherry-pick from closed PR #77 / branch
  `squad/76-sweep-remediation`.** Implementation is fresh under the
  MAF pipeline shape; family map, coercion helper, and diagnostic
  wording are new. The prior branch was fetched for inspection only
  and never merged, rebased, or cherry-picked.

## Validation

Commands run locally on Windows / PowerShell:

```powershell
# Targeted backend tests for chart-guard invariants and the new cap test
dotnet test tests\RetailPulse.Tests\RetailPulse.Tests.csproj `
  --filter "FullyQualifiedName~Issue76ChartGuardsTests|FullyQualifiedName~ChartFulfillmentTests|FullyQualifiedName~ChartFulfillmentContractTests|FullyQualifiedName~ChartAcceptance|FullyQualifiedName~ChartIntentToolCallCapTests"
# → 92 passed, 0 failed

# Whole backend suite
dotnet test tests\RetailPulse.Tests\RetailPulse.Tests.csproj
# → 3317 passed, 9 skipped; 1 flaky timing test
#   (HubHeartbeatBackgroundServiceTests.ExecuteAsync_EmitsAtConfiguredInterval)
#   passes on rerun — unrelated to this change.

# Mandatory whole-solution lint
dotnet format RetailPulse.slnx --verify-no-changes
# → clean (exit 0)
```

## Files changed

* `src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs`
  — prose drop (Group A) + family enforcement helper + cross-family
  diagnostic (Group D).
* `tests/RetailPulse.Tests/Agents/Issue76ChartGuardsTests.cs` — new,
  fast-path + plan-path contract coverage for A and D.
* `tests/RetailPulse.Tests/Budget/ChartIntentToolCallCapTests.cs` —
  Group F: `ChartIntent_UsesDefaultCapOfFive_WithoutExplicitOverride`.
