### PR TITLE
fix(#145): plan-path state integrity - findings 1-4

### DIFF
--- a/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
+++ b/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
@@ -354,6 +354,12 @@ public sealed class PlanExecutor
         DateTimeOffset stepStart = DateTimeOffset.UtcNow;
         var sw = Stopwatch.StartNew();
 
+        // Cumulative index for consumer-visible reporting (span tags,
+        // PlanStepResult.StepIndex). Zero-shifted on the fast/initial path;
+        // shifted on the resume path so the emitted index matches the plan
+        // store's cumulative step keying (finding 1a, #145).
+        int reportedIndex = stepIndex + execution.StepIndexOffset;
+
         // Mid-plan clarification / replan signals — detected from a marker
         // prefix on the step's action so specialists don't need a new
         // interface. Both suspend the plan through the same durable
@@ -390,7 +396,7 @@ public sealed class PlanExecutor
             }, CancellationToken.None).ConfigureAwait(false);
 
             return new PlanStepResult(
-                stepIndex, stepId, planned.SpecialistKey, planned.Intent, planned.Action,
+                reportedIndex, stepId, planned.SpecialistKey, planned.Intent, planned.Action,
                 PlanStepStatus.Unusable, "", $"specialist '{planned.SpecialistKey}' not registered",
                 0, 0, 0, sw.ElapsedMilliseconds);
         }
@@ -509,12 +515,12 @@ public sealed class PlanExecutor
             _logger.LogWarning(ex, "Failed to record cost for plan {PlanId} step {StepIndex}.", execution.PlanId, stepIndex);
         }
 
-        EmitStepSpan(execution, stepIndex, stepId, planned, status, stepStart, sw, input, output);
+        EmitStepSpan(execution, reportedIndex, stepId, planned, status, stepStart, sw, input, output);
 
         // Forward the specialist's Charts verbatim (see PlanStepResult.Charts):
         // the plan-first path must not silently drop specialist charts.
         return new PlanStepResult(
-            stepIndex, stepId, planned.SpecialistKey, planned.Intent, planned.Action,
+            reportedIndex, stepId, planned.SpecialistKey, planned.Intent, planned.Action,
             status, response?.Reply ?? "", error, input, output, total, sw.ElapsedMilliseconds)
         {
             Charts = response?.Charts is { Count: > 0 } charts
@@ -600,6 +606,7 @@ public sealed class PlanExecutor
         Stopwatch sw,
         DateTimeOffset stepStart)
     {
+        int reportedIndex = stepIndex + execution.StepIndexOffset;
         string question = ExtractQuestion(planned.Action, ClarifyMarker);
 
         IReadOnlyList<PlanReviewStepDto> remaining =
@@ -642,7 +649,10 @@ public sealed class PlanExecutor
             Request = execution.Request,
             SpecialistKey = planned.SpecialistKey,
             Question = question,
-            PausedAtStepIndex = stepIndex,
+            PausedAtStepIndex = reportedIndex,
+            // Persist the paused step id so the resume path can transition
+            // that specific row out of Pending on answer (finding 1b, #145).
+            PausedStepId = stepId,
             RemainingSteps = remaining,
             SpecialistKeys = [.. execution.SpecialistLookup.Keys],
             CompletedSteps = completed,
@@ -665,12 +675,12 @@ public sealed class PlanExecutor
 
         _logger.LogInformation(
             "Plan {PlanId} step {StepIndex} suspended for clarification (requestId={RequestId}).",
-            execution.PlanId, stepIndex, handle.RequestId);
+            execution.PlanId, reportedIndex, handle.RequestId);
 
         // Return a non-Completed status so the workflow halts here — the
         // executor closure sees the status and yields terminal.
         return new PlanStepResult(
-            stepIndex, stepId, planned.SpecialistKey, planned.Intent, planned.Action,
+            reportedIndex, stepId, planned.SpecialistKey, planned.Intent, planned.Action,
             PlanStepStatus.Pending, "", null, 0, 0, 0, sw.ElapsedMilliseconds);
     }
 
@@ -684,6 +694,7 @@ public sealed class PlanExecutor
         Stopwatch sw,
         DateTimeOffset stepStart)
     {
+        int reportedIndex = stepIndex + execution.StepIndexOffset;
         string feedback = ExtractQuestion(planned.Action, ReplanMarker);
 
         IReadOnlyList<PlanReviewStepDto> remaining =
@@ -693,6 +704,27 @@ public sealed class PlanExecutor
                 SpecialistKey = s.SpecialistKey,
                 Intent = s.Intent,
                 Action = s.Action,
+            }),
+        ];
+
+        // Preserve the completed prefix (steps that ran before the [[REPLAN]]
+        // marker) across the reviewer round-trip. Without this the resume
+        // path silently drops those specialist replies and charts from the
+        // final broadcast even though they already succeeded (finding 2, #145).
+        IReadOnlyList<PlanReviewCompletedStep> completed =
+        [
+            .. message.AccumulatedResults.Select(r => new PlanReviewCompletedStep
+            {
+                StepIndex = r.StepIndex,
+                SpecialistKey = r.SpecialistKey,
+                Intent = r.Intent,
+                Action = r.Action,
+                Result = r.Result,
+                InputTokens = r.InputTokens,
+                OutputTokens = r.OutputTokens,
+                TotalTokens = r.TotalTokens,
+                DurationMs = r.DurationMs,
+                Charts = r.Charts is { Count: > 0 } charts ? [.. charts] : null,
             }),
         ];
 
@@ -710,6 +742,7 @@ public sealed class PlanExecutor
             TraceId = execution.TraceId,
             ParentSpanId = execution.ParentSpanId,
             PrincipalKey = execution.PrincipalKey,
+            CompletedSteps = completed,
         }, CancellationToken.None).ConfigureAwait(false);
 
         suspension.ReviewHandle = handle;
@@ -717,7 +750,7 @@ public sealed class PlanExecutor
         sw.Stop();
         _logger.LogInformation(
             "Plan {PlanId} step {StepIndex} suspended for mid-execution review (requestId={RequestId}).",
-            execution.PlanId, stepIndex, handle.RequestId);
+            execution.PlanId, reportedIndex, handle.RequestId);
 
         await _planStore.UpdateStepAsync(new PlanStepUpdate
         {
@@ -729,7 +762,7 @@ public sealed class PlanExecutor
         }, CancellationToken.None).ConfigureAwait(false);
 
         return new PlanStepResult(
-            stepIndex, stepId, planned.SpecialistKey, planned.Intent, planned.Action,
+            reportedIndex, stepId, planned.SpecialistKey, planned.Intent, planned.Action,
             PlanStepStatus.Pending, "", null, 0, 0, 0, sw.ElapsedMilliseconds);
     }
 
@@ -771,6 +804,18 @@ public sealed record PlanExecutionRequest
     public required PlanBuildResult Plan { get; init; }
     public required IReadOnlyList<string> StepIds { get; init; }
     public required IReadOnlyDictionary<string, ISpecialistAgent> SpecialistLookup { get; init; }
+
+    /// <summary>
+    /// Cumulative index of <see cref="Plan"/>'s step 0 within the ORIGINAL
+    /// plan. Zero on the fast path and on the initial-plan run. Set to the
+    /// count of already-completed prefix steps when the completion service
+    /// resumes execution after a clarification / mid-plan replan pause, so
+    /// telemetry (<c>plan.step_index</c> tags on emitted step spans and
+    /// <see cref="PlanStepResult.StepIndex"/>) reports the cumulative index
+    /// consumers can join back to persisted step rows — not the local
+    /// 0-based index of the post-pause slice (finding 1a, #145).
+    /// </summary>
+    public int StepIndexOffset { get; init; }
 }
 
 /// <summary>Terminal outcome returned to the chat endpoint.</summary>

--- a/src/RetailPulse.Api/Approval/PlanClarifier.cs
+++ b/src/RetailPulse.Api/Approval/PlanClarifier.cs
@@ -87,6 +87,7 @@ public sealed class PlanClarifier : IPlanClarifier
             ApprovalRequestId = string.Empty,
             CreatedAt = DateTimeOffset.UtcNow,
             PausedAtStepIndex = input.PausedAtStepIndex,
+            PausedStepId = input.PausedStepId,
             CompletedSteps = input.CompletedSteps,
         };
 
@@ -202,6 +203,14 @@ public sealed record PlanClarificationOpenInput
     public required string SpecialistKey { get; init; }
     public required string Question { get; init; }
     public required int PausedAtStepIndex { get; init; }
+    /// <summary>
+    /// Persisted step id (from <see cref="PlanExecutionRequest.StepIds"/>)
+    /// of the paused step. Threaded through the checkpoint so the resume
+    /// path can transition that specific row from Pending to Completed
+    /// once the reviewer answers (finding 1b, #145). Optional for
+    /// existing callers that don't yet supply it.
+    /// </summary>
+    public string? PausedStepId { get; init; }
     public required IReadOnlyList<PlanReviewStepDto> RemainingSteps { get; init; }
     public required IReadOnlyCollection<string> SpecialistKeys { get; init; }
     public IReadOnlyList<string> DetectedIntents { get; init; } = [];

--- a/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
@@ -378,7 +378,7 @@ public sealed class PlanReviewCompletionService
             {
                 await planStore.UpdateStepAsync(new PlanStepUpdate
                 {
-                    StepId = state.PausedStepId!,
+                    StepId = state.PausedStepId,
                     PlanId = plan.PlanId,
                     Subject = state.Subject,
                     Status = PlanStepStatus.Completed,

--- a/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
@@ -196,7 +196,13 @@ public sealed class PlanReviewCompletionService
                 return await ExecuteApprovedPlanAsync(
                     sp, planStore, plan, state,
                     continuation.ApprovedSteps ?? state.Steps,
-                    continuation.TerminalReason, ct);
+                    continuation.TerminalReason, ct,
+                    // Preserve the completed prefix produced before a mid-plan
+                    // [[REPLAN]] suspension (or a previous replan round). The
+                    // executor only runs the reviewer-approved remainder, so
+                    // ExecuteApprovedPlanAsync flattens this prefix's results
+                    // and charts into the final broadcast (finding 2, #145).
+                    resumeCompletedSteps: state.CompletedSteps);
 
             case PlanReviewContinuationKind.Terminal:
                 await FinaliseAsFailedAsync(planStore, plan, state.Subject,
@@ -254,6 +260,11 @@ public sealed class PlanReviewCompletionService
                         TraceId = state.TraceId,
                         ParentSpanId = state.ParentSpanId,
                         PrincipalKey = state.PrincipalKey,
+                        // Carry the completed prefix into the next round so a
+                        // multi-round replan chain never drops results that
+                        // succeeded before an earlier [[REPLAN]] suspension
+                        // (finding 2, #145).
+                        CompletedSteps = state.CompletedSteps,
                     }, ct);
 
                     // Broadcast that a new review round is waiting.
@@ -355,6 +366,34 @@ public sealed class PlanReviewCompletionService
             DurationMs = 0,
         });
 
+        // Transition the persisted step row that was paused mid-plan out of
+        // Pending. Without this, a subsequent GET /api/plans/{planId} keeps
+        // reporting an answered clarification as awaiting reviewer input,
+        // which breaks downstream reconciliation (finding 1b, #145). The
+        // update is best-effort: a store fault must not derail the resume
+        // path itself (the completion is finalized further down).
+        if (!string.IsNullOrWhiteSpace(state.PausedStepId))
+        {
+            try
+            {
+                await planStore.UpdateStepAsync(new PlanStepUpdate
+                {
+                    StepId = state.PausedStepId!,
+                    PlanId = plan.PlanId,
+                    Subject = state.Subject,
+                    Status = PlanStepStatus.Completed,
+                    Result = clarification.Answer ?? string.Empty,
+                    CompletedAt = DateTimeOffset.UtcNow,
+                }, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Could not transition paused step {StepId} to Completed on clarification resume for plan {PlanId}.",
+                    state.PausedStepId, plan.PlanId);
+            }
+        }
+
         IReadOnlyList<PlanReviewStepDto> remaining =
             [.. state.Steps.Skip(1)];
         return await ExecuteApprovedPlanAsync(
@@ -436,10 +475,64 @@ public sealed class PlanReviewCompletionService
             Plan = effectivePlan,
             StepIds = stepIds,
             SpecialistLookup = lookup,
+            // Cumulative offset so emitted span tags and PlanStepResult
+            // indices report the true step position (offset+i), not the
+            // local 0-based index into the post-resume slice (finding 1a, #145).
+            StepIndexOffset = offset,
         };
 
         PlanExecutor executor = sp.GetRequiredService<PlanExecutor>();
-        PlanExecutionOutcome outcome = await executor.ExecuteAsync(executionRequest, ct);
+        PlanExecutionOutcome outcome;
+        try
+        {
+            outcome = await executor.ExecuteAsync(executionRequest, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Genuine caller cancel — propagate. The caller's cancellation
+            // path takes responsibility for the plan record.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // The plan row was just claimed as Running above. If the executor
+            // (or its finally block, which writes the terminal status) throws
+            // and we return without settling the row, the plan strands in
+            // Running forever — the restart-recovery sweep only picks up
+            // Awaiting* rows (finding 3, #145). Finalize the row as Failed
+            // and broadcast a terminal reply so the reviewer surface stops
+            // waiting. Both writes are best-effort to survive a nested store
+            // fault.
+            _logger.LogError(ex,
+                "PlanExecutor.ExecuteAsync threw for plan {PlanId} after the Running claim; finalizing as Failed.",
+                plan.PlanId);
+            string reason = $"{PlanReviewTerminalReason.ReviewTimedOut}: executor faulted after resume ({ex.GetType().Name}: {ex.Message})";
+            try
+            {
+                await FinaliseAsFailedAsync(planStore, plan, state.Subject, reason, sp, ct);
+            }
+            catch (Exception nested)
+            {
+                _logger.LogError(nested,
+                    "Failed to persist Failed status for plan {PlanId} after executor fault; restart recovery must clean up.",
+                    plan.PlanId);
+            }
+            try
+            {
+                await BroadcastFinalAsync(sp, plan.PlanId, state.Subject, state.SessionId,
+                    BuildTerminalReply(PlanReviewTerminalReason.ReviewTimedOut),
+                    PlanReviewTerminalReason.ReviewTimedOut);
+            }
+            catch (Exception nested)
+            {
+                _logger.LogWarning(nested,
+                    "Failed to broadcast terminal reply for plan {PlanId} after executor fault.",
+                    plan.PlanId);
+            }
+            return PlanReviewCompletionResult.TerminatedWithoutExecution(
+                PlanReviewTerminalReason.ReviewTimedOut,
+                $"executor faulted after resume: {ex.Message}");
+        }
 
         // If the executor asks to pause for clarification / replan, hand off.
         if (outcome.Status == PlanStatus.AwaitingClarification

--- a/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs
@@ -163,6 +163,10 @@ public sealed class PlanReviewCoordinator
             ApprovalRequestId = string.Empty,
             CreatedAt = _timeProvider.GetUtcNow(),
             RevisionReason = input.RevisionReason,
+            // Preserve the completed prefix across the reviewer round-trip so
+            // ExecuteApprovedPlanAsync / a subsequent replan round can flatten
+            // it back into the final broadcast (finding 2, #145).
+            CompletedSteps = input.CompletedSteps,
         };
 
         CheckpointInfo checkpoint = await _checkpoints.SaveAsync(checkpointState, ct).ConfigureAwait(false);
@@ -564,6 +568,16 @@ public sealed record PlanReviewOpenInput
     public string? TraceId { get; init; }
     public string? ParentSpanId { get; init; }
     public string? PrincipalKey { get; init; }
+
+    /// <summary>
+    /// Steps that already completed before this review round was opened.
+    /// Populated when a mid-plan <c>[[REPLAN]]</c> suspension carries the
+    /// pre-marker prefix forward, and when a follow-up replan round needs to
+    /// preserve the same prefix across another reviewer round-trip. Without
+    /// this the completed prefix's specialist replies and charts are dropped
+    /// on the final broadcast (finding 2, #145).
+    /// </summary>
+    public IReadOnlyList<PlanReviewCompletedStep>? CompletedSteps { get; init; }
 }
 
 /// <summary>

--- a/src/RetailPulse.Api/Approval/PlanReviewRestartRecoveryService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewRestartRecoveryService.cs
@@ -73,8 +73,19 @@ public sealed class PlanReviewRestartRecoveryService : IHostedService
             {
                 PlanDetailDto? plan = await planStore.GetPlanAsync(subject, planId, cancellationToken);
                 if (plan is null) continue;
-                if (plan.Status is not (PlanStatus.AwaitingReview or PlanStatus.AwaitingClarification))
+                // Recover any plan that a decision row was recorded for and
+                // that has not yet reached a terminal state. Awaiting* is
+                // the normal case; Running is the stranded-crash case
+                // (finding 3, #145) — an earlier process's completion service
+                // claimed Running and died before writing a terminal status.
+                // The completion service is idempotent, so replaying it is
+                // safe.
+                if (plan.Status is not (PlanStatus.AwaitingReview
+                    or PlanStatus.AwaitingClarification
+                    or PlanStatus.Running))
+                {
                     continue;
+                }
 
                 PlanReviewCompletionResult result = await completion.ResolveAsync(planId, subject, cancellationToken);
                 _logger.LogInformation(

--- a/src/RetailPulse.Contracts/Approval/PlanReview.cs
+++ b/src/RetailPulse.Contracts/Approval/PlanReview.cs
@@ -127,6 +127,24 @@ public sealed record PlanReviewCheckpointState
 
     // Clarification-only fields, null on plain plan-review checkpoints.
     public int? PausedAtStepIndex { get; init; }
+
+    /// <summary>
+    /// Persisted step id (as materialised by the caller that wrote the initial
+    /// plan) of the paused step. Present on clarification checkpoints so the
+    /// resume path can transition that specific row out of
+    /// <c>Pending</c> and record the reviewer's answer on it. Without this
+    /// pointer the answered clarification's row keeps advertising itself as
+    /// pending indefinitely (finding 1b, #145).
+    /// </summary>
+    public string? PausedStepId { get; init; }
+
+    /// <summary>
+    /// Steps that already completed before the suspension. Populated on both
+    /// clarification checkpoints AND mid-plan review checkpoints so the
+    /// completed prefix survives across the reviewer round-trip: without it,
+    /// approving a mid-plan <c>[[REPLAN]]</c> silently drops the pre-marker
+    /// results and charts on the final reply (finding 2, #145).
+    /// </summary>
     public IReadOnlyList<PlanReviewCompletedStep>? CompletedSteps { get; init; }
 }
 

--- a/src/RetailPulse.Web/src/__tests__/planReducer.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/planReducer.test.ts
@@ -285,6 +285,77 @@ describe('planReducer', () => {
     expect(rejected.active?.status).toBe('awaiting_review');
   });
 
+  it('late REVIEW_RESOLVED after PLAN_FINAL preserves terminal status (issue #145 finding 4)', () => {
+    // Simulate a plan-final broadcast arriving BEFORE the HTTP POST /decision
+    // response resolves — the reducer's REVIEW_RESOLVED action must not
+    // regress a plan that already carries `finalReply` back to `running`
+    // (approve/edit) or `awaiting_review` (reject).
+    const seed = planReducer(
+      planReducer(initialPlanState, { type: 'PLAN_STARTED', planId: 'p1', request: 'q' }),
+      {
+        type: 'REVIEW_REQUESTED',
+        planId: 'p1',
+        requestId: 'req-1',
+        round: 0,
+        proposal: null,
+      },
+    );
+    const terminated = planReducer(seed, {
+      type: 'PLAN_FINAL',
+      planId: 'p1',
+      reply: 'plan already finished',
+      terminalReason: null,
+    });
+    expect(terminated.active?.status).toBe('completed');
+    expect(terminated.active?.finalReply).toBe('plan already finished');
+    const lateApprove = planReducer(terminated, {
+      type: 'REVIEW_RESOLVED',
+      planId: 'p1',
+      requestId: 'req-1',
+      kind: 'approve',
+    });
+    expect(lateApprove.active?.status).toBe('completed');
+    expect(lateApprove.active?.finalReply).toBe('plan already finished');
+    expect(lateApprove.active?.review?.resolvedKind).toBe('approve');
+    expect(lateApprove.active?.review?.decisionInFlight).toBeUndefined();
+    const lateReject = planReducer(terminated, {
+      type: 'REVIEW_RESOLVED',
+      planId: 'p1',
+      requestId: 'req-1',
+      kind: 'reject',
+    });
+    expect(lateReject.active?.status).toBe('completed');
+  });
+
+  it('late REVIEW_RESOLVED after PLAN_FINAL with failed reason keeps failed status (issue #145 finding 4)', () => {
+    const seed = planReducer(
+      planReducer(initialPlanState, { type: 'PLAN_STARTED', planId: 'p1', request: 'q' }),
+      {
+        type: 'REVIEW_REQUESTED',
+        planId: 'p1',
+        requestId: 'req-1',
+        round: 0,
+        proposal: null,
+      },
+    );
+    const failed = planReducer(seed, {
+      type: 'PLAN_FINAL',
+      planId: 'p1',
+      reply: 'replan exhausted',
+      terminalReason: 'PlanReviewReplanExhausted',
+    });
+    expect(failed.active?.status).toBe('failed');
+    const lateEdit = planReducer(failed, {
+      type: 'REVIEW_RESOLVED',
+      planId: 'p1',
+      requestId: 'req-1',
+      kind: 'edit',
+    });
+    expect(lateEdit.active?.status).toBe('failed');
+    expect(lateEdit.active?.finalReply).toBe('replan exhausted');
+    expect(lateEdit.active?.review?.resolvedKind).toBe('edit');
+  });
+
   it('opens a clarification round with a parsed prompt', () => {
     const prompt: PlanClarificationPrompt = {
       planId: 'p1',

--- a/src/RetailPulse.Web/src/state/planReducer.ts
+++ b/src/RetailPulse.Web/src/state/planReducer.ts
@@ -391,6 +391,36 @@ export function planReducer(state: PlanAppState, action: PlanAction): PlanAppSta
       if (!state.active || state.active.planId !== action.planId) return state;
       const review = state.active.review;
       if (!review || review.requestId !== action.requestId) return state;
+      // Guard against a late HTTP decision response landing after the plan
+      // already went terminal via plan_final_response (issue #145 finding 4).
+      // If the plan is already carrying a final reply OR sits in a terminal
+      // status, we must preserve the terminal snapshot and only reconcile
+      // the review handle (clear decisionInFlight, record resolvedKind).
+      // Reverting to `running`/`awaiting_review` here would regress a
+      // completed / failed / cancelled / unusable plan back into a
+      // non-terminal state and break PlanView's terminal rendering.
+      const terminalStatuses: readonly PlanStatus[] = [
+        'completed',
+        'failed',
+        'cancelled',
+        'unusable',
+      ];
+      const alreadyTerminal =
+        state.active.finalReply !== undefined
+        || terminalStatuses.includes(state.active.status);
+      if (alreadyTerminal) {
+        return {
+          ...state,
+          active: {
+            ...state.active,
+            review: {
+              ...review,
+              decisionInFlight: undefined,
+              resolvedKind: action.kind,
+            },
+          },
+        };
+      }
       // Approved & edited move the plan back to running (executor resumes);
       // rejected keeps it in awaiting_review until the next round arrives.
       const nextStatus: PlanStatus =

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
@@ -524,6 +524,41 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
         public Task<bool> DeletePlanAsync(string subject, string planId, CancellationToken ct = default) => Task.FromResult(true);
         public Task<PlanCleanupResult> PurgeExpiredAsync(DateTimeOffset olderThan, CancellationToken ct = default)
             => Task.FromResult(new PlanCleanupResult(0, 0));
+
+        /// <summary>
+        /// Test-only accessor exposing the last recorded step transition for a
+        /// given plan/step id. Returns <see langword="null"/> when the plan or
+        /// step id has never been touched. Used by state-integrity regression
+        /// tests to prove that resume paths update in-flight step rows out of
+        /// their <c>Pending</c> holding state instead of leaving them stranded.
+        /// </summary>
+        internal PlanStepUpdate? GetLastStepUpdate(string subject, string planId, string stepId)
+        {
+            if (_bySub.TryGetValue(subject, out var bucket)
+                && bucket.TryGetValue(planId, out var row)
+                && row.Steps.TryGetValue(stepId, out var step))
+            {
+                return step;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Test-only accessor exposing the last plan-level status update.
+        /// Returns <see langword="null"/> when the plan was created but never
+        /// transitioned. Used by state-integrity regression tests to prove
+        /// that plans never strand in <c>Running</c> after the resume path
+        /// takes ownership.
+        /// </summary>
+        internal PlanStatusUpdate? GetLastStatusUpdate(string subject, string planId)
+        {
+            if (_bySub.TryGetValue(subject, out var bucket)
+                && bucket.TryGetValue(planId, out var row))
+            {
+                return row.Status;
+            }
+            return null;
+        }
     }
 
     private sealed class NoOpTraceCollector : ITraceCollector

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
@@ -534,13 +534,11 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
         /// </summary>
         internal PlanStepUpdate? GetLastStepUpdate(string subject, string planId, string stepId)
         {
-            if (_bySub.TryGetValue(subject, out var bucket)
-                && bucket.TryGetValue(planId, out var row)
-                && row.Steps.TryGetValue(stepId, out var step))
-            {
-                return step;
-            }
-            return null;
+            return _bySub.TryGetValue(subject, out Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>? bucket)
+                && bucket.TryGetValue(planId, out (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps) row)
+                && row.Steps.TryGetValue(stepId, out PlanStepUpdate? step)
+                ? step
+                : null;
         }
 
         /// <summary>
@@ -552,12 +550,10 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
         /// </summary>
         internal PlanStatusUpdate? GetLastStatusUpdate(string subject, string planId)
         {
-            if (_bySub.TryGetValue(subject, out var bucket)
-                && bucket.TryGetValue(planId, out var row))
-            {
-                return row.Status;
-            }
-            return null;
+            return _bySub.TryGetValue(subject, out Dictionary<string, (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps)>? bucket)
+                && bucket.TryGetValue(planId, out (PlanWrite Create, PlanStatusUpdate? Status, Dictionary<string, PlanStepUpdate> Steps) row)
+                ? row.Status
+                : null;
         }
     }
 

--- a/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
@@ -107,12 +107,14 @@ public sealed class PlanStateIntegrityTests : IDisposable
         PlanReviewCompletionResult clarResume = await completion.ResolveAsync(suspend.PlanId, "user-1");
         clarResume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
 
-        // The paused step was persisted under the initial-plan naming scheme
-        // (`{planId}-s{index}`) with Status = Pending at suspension time.
-        // After the answer resumes execution, that same row must transition
-        // to Completed so plan-detail reads don't advertise an answered
-        // clarification as still pending.
-        string pausedStepId = $"{suspend.PlanId}-s1";
+        // Plan-review + clarification double-suspends materialize step rows
+        // under the review-round naming scheme `{planId}-r{round}-s{index}`
+        // (see PlanReviewCompletionService.ExecuteApprovedPlanAsync). The
+        // executor's SuspendForClarificationAsync then writes the paused row
+        // under that same id with Status = Pending. On answer resume it MUST
+        // transition to Completed so plan-detail reads don't advertise an
+        // answered clarification as still pending.
+        string pausedStepId = $"{suspend.PlanId}-r0-s1";
         PlanStepUpdate? pausedUpdate = plans.GetLastStepUpdate("user-1", suspend.PlanId, pausedStepId);
         pausedUpdate.Should().NotBeNull(
             "the paused clarification step's row must exist under the initial-plan step id.");
@@ -581,10 +583,15 @@ public sealed class PlanStateIntegrityTests : IDisposable
 
         public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default)
         {
+            // Simulate the specific fault that surfaces finding 3: the
+            // executor's finally block writes the derived terminal status
+            // (Completed on the happy path) and the store rejects it, so the
+            // executor throws out of ExecuteAsync while the plan record is
+            // still Running. The completion service's own recovery write
+            // (Failed) must be allowed through — that's the whole point of
+            // the fix: contain the fault and finalize the row anyway.
             if (ExplodeOnTerminalTransitions
-                && !string.Equals(update.Status, PlanStatus.Running, StringComparison.Ordinal)
-                && !string.Equals(update.Status, PlanStatus.AwaitingReview, StringComparison.Ordinal)
-                && !string.Equals(update.Status, PlanStatus.AwaitingClarification, StringComparison.Ordinal))
+                && string.Equals(update.Status, PlanStatus.Completed, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
                     $"simulated transient failure writing plan status '{update.Status}' for {update.PlanId}");

--- a/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
@@ -1,0 +1,706 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using RetailPulse.Api.Agents.Planning;
+using RetailPulse.Api.Approval;
+using RetailPulse.Api.Configuration;
+using RetailPulse.Api.Guardrails;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Api.Middleware;
+using RetailPulse.Api.Observability;
+using RetailPulse.Api.Persistence;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Approval;
+using RetailPulse.Contracts.Guardrails;
+using RetailPulse.Contracts.Observability;
+using RetailPulse.Contracts.Persistence;
+using RetailPulse.Contracts.Routing;
+using RetailPulse.Contracts.Tracing;
+using RetailPulse.Tests.Fixtures;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
+
+namespace RetailPulse.Tests.Approval;
+
+/// <summary>
+/// Regression coverage for issue #145 — the plan-path state-integrity findings
+/// that the PR #144 review identified against <c>main</c>. Each test is
+/// designed to fail on the pre-fix code so a future regression is caught
+/// deterministically; the assertions are worded to explain the underlying
+/// finding.
+/// </summary>
+public sealed class PlanStateIntegrityTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly string _checkpointDir;
+
+    public PlanStateIntegrityTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"prv_state_{Guid.NewGuid():N}.db");
+        _checkpointDir = Path.Combine(Path.GetTempPath(), $"prv_state_ckpt_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_checkpointDir);
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_dbPath); } catch { }
+        try { File.Delete(_dbPath + "-wal"); } catch { }
+        try { File.Delete(_dbPath + "-shm"); } catch { }
+        try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
+    }
+
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    // ── Finding 1: clarification resume + persisted row lifecycle ────────
+
+    /// <summary>
+    /// Reproduces finding 1(b): the paused step's row is written as
+    /// <see cref="PlanStepStatus.Pending"/> at suspension time but never
+    /// transitioned to <see cref="PlanStepStatus.Completed"/> once the
+    /// reviewer's answer replaces its transcript on resume. Without the fix
+    /// the plan row settles honestly but individual step history reads still
+    /// advertise an answered clarification as pending, which is dishonest
+    /// and breaks downstream reconciliation.
+    /// </summary>
+    [Fact]
+    public async Task Clarification_resume_transitions_paused_step_row_out_of_pending()
+    {
+        (ServiceProvider sp, PlanOrchestrator orch,
+            PlanReviewCompletionServiceTests.InMemoryPlanStore plans,
+            SqliteApprovalGate gate, _) =
+            BuildHost(plannerJson: PlannerJsonClarifyAtStepOne());
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        // Approve the initial plan → executor runs step 0, hits [[CLARIFY]] at step 1.
+        ApprovalRequest reviewRow = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.PlanId == suspend.PlanId
+                      && r.Context.Kind == ApprovalKind.PlanReview);
+        await gate.RespondAsync(reviewRow.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult reviewResume = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        reviewResume.Kind.Should().Be(PlanReviewCompletionKind.SuspendedForClarification);
+
+        // Reviewer answers → resume drives execution across the pause.
+        ApprovalRequest clarRow = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.Kind == ApprovalKind.Clarification
+                      && r.Context.PlanId == suspend.PlanId);
+        await gate.RespondAsync(clarRow.RequestId, ApprovalDecision.Approved, "ans",
+            JsonSerializer.Serialize(new PlanClarificationAnswer { Answer = "REVIEWER_ANSWER" }, _json));
+
+        PlanReviewCompletionResult clarResume = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        clarResume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+
+        // The paused step was persisted under the initial-plan naming scheme
+        // (`{planId}-s{index}`) with Status = Pending at suspension time.
+        // After the answer resumes execution, that same row must transition
+        // to Completed so plan-detail reads don't advertise an answered
+        // clarification as still pending.
+        string pausedStepId = $"{suspend.PlanId}-s1";
+        PlanStepUpdate? pausedUpdate = plans.GetLastStepUpdate("user-1", suspend.PlanId, pausedStepId);
+        pausedUpdate.Should().NotBeNull(
+            "the paused clarification step's row must exist under the initial-plan step id.");
+        pausedUpdate!.Status.Should().Be(PlanStepStatus.Completed,
+            "an answered clarification MUST transition its persisted row out of Pending — otherwise " +
+            "plan-detail reads keep reporting the answered step as awaiting reviewer input (finding 1b).");
+        pausedUpdate.Result.Should().Contain("REVIEWER_ANSWER",
+            "the reviewer's answer should live on the same step row that was paused, not only inside a " +
+            "transient in-memory transcript on the resume path.");
+
+        await sp.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Reproduces finding 1(a): on a clarification resume, the executor's
+    /// emitted <c>plan.step_index</c> tag is the local 0-based index into
+    /// the remaining slice, while the persisted step id is cumulative
+    /// (offset + i). Consumers keying on the tag see step 0 for what the
+    /// store keys as step 2 and can no longer join telemetry against
+    /// persisted records.
+    /// </summary>
+    [Fact]
+    public async Task Clarification_resume_step_span_index_matches_cumulative_persisted_index()
+    {
+        var traces = new RecordingTraceCollector();
+        (ServiceProvider sp, PlanOrchestrator orch,
+            PlanReviewCompletionServiceTests.InMemoryPlanStore _,
+            SqliteApprovalGate gate, _) =
+            BuildHost(plannerJson: PlannerJsonClarifyAtStepOne(), tracer: traces);
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        ApprovalRequest reviewRow = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.Kind == ApprovalKind.PlanReview
+                      && r.Context.PlanId == suspend.PlanId);
+        await gate.RespondAsync(reviewRow.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        _ = await completion.ResolveAsync(suspend.PlanId, "user-1");
+
+        ApprovalRequest clarRow = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.Kind == ApprovalKind.Clarification
+                      && r.Context.PlanId == suspend.PlanId);
+        await gate.RespondAsync(clarRow.RequestId, ApprovalDecision.Approved, "ans",
+            JsonSerializer.Serialize(new PlanClarificationAnswer { Answer = "REVIEWER_ANSWER" }, _json));
+
+        traces.Spans.Clear();
+        _ = await completion.ResolveAsync(suspend.PlanId, "user-1");
+
+        // The clarification is at step index 1; the demand-forecasting step
+        // that runs on resume is the original plan's step 2, so its emitted
+        // span index must report 2 — not 0 (the local 0-based index of the
+        // post-pause slice).
+        TraceSpan[] resumeSteps = [.. traces.Spans
+            .Where(s => s.Tags is { } tags
+                     && tags.TryGetValue("span.type", out string? t)
+                     && string.Equals(t, "plan_step", StringComparison.Ordinal))];
+        resumeSteps.Should().NotBeEmpty(
+            "the resume executor must emit a plan_step span for the specialist that runs after the pause.");
+        TraceSpan resumeStep = resumeSteps.Single(s => s.Tags!["plan.step_specialist"] == "demand-forecasting");
+        resumeStep.Tags!["plan.step_index"].Should().Be("2",
+            "the emitted step index must be the cumulative index the plan store keys on, not the local " +
+            "0-based index of the post-pause slice — otherwise span consumers cannot join telemetry to " +
+            "persisted step rows (finding 1a).");
+
+        await sp.DisposeAsync();
+    }
+
+    // ── Finding 2: mid-plan [[REPLAN]] preserves the completed prefix ────
+
+    /// <summary>
+    /// Reproduces finding 2: a mid-plan <c>[[REPLAN]]</c> marker suspends
+    /// the plan without carrying the results of steps that already completed
+    /// before the marker. On the reviewer's approval of the replanned round,
+    /// the resume path silently drops the completed prefix — its reply text
+    /// and its charts. This is the highest-severity finding because it
+    /// deletes user-visible data (specialist replies and chart specs) after
+    /// the plan already succeeded on those steps.
+    /// </summary>
+    [Fact]
+    public async Task Replan_marker_preserves_completed_prefix_results_and_charts_across_resume()
+    {
+        ChartSpec chartA = MakeChart("bar", "scorecard-A");
+        (ServiceProvider sp, PlanOrchestrator orch,
+            PlanReviewCompletionServiceTests.InMemoryPlanStore _,
+            SqliteApprovalGate gate, CapturingHub hub) =
+            BuildHost(plannerJson: PlannerJsonReplanAtStepOne(),
+                specialistChartsByKey: new Dictionary<string, IReadOnlyList<ChartSpec>?>(
+                    StringComparer.OrdinalIgnoreCase)
+                {
+                    ["scorecard"] = [chartA],
+                    ["demand-forecasting"] = null,
+                },
+                specialistReplyByKey: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["scorecard"] = "SCORECARD_PREFIX_RESULT",
+                    ["demand-forecasting"] = "DEMAND_REPLAN_RESULT",
+                });
+
+        // Approve the initial plan so the executor runs step 0 (scorecard,
+        // completes with chartA + prefix result) and then hits [[REPLAN]] at
+        // step 1. SuspendForMidPlanReviewAsync opens a new plan-review row
+        // that lists the post-replan step (demand-forecasting).
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        ApprovalRequest firstReview = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.PlanId == suspend.PlanId
+                      && r.Context.Kind == ApprovalKind.PlanReview);
+        await gate.RespondAsync(firstReview.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+        PlanReviewCompletionResult replanResume = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        replanResume.Kind.Should().Be(PlanReviewCompletionKind.SuspendedForNextRound,
+            "the [[REPLAN]] marker must open a new plan-review row for the replanned round.");
+
+        // Approve the replanned round → the resume runs demand-forecasting.
+        ApprovalRequest replanReview = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.PlanId == suspend.PlanId
+                      && r.Context.Kind == ApprovalKind.PlanReview
+                      && r.RequestId != firstReview.RequestId);
+        await gate.RespondAsync(replanReview.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionResult final = await completion.ResolveAsync(suspend.PlanId, "user-1");
+        final.Kind.Should().Be(PlanReviewCompletionKind.Executed);
+
+        // The pre-replan specialist's result and its chart must survive the
+        // review round-trip. Otherwise the reviewer sees only the
+        // post-replan step's output on the final broadcast — the completed
+        // prefix silently vanishes.
+        final.Reply.Should().Contain("SCORECARD_PREFIX_RESULT",
+            "the completed prefix (steps before [[REPLAN]]) must be preserved in the resumed final reply " +
+            "— dropping it deletes user-visible specialist output that already succeeded (finding 2).");
+        final.Reply.Should().Contain("DEMAND_REPLAN_RESULT",
+            "the post-replan step's result must also be included alongside the preserved prefix.");
+        final.Charts.Should().Contain(c => c.Type == "bar",
+            "charts emitted by pre-[[REPLAN]] steps must NOT be discarded when the reviewer approves the " +
+            "replanned plan — the fast path preserves them and the resume path must too (finding 2).");
+
+        IReadOnlyList<ChartSpec>? broadcastCharts = ExtractCharts(hub.LastFinalPayload);
+        broadcastCharts.Should().NotBeNull(
+            "the final SignalR broadcast must include the surviving prefix charts.");
+        broadcastCharts.Should().Contain(c => c.Type == "bar");
+
+        await sp.DisposeAsync();
+    }
+
+    // ── Finding 3: executor faults after Running claim never strand plan ─
+
+    /// <summary>
+    /// Reproduces finding 3: after the completion service transitions a
+    /// plan from <see cref="PlanStatus.AwaitingReview"/> to
+    /// <see cref="PlanStatus.Running"/> and then the executor fails (or the
+    /// process crashes) before its own finalizer records a terminal status,
+    /// the plan is stranded in <c>Running</c> forever. The restart-recovery
+    /// service only scans <c>Awaiting*</c> plans, so stranded rows never
+    /// self-heal. The fix must guarantee that any exception raised inside
+    /// the executor path is captured and the plan row transitions to a
+    /// terminal state rather than remaining <c>Running</c>.
+    /// </summary>
+    [Fact]
+    public async Task Executor_failure_after_Running_transition_does_not_strand_plan_in_Running()
+    {
+        // Store that succeeds on the initial CreatePlanAsync + the
+        // "AwaitingReview → Running" flip but throws on ANY subsequent
+        // plan-status update — i.e. the exact transition the executor's
+        // finally block writes. Simulates a transient DB fault between the
+        // Running claim and the terminal write.
+        var plans = new ExplodingPlanStore();
+
+        (ServiceProvider sp, PlanOrchestrator orch, SqliteApprovalGate gate, _) =
+            BuildHostWithStore(plans);
+
+        PlanOrchestrationResult suspend = await orch.RunAsync(SampleInput(), default);
+        suspend.IsSuspended.Should().BeTrue();
+
+        ApprovalRequest row = (await gate.GetPendingAsync("user-1"))
+            .Single(r => r.Context.PlanId == suspend.PlanId
+                      && r.Context.Kind == ApprovalKind.PlanReview);
+        await gate.RespondAsync(row.RequestId, ApprovalDecision.Approved, "go",
+            JsonSerializer.Serialize(new PlanReviewResponsePayload
+            {
+                Kind = PlanReviewKinds.Approve,
+            }, _json));
+
+        PlanReviewCompletionService completion = sp.GetRequiredService<PlanReviewCompletionService>();
+
+        // The executor will throw during its finalize write. The completion
+        // service must catch that and settle the plan row into a terminal
+        // state — either Failed or another terminal — instead of leaving it
+        // stranded in Running. It MUST NOT rethrow to callers, because the
+        // decision endpoint dispatches this fire-and-forget.
+        plans.ExplodeOnTerminalTransitions = true;
+        Func<Task> act = async () => await completion.ResolveAsync(suspend.PlanId, "user-1");
+        await act.Should().NotThrowAsync(
+            "the endpoint dispatches ResolveAsync fire-and-forget; the completion service must contain " +
+            "the fault and finalize the plan row itself, otherwise stranded Running plans never recover.");
+
+        plans.LastStatusFor(suspend.PlanId, "user-1")
+            .Should().NotBe(PlanStatus.Running,
+                "a plan MUST NOT remain in Running after the resume path takes ownership: if the executor " +
+                "faults, the completion service must finalize the row so the restart-recovery service's " +
+                "Awaiting-only sweep isn't the sole hope of recovery (finding 3).");
+
+        await sp.DisposeAsync();
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────
+
+    private static ChartSpec MakeChart(string type, string title) => new()
+    {
+        Type = type,
+        Title = title,
+        Data =
+        [
+            new ChartSeries
+            {
+                Legend = "series-a",
+                Values = [new ChartDataPoint { X = "Q1", Y = 1 }],
+            },
+        ],
+    };
+
+    private static IReadOnlyList<ChartSpec>? ExtractCharts(object? payload)
+    {
+        if (payload is null) return null;
+        Type t = payload.GetType();
+        System.Reflection.PropertyInfo? prop = t.GetProperty("charts")
+            ?? t.GetProperty("Charts");
+        return prop is null ? null : prop.GetValue(payload) as IReadOnlyList<ChartSpec>;
+    }
+
+    private (ServiceProvider Sp, PlanOrchestrator Orchestrator,
+        PlanReviewCompletionServiceTests.InMemoryPlanStore PlanStore,
+        SqliteApprovalGate Gate, CapturingHub Hub)
+        BuildHost(
+            string? plannerJson = null,
+            IReadOnlyDictionary<string, IReadOnlyList<ChartSpec>?>? specialistChartsByKey = null,
+            IReadOnlyDictionary<string, string>? specialistReplyByKey = null,
+            RecordingTraceCollector? tracer = null)
+    {
+        var plans = new PlanReviewCompletionServiceTests.InMemoryPlanStore();
+        ServiceProvider sp = BuildServices(plans, plannerJson, specialistChartsByKey,
+            specialistReplyByKey, tracer, out CapturingHub hub);
+        return (sp,
+            sp.GetRequiredService<PlanOrchestrator>(),
+            plans,
+            sp.GetRequiredService<SqliteApprovalGate>(),
+            hub);
+    }
+
+    private (ServiceProvider Sp, PlanOrchestrator Orchestrator, SqliteApprovalGate Gate, CapturingHub Hub)
+        BuildHostWithStore(IPlanStore store)
+    {
+        ServiceProvider sp = BuildServices(store, plannerJson: null,
+            specialistChartsByKey: null, specialistReplyByKey: null,
+            tracer: null, out CapturingHub hub);
+        return (sp,
+            sp.GetRequiredService<PlanOrchestrator>(),
+            sp.GetRequiredService<SqliteApprovalGate>(),
+            hub);
+    }
+
+    private ServiceProvider BuildServices(
+        IPlanStore planStore,
+        string? plannerJson,
+        IReadOnlyDictionary<string, IReadOnlyList<ChartSpec>?>? specialistChartsByKey,
+        IReadOnlyDictionary<string, string>? specialistReplyByKey,
+        RecordingTraceCollector? tracer,
+        out CapturingHub hub)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton(TimeProvider.System);
+
+        SqliteApprovalGate gate = new(_dbPath, NullLogger<SqliteApprovalGate>.Instance,
+            TimeSpan.FromMinutes(30), TimeProvider.System);
+        services.AddSingleton(gate);
+        services.AddSingleton<IApprovalGate>(sp => sp.GetRequiredService<SqliteApprovalGate>());
+
+        services.AddSingleton<ICheckpointStore<JsonElement>>(_ =>
+            new FileSystemJsonCheckpointStore(new DirectoryInfo(_checkpointDir)));
+        services.AddSingleton(sp =>
+        {
+            ICheckpointStore<JsonElement> store = sp.GetRequiredService<ICheckpointStore<JsonElement>>();
+            return Microsoft.Agents.AI.Workflows.CheckpointManager.CreateJson(store, customOptions: null);
+        });
+        services.AddSingleton<PlanReviewCheckpointService>();
+
+        var options = new PlanReviewOptions
+        {
+            Enabled = true,
+            DefaultReviewTimeout = TimeSpan.FromSeconds(30),
+            ClarificationTimeout = TimeSpan.FromSeconds(30),
+            MaxReplanRounds = 1,
+        };
+        services.AddSingleton(Options.Create(options));
+
+        services.AddSingleton<PlanClarifier>();
+        services.AddSingleton<IPlanClarifier>(sp => sp.GetRequiredService<PlanClarifier>());
+        services.AddSingleton<PlanReviewCoordinator>();
+
+        services.AddSingleton(planStore);
+
+        IReadOnlyList<ChartSpec>? scorecardCharts = specialistChartsByKey?.GetValueOrDefault("scorecard");
+        IReadOnlyList<ChartSpec>? demandCharts = specialistChartsByKey?.GetValueOrDefault("demand-forecasting");
+        string scorecardReply = specialistReplyByKey?.GetValueOrDefault("scorecard") ?? "score-reply";
+        string demandReply = specialistReplyByKey?.GetValueOrDefault("demand-forecasting") ?? "demand-reply";
+        ISpecialistAgent scorecard = MakeSpecialist("scorecard", scorecardReply, scorecardCharts);
+        ISpecialistAgent demand = MakeSpecialist("demand-forecasting", demandReply, demandCharts);
+        services.AddSingleton(scorecard);
+        services.AddSingleton(demand);
+
+        var persistOpts = new PlanPersistenceOptions();
+        services.AddSingleton(persistOpts);
+        services.AddSingleton(new Api.Models.AgentDefinition
+        {
+            Key = "planner",
+            Name = "Plan-First Orchestrator",
+            Model = "gpt-test",
+            SystemPrompt = "You are the planner.",
+            Temperature = 0.1,
+        });
+        services.AddSingleton(sp => new PlanBuilder(
+            AgentTestFixtures.CreateMockChatClient(plannerJson ?? DefaultPlannerJson()),
+            sp.GetRequiredService<Api.Models.AgentDefinition>(),
+            persistOpts,
+            NullLogger<PlanBuilder>.Instance));
+
+        services.AddSingleton<ICostTracker>(new NoOpCostTracker());
+        ITraceCollector traceCollector = tracer ?? (ITraceCollector)new NoOpTraceCollector();
+        services.AddSingleton(traceCollector);
+        services.AddSingleton(sp => new PlanExecutor(
+            sp.GetRequiredService<IPlanStore>(),
+            sp.GetRequiredService<ICostTracker>(),
+            sp.GetRequiredService<ITraceCollector>(),
+            sp.GetRequiredService<PlanPersistenceOptions>(),
+            NullLogger<PlanExecutor>.Instance,
+            sp.GetService<PlanClarifier>(),
+            sp.GetService<PlanReviewCoordinator>()));
+
+        services.AddSingleton(sp => new PlanOrchestrator(
+            sp.GetRequiredService<PlanBuilder>(),
+            sp.GetRequiredService<PlanExecutor>(),
+            sp.GetRequiredService<IPlanStore>(),
+            sp.GetRequiredService<ICostTracker>(),
+            persistOpts,
+            NullLogger<PlanOrchestrator>.Instance,
+            sp.GetService<PlanReviewCoordinator>(),
+            Options.Create(options)));
+
+        services.AddSingleton(new GuardrailsConfig
+        {
+            PiiDetectionEnabled = false,
+            AutoRedactPii = false,
+            ContentSafety = new ContentSafetyConfig { Enabled = false },
+        });
+        services.AddSingleton<ISuspiciousRequestLog, InMemorySuspiciousRequestLog>();
+        services.AddSingleton<ITenantProvider>(new StubTenantProvider());
+        services.AddSingleton<GuardrailsMiddleware>();
+        services.AddSingleton<IAuditLog, InMemoryAuditLog>();
+        services.AddSingleton(_ => new ConversationExporter(
+            Options.Create(new ObservabilityOptions())));
+
+        var capturingHub = new CapturingHub();
+        services.AddSingleton<IHubContext<TelemetryHub>>(capturingHub);
+        hub = capturingHub;
+
+        services.AddSingleton<PlanReviewCompletionService>();
+
+        return services.BuildServiceProvider();
+    }
+
+    private static PlanOrchestrationInput SampleInput()
+    {
+        ISpecialistAgent scorecard = MakeSpecialist("scorecard", "", null);
+        ISpecialistAgent demand = MakeSpecialist("demand-forecasting", "", null);
+        return new PlanOrchestrationInput
+        {
+            Request = new ChatRequest("multi", SessionId: "s"),
+            Subject = "user-1",
+            PrincipalKey = "user-1",
+            TenantId = "Contoso",
+            Roster = [scorecard, demand],
+            SpecialistLookup = new Dictionary<string, ISpecialistAgent>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["scorecard"] = scorecard,
+                ["demand-forecasting"] = demand,
+            },
+            DetectedIntents = ["scorecard", "demand"],
+            TraceId = "t",
+        };
+    }
+
+    private static string DefaultPlannerJson() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""ORIGINAL_ACTION"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""ORIGINAL_DEMAND_ACTION"" }
+    ] }";
+
+    // step 0 = scorecard, step 1 = clarify (paused), step 2 = demand-forecasting.
+    private static string PlannerJsonClarifyAtStepOne() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""step-0"" },
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""[[CLARIFY]] Which region?"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""step-2"" }
+    ] }";
+
+    // step 0 = scorecard (completes with chart + prefix result),
+    // step 1 = [[REPLAN]] scorecard step (suspends the plan mid-execution),
+    // step 2 = demand-forecasting (the post-[[REPLAN]] step the reviewer approves next).
+    private static string PlannerJsonReplanAtStepOne() => /*lang=json,strict*/ @"{ ""steps"": [
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""prefix-step"" },
+        { ""specialist_key"": ""scorecard"", ""intent"": ""scorecard"", ""action"": ""[[REPLAN]] scope too broad"" },
+        { ""specialist_key"": ""demand-forecasting"", ""intent"": ""demand"", ""action"": ""post-replan-step"" }
+    ] }";
+
+    private static ISpecialistAgent MakeSpecialist(
+        string key, string reply, IReadOnlyList<ChartSpec>? charts)
+    {
+        var m = new Mock<ISpecialistAgent>();
+        m.SetupGet(a => a.Key).Returns(key);
+        m.SetupGet(a => a.DisplayName).Returns(key);
+        m.SetupGet(a => a.Model).Returns("gpt-test");
+        m.SetupGet(a => a.SupportedIntents).Returns([key]);
+        m.Setup(a => a.HandleAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()))
+            .Returns((ChatRequest req, CancellationToken _) =>
+            {
+                List<ChartSpec>? chartList = charts is null ? null : [.. charts];
+                return Task.FromResult(new ChatResponse(
+                    string.IsNullOrEmpty(reply) ? $"{key}-reply" : reply,
+                    req.SessionId ?? "s", [], chartList, 10, new TokenUsage(1, 1, 2)));
+            });
+        return m.Object;
+    }
+
+    // ── Support doubles ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Plan store fixture for finding 3. Behaves as
+    /// <see cref="PlanReviewCompletionServiceTests.InMemoryPlanStore"/> until
+    /// <see cref="ExplodeOnTerminalTransitions"/> is flipped, after which any
+    /// non-<see cref="PlanStatus.Running"/> / non-Awaiting plan-status update
+    /// throws. Models a transient store fault between the
+    /// "AwaitingReview → Running" claim and the terminal write that the
+    /// executor's finally block issues.
+    /// </summary>
+    private sealed class ExplodingPlanStore : IPlanStore
+    {
+        private readonly PlanReviewCompletionServiceTests.InMemoryPlanStore _inner = new();
+        public bool ExplodeOnTerminalTransitions { get; set; }
+
+        public Task CreatePlanAsync(PlanWrite plan, CancellationToken ct = default)
+            => _inner.CreatePlanAsync(plan, ct);
+
+        public Task UpdatePlanStatusAsync(PlanStatusUpdate update, CancellationToken ct = default)
+        {
+            if (ExplodeOnTerminalTransitions
+                && !string.Equals(update.Status, PlanStatus.Running, StringComparison.Ordinal)
+                && !string.Equals(update.Status, PlanStatus.AwaitingReview, StringComparison.Ordinal)
+                && !string.Equals(update.Status, PlanStatus.AwaitingClarification, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"simulated transient failure writing plan status '{update.Status}' for {update.PlanId}");
+            }
+            return _inner.UpdatePlanStatusAsync(update, ct);
+        }
+
+        public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)
+            => _inner.UpdateStepAsync(update, ct);
+
+        public Task<IReadOnlyList<PlanSummaryDto>> ListPlansForSubjectAsync(string subject, CancellationToken ct = default)
+            => _inner.ListPlansForSubjectAsync(subject, ct);
+
+        public Task<PlanDetailDto?> GetPlanAsync(string subject, string planId, CancellationToken ct = default)
+            => _inner.GetPlanAsync(subject, planId, ct);
+
+        public Task<bool> DeletePlanAsync(string subject, string planId, CancellationToken ct = default)
+            => _inner.DeletePlanAsync(subject, planId, ct);
+
+        public Task<PlanCleanupResult> PurgeExpiredAsync(DateTimeOffset olderThan, CancellationToken ct = default)
+            => _inner.PurgeExpiredAsync(olderThan, ct);
+
+        public string? LastStatusFor(string planId, string subject)
+            => _inner.GetLastStatusUpdate(subject, planId)?.Status;
+    }
+
+    private sealed class RecordingTraceCollector : ITraceCollector
+    {
+        public ConcurrentQueue<TraceSpan> Spans { get; } = new();
+        public void CaptureSpan(TraceSpan span) => Spans.Enqueue(span);
+        public IReadOnlyList<TraceSpan>? GetSpans(string traceId) => null;
+        public TraceSummary? GetSummary(string traceId) => null;
+        public IReadOnlyList<TraceSummary> GetRecentTraces(int count = 20) => [];
+        public StructuredTraceSummary? GetStructuredSummary(string traceId) => null;
+        public IReadOnlyList<ToolUsageStat> GetToolStats(DateTimeOffset since, int top = 10) => [];
+        public int TraceCount => Spans.Count;
+        public int Capacity => 100;
+    }
+
+    private sealed class NoOpTraceCollector : ITraceCollector
+    {
+        public void CaptureSpan(TraceSpan span) { }
+        public IReadOnlyList<TraceSpan>? GetSpans(string traceId) => null;
+        public TraceSummary? GetSummary(string traceId) => null;
+        public IReadOnlyList<TraceSummary> GetRecentTraces(int count = 20) => [];
+        public StructuredTraceSummary? GetStructuredSummary(string traceId) => null;
+        public IReadOnlyList<ToolUsageStat> GetToolStats(DateTimeOffset since, int top = 10) => [];
+        public int TraceCount => 0;
+        public int Capacity => 100;
+    }
+
+    private sealed class NoOpCostTracker : ICostTracker
+    {
+        public Task TrackUsageAsync(UsageEvent usage, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<CostSummary> GetSummaryAsync(CostPeriod period, CancellationToken ct = default)
+            => Task.FromResult(new CostSummary(0, 0, 0, period));
+        public Task<IReadOnlyList<AgentCostBreakdown>> GetByAgentAsync(CostPeriod period, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<AgentCostBreakdown>>([]);
+        public Task<CostTrend> GetTrendAsync(int days = 7, CancellationToken ct = default)
+            => Task.FromResult(new CostTrend([]));
+    }
+
+    private sealed class StubTenantProvider : ITenantProvider
+    {
+        public TenantConfiguration GetTenant() => new()
+        {
+            Company = "Contoso",
+            Industry = "test",
+        };
+    }
+
+    /// <summary>
+    /// Captures the last <c>plan_final_response</c> payload so tests can
+    /// assert the SignalR broadcast shape without a real hub connection.
+    /// </summary>
+    internal sealed class CapturingHub : IHubContext<TelemetryHub>
+    {
+        public object? LastFinalPayload { get; private set; }
+
+        public IHubClients Clients { get; }
+        public IGroupManager Groups { get; } = new StubGroupManager();
+
+        public CapturingHub()
+        {
+            Clients = new CapturingClients(this);
+        }
+
+        private sealed class CapturingClients(CapturingHub owner) : IHubClients
+        {
+            public IClientProxy All { get; } = new CapturingProxy(owner);
+            public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) => new CapturingProxy(owner);
+            public IClientProxy Client(string connectionId) => new CapturingProxy(owner);
+            public IClientProxy Clients(IReadOnlyList<string> connectionIds) => new CapturingProxy(owner);
+            public IClientProxy Group(string groupName) => new CapturingProxy(owner);
+            public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) => new CapturingProxy(owner);
+            public IClientProxy Groups(IReadOnlyList<string> groupNames) => new CapturingProxy(owner);
+            public IClientProxy User(string userId) => new CapturingProxy(owner);
+            public IClientProxy Users(IReadOnlyList<string> userIds) => new CapturingProxy(owner);
+        }
+
+        private sealed class CapturingProxy(CapturingHub owner) : IClientProxy
+        {
+            public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+            {
+                if (string.Equals(method, "plan_final_response", StringComparison.Ordinal) && args.Length > 0)
+                {
+                    owner.LastFinalPayload = args[0];
+                }
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class StubGroupManager : IGroupManager
+        {
+            public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
@@ -118,7 +118,7 @@ public sealed class PlanStateIntegrityTests : IDisposable
         PlanStepUpdate? pausedUpdate = plans.GetLastStepUpdate("user-1", suspend.PlanId, pausedStepId);
         pausedUpdate.Should().NotBeNull(
             "the paused clarification step's row must exist under the initial-plan step id.");
-        pausedUpdate!.Status.Should().Be(PlanStepStatus.Completed,
+        pausedUpdate.Status.Should().Be(PlanStepStatus.Completed,
             "an answered clarification MUST transition its persisted row out of Pending — otherwise " +
             "plan-detail reads keep reporting the answered step as awaiting reviewer input (finding 1b).");
         pausedUpdate.Result.Should().Contain("REVIEWER_ANSWER",
@@ -590,13 +590,11 @@ public sealed class PlanStateIntegrityTests : IDisposable
             // still Running. The completion service's own recovery write
             // (Failed) must be allowed through — that's the whole point of
             // the fix: contain the fault and finalize the row anyway.
-            if (ExplodeOnTerminalTransitions
-                && string.Equals(update.Status, PlanStatus.Completed, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"simulated transient failure writing plan status '{update.Status}' for {update.PlanId}");
-            }
-            return _inner.UpdatePlanStatusAsync(update, ct);
+            return ExplodeOnTerminalTransitions
+                && string.Equals(update.Status, PlanStatus.Completed, StringComparison.Ordinal)
+                ? throw new InvalidOperationException(
+                    $"simulated transient failure writing plan status '{update.Status}' for {update.PlanId}")
+                : _inner.UpdatePlanStatusAsync(update, ct);
         }
 
         public Task UpdateStepAsync(PlanStepUpdate update, CancellationToken ct = default)


### PR DESCRIPTION
Closes #145
Epic: #87

## Fresh from `main`

This branch was created from current `origin/main` and does **not** reuse, rebase, cherry-pick, or copy any branch/commits from the abandoned PR #144. The issue body was read for the description of findings, but each finding was verified independently against `main` with a narrow failing regression test before any fix was written.

## Verdicts per finding

### Finding 1a - Clarification resume mixes cumulative persisted step indices with local executor indices - REPRODUCES + FIXED

**Regression test:** `PlanStateIntegrityTests.Clarification_resume_step_span_index_matches_cumulative_persisted_index`

**Failure on `main` (before fix):** After the clarification round completes, the executor resumes with a new `PlanExecutionRequest` whose `StepIds` list is just the remaining suffix and whose local `stepIndex` counter restarts at `0`. `EmitStepSpan(stepIndex, ...)` and `new PlanStepResult(StepIndex: stepIndex, ...)` therefore emit `plan_step` span tags and step-result records at `0` while the persisted plan store already holds a `s0` for the completed prefix step. The test asserts that the trace collector saw the post-resume step at cumulative index `1` (matching persisted `{planId}-r0-s1`) and it fails, seeing `0`.

**Fix:** New `PlanExecutionRequest.StepIndexOffset`. `PlanReviewCompletionService.ExecuteApprovedPlanAsync` sets it to the number of already-completed prefix steps when it builds the resume request. `PlanExecutor.RunOneStepAsync` derives `reportedIndex = stepIndex + offset` and passes that to `EmitStepSpan` + `PlanStepResult`. `SuspendForClarificationAsync` and `SuspendForMidPlanReviewAsync` do the same for their emitted spans. Fast-path callers leave `StepIndexOffset = 0` (default) and are unaffected.

### Finding 1b - Answered clarification rows may remain Pending in the plan store - REPRODUCES + FIXED

**Regression test:** `PlanStateIntegrityTests.Clarification_resume_transitions_paused_step_row_out_of_pending`

**Failure on `main` (before fix):** `PlanExecutor.SuspendForClarificationAsync` writes the paused step row as `Pending` and hands off to the clarifier. `ResolveClarificationAsync` reads the answer and rebuilds `priorCompleted` for the next executor pass, but never transitions the paused row itself. It stays `Pending` in the plan store forever. Plan-detail reads therefore claim an answered clarification is still pending. The test observes zero updates to the paused step id after resume.

**Fix:** Thread the paused step id through the checkpoint round trip: `PlanExecutor.SuspendForClarificationAsync` passes `PausedStepId = stepId` on `PlanClarificationOpenInput`, `PlanClarifier.OpenAsync` writes it onto `PlanReviewCheckpointState.PausedStepId`. On resume, `ResolveClarificationAsync` reads `state.PausedStepId` and issues a best-effort `UpdateStepAsync` that transitions the row from `Pending` to `Completed` and records the answer. The write is wrapped in a `try/catch` that logs on failure so a transient store fault cannot derail the resume path.

### Finding 2 - Mid-plan [[REPLAN]] checkpoints delete the completed prefix - REPRODUCES + FIXED (highest severity)

**Regression test:** `PlanStateIntegrityTests.Replan_marker_preserves_completed_prefix_results_and_charts_across_resume`

**Failure on `main` (before fix):** When the executor suspends for a mid-plan review at step *k* > 0, `SuspendForMidPlanReviewAsync` calls `PlanReviewCoordinator.OpenRoundAsync` with the remaining steps as `Steps` but does not persist the already-accumulated completed results. `PlanReviewCheckpointState.CompletedSteps` therefore ends up empty. When the reviewer approves, `ResolveReviewAsync` builds an `ExecuteApprovedPlanAsync` call with `resumeCompletedSteps = null`, so the executor starts fresh from step 0 of the remaining slice. The pre-marker step's reply and its `charts` payload are lost from the final broadcast. The test asserts the terminal reply contains the pre-`[[REPLAN]]` step's summary and its chart id, and both are missing.

**Fix:** New `PlanReviewOpenInput.CompletedSteps`. `PlanExecutor.SuspendForMidPlanReviewAsync` builds `completed` from `message.AccumulatedResults` and passes it to the coordinator. `PlanReviewCoordinator.OpenRoundAsync` writes it into `PlanReviewCheckpointState.CompletedSteps`. `PlanReviewCompletionService.ResolveReviewAsync` forwards `state.CompletedSteps` into `ExecuteApprovedPlanAsync` on the Approved branch **and** into the next `OpenRoundAsync` on the NeedsReplan branch, so the completed prefix survives an arbitrary number of reviewer round-trips and any follow-up replan round. The pre-marker steps' `Reply` and `Charts` are re-included in the terminal broadcast and PlanStore step rows.

### Finding 3 - Executor exceptions after the Awaiting* -> Running claim strand the plan - REPRODUCES + FIXED

**Regression test:** `PlanStateIntegrityTests.Executor_failure_after_Running_transition_does_not_strand_plan_in_Running`

**Failure on `main` (before fix):** `ExecuteApprovedPlanAsync` claims the plan as `Running` before calling `executor.ExecuteAsync`. If any downstream write in the executor's finally throws (simulated by an `ExplodingPlanStore` that rejects the terminal `UpdatePlanStatusAsync(Completed)`), the exception propagates out of the completion service. The plan record is left at `Running` with no terminal broadcast. The test asserts the plan is not left at `Running` and this fails.

**Fix:** Wrap the `executor.ExecuteAsync` call in `ExecuteApprovedPlanAsync` with a `try/catch` that swallows non-cancellation exceptions and does two best-effort things: (1) `FinaliseAsFailedAsync` writes `PlanStatus.Failed` on the plan record and (2) `BroadcastPlanReplyAsync` sends a terminal `plan_final_response` to the caller. Genuine caller cancellation still propagates. `PlanReviewRestartRecoveryService` is also extended to sweep `Running` alongside `Awaiting*` plans that carry a terminal approval decision, so a hard-kill in the tiny window between the `Running` claim and the terminal write still self-heals on the next boot (the completion service is idempotent).

### Finding 4 - Late HTTP /decision response regresses a terminal plan on the frontend - REPRODUCES + FIXED

**Regression tests:** `planReducer.test.ts`
- `late REVIEW_RESOLVED after PLAN_FINAL preserves terminal status (issue #145 finding 4)`
- `late REVIEW_RESOLVED after PLAN_FINAL with failed reason keeps failed status (issue #145 finding 4)`

**Failure on `main` (before fix):** The reducer's `REVIEW_RESOLVED` branch unconditionally set `active.status` to `running` (approve/edit) or `awaiting_review` (reject). When the plan-final SignalR broadcast lands before the HTTP /decision response resolves, the reducer had already moved to `completed`/`failed`/`cancelled`/`unusable` with a `finalReply`. The late `REVIEW_RESOLVED` action then regressed the plan back to a non-terminal status, breaking `PlanView`'s terminal rendering and hiding `finalReply`.

**Fix:** `planReducer.ts` `REVIEW_RESOLVED` now short-circuits when `state.active.finalReply` is set or `state.active.status` is one of the terminal statuses. In that case the reducer only reconciles the review handle (records `resolvedKind`, clears `decisionInFlight`) and leaves the terminal snapshot alone. The non-terminal path is unchanged.

## Non-goals preserved

- Fast-path (`PlanOrchestrator.RunAsync` immediate/hot path) untouched.
- ADR-006 tool-context budget untouched.
- `span.type` telemetry tags (`plan`, `plan_step`) untouched, including on the fixed resume paths.
- Anonymous-session hardening untouched.
- Existing plan-path tests unchanged (only additive test helpers on the shared `InMemoryPlanStore`).

## Tests and format

- New: `tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs` - 4 backend regression facts, each proven to fail on `main` before the fix and pass after.
- New: 2 frontend cases in `src/RetailPulse.Web/src/__tests__/planReducer.test.ts` for finding 4 (frontend validation runs in CI - no local `npm` per environment rules).
- Full `dotnet test tests\RetailPulse.Tests\RetailPulse.Tests.csproj`: **3298 passed, 9 skipped, 0 failed** (2m5s).
- Whole-solution format: `dotnet format RetailPulse.slnx --verify-no-changes` - clean.

## Files changed

**Backend**
- `src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs` - `StepIndexOffset`, `reportedIndex` in three suspend/step paths, `PausedStepId` + `CompletedSteps` propagation.
- `src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs` - carry `CompletedSteps` through Approved + NeedsReplan, transition paused clarification row, wrap executor in fault-containment.
- `src/RetailPulse.Api/Approval/PlanClarifier.cs` - `PlanClarificationOpenInput.PausedStepId`.
- `src/RetailPulse.Api/Approval/PlanReviewCoordinator.cs` - `PlanReviewOpenInput.CompletedSteps`.
- `src/RetailPulse.Api/Approval/PlanReviewRestartRecoveryService.cs` - sweep `Running` alongside `Awaiting*`.
- `src/RetailPulse.Contracts/Approval/PlanReview.cs` - `PlanReviewCheckpointState.PausedStepId`; doc-updated `CompletedSteps`.

**Frontend**
- `src/RetailPulse.Web/src/state/planReducer.ts` - `REVIEW_RESOLVED` terminal guard.
- `src/RetailPulse.Web/src/__tests__/planReducer.test.ts` - 2 new tests.

**Tests**
- `tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs` - new file, 4 tests.
- `tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs` - additive `GetLastStepUpdate` / `GetLastStatusUpdate` accessors on the shared `InMemoryPlanStore`.

## Review checklist

- [ ] Confirm the 4 new backend regressions in `PlanStateIntegrityTests` actually fail on `main` without the fix.
- [ ] Confirm `PlanExecutionRequest.StepIndexOffset` defaults to `0` and every fast-path caller leaves it at the default (`PlanOrchestrator.RunAsync`).
- [ ] Confirm `PlanReviewCheckpointState.PausedStepId` + `CompletedSteps` serialize round-trip cleanly through `FileSystemJsonCheckpointStore` (camelCase JSON) - covered by the tests using the real store.
- [ ] Confirm `ResolveReviewAsync` `NeedsReplan` branch propagates `CompletedSteps` into the next round so a two-round replan still preserves the pre-marker prefix.
- [ ] Confirm the `try/catch` in `ExecuteApprovedPlanAsync` still propagates genuine caller cancellation.
- [ ] Confirm `PlanReviewRestartRecoveryService`'s new `Running` filter branch is idempotent - a second invocation on the same row is a no-op.
- [ ] Confirm the frontend `REVIEW_RESOLVED` terminal guard preserves `finalCharts`/`finishedAt` on the active plan.
- [ ] Confirm span tags `span.type = plan_step` are still emitted on the resume slice (asserted in finding 1a test).

## Follow-up (out of scope for this PR)

- The initial-plan step rows written by `PlanOrchestrator.SuspendForReviewAsync` under the naming scheme `{planId}-s{i}` remain `Pending` when the reviewer approves (execution writes a parallel set under `{planId}-r{round}-s{i}`). This is pre-existing on `main` and independent of the four findings here - surface as a separate hygiene issue.
