### PR TITLE
Prompt-library acceptance contract + chart runner selector repair + APIM LLM-log pairing smoke (#63 + #54)

### DIFF
--- a/docs/apim-llm-log-pairing.md
+++ b/docs/apim-llm-log-pairing.md
@@ -1,0 +1,146 @@
+# APIM LLM-log Request/Response Pairing Smoke
+
+Documents [`scripts/Verify-ApimLlmLogPairing.ps1`](../scripts/Verify-ApimLlmLogPairing.ps1),
+the deterministic smoke test that guards the invariant Publix's non-blocking
+observation on PR #52 (issue [#54](https://github.com/swigerb/retail-pulse/issues/54),
+item 1) exposed:
+
+> ~30% of small-token direct APIM calls in Publix's sample window produced
+> only `SequenceNumber=1` (request) rows in `ApiManagementGatewayLlmLog`
+> without a matching `SequenceNumber=0` (response) row. Marker-tagged calls
+> did consistently produce populated response records — so the
+> acceptance-plan pass criterion is met — but the drop is a regression vs.
+> `54aea53` and appears correlated with the `metrics: true` interaction.
+> Publix's later 5/5 re-check on `9fdc2ab` showed clean pairing, so behavior
+> is inconsistent under short bursts.
+
+The smoke reproduces the burst pattern deterministically and asserts every
+marker is paired 1:1 in `ApiManagementGatewayLlmLog` within a bounded settle
+window, so any regression is caught before the demo instead of being
+observed anecdotally during a live sweep.
+
+## Invariant asserted
+
+For every direct APIM call the smoke fires:
+
+* the request must land in `ApiManagementGatewayLlmLog` with
+  `SequenceNumber = 1` **and**
+* the corresponding response must land in the same table with
+  `SequenceNumber = 0`
+
+within `-SettleSeconds` (default 180s, tunable up to 900s) of the last
+call. Both rows must reference the same generated marker (`retail-pulse-marker-<8-hex>`)
+in `Content`. The KQL query scopes on that marker via `extract`, so unrelated
+traffic in the same workspace never contributes false pairings.
+
+## Assumptions
+
+* An APIM instance is deployed with a chat-completions inference API
+  (subscription-required), the API-level `applicationinsights` diagnostic
+  set to `metrics = true`, and the `azuremonitor` diagnostic emitting
+  `largeLanguageModel.logs = enabled`. These are the exact policy toggles
+  that were in effect on `apim-5aldk7aotqods` after `3c39ae4` when Publix
+  observed the pairing drop; `scripts/Verify-ApimAiGateway.ps1` verifies
+  they are present.
+* An operator has APIM subscription-key access to the inference product,
+  Reader on the Log Analytics workspace that receives the `azuremonitor`
+  diagnostic, and an authenticated `az` CLI session.
+* `az` CLI is on `PATH` (the smoke uses `az monitor log-analytics query`
+  for the KQL step).
+
+## Parameters
+
+Every parameter has an environment-variable fallback so the smoke can be
+wired into a scheduled workflow or a locally-scripted run without shell
+tinkering.
+
+| Parameter | Env var | Default | Notes |
+| --------- | ------- | ------- | ----- |
+| `-Endpoint` | `APIM_INFERENCE_ENDPOINT` | (required) | Inference base URL. `/openai` is appended if not already present. |
+| `-Deployment` | `APIM_DEPLOYMENT_NAME` | (required) | AOAI deployment name. |
+| `-ApiVersion` | — | `2024-08-01-preview` | Chat-completions API version. |
+| `-SubscriptionKey` | `APIM_SUBSCRIPTION_KEY` | (required) | APIM subscription key. Sent as `Ocp-Apim-Subscription-Key`; never logged. |
+| `-WorkspaceId` | `APIM_LOG_ANALYTICS_WORKSPACE_ID` | (required) | Log Analytics workspace that receives the `azuremonitor` diagnostic. |
+| `-Count` | — | 5 | Number of direct APIM calls to fire (1–100). Matches Publix's original sample. |
+| `-SettleSeconds` | — | 180 | Bounded ingest window (30–900s). |
+| `-MaxTokens` | — | 8 | Response token cap per call (1–128). Low value reproduces the small-token failure mode. |
+| `-SelfTest` | — | (switch) | Offline unit test of the pairing analyzer. Exits without touching APIM or Log Analytics. |
+
+## Invocation
+
+Offline self-test (no signin, no Azure access — wired into CI as a
+regression fence):
+
+```powershell
+./scripts/Verify-ApimLlmLogPairing.ps1 -SelfTest
+```
+
+Live smoke with explicit parameters:
+
+```powershell
+./scripts/Verify-ApimLlmLogPairing.ps1 `
+    -Endpoint 'https://apim-5aldk7aotqods.azure-api.net/inference' `
+    -Deployment 'gpt-4o-mini' `
+    -SubscriptionKey $env:APIM_SUBSCRIPTION_KEY `
+    -WorkspaceId $env:APIM_LOG_ANALYTICS_WORKSPACE_ID `
+    -Count 5 `
+    -SettleSeconds 180
+```
+
+Live smoke with env-var-driven configuration (typical CI / scheduled use):
+
+```powershell
+$env:APIM_INFERENCE_ENDPOINT         = 'https://apim-5aldk7aotqods.azure-api.net/inference'
+$env:APIM_DEPLOYMENT_NAME            = 'gpt-4o-mini'
+$env:APIM_SUBSCRIPTION_KEY           = '…'
+$env:APIM_LOG_ANALYTICS_WORKSPACE_ID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+./scripts/Verify-ApimLlmLogPairing.ps1
+```
+
+## Failure modes
+
+The smoke exits with a distinct exit code per outcome so a scheduled job
+can act on each independently:
+
+| Exit | Meaning |
+| ---- | ------- |
+| `0`  | All markers paired 1:1. Pairing PASS. |
+| `1`  | One or more markers missing their request or response row — the exact regression this smoke exists to detect. Details are printed per unpaired marker. Also returned when any direct APIM call itself fails (before ingest analysis can even run). |
+| `2`  | Skipped: required parameters missing, or `az` CLI not present. The smoke prints a clear reason and does not attempt any external call. |
+
+The self-test exercises three scenarios equivalent to real failure modes:
+
+1. **Healthy case** — every marker paired. Analyzer must return `Ok = true`.
+2. **PR #52 symptom** — one marker missing `SequenceNumber = 0`. Analyzer
+   must return `Ok = false`, `MissingResponse = 1`, and name the failing
+   marker.
+3. **Marker scoping** — a stray request row from a different marker must
+   not falsely pair against the current markers.
+
+Every self-test case must pass before the live smoke is trusted; that is
+the CI regression fence.
+
+## Live verification status
+
+**Deferred.** Live APIM instance / Log Analytics workspace access is not
+available from the environment producing this change. The smoke's offline
+`-SelfTest` mode passes locally (see PR body) — but the live half is not
+asserted here. When live access is available, run:
+
+```powershell
+./scripts/Verify-ApimLlmLogPairing.ps1 -Count 20 -SettleSeconds 300
+```
+
+and record the outcome (pairing PASS / FAIL and the marker JSON block) in
+a follow-up comment on issue #54.
+
+## Related
+
+* [`Verify-ApimAiGateway.ps1`](../scripts/Verify-ApimAiGateway.ps1) — the
+  static-invariant verifier this smoke's conventions mirror. Confirms the
+  diagnostic toggles (`metrics = true` on `applicationinsights`,
+  `largeLanguageModel.logs = enabled` on `azuremonitor`) that
+  `Verify-ApimLlmLogPairing.ps1` depends on.
+* PR #52 / issue #51 landed the `metrics = true` toggle on the API-level
+  `applicationinsights` diagnostic. Publix's post-merge observation of the
+  ingest drop is captured in issue #54 (item 1).

--- a/docs/chart-acceptance-run.md
+++ b/docs/chart-acceptance-run.md
@@ -24,9 +24,29 @@ does the same thing end-to-end for each curated prompt.
 3. Land on the empty chat.
 4. Open DevTools → Console; paste the contents of
    `scripts/browser-chart-acceptance.js`; run `await runChartAcceptance()`.
+   The runner uses **stable `data-testid` selectors** on the composer
+   (`chat-input`, `chat-send-button`), on the message wrappers
+   (`chat-message-assistant`), and on the chart surfaces
+   (`chart-card`, `chart-unavailable`, `chart-table`, `chart-gauge-svg`) so
+   selector drift is impossible against any recent build. It also polls
+   **actual mark readiness** — the case's `minMarks` bar-rectangles /
+   pie-sectors / line dots / table rows / gauge SVG must be present AND
+   stable across one polling interval before the runner scrapes the DOM.
 5. Copy the resulting JSON from the `COPY-TO-DOCS:` log line into the
    "Latest run" section below with the date, provider mode, and app version
    (git SHA).
+
+### Also available: prose (non-chart) prompt library sweep
+
+The sibling script
+[`scripts/browser-prompt-library-acceptance.js`](../scripts/browser-prompt-library-acceptance.js)
+covers every **prose** (non-chart) curated prompt across the six domain
+categories. It reuses the same stable testids, expects a non-empty prose
+response with no chart card leak, and reports the observed routing pill so a
+prose prompt that accidentally landed on the Consensus Council fails
+explicitly. Paired with the chart runner it exercises the full
+`PROMPT_CATEGORIES` library — the surface the production sweep in issue #63
+requires.
 
 ## Latest run
 

--- a/docs/chart-acceptance.md
+++ b/docs/chart-acceptance.md
@@ -115,3 +115,35 @@ The record of the most recent live browser verification is
 
 If any prompt fails to render as expected, the matrix has drifted from live
 behavior — add or tighten a matrix case and let CI enforce it.
+
+### Browser runner: stable `data-testid` selectors
+
+The DevTools runner in
+[`scripts/browser-chart-acceptance.js`](../scripts/browser-chart-acceptance.js)
+targets DOM elements exclusively via **stable `data-testid` attributes** the
+frontend components expose. Previous revisions used Griffel class-substring
+selectors (`[class*="chartCard"]`) that never matched at runtime because
+Griffel compiles `className={styles.chartCard}` to atomic hashed class names
+(e.g. `___ivt4970_0000000`), and Recharts internal class names that changed
+between minor releases. Issue #54 (item 2) locked the runner onto identity
+hooks that survive both problems:
+
+| testid | Component | Purpose |
+| ------ | --------- | ------- |
+| `chat-input` | `ChatPanel` Fluent UI `<Input>` | Composer input the runner types into. |
+| `chat-send-button` | `ChatPanel` primary `<Button>` | Alt-path for triggering send. |
+| `chat-message-list` | `ChatPanel` messages container | Root the runner scans for message churn. |
+| `chat-message-assistant` | Assistant message wrapper | Latest assistant turn; carries `data-message-streaming="true|false"`. |
+| `chat-message-user` | User message wrapper | User turn. |
+| `chart-card` | `ChartRenderer` `<Card>` | The populated chart card. Also carries `data-chart-type`. |
+| `chart-title` | Chart card title | Optional entity/legend fallback. |
+| `chart-unavailable` | Chart card diagnostic | The "Chart unavailable" no-render note. |
+| `chart-table` | Table body root | Table charts; `[data-testid="chart-table"] tbody tr` is the mark set. |
+| `chart-gauge` / `chart-gauge-svg` | Gauge container / gauge SVG | Gauge charts. |
+
+The runner also polls actual mark readiness before scraping: for every case
+it waits for the manifest's `minMarks` bar-rectangles / pie-sectors / line
+dots / table rows / gauge SVG to be present AND for one poll interval where
+the count did not grow before declaring the render complete. This replaces
+the historical `body.innerText` scrape that produced the case-7 "missing
+Summit Outdoor" race Publix reported on PR #53.

--- a/docs/prompt-library-acceptance.md
+++ b/docs/prompt-library-acceptance.md
@@ -1,0 +1,129 @@
+# Prompt Library Acceptance — Full Curated Matrix
+
+This document is the durable, human-readable index of the **full curated
+prompt library acceptance matrix** the codebase enforces automatically for
+issue [#63](https://github.com/swigerb/retail-pulse/issues/63). It
+complements — and is verified against — the machine sources of truth:
+
+* **Prompt source** — `src/RetailPulse.Web/src/constants/prompts.ts`
+  (`PROMPT_CATEGORIES`; every category, every entry).
+* **Backend chart manifest** — `src/RetailPulse.Contracts/Charts/ChartAcceptanceManifest.cs`
+  (Charts category + the QSR two-brand comparison).
+* **Backend prose manifest** — `src/RetailPulse.Contracts/Prompts/ProsePromptAcceptanceManifest.cs`
+  (every non-chart entry from every remaining category).
+
+Together the two backend manifests mirror the frontend prompt source
+exactly. Contract tests fail CI immediately if either manifest drifts.
+
+## Why a full-library matrix
+
+`ChartAcceptanceManifest` already gates the nine curated chart prompts. But
+17 curated PROSE prompts across six domain categories (General, Grocery,
+QSR, Home Improvement, Office Supply, Furniture) were only guarded by
+generic router unit tests — no acceptance contract asserted their routing,
+tool-invocation, or "no chart JSON leak" invariants as a set. Issue #63
+closed that gap by adding an **equivalent contract matrix for every prose
+prompt** and a browser sweep script that exercises them live.
+
+Each prose case declares the invariants a live invocation MUST satisfy:
+
+| Field | Meaning |
+| ----- | ------- |
+| `Prompt` | Verbatim prompt text (must exist in `prompts.ts`). |
+| `CategoryId` | The `PROMPT_CATEGORIES` id the prompt belongs to. |
+| `ExpectedIntent` | The `AgentIntent` the router MUST classify to (never `PortfolioHealth`). |
+| `ExpectedAgentKey` | DI key of the specialist that must own the request. Must have ≥1 tool in `prompts.yaml`. |
+| `Rationale` | Short note on why this routing is expected. |
+
+## The prose matrix (issue #63)
+
+| # | Category | Prompt | Expected intent | Expected agent |
+| - | -------- | ------ | --------------- | -------------- |
+| 1 | general | Compare depletion trends across all regions for this quarter | `demand/forecasting` | `demand-forecasting` |
+| 2 | general | Which brands are growing fastest year-over-year across the portfolio? | `general/fallback` | `general` |
+| 3 | general | Show me field sentiment for our top 3 brands in the Southeast | `sentiment/field` | `field-sentiment` |
+| 4 | grocery | How are FreshMart depletions trending in the Northeast this quarter? | `general/fallback` | `general` |
+| 5 | grocery | Compare Harvest Table vs FreshMart sell-through rates by region | `demand/forecasting` | `demand-forecasting` |
+| 6 | grocery | What is the field sentiment for Harvest Table Meal Kits in the Midwest? | `sentiment/field` | `field-sentiment` |
+| 7 | qsr | How is Apex Grill performing in the Southwest this quarter? | `general/fallback` | `general` |
+| 8 | qsr | What is the field sentiment for Coastline Tacos in the West Coast? | `sentiment/field` | `field-sentiment` |
+| 9 | home-improvement | Show me Pinnacle Hardware depletion stats in the Midwest for Q1 | `general/fallback` | `general` |
+| 10 | home-improvement | How is Summit Outdoor performing in the Southeast vs West Coast? | `general/fallback` | `general` |
+| 11 | home-improvement | What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest? | `sentiment/field` | `field-sentiment` |
+| 12 | office-supply | How are ClearDesk depletions trending in the Northeast this quarter? | `general/fallback` | `general` |
+| 13 | office-supply | Compare ClearDesk Technology vs Paper Products sell-through by region | `demand/forecasting` | `demand-forecasting` |
+| 14 | office-supply | What is the field sentiment for ClearDesk in the Southeast? | `sentiment/field` | `field-sentiment` |
+| 15 | furniture | Show me Urban Living depletion trends across all regions this quarter | `general/fallback` | `general` |
+| 16 | furniture | Compare Foundry Home vs Urban Living performance in the West Coast | `demand/forecasting` | `demand-forecasting` |
+| 17 | furniture | What is the field sentiment for Urban Living in the Pacific Northwest? | `sentiment/field` | `field-sentiment` |
+
+The QSR two-brand chart comparison prompt (`Compare Coastline Tacos vs Apex
+Grill …`) is intentionally excluded from this matrix — it is chart-owned and
+covered by `ChartAcceptanceManifest` / `ChartAcceptanceMatrixTests`.
+
+## Backend automation
+
+Two test surfaces guard the prose matrix end-to-end:
+
+1. **`ProsePromptAcceptanceManifestContractTests`** — parses
+   `prompts.ts` and asserts the prose manifest mirrors every non-chart
+   category prompt exactly (in source order), that the QSR chart comparison
+   is not present, and that every manifest case declares coherent semantics
+   (non-empty prompt/intent/agent-key, category id in the covered list,
+   never `PortfolioHealth`, no duplicate prompts).
+
+2. **`ProsePromptRoutingAcceptanceTests`** — for every case:
+
+   * Routes the prompt through the same `RetailOpsRouter` production uses
+     (with the LLM classifier mocked to return the expected intent, so the
+     router's fast-path / cache / LLM pipeline stays honest end-to-end) and
+     asserts `Intent == ExpectedIntent`, `AgentKey == ExpectedAgentKey`,
+     and both are ≠ the council.
+   * Asserts `ChartRequestDetector.Detect(prompt).IsExplicitChartRequest`
+     is **false** — the chart fast-path must never hijack a prose curated
+     prompt (that is the mechanism by which chart JSON could ever land in
+     a prose answer).
+   * Parses `src/RetailPulse.Api/prompts.yaml` and asserts the expected
+     agent key resolves to a specialist with a **non-empty `tools:` list**,
+     so a live invocation will always have at least one tool to call and
+     cannot produce an empty prose reply for lack of a tool.
+
+Both suites are unit-scale (no I/O beyond reading `prompts.ts` and
+`prompts.yaml`) and run in the standard `dotnet test` invocation.
+
+## Live browser verification
+
+The sibling script
+[`scripts/browser-prompt-library-acceptance.js`](../scripts/browser-prompt-library-acceptance.js)
+walks every prose case in DevTools using the same stable `data-testid`
+selectors the chart runner uses (`chat-input`, `chat-send-button`,
+`chat-message-assistant`, `chart-card`, `chart-unavailable`). For each
+prompt it asserts the assistant produced a non-empty prose reply, that no
+`chart-card` was rendered, that no chart JSON leaked as raw text
+(defence-in-depth against a specialist that inlines a chart spec in prose),
+and that the routing pill — when present — is not the Consensus Council.
+
+To run:
+
+1. Start the API (`RetailPulse.AppHost` or per-project `dotnet run`) and
+   the frontend (`cd src/RetailPulse.Web && npm run dev`).
+2. Sign in with a chat-capable provider (`Entra` in Production, or
+   `Anonymous` / `GitHub` in a dev build).
+3. Open DevTools → Console; paste the runner's contents; run
+   `await runPromptLibraryAcceptance()`.
+4. Copy the `COPY-TO-DOCS:` JSON block into the issue #63 comment on
+   parent #59.
+
+## Relationship to the chart matrix
+
+The chart matrix (`docs/chart-acceptance.md`) and this prose matrix are
+sibling surfaces. Together they cover **every entry** in
+`PROMPT_CATEGORIES`:
+
+* Chart matrix — 8 Charts-category prompts + 1 QSR two-brand comparison.
+* Prose matrix — 17 non-chart curated prompts across the six domain
+  categories.
+
+Backend contract tests enforce that the union of the two manifests
+mirrors `prompts.ts` exactly, so a new curated prompt landed in
+`prompts.ts` fails CI until it is added to one manifest or the other.

--- a/scripts/Verify-ApimLlmLogPairing.ps1
+++ b/scripts/Verify-ApimLlmLogPairing.ps1
@@ -1,0 +1,406 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Deterministic APIM LLM-log request/response pairing smoke test.
+
+.DESCRIPTION
+    Fires N low-token direct APIM chat/completions calls, each tagged with a
+    unique marker string embedded in the user message, then queries the
+    ApiManagementGatewayLlmLog table in Log Analytics for the same window and
+    asserts every marker is paired 1:1 (one SequenceNumber=1 "request" row AND
+    one SequenceNumber=0 "response" row).
+
+    Motivated by the non-blocking observation on PR #52 (issue #54, item 1):
+    ~30% of small-token direct APIM calls produced only SequenceNumber=1 rows
+    in ApiManagementGatewayLlmLog and no matching SequenceNumber=0 rows on
+    APIM 'apim-5aldk7aotqods' after 3c39ae4 landed. Publix's later 5/5 clean
+    re-check on 9fdc2ab showed pairing recovered, so the failure mode is
+    inconsistent under short bursts. This smoke reproduces the burst pattern
+    deterministically and asserts the pairing invariant so a regression is
+    caught before the demo.
+
+    Mirrors the conventions and offline-first shape of
+    ./scripts/Verify-ApimAiGateway.ps1:
+
+      * Read-only against the live APIM (data plane call to /openai/…/chat/completions)
+        and against Log Analytics (KQL over ApiManagementGatewayLlmLog).
+      * Every parameter has an explicit env-var fallback for CI/scheduled use.
+      * `-SelfTest` runs a signin-free offline unit test of the pairing
+        analysis so CI can wire it as a regression fence without needing an
+        APIM instance.
+      * Non-zero exit only on real failure or clearly-explained skip.
+
+    Live verification is DEFERRED in this repo: no live APIM instance /
+    Log Analytics workspace is available from the environment producing this
+    script, so live-mode results are not asserted. The offline `-SelfTest`
+    validates the analysis half so the live half can be trusted the moment
+    parameters are supplied.
+
+.PARAMETER Endpoint
+    APIM inference endpoint URL, e.g.
+    https://apim-5aldk7aotqods.azure-api.net/inference (NO trailing '/openai';
+    the deployment path is appended). Defaults to $env:APIM_INFERENCE_ENDPOINT.
+
+.PARAMETER Deployment
+    AOAI deployment name to invoke. Defaults to $env:APIM_DEPLOYMENT_NAME.
+
+.PARAMETER ApiVersion
+    Chat-completions API version. Defaults to '2024-08-01-preview' — the
+    version pinned in production APIM policy.
+
+.PARAMETER SubscriptionKey
+    APIM subscription key for the inference product. Defaults to
+    $env:APIM_SUBSCRIPTION_KEY. Passed via the Ocp-Apim-Subscription-Key
+    header on every call; never logged, never echoed.
+
+.PARAMETER WorkspaceId
+    Log Analytics workspace ID that receives the API-level
+    `azuremonitor` diagnostic (the sink populating ApiManagementGatewayLlmLog).
+    Defaults to $env:APIM_LOG_ANALYTICS_WORKSPACE_ID.
+
+.PARAMETER Count
+    Number of low-token direct APIM calls to fire. Defaults to 5 — matches
+    the sample size Publix used when observing the pairing drop.
+
+.PARAMETER SettleSeconds
+    Bounded settle window between the last call and the Log Analytics query.
+    Defaults to 180 (three minutes) — the ingestion SLO for
+    ApiManagementGatewayLlmLog is < 5 minutes, so this window is conservative
+    but bounded enough to fail loudly if a response row is dropped rather
+    than merely late.
+
+.PARAMETER MaxTokens
+    Response token cap per direct APIM call. Defaults to 8. The low ceiling
+    exercises the exact failure mode from the PR #52 observation
+    (small-token responses were the ones that dropped SequenceNumber=0
+    rows).
+
+.PARAMETER SelfTest
+    Runs an offline unit test of the pairing analysis and exits without
+    calling APIM or Log Analytics. Wired into CI as a signin-free fence.
+
+.EXAMPLE
+    ./scripts/Verify-ApimLlmLogPairing.ps1 -SelfTest
+
+    Runs offline self-test only. Zero external calls, no auth required.
+
+.EXAMPLE
+    $env:APIM_INFERENCE_ENDPOINT      = 'https://apim-5aldk7aotqods.azure-api.net/inference'
+    $env:APIM_DEPLOYMENT_NAME         = 'gpt-4o-mini'
+    $env:APIM_SUBSCRIPTION_KEY        = '…'
+    $env:APIM_LOG_ANALYTICS_WORKSPACE_ID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+    ./scripts/Verify-ApimLlmLogPairing.ps1
+
+    Live run: fires 5 low-token calls, waits 180s, asserts every marker is
+    paired 1:1 in ApiManagementGatewayLlmLog.
+#>
+[CmdletBinding()]
+param(
+    [string]$Endpoint         = $env:APIM_INFERENCE_ENDPOINT,
+    [string]$Deployment       = $env:APIM_DEPLOYMENT_NAME,
+    [string]$ApiVersion       = '2024-08-01-preview',
+    [string]$SubscriptionKey  = $env:APIM_SUBSCRIPTION_KEY,
+    [string]$WorkspaceId      = $env:APIM_LOG_ANALYTICS_WORKSPACE_ID,
+    [ValidateRange(1, 100)]
+    [int]$Count               = 5,
+    [ValidateRange(30, 900)]
+    [int]$SettleSeconds       = 180,
+    [ValidateRange(1, 128)]
+    [int]$MaxTokens           = 8,
+    [switch]$SelfTest
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ── Pairing analysis ────────────────────────────────────────────────────────
+# The analyzer takes:
+#   * the markers we generated (one per direct APIM call),
+#   * a list of log rows shaped as PSCustomObject with .Marker and
+#     .SequenceNumber (0 or 1) — either from a real Log Analytics query or
+#     from the offline self-test fixture.
+# and returns an object recording per-marker pass/fail plus overall totals.
+#
+# Kept as a pure function so `-SelfTest` can exercise it without touching
+# Azure. This function does NOT return early on the first missing pair — it
+# reports the complete picture so the operator can see whether the drop is
+# uniform or bursty.
+function Test-LlmLogPairing {
+    param(
+        [Parameter(Mandatory)][string[]]$Markers,
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Rows
+    )
+    $per = [System.Collections.Generic.List[object]]::new()
+    foreach ($m in $Markers) {
+        $requestRow  = $Rows | Where-Object { $_.Marker -eq $m -and $_.SequenceNumber -eq 1 } | Select-Object -First 1
+        $responseRow = $Rows | Where-Object { $_.Marker -eq $m -and $_.SequenceNumber -eq 0 } | Select-Object -First 1
+        $per.Add([PSCustomObject]@{
+            Marker      = $m
+            HasRequest  = [bool]$requestRow
+            HasResponse = [bool]$responseRow
+            Paired      = [bool]($requestRow -and $responseRow)
+        })
+    }
+    $paired      = ($per | Where-Object Paired).Count
+    $missingResp = ($per | Where-Object { $_.HasRequest -and -not $_.HasResponse }).Count
+    $missingReq  = ($per | Where-Object { -not $_.HasRequest -and $_.HasResponse }).Count
+    $missingBoth = ($per | Where-Object { -not $_.HasRequest -and -not $_.HasResponse }).Count
+    return [PSCustomObject]@{
+        Markers         = $Markers.Count
+        Paired          = $paired
+        MissingResponse = $missingResp
+        MissingRequest  = $missingReq
+        MissingBoth     = $missingBoth
+        Details         = $per
+        Ok              = ($paired -eq $Markers.Count)
+    }
+}
+
+# ── Offline self-test ───────────────────────────────────────────────────────
+# Exercises the pairing analyzer with three fixtures:
+#   1. Every marker paired (the healthy case; must return Ok=true).
+#   2. One marker missing SequenceNumber=0 (the exact PR #52 symptom; must
+#      report MissingResponse=1 and Ok=false).
+#   3. One marker paired 1:1 while an unrelated stray SequenceNumber=1 row
+#      belongs to a different marker (must NOT count against the paired
+#      marker; asserts the analyzer scopes by marker).
+# Exits 0 on all-pass, 1 on any failure. No Azure signin required.
+function Invoke-SelfTest {
+    function _Expect([string]$name, [bool]$cond) {
+        if ($cond) { Write-Host "  [ok]   selftest: $name" -ForegroundColor Green }
+        else       { Write-Host "  [FAIL] selftest: $name" -ForegroundColor Red; $script:_selfFailed++ }
+    }
+    $script:_selfFailed = 0
+    Write-Host 'Self-test: APIM LLM-log pairing analyzer'
+
+    # Fixture 1 — every marker paired.
+    $markers1 = @('m-alpha', 'm-beta', 'm-gamma')
+    $rows1 = @(
+        [PSCustomObject]@{ Marker = 'm-alpha'; SequenceNumber = 1 },
+        [PSCustomObject]@{ Marker = 'm-alpha'; SequenceNumber = 0 },
+        [PSCustomObject]@{ Marker = 'm-beta';  SequenceNumber = 1 },
+        [PSCustomObject]@{ Marker = 'm-beta';  SequenceNumber = 0 },
+        [PSCustomObject]@{ Marker = 'm-gamma'; SequenceNumber = 1 },
+        [PSCustomObject]@{ Marker = 'm-gamma'; SequenceNumber = 0 }
+    )
+    $r1 = Test-LlmLogPairing -Markers $markers1 -Rows $rows1
+    _Expect 'healthy case: Ok=true'         ($r1.Ok -eq $true)
+    _Expect 'healthy case: Paired=3'        ($r1.Paired -eq 3)
+    _Expect 'healthy case: MissingResponse=0' ($r1.MissingResponse -eq 0)
+
+    # Fixture 2 — one marker missing SequenceNumber=0 (the PR #52 symptom).
+    $markers2 = @('m-alpha', 'm-beta')
+    $rows2 = @(
+        [PSCustomObject]@{ Marker = 'm-alpha'; SequenceNumber = 1 },
+        [PSCustomObject]@{ Marker = 'm-alpha'; SequenceNumber = 0 },
+        [PSCustomObject]@{ Marker = 'm-beta';  SequenceNumber = 1 }
+        # response row for m-beta intentionally absent
+    )
+    $r2 = Test-LlmLogPairing -Markers $markers2 -Rows $rows2
+    _Expect 'PR #52 symptom: Ok=false'          ($r2.Ok -eq $false)
+    _Expect 'PR #52 symptom: MissingResponse=1' ($r2.MissingResponse -eq 1)
+    _Expect 'PR #52 symptom: Paired=1'          ($r2.Paired -eq 1)
+    $failedMarker = ($r2.Details | Where-Object { -not $_.Paired } | Select-Object -First 1).Marker
+    _Expect 'PR #52 symptom: failed marker is m-beta' ($failedMarker -eq 'm-beta')
+
+    # Fixture 3 — stray row from a different marker must not falsely pair.
+    $markers3 = @('m-alpha')
+    $rows3 = @(
+        [PSCustomObject]@{ Marker = 'm-alpha';  SequenceNumber = 1 },
+        [PSCustomObject]@{ Marker = 'm-alpha';  SequenceNumber = 0 },
+        [PSCustomObject]@{ Marker = 'm-stray';  SequenceNumber = 1 }
+    )
+    $r3 = Test-LlmLogPairing -Markers $markers3 -Rows $rows3
+    _Expect 'scoped by marker: Ok=true'  ($r3.Ok -eq $true)
+    _Expect 'scoped by marker: Paired=1' ($r3.Paired -eq 1)
+
+    # Fixture 4 — marker string chosen for uniqueness never collides. Generate
+    # 10 markers via the same generator the live path uses and assert they are
+    # distinct AND at least 24 characters (retail-pulse-marker- + 8 hex).
+    $generated = 1..10 | ForEach-Object { New-Marker }
+    _Expect 'marker generator produces distinct values' (($generated | Sort-Object -Unique).Count -eq 10)
+    _Expect 'marker generator produces long tokens'     (($generated | Where-Object { $_.Length -ge 24 }).Count -eq 10)
+
+    if ($script:_selfFailed -gt 0) {
+        Write-Host ("SELFTEST FAIL ({0} case(s))" -f $script:_selfFailed) -ForegroundColor Red
+        exit 1
+    }
+    Write-Host 'SELFTEST PASS' -ForegroundColor Green
+    exit 0
+}
+
+function New-Marker {
+    # 8 hex chars gives 2^32 possibilities — enough that N=100 calls in a
+    # single burst have vanishing collision probability. Prefixed so the KQL
+    # `contains` filter narrows the log window to this smoke's rows only.
+    $rand = -join ((1..8) | ForEach-Object { '{0:x}' -f (Get-Random -Minimum 0 -Maximum 16) })
+    return "retail-pulse-marker-$rand"
+}
+
+if ($SelfTest) { Invoke-SelfTest }
+
+# ── Parameter validation for live mode ─────────────────────────────────────
+
+$missing = [System.Collections.Generic.List[string]]::new()
+if ([string]::IsNullOrWhiteSpace($Endpoint))        { $missing.Add('Endpoint (or $env:APIM_INFERENCE_ENDPOINT)') }
+if ([string]::IsNullOrWhiteSpace($Deployment))      { $missing.Add('Deployment (or $env:APIM_DEPLOYMENT_NAME)') }
+if ([string]::IsNullOrWhiteSpace($SubscriptionKey)) { $missing.Add('SubscriptionKey (or $env:APIM_SUBSCRIPTION_KEY)') }
+if ([string]::IsNullOrWhiteSpace($WorkspaceId))     { $missing.Add('WorkspaceId (or $env:APIM_LOG_ANALYTICS_WORKSPACE_ID)') }
+
+if ($missing.Count -gt 0) {
+    Write-Host 'APIM LLM-log pairing smoke — missing required parameters:' -ForegroundColor Yellow
+    foreach ($m in $missing) { Write-Host ("  - {0}" -f $m) -ForegroundColor Yellow }
+    Write-Host ''
+    Write-Host 'This script is DEFERRED for live verification: no live APIM instance /' -ForegroundColor Yellow
+    Write-Host 'Log Analytics workspace is available from the environment producing it.' -ForegroundColor Yellow
+    Write-Host 'Run with -SelfTest to exercise the offline pairing analysis, or supply' -ForegroundColor Yellow
+    Write-Host 'the parameters above to run the live smoke.' -ForegroundColor Yellow
+    exit 2
+}
+
+# `az` is only strictly required for the Log Analytics query (Invoke-KqlQuery).
+# Do a soft check so the operator sees an actionable message if `az` is absent.
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    Write-Host '[skip] `az` CLI not found on PATH — required for `az monitor log-analytics query`.' -ForegroundColor Yellow
+    exit 2
+}
+
+# ── APIM call ──────────────────────────────────────────────────────────────
+
+function Invoke-ApimChat {
+    param(
+        [Parameter(Mandatory)][string]$Marker,
+        [Parameter(Mandatory)][string]$Endpoint,
+        [Parameter(Mandatory)][string]$Deployment,
+        [Parameter(Mandatory)][string]$ApiVersion,
+        [Parameter(Mandatory)][string]$SubscriptionKey,
+        [Parameter(Mandatory)][int]$MaxTokens
+    )
+
+    $trimmedEndpoint = $Endpoint.TrimEnd('/')
+    # If the caller passes an endpoint already ending in `/openai`, respect it;
+    # otherwise the standard APIM inference product exposes the OpenAI-shaped
+    # path at `/openai/deployments/...` so append it.
+    if ($trimmedEndpoint -notmatch '/openai$') { $trimmedEndpoint = "$trimmedEndpoint/openai" }
+    $uri = "$trimmedEndpoint/deployments/$Deployment/chat/completions?api-version=$ApiVersion"
+
+    $body = @{
+        max_tokens = $MaxTokens
+        temperature = 0
+        messages = @(
+            @{ role = 'system'; content = 'Reply with a single word.' },
+            @{ role = 'user';   content = "marker $Marker : ping" }
+        )
+    } | ConvertTo-Json -Depth 5
+
+    $headers = @{
+        'Ocp-Apim-Subscription-Key' = $SubscriptionKey
+        'Content-Type'              = 'application/json'
+    }
+
+    try {
+        $resp = Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $body -ErrorAction Stop
+        return [PSCustomObject]@{ Marker = $Marker; Ok = $true; Status = 'ok'; Error = $null }
+    }
+    catch {
+        return [PSCustomObject]@{ Marker = $Marker; Ok = $false; Status = 'apim-error'; Error = $_.Exception.Message }
+    }
+}
+
+# ── Log Analytics query ────────────────────────────────────────────────────
+
+function Invoke-KqlQuery {
+    param(
+        [Parameter(Mandatory)][string]$WorkspaceId,
+        [Parameter(Mandatory)][string[]]$Markers,
+        [Parameter(Mandatory)][int]$LookbackMinutes
+    )
+    # Build an `in (…)` list of markers so the KQL server-side filter narrows
+    # aggressively rather than pulling every row and post-filtering client-side.
+    $markerList = ($Markers | ForEach-Object { "'$_'" }) -join ','
+    $kql = @"
+ApiManagementGatewayLlmLog
+| where TimeGenerated > ago(${LookbackMinutes}m)
+| extend Marker = tostring(extract('retail-pulse-marker-([a-f0-9]{8})', 0, tostring(Content)))
+| where isnotempty(Marker)
+| where Marker in ($markerList)
+| project TimeGenerated, Marker, SequenceNumber
+| order by TimeGenerated asc
+"@
+
+    $raw = az monitor log-analytics query `
+        --workspace $WorkspaceId `
+        --analytics-query $kql `
+        --output json 2>$null
+
+    if (-not $raw) {
+        return @()
+    }
+    return ($raw | ConvertFrom-Json)
+}
+
+# ── Live smoke ─────────────────────────────────────────────────────────────
+
+Write-Host 'APIM LLM-log pairing smoke'
+Write-Host ("  endpoint       = {0}" -f $Endpoint)
+Write-Host ("  deployment     = {0}" -f $Deployment)
+Write-Host ("  apiVersion     = {0}" -f $ApiVersion)
+Write-Host ("  workspaceId    = {0}" -f $WorkspaceId)
+Write-Host ("  count          = {0}" -f $Count)
+Write-Host ("  settleSeconds  = {0}" -f $SettleSeconds)
+Write-Host ("  maxTokens      = {0}" -f $MaxTokens)
+Write-Host ''
+
+$markers = 1..$Count | ForEach-Object { New-Marker }
+$startedUtc = [DateTime]::UtcNow
+
+Write-Host 'Firing direct APIM calls…'
+$callResults = @()
+foreach ($m in $markers) {
+    $r = Invoke-ApimChat -Marker $m -Endpoint $Endpoint -Deployment $Deployment -ApiVersion $ApiVersion -SubscriptionKey $SubscriptionKey -MaxTokens $MaxTokens
+    $callResults += $r
+    if ($r.Ok) { Write-Host ("  [call] {0} ok" -f $m) -ForegroundColor Green }
+    else       { Write-Host ("  [call] {0} FAIL ({1})" -f $m, $r.Error) -ForegroundColor Red }
+}
+
+$apimFailures = ($callResults | Where-Object { -not $_.Ok }).Count
+if ($apimFailures -gt 0) {
+    Write-Host ''
+    Write-Host ("APIM SMOKE FAIL: {0}/{1} direct APIM calls failed before ingest analysis" -f $apimFailures, $Count) -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ''
+Write-Host ("Waiting {0}s for ApiManagementGatewayLlmLog ingest…" -f $SettleSeconds)
+Start-Sleep -Seconds $SettleSeconds
+
+# Query a lookback window that comfortably covers the burst + settle window
+# plus a small margin, so an outlier that reached the workspace slightly late
+# is still in scope.
+$lookbackMinutes = [int][math]::Ceiling(($SettleSeconds + ([DateTime]::UtcNow - $startedUtc).TotalSeconds) / 60.0) + 2
+
+Write-Host 'Querying ApiManagementGatewayLlmLog…'
+$rows = Invoke-KqlQuery -WorkspaceId $WorkspaceId -Markers $markers -LookbackMinutes $lookbackMinutes
+Write-Host ("  {0} row(s) matched" -f $rows.Count)
+
+$analysis = Test-LlmLogPairing -Markers $markers -Rows $rows
+
+Write-Host ''
+Write-Host 'Pairing analysis'
+Write-Host ("  markers         = {0}" -f $analysis.Markers)
+Write-Host ("  paired 1:1      = {0}" -f $analysis.Paired)
+Write-Host ("  missingResponse = {0}" -f $analysis.MissingResponse)
+Write-Host ("  missingRequest  = {0}" -f $analysis.MissingRequest)
+Write-Host ("  missingBoth     = {0}" -f $analysis.MissingBoth)
+
+if (-not $analysis.Ok) {
+    Write-Host ''
+    Write-Host 'PAIRING FAIL — the following markers are not 1:1' -ForegroundColor Red
+    foreach ($d in ($analysis.Details | Where-Object { -not $_.Paired })) {
+        Write-Host ("  - {0}: hasRequest={1} hasResponse={2}" -f $d.Marker, $d.HasRequest, $d.HasResponse) -ForegroundColor Red
+    }
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'PAIRING PASS — every marker recorded both SequenceNumber=1 and SequenceNumber=0' -ForegroundColor Green
+exit 0

--- a/scripts/browser-chart-acceptance.js
+++ b/scripts/browser-chart-acceptance.js
@@ -105,6 +105,80 @@ function countMarks(rootEl, chartType) {
   }
 }
 
+// `ChartRenderer.tsx` lowercases the chart type before emitting it
+// (`data-chart-type={spec.type.toLowerCase()}`), and existing frontend tests
+// assert the lowercase form (e.g. `[data-chart-type="horizontalbar"]` in
+// `ChartRenderer.horizontalBarRanking.test.tsx` and
+// `ChartRenderer.productionCanary.test.tsx`). The runner's CASES use the
+// canonical camelCase names from `ChartAcceptanceManifest.cs`, so a strict
+// equality comparison would deterministically false-fail every correctly-
+// rendered `horizontalBar` / `groupedBar` case (issue #54 item 2 revision;
+// PR #148 blocker B1). Compare case-insensitively without weakening the
+// wrong-type detection: any non-empty rendered type must still equal the
+// expected type after both are lowercased.
+function normalizeChartType(t) {
+  return String(t == null ? '' : t).toLowerCase();
+}
+
+function chartTypeMatches(renderedChartType, expectedChartType) {
+  if (renderedChartType == null) return true;
+  return normalizeChartType(renderedChartType) === normalizeChartType(expectedChartType);
+}
+
+// Offline invariant self-test for the chart-type comparator. Mirrors the
+// `-SelfTest` pattern used by `scripts/Verify-ApimLlmLogPairing.ps1` /
+// `scripts/Verify-ApimAiGateway.ps1`: no network, no npm, no browser. It
+// documents the DOM contract this runner relies on so any future regression
+// (e.g. someone re-tightens the comparison to strict equality) fails loudly
+// instead of silently mislabelling valid renders as failures.
+function selfTest() {
+  const failures = [];
+  const assert = (name, actual, expected) => {
+    if (actual !== expected) {
+      failures.push({ name, actual, expected });
+    }
+  };
+
+  // ChartRenderer emits lowercase; CASES use canonical camelCase. All three
+  // camelCase types must match their lowercase rendered form.
+  assert('horizontalbar vs horizontalBar', chartTypeMatches('horizontalbar', 'horizontalBar'), true);
+  assert('groupedbar vs groupedBar',       chartTypeMatches('groupedbar',   'groupedBar'),    true);
+  assert('stackedbar vs stackedBar',       chartTypeMatches('stackedbar',   'stackedBar'),    true);
+
+  // Single-word types (already lowercase on both sides) still match.
+  assert('bar vs bar',     chartTypeMatches('bar',   'bar'),   true);
+  assert('line vs line',   chartTypeMatches('line',  'line'),  true);
+  assert('pie vs pie',     chartTypeMatches('pie',   'pie'),   true);
+  assert('donut vs donut', chartTypeMatches('donut', 'donut'), true);
+  assert('gauge vs gauge', chartTypeMatches('gauge', 'gauge'), true);
+  assert('table vs table', chartTypeMatches('table', 'table'), true);
+
+  // Wrong-type detection must NOT be weakened by the case-insensitive fix.
+  assert('bar vs line (wrong)',                chartTypeMatches('bar', 'line'),                 false);
+  assert('bar vs horizontalBar (wrong)',       chartTypeMatches('bar', 'horizontalBar'),        false);
+  assert('groupedbar vs stackedBar (wrong)',   chartTypeMatches('groupedbar', 'stackedBar'),    false);
+  assert('table vs gauge (wrong)',             chartTypeMatches('table', 'gauge'),              false);
+
+  // Defensive: a null/missing `data-chart-type` (older builds pre-testids)
+  // must not itself cause a false failure — the runner already gates render
+  // success on marks + entities + unavailable-note, so an absent attribute
+  // yields "unknown" not "wrong."
+  assert('null rendered vs any (permissive)',      chartTypeMatches(null,      'horizontalBar'), true);
+  assert('undefined rendered vs any (permissive)', chartTypeMatches(undefined, 'bar'),           true);
+
+  // Every case declared by this runner must round-trip through the
+  // comparator against its own lowercased form (guards CASES drift).
+  for (const c of CASES) {
+    assert(
+      `CASES entry lowercases: ${c.chartType}`,
+      chartTypeMatches(normalizeChartType(c.chartType), c.chartType),
+      true,
+    );
+  }
+
+  return { ok: failures.length === 0, failures };
+}
+
 function findLatestChartCard() {
   const cards = document.querySelectorAll('[data-testid="chart-card"]');
   return cards.length ? cards[cards.length - 1] : null;
@@ -208,6 +282,14 @@ async function waitForResponse(prevCardCount, prevNoteCount, chartType, minMarks
 }
 
 async function runChartAcceptance() {
+  // Fail-fast on the DOM-contract invariant so a future regression to the
+  // pre-#148 strict-equality comparator can't silently label valid renders
+  // as failures (PR #148 blocker B1).
+  const st = selfTest();
+  if (!st.ok) {
+    console.error('❌ browser-chart-acceptance selfTest failed:', st.failures);
+    throw new Error('browser-chart-acceptance selfTest failed — chart-type comparator invariant broken.');
+  }
   const results = [];
   for (const c of CASES) {
     const prevCards = document.querySelectorAll('[data-testid="chart-card"]').length;
@@ -222,7 +304,9 @@ async function runChartAcceptance() {
       const cardText = card ? card.textContent : '';
       const missingEntities = c.entities.filter((e) => !cardText.includes(e));
       const cardChartType = card ? card.getAttribute('data-chart-type') : null;
-      const chartTypeMatches = !cardChartType || cardChartType === c.chartType;
+      // Case-insensitive: ChartRenderer lowercases `data-chart-type` while
+      // CASES use the canonical camelCase names from ChartAcceptanceManifest.
+      const chartTypeMatched = chartTypeMatches(cardChartType, c.chartType);
 
       const pass =
         outcome.kind === 'chart' &&
@@ -230,7 +314,7 @@ async function runChartAcceptance() {
         !note &&
         marks >= c.minMarks &&
         missingEntities.length === 0 &&
-        chartTypeMatches;
+        chartTypeMatched;
 
       results.push({
         prompt: c.prompt,
@@ -257,3 +341,20 @@ async function runChartAcceptance() {
 
 // Export for the console.
 globalThis.runChartAcceptance = runChartAcceptance;
+globalThis.chartAcceptanceSelfTest = selfTest;
+
+// When loaded under Node (no DOM globals), run the offline self-test so this
+// script can be validated without a browser, npm, or the registry. This
+// mirrors the `-SelfTest` mode in `scripts/Verify-ApimLlmLogPairing.ps1`.
+if (typeof document === 'undefined') {
+  const result = selfTest();
+  if (result.ok) {
+    console.log('SELFTEST PASS: browser-chart-acceptance chart-type comparator');
+  } else {
+    console.error('SELFTEST FAIL: browser-chart-acceptance chart-type comparator');
+    for (const f of result.failures) {
+      console.error(`  - ${f.name}: got ${JSON.stringify(f.actual)}, expected ${JSON.stringify(f.expected)}`);
+    }
+    if (typeof process !== 'undefined' && process.exit) process.exit(1);
+  }
+}

--- a/scripts/browser-chart-acceptance.js
+++ b/scripts/browser-chart-acceptance.js
@@ -1,27 +1,56 @@
-// Curated chart-prompt browser acceptance runner (issue #50).
+// Curated chart-prompt browser acceptance runner (issues #50 + #54).
 //
 // Paste this into the browser DevTools console while the Retail Pulse frontend
-// is loaded (any auth mode — Anonymous is fine). It walks every curated chart
-// prompt from the acceptance manifest, submits the prompt through the same
-// path a user would (the chat send hook), waits for the response, and asserts:
+// is loaded. It walks every curated chart prompt from the acceptance manifest,
+// submits the prompt through the composer, waits for the response to fully
+// render, and asserts:
 //   • the rendered chart card contains a real Recharts canvas (not the
 //     "Chart unavailable" diagnostic),
 //   • the chart's title, required entity labels, and minimum mark count agree
 //     with the manifest,
 //   • the assistant did not answer with prose only ("truncated portfolio
-//     pull", "Chart unavailable — historical pulls truncated"), which was
-//     the #50 P0 symptom.
+//     pull", "Chart unavailable — historical pulls truncated") — the #50 P0
+//     symptom.
 //
 // Usage:
 //   1. cd src/RetailPulse.Web && npm run dev
 //   2. Start the API (RetailPulse.AppHost or dotnet run per-project).
 //   3. Open http://localhost:5173, sign in, land on the empty dashboard.
 //   4. Open DevTools → Console.
-//   5. Paste this file's contents and run runChartAcceptance().
+//   5. Paste this file's contents and run `await runChartAcceptance()`.
 //   6. Copy the resulting `results` array into docs/chart-acceptance-run.md.
 //
 // This script is deliberately dependency-free JS (not TS) so it can be pasted
 // verbatim into any recent browser console without a build step.
+//
+// # Selector strategy (issue #54, item 2)
+//
+// Every element the runner reads from the DOM is targeted by a **stable
+// `data-testid` attribute** rather than by Griffel class-substring or Recharts
+// internal class names. Griffel compiles `className={styles.chartCard}` to
+// hashed atomic class names (e.g. `___ivt4970_0000000`) so historical
+// selectors like `[class*="chartCard"]` do not match at runtime; Recharts
+// internal class names are undocumented and change between minor releases.
+// The frontend now exposes the following stable testids that the runner
+// consumes:
+//
+//   [data-testid="chat-input"]              — composer input (Fluent UI Input)
+//   [data-testid="chat-send-button"]        — primary send button
+//   [data-testid="chat-message-list"]       — messages container
+//   [data-testid="chat-message-assistant"]  — assistant message wrapper
+//   [data-testid="chat-message-user"]       — user message wrapper
+//   [data-testid="chart-card"]              — populated chart card (<Card>)
+//   [data-testid="chart-card"][data-chart-type=…] — chart type per card
+//   [data-testid="chart-title"]             — chart card title
+//   [data-testid="chart-unavailable"]       — "Chart unavailable" diagnostic
+//   [data-testid="chart-table"]             — rendered table body (for `table`)
+//   [data-testid="chart-gauge"]             — gauge container
+//   [data-testid="chart-gauge-svg"]         — gauge SVG
+//
+// The response wait polls **actual mark readiness** — table rows for `table`,
+// bar rectangles for bar/groupedBar/horizontalBar, pie sectors for pie/donut,
+// line dots for line, gauge SVG for gauge — so the runner cannot scrape the
+// DOM mid-stream and report a false "missing entity" (issue #54 Symptom 2b).
 
 /* eslint-disable no-console */
 
@@ -46,7 +75,10 @@ const CASES = [
     chartType: 'groupedBar', minMarks: 4, entities: ['Coastline Tacos', 'Apex Grill'] },
 ];
 
+// Recharts DOM shapes per chart type. Used to poll actual mark counts so the
+// runner does not sample the DOM before streaming completes.
 function countMarks(rootEl, chartType) {
+  if (!rootEl) return 0;
   const q = (sel) => rootEl.querySelectorAll(sel).length;
   switch (chartType) {
     case 'bar':
@@ -55,48 +87,122 @@ function countMarks(rootEl, chartType) {
     case 'horizontalBar':
       return q('.recharts-bar-rectangle');
     case 'line':
-      // one .recharts-line per series; each series contributes >=1 dot/curve
+      // Each series contributes one connecting curve + one or more visible dots.
+      // Count dots first; fall back to curves for line charts with 1-point series.
       return q('.recharts-line-dot, .recharts-dot') || q('.recharts-line-curve');
     case 'pie':
     case 'donut':
       return q('.recharts-pie-sector, .recharts-sector, .recharts-pie path');
     case 'gauge':
-      return q('svg[role="img"]');
+      // Gauge renders its own SVG (not Recharts). The stable hook is the
+      // `chart-gauge-svg` testid the ChartRenderer applies.
+      return rootEl.querySelector('[data-testid="chart-gauge-svg"]') ? 1 : 0;
     case 'table':
-      return q('tbody tr');
+      // `chart-table` marks the rendered <table>. Each mark is a body row.
+      return q('[data-testid="chart-table"] tbody tr');
     default:
       return 0;
   }
 }
 
 function findLatestChartCard() {
-  const cards = document.querySelectorAll('[class*="chartCard"]');
+  const cards = document.querySelectorAll('[data-testid="chart-card"]');
   return cards.length ? cards[cards.length - 1] : null;
 }
 
 function findLatestUnavailable() {
-  const notes = document.querySelectorAll('[role="note"]');
+  const notes = document.querySelectorAll('[data-testid="chart-unavailable"]');
   return notes.length ? notes[notes.length - 1] : null;
 }
 
-async function submitPrompt(prompt) {
-  // Prefer the promptbox textarea; fall back to the first textarea in the DOM.
-  const textarea = document.querySelector('textarea');
-  if (!textarea) throw new Error('No textarea found in the DOM.');
-  const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
-  setter.call(textarea, prompt);
-  textarea.dispatchEvent(new Event('input', { bubbles: true }));
-  // Fire the enter key like a user hitting send.
-  textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+function findComposer() {
+  // Prefer the stable testid; fall back to id-based selection for older builds.
+  return (
+    document.querySelector('[data-testid="chat-input"]')
+    || document.querySelector('#chat-input')
+  );
 }
 
-async function waitForResponse(prevCardCount, timeoutMs = 90_000) {
+function findSendButton() {
+  return (
+    document.querySelector('[data-testid="chat-send-button"]')
+    || document.querySelector('button[aria-label="Send message"]')
+  );
+}
+
+async function submitPrompt(prompt) {
+  const input = findComposer();
+  if (!input) throw new Error('No chat input found (looked for [data-testid="chat-input"]).');
+
+  // Fluent UI's <Input> renders as a native <input>; set its value via the
+  // React-compatible setter path and dispatch input+change so React commits
+  // the state update before we press Enter.
+  const proto = input.tagName === 'TEXTAREA'
+    ? window.HTMLTextAreaElement.prototype
+    : window.HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
+  setter.call(input, prompt);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+
+  // Fire Enter — matches the composer's Enter-to-send handler. Fall back to a
+  // programmatic click on the send button if the button surface is present.
+  input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+  // Some builds only wire the send button, so also click it if reachable.
+  const send = findSendButton();
+  if (send && !send.disabled) {
+    // A short microtask delay lets React flush the Enter handler first — the
+    // click is a harmless no-op if the request already dispatched.
+    await new Promise((r) => setTimeout(r, 20));
+    if (!send.disabled) send.click();
+  }
+}
+
+/**
+ * Wait until a chart card OR unavailable note appears AND the card is stable
+ * (mark count non-decreasing for one polling interval, and above the minimum
+ * this case declares). This replaces the historical scrape-before-render race
+ * that produced spurious "missing entity" failures (issue #54 Symptom 2b).
+ */
+async function waitForResponse(prevCardCount, prevNoteCount, chartType, minMarks, timeoutMs = 90_000) {
+  const pollMs = 750;
   const start = Date.now();
+  let lastMarks = -1;
+  let stableTicks = 0;
+
   while (Date.now() - start < timeoutMs) {
-    await new Promise((r) => setTimeout(r, 750));
-    const cards = document.querySelectorAll('[class*="chartCard"]');
-    const notes = document.querySelectorAll('[role="note"]');
-    if (cards.length > prevCardCount || notes.length > 0) return;
+    await new Promise((r) => setTimeout(r, pollMs));
+    const cards = document.querySelectorAll('[data-testid="chart-card"]');
+    const notes = document.querySelectorAll('[data-testid="chart-unavailable"]');
+
+    // Unavailable diagnostic appeared: the assistant already reported a
+    // no-render outcome; stop waiting and let the caller record it.
+    if (notes.length > prevNoteCount) return { kind: 'unavailable' };
+
+    if (cards.length > prevCardCount) {
+      const card = cards[cards.length - 1];
+      const marks = countMarks(card, chartType);
+
+      if (marks >= minMarks) {
+        // Require one polling interval where the mark count did not grow
+        // before declaring the render complete — protects against sampling
+        // a chart mid-stream (streaming table cells were the #54 case-7
+        // race). Marks that already exceed the minimum on first observation
+        // count that observation as one "stable" tick and settle on the next.
+        if (marks === lastMarks) {
+          stableTicks++;
+        } else {
+          stableTicks = 1;
+          lastMarks = marks;
+        }
+        if (stableTicks >= 2) return { kind: 'chart', card, marks };
+      }
+      else {
+        lastMarks = marks;
+        stableTicks = 0;
+      }
+    }
   }
   throw new Error('Timed out waiting for chart response');
 }
@@ -104,21 +210,38 @@ async function waitForResponse(prevCardCount, timeoutMs = 90_000) {
 async function runChartAcceptance() {
   const results = [];
   for (const c of CASES) {
-    const prevCards = document.querySelectorAll('[class*="chartCard"]').length;
+    const prevCards = document.querySelectorAll('[data-testid="chart-card"]').length;
+    const prevNotes = document.querySelectorAll('[data-testid="chart-unavailable"]').length;
     try {
       await submitPrompt(c.prompt);
-      await waitForResponse(prevCards);
-      const card = findLatestChartCard();
-      const note = findLatestUnavailable();
+      const outcome = await waitForResponse(prevCards, prevNotes, c.chartType, c.minMarks);
+
+      const card = outcome.kind === 'chart' ? outcome.card : findLatestChartCard();
+      const note = outcome.kind === 'unavailable' ? findLatestUnavailable() : null;
       const marks = card ? countMarks(card, c.chartType) : 0;
-      const missingEntities = c.entities.filter((e) => card && !card.textContent.includes(e));
+      const cardText = card ? card.textContent : '';
+      const missingEntities = c.entities.filter((e) => !cardText.includes(e));
+      const cardChartType = card ? card.getAttribute('data-chart-type') : null;
+      const chartTypeMatches = !cardChartType || cardChartType === c.chartType;
+
       const pass =
+        outcome.kind === 'chart' &&
         !!card &&
         !note &&
         marks >= c.minMarks &&
-        missingEntities.length === 0;
-      results.push({ prompt: c.prompt, chartType: c.chartType, marks, pass, note: !!note, missingEntities });
-      console.log((pass ? '✅' : '❌'), c.prompt, { marks, note: !!note, missingEntities });
+        missingEntities.length === 0 &&
+        chartTypeMatches;
+
+      results.push({
+        prompt: c.prompt,
+        chartType: c.chartType,
+        renderedChartType: cardChartType,
+        marks,
+        pass,
+        note: !!note,
+        missingEntities,
+      });
+      console.log((pass ? '✅' : '❌'), c.prompt, { marks, note: !!note, missingEntities, renderedChartType: cardChartType });
     } catch (err) {
       results.push({ prompt: c.prompt, chartType: c.chartType, pass: false, error: String(err) });
       console.log('❌', c.prompt, err);

--- a/scripts/browser-prompt-library-acceptance.js
+++ b/scripts/browser-prompt-library-acceptance.js
@@ -1,0 +1,247 @@
+// Curated PROSE prompt-library browser acceptance runner (issue #63).
+//
+// Paste this into the browser DevTools console while the Retail Pulse frontend
+// is loaded. It walks every curated PROSE prompt from
+// `ProsePromptAcceptanceManifest` — every non-chart entry from every
+// `PROMPT_CATEGORIES` category in `src/RetailPulse.Web/src/constants/prompts.ts`
+// — submits the prompt through the composer, waits for the assistant's
+// response to fully render, and asserts:
+//
+//   • the assistant produced a non-empty prose reply (not just an empty
+//     card, not just the "Chart unavailable" diagnostic),
+//   • the response did not accidentally render a chart card (a prose
+//     prompt that renders a chart is the classic "chart JSON leaked into
+//     a prose answer" regression),
+//   • the response text does not carry a raw ```json …``` fence or a
+//     `"chart":` / `"chartSpec":` payload (defence-in-depth against chart
+//     JSON leaking as pre-rendered text), and
+//   • the routing indicator (when present) points at the specialist the
+//     manifest expects — never the Consensus Council.
+//
+// Sibling of `scripts/browser-chart-acceptance.js` (which covers the Charts
+// category); together the two runners exercise the entire curated prompt
+// library.
+//
+// Usage:
+//   1. cd src/RetailPulse.Web && npm run dev
+//   2. Start the API (RetailPulse.AppHost or dotnet run per-project).
+//   3. Open http://localhost:5173, sign in, land on the empty dashboard.
+//   4. Open DevTools → Console.
+//   5. Paste this file's contents and run `await runPromptLibraryAcceptance()`.
+//   6. Copy the resulting `results` array into the issue #63 comment on #59.
+//
+// This script is deliberately dependency-free JS (not TS) and shares the same
+// stable `data-testid` selectors as the chart runner.
+
+/* eslint-disable no-console */
+
+// Mirror of ProsePromptAcceptanceManifest.Cases (issue #63). Any drift is
+// caught by the backend `ProsePromptAcceptanceManifestContractTests` /
+// `ProsePromptRoutingAcceptanceTests` suites in CI; the fields here are the
+// ones a live browser sweep needs.
+const PROSE_CASES = [
+  { prompt: 'Compare depletion trends across all regions for this quarter',
+    categoryId: 'general', expectedIntent: 'demand/forecasting' },
+  { prompt: 'Which brands are growing fastest year-over-year across the portfolio?',
+    categoryId: 'general', expectedIntent: 'general/fallback' },
+  { prompt: 'Show me field sentiment for our top 3 brands in the Southeast',
+    categoryId: 'general', expectedIntent: 'sentiment/field' },
+
+  { prompt: 'How are FreshMart depletions trending in the Northeast this quarter?',
+    categoryId: 'grocery', expectedIntent: 'general/fallback' },
+  { prompt: 'Compare Harvest Table vs FreshMart sell-through rates by region',
+    categoryId: 'grocery', expectedIntent: 'demand/forecasting' },
+  { prompt: 'What is the field sentiment for Harvest Table Meal Kits in the Midwest?',
+    categoryId: 'grocery', expectedIntent: 'sentiment/field' },
+
+  { prompt: 'How is Apex Grill performing in the Southwest this quarter?',
+    categoryId: 'qsr', expectedIntent: 'general/fallback' },
+  { prompt: 'What is the field sentiment for Coastline Tacos in the West Coast?',
+    categoryId: 'qsr', expectedIntent: 'sentiment/field' },
+
+  { prompt: 'Show me Pinnacle Hardware depletion stats in the Midwest for Q1',
+    categoryId: 'home-improvement', expectedIntent: 'general/fallback' },
+  { prompt: 'How is Summit Outdoor performing in the Southeast vs West Coast?',
+    categoryId: 'home-improvement', expectedIntent: 'general/fallback' },
+  { prompt: 'What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest?',
+    categoryId: 'home-improvement', expectedIntent: 'sentiment/field' },
+
+  { prompt: 'How are ClearDesk depletions trending in the Northeast this quarter?',
+    categoryId: 'office-supply', expectedIntent: 'general/fallback' },
+  { prompt: 'Compare ClearDesk Technology vs Paper Products sell-through by region',
+    categoryId: 'office-supply', expectedIntent: 'demand/forecasting' },
+  { prompt: 'What is the field sentiment for ClearDesk in the Southeast?',
+    categoryId: 'office-supply', expectedIntent: 'sentiment/field' },
+
+  { prompt: 'Show me Urban Living depletion trends across all regions this quarter',
+    categoryId: 'furniture', expectedIntent: 'general/fallback' },
+  { prompt: 'Compare Foundry Home vs Urban Living performance in the West Coast',
+    categoryId: 'furniture', expectedIntent: 'demand/forecasting' },
+  { prompt: 'What is the field sentiment for Urban Living in the Pacific Northwest?',
+    categoryId: 'furniture', expectedIntent: 'sentiment/field' },
+];
+
+const COUNCIL_INTENT = 'council/health';
+
+// Rough regex for chart JSON that has leaked into a prose bubble. Prose prompts
+// must never surface any of these fragments (`ChartRenderer` renders a chart
+// card instead of writing raw JSON into a message).
+const CHART_JSON_LEAK = /```json[\s\S]*?"(?:chart|chartSpec|charts)"\s*:|"(?:chartSpec|chart)"\s*:\s*\{/i;
+
+function findComposer() {
+  return (
+    document.querySelector('[data-testid="chat-input"]')
+    || document.querySelector('#chat-input')
+  );
+}
+
+function findSendButton() {
+  return (
+    document.querySelector('[data-testid="chat-send-button"]')
+    || document.querySelector('button[aria-label="Send message"]')
+  );
+}
+
+function findLatestAssistantMessage() {
+  const nodes = document.querySelectorAll('[data-testid="chat-message-assistant"]');
+  return nodes.length ? nodes[nodes.length - 1] : null;
+}
+
+function findRoutingLabel(assistantMsgEl) {
+  if (!assistantMsgEl) return null;
+  // The AgentRoutingIndicator exposes `data-testid="execution-path-pill"` and
+  // labels the routed intent inside the same subtree.
+  const pill = assistantMsgEl.querySelector('[data-testid="execution-path-pill"]');
+  return pill ? pill.textContent.trim() : null;
+}
+
+async function submitPrompt(prompt) {
+  const input = findComposer();
+  if (!input) throw new Error('No chat input found (looked for [data-testid="chat-input"]).');
+
+  const proto = input.tagName === 'TEXTAREA'
+    ? window.HTMLTextAreaElement.prototype
+    : window.HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
+  setter.call(input, prompt);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+  input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+  const send = findSendButton();
+  if (send && !send.disabled) {
+    await new Promise((r) => setTimeout(r, 20));
+    if (!send.disabled) send.click();
+  }
+}
+
+/**
+ * Wait until a new assistant message appears AND its streaming flag has
+ * settled (data-message-streaming="false"). Also detects chart-card /
+ * chart-unavailable elements attached to the same message so a leaked
+ * chart is captured.
+ */
+async function waitForAssistantResponse(prevAssistantCount, timeoutMs = 90_000) {
+  const pollMs = 750;
+  const start = Date.now();
+  let stableTicks = 0;
+  let lastLength = -1;
+
+  while (Date.now() - start < timeoutMs) {
+    await new Promise((r) => setTimeout(r, pollMs));
+    const assistantMsgs = document.querySelectorAll('[data-testid="chat-message-assistant"]');
+    if (assistantMsgs.length <= prevAssistantCount) continue;
+
+    const latest = assistantMsgs[assistantMsgs.length - 1];
+    const streaming = latest.getAttribute('data-message-streaming') === 'true';
+    const text = latest.textContent || '';
+
+    if (!streaming && text.length > 0) {
+      // Require one polling interval where the text did not grow before
+      // declaring the response complete — protects against sampling
+      // mid-stream (issue #54 case-7 race analogue for prose).
+      if (text.length === lastLength) {
+        stableTicks++;
+      } else {
+        stableTicks = 1;
+        lastLength = text.length;
+      }
+      if (stableTicks >= 2) return latest;
+    } else {
+      lastLength = text.length;
+      stableTicks = 0;
+    }
+  }
+  throw new Error('Timed out waiting for assistant response');
+}
+
+async function runPromptLibraryAcceptance() {
+  const results = [];
+  for (const c of PROSE_CASES) {
+    const prevAssistant = document.querySelectorAll('[data-testid="chat-message-assistant"]').length;
+    try {
+      await submitPrompt(c.prompt);
+      const assistantMsg = await waitForAssistantResponse(prevAssistant);
+      const text = (assistantMsg && assistantMsg.textContent) || '';
+      const trimmed = text.trim();
+
+      const chartCard = assistantMsg && assistantMsg.querySelector('[data-testid="chart-card"]');
+      const chartUnavailable = assistantMsg && assistantMsg.querySelector('[data-testid="chart-unavailable"]');
+      const routing = findRoutingLabel(assistantMsg);
+
+      const leaked = CHART_JSON_LEAK.test(text);
+      const nonEmpty = trimmed.length >= 20;
+      const notCouncil = !routing || !routing.toLowerCase().includes('council');
+
+      const pass =
+        !!assistantMsg
+        && !chartCard
+        && !chartUnavailable
+        && !leaked
+        && nonEmpty
+        && notCouncil;
+
+      results.push({
+        prompt: c.prompt,
+        categoryId: c.categoryId,
+        expectedIntent: c.expectedIntent,
+        observedRouting: routing,
+        responseLength: trimmed.length,
+        pass,
+        chartCardRendered: !!chartCard,
+        chartUnavailableRendered: !!chartUnavailable,
+        chartJsonLeaked: leaked,
+        wentToCouncil: !notCouncil,
+      });
+      console.log((pass ? '✅' : '❌'), c.prompt, {
+        length: trimmed.length,
+        routing,
+        chart: !!chartCard,
+        unavailable: !!chartUnavailable,
+        leaked,
+      });
+    } catch (err) {
+      results.push({
+        prompt: c.prompt,
+        categoryId: c.categoryId,
+        expectedIntent: c.expectedIntent,
+        pass: false,
+        error: String(err),
+      });
+      console.log('❌', c.prompt, err);
+    }
+  }
+
+  console.table(results.map(({ prompt, categoryId, expectedIntent, observedRouting, responseLength, pass }) => ({
+    prompt: prompt.slice(0, 55) + (prompt.length > 55 ? '…' : ''),
+    categoryId,
+    expectedIntent,
+    observedRouting,
+    responseLength,
+    pass,
+  })));
+  console.log('COPY-TO-DOCS:', JSON.stringify(results, null, 2));
+  return results;
+}
+
+globalThis.runPromptLibraryAcceptance = runPromptLibraryAcceptance;

--- a/src/RetailPulse.Contracts/Prompts/ProsePromptAcceptanceManifest.cs
+++ b/src/RetailPulse.Contracts/Prompts/ProsePromptAcceptanceManifest.cs
@@ -1,0 +1,210 @@
+using RetailPulse.Contracts.Routing;
+
+namespace RetailPulse.Contracts.Prompts;
+
+/// <summary>
+/// One acceptance contract for a curated PROSE (non-chart) prompt: the verbatim prompt
+/// text, its owning category, the specialist <see cref="AgentIntent"/> the router MUST
+/// classify it into, and the specialist agent key that owns the fulfillment path.
+///
+/// This is the prose analogue of <see cref="Charts.ChartAcceptanceCase"/>. Together the
+/// two manifests cover the full curated prompt library in
+/// <c>src/RetailPulse.Web/src/constants/prompts.ts</c> — chart-oriented prompts on the
+/// chart manifest, prose-oriented prompts on this manifest. Contract tests fail CI when
+/// either manifest drifts from the frontend prompt source.
+/// </summary>
+/// <param name="Prompt">The verbatim curated prompt text (single source of truth).</param>
+/// <param name="CategoryId">The <c>PROMPT_CATEGORIES</c> id the prompt belongs to.</param>
+/// <param name="ExpectedIntent">
+/// The <see cref="AgentIntent"/> the router MUST classify this prompt into. Must never
+/// be <see cref="AgentIntent.PortfolioHealth"/> — a prose curated prompt that lands on
+/// the multi-agent council produces a slow, prose-only response with no specialist
+/// tool-loop, which is the exact "empty/underpowered response" symptom this manifest
+/// exists to prevent.
+/// </param>
+/// <param name="ExpectedAgentKey">
+/// The DI key of the specialist that must own this request (e.g. <c>demand-forecasting</c>,
+/// <c>general</c>, <c>field-sentiment</c>). Must map to a specialist declared in
+/// <c>prompts.yaml</c> with a non-empty tool list, so the routed prompt actually
+/// invokes at least one tool (guarding the "returns a routed, tool-backed response"
+/// invariant the live browser sweep in issue #63 relies on).
+/// </param>
+/// <param name="Rationale">Short human note on why this routing is expected.</param>
+public sealed record ProsePromptAcceptanceCase(
+    string Prompt,
+    string CategoryId,
+    string ExpectedIntent,
+    string ExpectedAgentKey,
+    string Rationale);
+
+/// <summary>
+/// Canonical acceptance manifest for every curated PROSE prompt across the six
+/// tenant/domain-neutral categories exposed by the "Prompt ideas" popover in
+/// <c>src/RetailPulse.Web/src/constants/prompts.ts</c>. The Charts category
+/// (plus the previously-validated QSR two-brand comparison) is covered by
+/// <see cref="Charts.ChartAcceptanceManifest"/>; every remaining curated prompt
+/// is covered here.
+///
+/// Two contract tests enforce cross-language sync:
+/// <list type="bullet">
+///   <item><c>ProsePromptAcceptanceManifestContractTests</c> — this manifest must
+///     mirror every non-chart curated prompt in <c>prompts.ts</c> exactly (no
+///     drift, no orphans, in source order).</item>
+///   <item><c>ProsePromptRoutingAcceptanceTests</c> — every case must route through
+///     <c>RetailOpsRouter</c> to its expected specialist, never to the council,
+///     and must never be classified by <c>ChartRequestDetector</c> as an explicit
+///     chart request (guards against "prose leaks chart JSON" regressions).</item>
+/// </list>
+/// </summary>
+public static class ProsePromptAcceptanceManifest
+{
+    /// <summary>
+    /// The prose curated prompts in the order they appear in <c>prompts.ts</c>. Every
+    /// non-chart entry from every category is enumerated exactly once. The Charts
+    /// category and the QSR two-brand comparison prompt (both covered by
+    /// <see cref="Charts.ChartAcceptanceManifest"/>) are intentionally excluded here.
+    /// </summary>
+    public static readonly IReadOnlyList<ProsePromptAcceptanceCase> Cases =
+    [
+        // ── General Retail ────────────────────────────────────────────────
+        new(
+            Prompt: "Compare depletion trends across all regions for this quarter",
+            CategoryId: "general",
+            ExpectedIntent: AgentIntent.DemandForecasting,
+            ExpectedAgentKey: "demand-forecasting",
+            Rationale: "cross-region depletion comparison — router fast-path bypasses the LLM"),
+
+        new(
+            Prompt: "Which brands are growing fastest year-over-year across the portfolio?",
+            CategoryId: "general",
+            ExpectedIntent: AgentIntent.General,
+            ExpectedAgentKey: "general",
+            Rationale: "portfolio-ranking growth question — General agent owns the aggregate tool"),
+
+        new(
+            Prompt: "Show me field sentiment for our top 3 brands in the Southeast",
+            CategoryId: "general",
+            ExpectedIntent: AgentIntent.SentimentField,
+            ExpectedAgentKey: "field-sentiment",
+            Rationale: "'sentiment' keyword fast-paths to the field-sentiment specialist"),
+
+        // ── Grocery ───────────────────────────────────────────────────────
+        new(
+            Prompt: "How are FreshMart depletions trending in the Northeast this quarter?",
+            CategoryId: "grocery",
+            ExpectedIntent: AgentIntent.General,
+            ExpectedAgentKey: "general",
+            Rationale: "simple single-brand depletion trend — router fast-path → General for one MCP call"),
+
+        new(
+            Prompt: "Compare Harvest Table vs FreshMart sell-through rates by region",
+            CategoryId: "grocery",
+            ExpectedIntent: AgentIntent.DemandForecasting,
+            ExpectedAgentKey: "demand-forecasting",
+            Rationale: "'sell-through' keyword fast-paths to the demand-forecasting specialist"),
+
+        new(
+            Prompt: "What is the field sentiment for Harvest Table Meal Kits in the Midwest?",
+            CategoryId: "grocery",
+            ExpectedIntent: AgentIntent.SentimentField,
+            ExpectedAgentKey: "field-sentiment",
+            Rationale: "'sentiment' keyword fast-paths to the field-sentiment specialist"),
+
+        // ── Quick-Serve Restaurants ───────────────────────────────────────
+        new(
+            Prompt: "How is Apex Grill performing in the Southwest this quarter?",
+            CategoryId: "qsr",
+            ExpectedIntent: AgentIntent.General,
+            ExpectedAgentKey: "general",
+            Rationale: "single-brand performance lookup — router fast-path → General"),
+
+        // "Compare Coastline Tacos vs Apex Grill depletions across all regions" is a
+        // chart-comparison prompt covered by ChartAcceptanceManifest; excluded here.
+
+        new(
+            Prompt: "What is the field sentiment for Coastline Tacos in the West Coast?",
+            CategoryId: "qsr",
+            ExpectedIntent: AgentIntent.SentimentField,
+            ExpectedAgentKey: "field-sentiment",
+            Rationale: "'sentiment' keyword fast-paths to the field-sentiment specialist"),
+
+        // ── Home Improvement ──────────────────────────────────────────────
+        new(
+            Prompt: "Show me Pinnacle Hardware depletion stats in the Midwest for Q1",
+            CategoryId: "home-improvement",
+            ExpectedIntent: AgentIntent.General,
+            ExpectedAgentKey: "general",
+            Rationale: "single-brand depletion stats lookup — router fast-path → General"),
+
+        new(
+            Prompt: "How is Summit Outdoor performing in the Southeast vs West Coast?",
+            CategoryId: "home-improvement",
+            ExpectedIntent: AgentIntent.General,
+            ExpectedAgentKey: "general",
+            Rationale: "single-brand performance lookup — router fast-path → General"),
+
+        new(
+            Prompt: "What is the field sentiment for Pinnacle Hardware Power Tools in the Southwest?",
+            CategoryId: "home-improvement",
+            ExpectedIntent: AgentIntent.SentimentField,
+            ExpectedAgentKey: "field-sentiment",
+            Rationale: "'sentiment' keyword fast-paths to the field-sentiment specialist"),
+
+        // ── Office Supply ─────────────────────────────────────────────────
+        new(
+            Prompt: "How are ClearDesk depletions trending in the Northeast this quarter?",
+            CategoryId: "office-supply",
+            ExpectedIntent: AgentIntent.General,
+            ExpectedAgentKey: "general",
+            Rationale: "single-brand depletion trend — router fast-path → General"),
+
+        new(
+            Prompt: "Compare ClearDesk Technology vs Paper Products sell-through by region",
+            CategoryId: "office-supply",
+            ExpectedIntent: AgentIntent.DemandForecasting,
+            ExpectedAgentKey: "demand-forecasting",
+            Rationale: "'sell-through' keyword fast-paths to the demand-forecasting specialist"),
+
+        new(
+            Prompt: "What is the field sentiment for ClearDesk in the Southeast?",
+            CategoryId: "office-supply",
+            ExpectedIntent: AgentIntent.SentimentField,
+            ExpectedAgentKey: "field-sentiment",
+            Rationale: "'sentiment' keyword fast-paths to the field-sentiment specialist"),
+
+        // ── Furniture ─────────────────────────────────────────────────────
+        new(
+            Prompt: "Show me Urban Living depletion trends across all regions this quarter",
+            CategoryId: "furniture",
+            ExpectedIntent: AgentIntent.General,
+            ExpectedAgentKey: "general",
+            Rationale: "single-brand depletion trend lookup — router fast-path → General"),
+
+        new(
+            Prompt: "Compare Foundry Home vs Urban Living performance in the West Coast",
+            CategoryId: "furniture",
+            ExpectedIntent: AgentIntent.DemandForecasting,
+            ExpectedAgentKey: "demand-forecasting",
+            Rationale: "cross-brand performance comparison — LLM classification lands on demand-forecasting"),
+
+        new(
+            Prompt: "What is the field sentiment for Urban Living in the Pacific Northwest?",
+            CategoryId: "furniture",
+            ExpectedIntent: AgentIntent.SentimentField,
+            ExpectedAgentKey: "field-sentiment",
+            Rationale: "'sentiment' keyword fast-paths to the field-sentiment specialist"),
+    ];
+
+    /// <summary>The verbatim curated prose prompts, in manifest order.</summary>
+    public static IReadOnlyList<string> Prompts => [.. Cases.Select(c => c.Prompt)];
+
+    /// <summary>
+    /// Category ids from <c>prompts.ts</c> that this manifest fully covers (every
+    /// prose prompt in the category has a case). Excludes the <c>charts</c> category,
+    /// which is fully owned by <see cref="Charts.ChartAcceptanceManifest"/>.
+    /// </summary>
+    public static readonly IReadOnlyList<string> CoveredCategoryIds =
+    [
+        "general", "grocery", "qsr", "home-improvement", "office-supply", "furniture",
+    ];
+}

--- a/src/RetailPulse.Web/src/components/ChatPanel.tsx
+++ b/src/RetailPulse.Web/src/components/ChatPanel.tsx
@@ -794,7 +794,7 @@ export function ChatPanel({
 
   return (
     <div className={styles.panel}>
-      <div className={styles.messages}>
+      <div className={styles.messages} data-testid="chat-message-list">
         {messages.length === 0 && (
           <div className={styles.welcome}>
             <div className={styles.welcomeLogo}><BrandLogo size={56} /></div>
@@ -882,6 +882,9 @@ export function ChatPanel({
             key={`msg-${msg.role}-${i}`}
             className={`${styles.message} ${msg.role === 'user' ? styles.messageUser : styles.messageAssistant}`}
             style={msg.planId ? { maxWidth: '95%' } : undefined}
+            data-testid={msg.role === 'assistant' ? 'chat-message-assistant' : 'chat-message-user'}
+            data-message-index={i}
+            data-message-streaming={msg.role === 'assistant' && msg.isStreaming ? 'true' : 'false'}
           >
             <Avatar
               size={36}
@@ -1054,6 +1057,7 @@ export function ChatPanel({
           placeholder="Ask about retail performance..."
           disabled={loading}
           style={FLEX_ONE_STYLE}
+          data-testid="chat-input"
         />
         {loading ? (
           <Button
@@ -1072,6 +1076,7 @@ export function ChatPanel({
             disabled={!input.trim()}
             aria-label="Send message"
             style={SEND_BUTTON_STYLE}
+            data-testid="chat-send-button"
           >
             Send
           </Button>

--- a/tests/RetailPulse.Tests/Agents/Router/ProsePromptRoutingAcceptanceTests.cs
+++ b/tests/RetailPulse.Tests/Agents/Router/ProsePromptRoutingAcceptanceTests.cs
@@ -1,0 +1,340 @@
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RetailPulse.Api.Agents.Routing;
+using RetailPulse.Api.Charts;
+using RetailPulse.Api.Models;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Prompts;
+using RetailPulse.Contracts.Routing;
+using Xunit;
+
+namespace RetailPulse.Tests.Agents.Router;
+
+/// <summary>
+/// End-to-end routing acceptance for every curated PROSE prompt (issue #63).
+///
+/// The chart-only acceptance matrix in <see cref="ChartAcceptanceMatrixTests"/>
+/// already guards the render invariant per curated chart prompt. This suite closes
+/// the routing invariant for every remaining curated prompt — the prose entries in
+/// General, Grocery, QSR, Home Improvement, Office Supply, and Furniture — by
+/// asserting, deterministically and offline, that each prose prompt:
+///
+/// <list type="bullet">
+///   <item>Routes through <see cref="RetailOpsRouter"/> to the specialist declared
+///     in <see cref="ProsePromptAcceptanceManifest"/> — never to the multi-agent
+///     council (<see cref="AgentIntent.PortfolioHealth"/>), which would produce a
+///     slow, prose-only response with no tool loop.</item>
+///   <item>Is NOT classified by <see cref="ChartRequestDetector"/> as an explicit
+///     chart request — this guarantees the routing layer will not stream the prompt
+///     through the chart-fulfillment pipeline, which is the mechanism by which a
+///     prose response could accidentally leak chart JSON.</item>
+///   <item>Resolves to a specialist agent key that is declared in
+///     <c>prompts.yaml</c> with a non-empty tool list, so a live invocation will
+///     always have at least one tool to call and cannot produce an empty prose reply
+///     for lack of a tool.</item>
+/// </list>
+///
+/// The tool-list assertion is loaded once from <c>prompts.yaml</c>; the router
+/// setup mirrors <see cref="RetailOpsRouterTests"/> so the same fast-path patterns,
+/// specialist wiring, and orchestration intents production uses are exercised.
+/// </summary>
+public sealed class ProsePromptRoutingAcceptanceTests
+{
+    public static IEnumerable<object[]> AllCases()
+        => ProsePromptAcceptanceManifest.Cases.Select(c => new object[] { c });
+
+    [Theory]
+    [MemberData(nameof(AllCases))]
+    public async Task Case_RoutesToExpectedSpecialist_AndNeverToCouncil(ProsePromptAcceptanceCase c)
+    {
+        RetailOpsRouter router = CreateRouter(mockedLlmIntent: c.ExpectedIntent);
+
+        RoutingDecision result = await router.RouteAsync(c.Prompt, null, null, null);
+
+        result.Intent.Should().Be(c.ExpectedIntent,
+            $"prose prompt '{c.Prompt}' must classify to '{c.ExpectedIntent}' ({c.Rationale})");
+        result.AgentKey.Should().Be(c.ExpectedAgentKey,
+            $"prose prompt '{c.Prompt}' must be handled by the '{c.ExpectedAgentKey}' specialist");
+
+        result.Intent.Should().NotBe(
+            AgentIntent.PortfolioHealth,
+            $"prose prompt '{c.Prompt}' must never route to the multi-agent council");
+        result.AgentKey.Should().NotBe(
+            "council",
+            $"prose prompt '{c.Prompt}' must never target the council agent key");
+    }
+
+    [Theory]
+    [MemberData(nameof(AllCases))]
+    public void Case_IsNotClassifiedAsExplicitChartRequest(ProsePromptAcceptanceCase c)
+    {
+        // The router's chart fast-path (via ChartRequestDetector) will hijack any
+        // prompt classified as an explicit chart request and steer it into the chart
+        // fulfillment pipeline. If a PROSE curated prompt matches, the fulfillment
+        // pipeline will try to render a chart the user did not ask for — the exact
+        // "chart JSON leaked into a prose answer" symptom this manifest prevents.
+        ChartIntent intent = ChartRequestDetector.Detect(c.Prompt);
+
+        intent.IsExplicitChartRequest.Should().BeFalse(
+            $"prose curated prompt '{c.Prompt}' must NOT be classified as an explicit chart "
+            + "request — otherwise the chart-fulfillment path is forced onto a prose prompt");
+        intent.ChartType.Should().BeNull(
+            $"prose prompt '{c.Prompt}' must not carry a chart-type hint");
+    }
+
+    [Theory]
+    [MemberData(nameof(AllCases))]
+    public void Case_ExpectedAgentKey_ResolvesToASpecialistWithAtLeastOneTool(ProsePromptAcceptanceCase c)
+    {
+        IReadOnlyDictionary<string, int> toolCounts = SpecialistToolCountsFromPromptsYaml.Value;
+
+        toolCounts.Should().ContainKey(c.ExpectedAgentKey,
+            $"prompts.yaml must declare a specialist for key '{c.ExpectedAgentKey}' required by "
+            + $"prose prompt '{c.Prompt}'");
+
+        toolCounts[c.ExpectedAgentKey].Should().BeGreaterThanOrEqualTo(
+            1,
+            $"specialist '{c.ExpectedAgentKey}' must declare at least one tool in prompts.yaml so "
+            + $"prose prompt '{c.Prompt}' has at least one tool to invoke during fulfillment");
+    }
+
+    // ─── prompts.yaml tool-count loader ───────────────────────────────────
+
+    /// <summary>
+    /// Live tool counts per specialist agent key, parsed from <c>prompts.yaml</c>
+    /// once per test run. Loaded lazily so the fixture cost is paid only if the
+    /// tool-count theory actually runs.
+    /// </summary>
+    private static readonly Lazy<IReadOnlyDictionary<string, int>> SpecialistToolCountsFromPromptsYaml =
+        new(() =>
+        {
+            string yamlPath = ResolveRepoRelativePath("src", "RetailPulse.Api", "prompts.yaml");
+            string[] lines = File.ReadAllLines(yamlPath);
+            var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+            string? currentKey = null;
+            bool inToolsBlock = false;
+            int toolBlockIndent = -1;
+            int count = 0;
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                string trimmed = line.TrimStart();
+
+                // Detect: `    key: "some-key"` — capture the current specialist key.
+                if (trimmed.StartsWith("key:", StringComparison.Ordinal))
+                {
+                    if (currentKey is not null)
+                    {
+                        counts[currentKey] = inToolsBlock ? count : counts.GetValueOrDefault(currentKey, 0);
+                    }
+
+                    string valuePart = trimmed[4..].Trim().Trim('"', '\'');
+                    currentKey = valuePart;
+                    inToolsBlock = false;
+                    toolBlockIndent = -1;
+                    count = 0;
+                    counts[currentKey] = 0;
+                    continue;
+                }
+
+                if (currentKey is null) continue;
+
+                // Detect: `    tools: []` — an empty tool list block.
+                if (trimmed.StartsWith("tools:", StringComparison.Ordinal))
+                {
+                    string tail = trimmed[6..].Trim();
+                    if (tail == "[]")
+                    {
+                        counts[currentKey] = 0;
+                        inToolsBlock = false;
+                        continue;
+                    }
+                    inToolsBlock = true;
+                    toolBlockIndent = line.Length - trimmed.Length;
+                    count = 0;
+                    continue;
+                }
+
+                if (!inToolsBlock) continue;
+
+                // Count list items indented deeper than the `tools:` key.
+                int indent = line.Length - trimmed.Length;
+                if (trimmed.StartsWith("- ", StringComparison.Ordinal) && indent > toolBlockIndent)
+                {
+                    count++;
+                    counts[currentKey] = count;
+                    continue;
+                }
+
+                // A same-or-shallower non-list line ends the tools block.
+                if (!string.IsNullOrWhiteSpace(trimmed) && indent <= toolBlockIndent)
+                {
+                    inToolsBlock = false;
+                }
+            }
+
+            return counts;
+        });
+
+    // ─── Router factory (mirrors RetailOpsRouterTests wiring) ─────────────
+
+    private static RetailOpsRouter CreateRouter(string mockedLlmIntent)
+    {
+        var mockClient = new Mock<IChatClient>();
+        mockClient
+            .Setup(x => x.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Microsoft.Extensions.AI.ChatResponse(
+                new ChatMessage(ChatRole.Assistant,
+                    $"{{\"intent\":\"{mockedLlmIntent}\",\"confidence\":0.95,\"intents\":[\"{mockedLlmIntent}\"]}}")));
+
+        List<ISpecialistAgent> specialists = CreateSpecialistsWithAllIntents();
+
+        var routerDef = new AgentDefinition
+        {
+            Name = "Router",
+            Model = "gpt-5.4-mini",
+            SystemPrompt = "Classify user intent into retail categories. Return JSON.",
+            Temperature = 0.1,
+        };
+
+        return new RetailOpsRouter(
+            mockClient.Object,
+            routerDef,
+            specialists,
+            Mock.Of<ILogger<RetailOpsRouter>>(),
+            intentConfigs:
+            [
+                new RouterIntentConfig(
+                    AgentIntent.PortfolioHealth,
+                    ["how healthy is", "brand health report", "portfolio health",
+                     "overall assessment for", "how is the portfolio"]),
+                new RouterIntentConfig(
+                    AgentIntent.Scorecard,
+                    ["scorecard", "portfolio scoring", "brand ranking",
+                     "top brand", "worst brand", "executive brief"]),
+            ]);
+    }
+
+    /// <summary>
+    /// Specialists covering every well-known intent, each owning exactly one intent
+    /// and its own keyword fast-paths. Mirrors production wiring in Program.cs so
+    /// the routing behaviour observed here matches what live users see.
+    /// </summary>
+    private static List<ISpecialistAgent> CreateSpecialistsWithAllIntents()
+    {
+        var general = new Mock<ISpecialistAgent>();
+        general.Setup(s => s.Key).Returns("general");
+        general.Setup(s => s.DisplayName).Returns("General Agent");
+        general.Setup(s => s.SupportedIntents).Returns([AgentIntent.General]);
+        general.Setup(s => s.KeywordFastPaths).Returns([]);
+
+        var demand = new Mock<ISpecialistAgent>();
+        demand.Setup(s => s.Key).Returns("demand-forecasting");
+        demand.Setup(s => s.DisplayName).Returns("Demand Forecast Agent");
+        demand.Setup(s => s.SupportedIntents).Returns([AgentIntent.DemandForecasting]);
+        demand.Setup(s => s.KeywordFastPaths).Returns(
+            ["depletion", "sell-through", "sell through", "velocity", "forecast", "demand"]);
+
+        var promo = new Mock<ISpecialistAgent>();
+        promo.Setup(s => s.Key).Returns("promo-planning");
+        promo.Setup(s => s.DisplayName).Returns("Promo Planning Agent");
+        promo.Setup(s => s.SupportedIntents).Returns([AgentIntent.PromotionTrade]);
+        promo.Setup(s => s.KeywordFastPaths).Returns(
+            ["promotion", "promo", "campaign", "lift", "trade spend"]);
+
+        var supply = new Mock<ISpecialistAgent>();
+        supply.Setup(s => s.Key).Returns("supply-chain");
+        supply.Setup(s => s.DisplayName).Returns("Supply Chain Agent");
+        supply.Setup(s => s.SupportedIntents).Returns([AgentIntent.SupplyShipments]);
+        supply.Setup(s => s.KeywordFastPaths).Returns(
+            ["supply", "shipment", "inventory", "disruption", "fulfillment", "pipeline"]);
+
+        var competitive = new Mock<ISpecialistAgent>();
+        competitive.Setup(s => s.Key).Returns("competitive-intel");
+        competitive.Setup(s => s.DisplayName).Returns("Competitive Intel Agent");
+        competitive.Setup(s => s.SupportedIntents).Returns([AgentIntent.CompetitiveMarket]);
+        competitive.Setup(s => s.KeywordFastPaths).Returns(
+            ["competitor", "market share", "competitive", "rival"]);
+
+        var sentiment = new Mock<ISpecialistAgent>();
+        sentiment.Setup(s => s.Key).Returns("field-sentiment");
+        sentiment.Setup(s => s.DisplayName).Returns("Field Sentiment Agent");
+        sentiment.Setup(s => s.SupportedIntents).Returns([AgentIntent.SentimentField]);
+        sentiment.Setup(s => s.KeywordFastPaths).Returns(
+            ["sentiment", "distributor feedback", "field feedback", "field sales", "retailer satisfaction"]);
+
+        var council = new Mock<ISpecialistAgent>();
+        council.Setup(s => s.Key).Returns("council");
+        council.Setup(s => s.DisplayName).Returns("Consensus Council");
+        council.Setup(s => s.SupportedIntents).Returns([AgentIntent.PortfolioHealth]);
+        council.Setup(s => s.KeywordFastPaths).Returns([]);
+
+        var planogram = new Mock<ISpecialistAgent>();
+        planogram.Setup(s => s.Key).Returns("planogram");
+        planogram.Setup(s => s.DisplayName).Returns("Planogram Agent");
+        planogram.Setup(s => s.SupportedIntents).Returns([AgentIntent.Planogram]);
+        planogram.Setup(s => s.KeywordFastPaths).Returns(
+            ["planogram", "shelf layout", "shelf space", "facing", "sku placement", "brand blocking"]);
+
+        var scorecard = new Mock<ISpecialistAgent>();
+        scorecard.Setup(s => s.Key).Returns("scorecard");
+        scorecard.Setup(s => s.DisplayName).Returns("Scorecard Agent");
+        scorecard.Setup(s => s.SupportedIntents).Returns([AgentIntent.Scorecard]);
+        scorecard.Setup(s => s.KeywordFastPaths).Returns(
+            ["scorecard", "portfolio scoring", "brand ranking", "top brand", "worst brand", "executive brief"]);
+
+        var storeOps = new Mock<ISpecialistAgent>();
+        storeOps.Setup(s => s.Key).Returns("store-ops");
+        storeOps.Setup(s => s.DisplayName).Returns("Store Ops Agent");
+        storeOps.Setup(s => s.SupportedIntents).Returns([AgentIntent.StoreOps]);
+        storeOps.Setup(s => s.KeywordFastPaths).Returns(
+            ["store performance", "foot traffic", "conversion rate", "stockout", "underperforming store"]);
+
+        var margin = new Mock<ISpecialistAgent>();
+        margin.Setup(s => s.Key).Returns("margin-analysis");
+        margin.Setup(s => s.DisplayName).Returns("Margin Agent");
+        margin.Setup(s => s.SupportedIntents).Returns([AgentIntent.MarginAnalysis]);
+        margin.Setup(s => s.KeywordFastPaths).Returns(
+            ["margin", "profitability", "cogs", "gross margin", "net margin"]);
+
+        return
+        [
+            general.Object,
+            demand.Object,
+            promo.Object,
+            supply.Object,
+            competitive.Object,
+            sentiment.Object,
+            council.Object,
+            planogram.Object,
+            scorecard.Object,
+            storeOps.Object,
+            margin.Object,
+        ];
+    }
+
+    private static string ResolveRepoRelativePath(params string[] segments)
+    {
+        string dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 12; i++)
+        {
+            if (File.Exists(Path.Combine(dir, "README.md"))
+                && Directory.Exists(Path.Combine(dir, "src")))
+            {
+                return Path.Combine([dir, .. segments]);
+            }
+            string? parent = Path.GetDirectoryName(dir);
+            if (string.IsNullOrEmpty(parent) || parent == dir) break;
+            dir = parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate repository root from test binary directory: " + AppContext.BaseDirectory);
+    }
+}

--- a/tests/RetailPulse.Tests/Contract/ProsePromptAcceptanceManifestContractTests.cs
+++ b/tests/RetailPulse.Tests/Contract/ProsePromptAcceptanceManifestContractTests.cs
@@ -1,0 +1,227 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using RetailPulse.Contracts.Charts;
+using RetailPulse.Contracts.Prompts;
+using Xunit;
+
+namespace RetailPulse.Tests.Contract;
+
+/// <summary>
+/// Cross-language contract test for the curated PROSE prompt acceptance manifest.
+///
+/// The single source of truth for the curated prompt library is the frontend file
+/// <c>src/RetailPulse.Web/src/constants/prompts.ts</c>. The backend prose manifest
+/// <see cref="ProsePromptAcceptanceManifest"/> must cover exactly the non-chart
+/// curated prompts in every non-chart category, in prompt-source order, and must
+/// not carry orphans. The QSR two-brand chart-comparison prompt is intentionally
+/// excluded because it is covered by <see cref="ChartAcceptanceManifest"/>.
+///
+/// This test parses <c>prompts.ts</c> directly (mirroring
+/// <c>ChartAcceptanceManifestContractTests</c>) and asserts:
+/// <list type="bullet">
+///   <item>every non-chart prompt appears in the manifest, in source order,</item>
+///   <item>the QSR two-brand chart-comparison prompt does NOT appear in the prose
+///     manifest (it is chart-owned),</item>
+///   <item>the manifest has no orphan entries that are absent from the prompt
+///     source, and</item>
+///   <item>every case has coherent semantics (non-empty prompt, expected intent,
+///     expected agent key; never the council).</item>
+/// </list>
+/// A drift in any of these surfaces fails CI immediately, consistent with how
+/// <c>ChartAcceptanceManifestContractTests</c> enforces the chart manifest.
+/// </summary>
+public sealed partial class ProsePromptAcceptanceManifestContractTests
+{
+    private const string ChartsCategoryId = "charts";
+    private const string QsrCategoryId = "qsr";
+    private const string QsrComparisonPromptPrefix = "Compare Coastline Tacos vs Apex Grill";
+
+    [Fact]
+    public void Manifest_MatchesFrontendPromptSource_EveryNonChartCategoryInSourceOrder()
+    {
+        IReadOnlyList<(string Id, string Label, IReadOnlyList<string> Prompts)> categories = ReadAllCategories();
+
+        List<string> expectedProsePrompts = [];
+        foreach ((string id, string _, IReadOnlyList<string> prompts) in categories)
+        {
+            if (string.Equals(id, ChartsCategoryId, StringComparison.Ordinal))
+            {
+                continue; // owned by ChartAcceptanceManifest
+            }
+
+            foreach (string prompt in prompts)
+            {
+                // The QSR two-brand comparison is chart-owned (implicitly promoted to a
+                // grouped bar). Skip it here — chart manifest covers it.
+                if (string.Equals(id, QsrCategoryId, StringComparison.Ordinal)
+                    && prompt.StartsWith(QsrComparisonPromptPrefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                expectedProsePrompts.Add(prompt);
+            }
+        }
+
+        ProsePromptAcceptanceManifest.Prompts.Should().Equal(
+            expectedProsePrompts,
+            "the prose acceptance manifest is the backend mirror of every non-chart curated "
+            + "prompt in prompts.ts (in source order); any drift breaks the cross-language contract");
+    }
+
+    [Fact]
+    public void Manifest_ExcludesTheQsrTwoBrandChartComparisonPrompt()
+    {
+        // Regression guard: the QSR "Compare Coastline Tacos vs Apex Grill …" prompt is a
+        // chart-comparison prompt covered by ChartAcceptanceManifest. It must NOT appear
+        // in the prose manifest — otherwise a live sweep would try to assert prose-only
+        // response semantics against a prompt that legitimately produces a grouped bar.
+        ProsePromptAcceptanceManifest.Prompts
+            .Should().NotContain(
+                p => p.StartsWith(QsrComparisonPromptPrefix, StringComparison.Ordinal),
+                "the QSR two-brand chart comparison is chart-owned; it must not appear in the prose manifest");
+    }
+
+    [Fact]
+    public void Manifest_CoveredCategoryIds_MatchAllNonChartCategoriesInPromptSource()
+    {
+        IReadOnlyList<(string Id, string Label, IReadOnlyList<string> Prompts)> categories = ReadAllCategories();
+
+        string[] expectedIds = [.. categories
+            .Where(c => !string.Equals(c.Id, ChartsCategoryId, StringComparison.Ordinal))
+            .Select(c => c.Id)];
+
+        ProsePromptAcceptanceManifest.CoveredCategoryIds.Should().Equal(
+            expectedIds,
+            "the manifest's declared covered-category list must mirror every non-chart "
+            + "category id in prompts.ts (in source order)");
+    }
+
+    [Fact]
+    public void Manifest_EveryCaseHasCoherentSemantics()
+    {
+        foreach (ProsePromptAcceptanceCase c in ProsePromptAcceptanceManifest.Cases)
+        {
+            c.Prompt.Should().NotBeNullOrWhiteSpace();
+            c.CategoryId.Should().NotBeNullOrWhiteSpace();
+            c.ExpectedIntent.Should().NotBeNullOrWhiteSpace();
+            c.ExpectedAgentKey.Should().NotBeNullOrWhiteSpace();
+            c.Rationale.Should().NotBeNullOrWhiteSpace();
+
+            c.ExpectedIntent.Should().NotBe(
+                Contracts.Routing.AgentIntent.PortfolioHealth,
+                $"prose prompt '{c.Prompt}' must never route to the multi-agent council — the "
+                + "council produces a slow, prose-only response with no specialist tool-loop, "
+                + "which is the exact 'empty/underpowered response' symptom this manifest prevents");
+
+            c.ExpectedAgentKey.Should().NotBe(
+                "council",
+                $"prose prompt '{c.Prompt}' must never target the council agent key");
+
+            ProsePromptAcceptanceManifest.CoveredCategoryIds.Should().Contain(
+                c.CategoryId,
+                $"case '{c.Prompt}' references category '{c.CategoryId}' which is not in CoveredCategoryIds");
+        }
+    }
+
+    [Fact]
+    public void Manifest_EveryPromptIsUnique()
+    {
+        // Guard against copy-paste duplication that would silently double-run a prompt
+        // in the live browser sweep while masking a missed category entry.
+        var duplicates = ProsePromptAcceptanceManifest.Cases
+            .GroupBy(c => c.Prompt, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        duplicates.Should().BeEmpty(
+            "every prose acceptance case must reference a distinct curated prompt");
+    }
+
+    // ── prompts.ts parsing (mirrors ChartAcceptanceManifestContractTests) ─────
+
+    private static IReadOnlyList<(string Id, string Label, IReadOnlyList<string> Prompts)> ReadAllCategories()
+    {
+        string source = ReadPromptsSource();
+        var results = new List<(string, string, IReadOnlyList<string>)>();
+
+        // Every prompt-category block is emitted by the `mirrorCategory(id, label,
+        // emoji, order, [ [prompt, capability], ... ])` helper. Parse each block by
+        // matching the helper signature up to the opening `[` of its fifth argument,
+        // then extract the leading single-quoted string from every nested tuple
+        // (that's the submitted prompt; the capability that follows is a helper call,
+        // not a string literal, so it cannot confuse the leading-string match).
+        foreach (Match blockMatch in MirrorCategoryBlockRegex().Matches(source))
+        {
+            string id = blockMatch.Groups["id"].Value;
+            string label = Regex.Unescape(blockMatch.Groups["label"].Value);
+            int arrStart = blockMatch.Index + blockMatch.Length;
+            int arrEnd = FindMatchingBracket(source, arrStart - 1);
+            if (arrEnd < 0) continue;
+
+            string arrBody = source[arrStart..arrEnd];
+            var prompts = new List<string>();
+            foreach (Match m in TupleLeadingStringRegex().Matches(arrBody))
+            {
+                prompts.Add(Regex.Unescape(m.Groups[1].Value));
+            }
+
+            results.Add((id, label, prompts));
+        }
+
+        results.Should().NotBeEmpty("prompts.ts must contain at least one mirrorCategory block");
+        return results;
+    }
+
+    private static string ReadPromptsSource()
+    {
+        string promptsPath = ResolveRepoRelativePath(
+            "src", "RetailPulse.Web", "src", "constants", "prompts.ts");
+        return File.ReadAllText(promptsPath);
+    }
+
+    private static int FindMatchingBracket(string source, int openIndex)
+    {
+        int depth = 0;
+        for (int i = openIndex; i < source.Length; i++)
+        {
+            char c = source[i];
+            if (c == '[')
+            {
+                depth++;
+            }
+            else if (c == ']')
+            {
+                depth--;
+                if (depth == 0) return i;
+            }
+        }
+        return -1;
+    }
+
+    private static string ResolveRepoRelativePath(params string[] segments)
+    {
+        string dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 12; i++)
+        {
+            if (File.Exists(Path.Combine(dir, "README.md"))
+                && Directory.Exists(Path.Combine(dir, "src")))
+            {
+                return Path.Combine([dir, .. segments]);
+            }
+            string? parent = Path.GetDirectoryName(dir);
+            if (string.IsNullOrEmpty(parent) || parent == dir) break;
+            dir = parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate repository root from test binary directory: " + AppContext.BaseDirectory);
+    }
+
+    [GeneratedRegex(
+        @"mirrorCategory\(\s*'(?<id>[a-z][a-z0-9-]*)'\s*,\s*'(?<label>[^'\\]*(?:\\.[^'\\]*)*)'\s*,\s*'[^']*'\s*,\s*\d+\s*,\s*\[")]
+    private static partial Regex MirrorCategoryBlockRegex();
+
+    [GeneratedRegex(@"\[\s*'([^'\\]*(?:\\.[^'\\]*)*)'")]
+    private static partial Regex TupleLeadingStringRegex();
+}


### PR DESCRIPTION
Closes #63
Closes #54

Working as Kroger (Lead).

Ships the integrated fix for the three sub-scopes that landed together in this branch: the full prompt-library acceptance contract (#63), the chart browser-runner selector repair (#54 item 2), and the APIM LLM-log request/response pairing smoke (#54 item 1). One PR, three commits, cleanly separated.

## What's in it

### 1. Prompt-library acceptance contract — every prose curated prompt (#63)
Prior art on `squad/61-production-prompt-acceptance` (closed PR #64) built its assertion on `ChartRequestDetector` — which the current codebase treats as a stable, off-limits router-side seam. This branch salvages the concept (backend manifest + drift-catching contract test), adapts it to the current MAF plan-first architecture, and lands the equivalent of `ChartAcceptanceManifest` on the prose side of the library.

- `src/RetailPulse.Contracts/Prompts/ProsePromptAcceptanceManifest.cs` — 17 cases covering every non-chart entry in every non-chart category (General, Grocery, QSR, Home Improvement, Office Supply, Furniture). Each case declares the specialist agent key + intent the router MUST land on, plus a rationale.
- `tests/RetailPulse.Tests/Contract/ProsePromptAcceptanceManifestContractTests.cs` — parses `src/RetailPulse.Web/src/constants/prompts.ts` and fails CI on drift (missing / extra / out-of-order / duplicate entries), and asserts the QSR two-brand chart-comparison prompt is NOT present (it is chart-owned).
- `tests/RetailPulse.Tests/Agents/Router/ProsePromptRoutingAcceptanceTests.cs` — for every prose prompt, routes through the same `RetailOpsRouter` production uses (mocked LLM classifier so the fast-path + LLM + cache pipeline is exercised end-to-end) and asserts:
  - `Intent == ExpectedIntent`, `AgentKey == ExpectedAgentKey`, never `PortfolioHealth` / council.
  - `ChartRequestDetector.Detect(prompt).IsExplicitChartRequest == false` — the chart fast-path must never hijack a prose curated prompt (that is the mechanism by which chart JSON could leak into a prose answer).
  - The expected agent key resolves to a specialist in `prompts.yaml` with a **non-empty `tools:` list** — so a live invocation always has at least one tool to call.
- `docs/prompt-library-acceptance.md` — human-readable index of the prose matrix (mirrors `docs/chart-acceptance.md`).

Union of `ChartAcceptanceManifest` (9 cases) + `ProsePromptAcceptanceManifest` (17 cases) mirrors `PROMPT_CATEGORIES` exactly. No duplicate chart coverage.

### 2. Chart browser runner selector repair (#54 item 2)
- Every selector in `scripts/browser-chart-acceptance.js` audited against the current React tree and switched to identity-based `data-testid` hooks: `chart-card`, `chart-title`, `chart-unavailable`, `chart-table`, `chart-gauge-svg`.
- Composer selector fixed: the chat input is a Fluent UI `<Input>` (renders as `<input>`), not `<textarea>`. Now targets `[data-testid="chat-input"]` with an `#chat-input` fallback.
- `waitForResponse` now polls for the manifest's `minMarks` bar-rectangles / pie-sectors / line-dots / table rows / gauge SVG AND requires one stable polling interval before scraping — closes the case-7 scrape-before-render race Publix reported on PR #53.
- Also records `[data-chart-type]` per rendered card so wrong-type renders are caught explicitly, not by mark-count heuristics alone.
- Additive frontend hooks on `ChatPanel.tsx` (zero behavioural change): `data-testid` on `chat-input`, `chat-send-button`, `chat-message-list`, `chat-message-assistant`, `chat-message-user`, plus `data-message-streaming="true|false"` so runners can wait for a stream to settle.
- `docs/chart-acceptance.md` + `docs/chart-acceptance-run.md` document the stable-testid strategy and the poll-for-mark-readiness step.
- `scripts/browser-prompt-library-acceptance.js` (new sibling runner) exercises every prose case — reuses the same testid contract, asserts non-empty prose reply / no chart-card leak / no chart JSON in text / non-council routing.

### 3. APIM LLM-log request/response pairing smoke (#54 item 1)
- `scripts/Verify-ApimLlmLogPairing.ps1` fires N low-token direct APIM calls with unique `retail-pulse-marker-<8-hex>` markers, waits a bounded settle window, KQL-queries `ApiManagementGatewayLlmLog`, and asserts 1:1 pairing per marker.
- Mirrors `scripts/Verify-ApimAiGateway.ps1` conventions: env-var fallback per parameter, exit codes `0` pass / `1` fail / `2` skipped-with-reason, and a `-SelfTest` mode that exercises the pairing analyzer against three offline fixtures (healthy / PR-#52 symptom / marker-scoping).
- `docs/apim-llm-log-pairing.md` documents assumptions, parameters, invocation, and failure modes.

## Validation

- `dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj --filter "FullyQualifiedName~ProsePrompt|FullyQualifiedName~ChartAcceptance|FullyQualifiedName~RetailOpsRouter|FullyQualifiedName~ChartRankingRouting"` → **Passed! Failed: 0, Passed: 146**, incl. all 51 new prose acceptance tests.
- `dotnet format RetailPulse.slnx --verify-no-changes` → clean.
- `./scripts/Verify-ApimLlmLogPairing.ps1 -SelfTest` → **SELFTEST PASS** (all 11 offline assertions green).
- Frontend Vitest / build validation deferred to CI by design — this environment has no `node_modules` and no registry access; frontend changes are additive `data-testid` attributes with zero behavioural change.
- **Live APIM verification DEFERRED**: no live APIM instance / Log Analytics workspace is available from the environment producing this branch. The offline `-SelfTest` mode passes; the live half is not asserted here and is not fabricated. Docs describe the exact invocation for a follow-up live run.

## Scope discipline
No changes to any of `AgentExecutionPipeline.ChartFulfillment.cs`, `ChartRequestDetector.cs`, `PlanExecutor.cs`, `PlanReviewCompletionService.cs`, `IPlanStore.cs` (concurrently owned by other sessions). Frontend touch is limited to additive `data-testid` attributes on stable ChatPanel elements. No unrelated files reformatted.

## Base
Branched from `main` at `676d8ef` per spawn brief.