### PR TITLE
Docs & ADR pass: platform evolution (#111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,38 +242,42 @@ Navigate to [http://localhost:5173](http://localhost:5173) and start asking ques
 
 ## Tenant Configuration
 
-Retail Pulse reads `tenant.yaml` at the repo root to configure the entire platform:
+Retail Pulse loads a **content pack** at boot to configure the entire platform (see the **Content packs** reference table under [§ Configuration](#configuration) below). The active pack is selected by `Packs:Active` (default `default`) and the pack root by `Packs:Root` (default `packs`). `Program.cs` wires `PackTenantProvider(activePack)` as the `ITenantProvider`; the pack's `agents.yaml` is the roster consumed by `ConfiguredSpecialistAgent` + `MafAgentInvoker` (ADR-008). The legacy root `tenant.yaml` and `src/RetailPulse.Api/prompts.yaml` files are retained on disk for byte-equivalence comparison tests only — the runtime never reads them (see the "Legacy `tenant.yaml` and `prompts.yaml`" section in [`docs/tenant-configuration.md`](docs/tenant-configuration.md)).
+
+The `tenant:` block inside `packs/<pack>/pack.yaml` follows the historical tenant schema — company, industry, brands, regions, theme — so the sample below is the shape the runtime actually reads:
 
 ```yaml
-company: "Apex Retail Group"
-industry: "Multi-Category Retail"
-brands:
-  - name: "Sierra Gold Tequila"
-    category: "Spirits"
-    variants: ["Blanco", "Reposado", "Añejo", "Extra Añejo"]
-    priceSegment: "Premium"
-  - name: "FreshMart"
-    category: "Grocery"
-    variants: ["Organic Produce", "Bakery", "Deli", "Frozen"]
-    priceSegment: "Standard"
-  - name: "Apex Grill"
-    category: "Quick-Serve Restaurant"
-    variants: ["Burgers", "Chicken", "Breakfast", "Beverages"]
-    priceSegment: "Standard"
-  # ... 12 brands across 6 categories
-regions:
-  - "Northeast"
-  - "Southeast"
-  - "Midwest"
-  - "Southwest"
-  - "West Coast"
-  - "Pacific Northwest"
-theme:
-  primaryColor: "#1B4D7A"
-  accentColor: "#E8A838"
+# packs/default/pack.yaml (excerpt — `tenant:` block)
+tenant:
+  company: "Apex Retail Group"
+  industry: "Multi-Category Retail"
+  brands:
+    - name: "Sierra Gold Tequila"
+      category: "Spirits"
+      variants: ["Blanco", "Reposado", "Añejo", "Extra Añejo"]
+      priceSegment: "Premium"
+    - name: "FreshMart"
+      category: "Grocery"
+      variants: ["Organic Produce", "Bakery", "Deli", "Frozen"]
+      priceSegment: "Standard"
+    - name: "Apex Grill"
+      category: "Quick-Serve Restaurant"
+      variants: ["Burgers", "Chicken", "Breakfast", "Beverages"]
+      priceSegment: "Standard"
+    # ... 12 brands across 6 categories
+  regions:
+    - "Northeast"
+    - "Southeast"
+    - "Midwest"
+    - "Southwest"
+    - "West Coast"
+    - "Pacific Northwest"
+  theme:
+    primaryColor: "#1B4D7A"
+    accentColor: "#E8A838"
 ```
 
-The included **Apex Retail Group** sample tenant demonstrates a multi-category retail conglomerate with **12 brands** across **6 categories**:
+The shipped **Apex Retail Group** sample tenant (`packs/default`) demonstrates a multi-category retail conglomerate with **12 brands** across **6 categories**:
 
 | Category | Brands |
 |----------|--------|
@@ -284,7 +288,7 @@ The included **Apex Retail Group** sample tenant demonstrates a multi-category r
 | 📎 Office Supply | ClearDesk |
 | 🛋️ Furniture | Urban Living, Foundry Home |
 
-All brands operate across **6 regions**: Northeast, Southeast, Midwest, Southwest, West Coast, and Pacific Northwest. See the [Tenant Configuration Guide](docs/tenant-configuration.md) for full schema reference and examples for different industries.
+All brands operate across **6 regions**: Northeast, Southeast, Midwest, Southwest, West Coast, and Pacific Northwest. The `halcyon-pet-supply` and `prairiehearth-craft-supply` packs ship as alternate scenarios; switch by setting `Packs:Active` at boot. See the [Tenant Configuration Guide](docs/tenant-configuration.md) for the full pack schema, live validation rules, and a worked example of adding a specialist by configuration only.
 
 ---
 
@@ -317,8 +321,17 @@ All brands operate across **6 regions**: Northeast, Southeast, Midwest, Southwes
 
 ```
 retail-pulse/
-├── tenant.yaml                       # Tenant configuration (brands, regions, theme)
+├── tenant.yaml                       # Legacy sample tenant (byte-equivalent to packs/default's tenant: block) — no longer read at runtime
 ├── RetailPulse.slnx                  # Solution file
+├── packs/                            # Content packs (issue #108) — active runtime source of tenant + agents + knowledge
+│   ├── default/                      # Apex Retail Group sample (loaded by default)
+│   │   ├── pack.yaml                 # Tenant metadata (brands, regions, theme) + pack manifest
+│   │   ├── agents.yaml               # Agent roster (specialist prompts, model, tools, knowledge bindings)
+│   │   ├── starting-tasks.yaml       # Suggested starting prompts surfaced by the SPA
+│   │   ├── knowledge/                # Grounding corpus (indexed by the active knowledge provider)
+│   │   └── seed/scenario.yaml        # Deterministic SQLite seed data
+│   ├── halcyon-pet-supply/           # Alternate sample: specialty pet-supply retailer
+│   └── prairiehearth-craft-supply/   # Alternate sample: craft-supply retailer
 ├── src/
 │   ├── RetailPulse.AppHost/          # Aspire 13.3.0 orchestrator
 │   ├── RetailPulse.Api/              # Agent API service
@@ -333,7 +346,7 @@ retail-pulse/
 │   │   ├── Telemetry/                # Custom business metrics (OpenTelemetry)
 │   │   ├── Tools/                    # MCP tool wrappers
 │   │   ├── Validation/               # Input validation (ChatRequestValidator)
-│   │   └── prompts.yaml              # Agent prompt configuration (`src/RetailPulse.Api/prompts.yaml`, tenant-templated)
+│   │   └── prompts.yaml              # Legacy prompts file (mirrored to packs/default/agents.yaml; no longer read at runtime)
 │   ├── RetailPulse.McpServer/        # MCP server (data tools)
 │   │   ├── Tools/                    # MCP tool definitions (parameterized queries)
 │   │   └── Data/                     # SQLite-backed tenant-driven metrics
@@ -719,4 +732,4 @@ See [Testing Guide](docs/testing-guide.md) for manual testing options and test s
 
 MIT - see [LICENSE](LICENSE) for details.
 
-This project is for demonstration purposes. All data is fictional, seeded from `tenant.yaml`, and does not represent actual business data.
+This project is for demonstration purposes. All data is fictional, seeded from the active content pack (`packs/<Packs:Active>/pack.yaml` + `packs/<Packs:Active>/seed/scenario.yaml`), and does not represent actual business data.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,49 @@
 
 ## Overview
 
-Retail Pulse is an AI-powered brand intelligence platform that uses agentic AI to analyze depletion trends, shipment dynamics, and field sentiment for retail & CPG brands. A **multi-agent system** powered by the Microsoft AI Framework (MAF) and Model Context Protocol (MCP) reasons over natural-language questions, delegates to specialist agents, and calls MCP tools to fetch data, streaming every step back to the browser with full distributed tracing.
+Retail Pulse is an AI-powered brand intelligence platform that analyses depletion trends, shipment dynamics, and field sentiment for retail & CPG brands. The API is built on the **Microsoft Agent Framework** (`Microsoft.Agents.AI` 1.18.0). Every LLM call — router, specialists, planner, and consensus council — runs through the shared `MafAgentInvoker` seam, which materialises a per-invocation `ChatClientAgent` with `UseProvidedChatClientAsIs = true` so the DI-registered `IChatClient` decorator stack (function invocation cap, OpenTelemetry, MCP HTTP resilience) is preserved end-to-end. Multi-domain turns are lifted onto the plan-first orchestrator, which is a real `Microsoft.Agents.AI.Workflows.InProcessExecution` with framework checkpoints for suspend/resume, review, edit, replan, and mid-plan clarification.
 
-**Key differentiator:** Retail Pulse is **tenant-configurable**. Define your company, brands, regions, and theme in a single `tenant.yaml` file and the entire platform adapts. No code changes required.
+**Key differentiators:**
 
-**Built with:** .NET Aspire, Microsoft AI Framework (MAF), Model Context Protocol (MCP), React + Vite, Azure Container Apps, Azure Static Web Apps, Azure Bot Framework, and Azure API Management (AI Gateway).
+- **Data-driven specialists.** Adding an analyst-style agent is a `packs/<pack>/agents.yaml` edit — no C# change (ADR-008). A load-time safety validator (ADR-011) refuses to start with a violation.
+- **Content-pack tenanting.** `packs/<pack>/pack.yaml` bundles the tenant model, agent roster, starting tasks, and knowledge corpus in one directory. `Packs:Active` selects one at boot; a `default` pack (Apex Retail Group), a `halcyon-pet-supply` pack, and a `prairiehearth-craft-supply` pack ship with the repo.
+- **Plan-first, review-gated.** `HybridExecutionDecider` admits multi-domain / low-confidence / advisory-phrased turns to the plan path. When plan review is enabled, `/api/chat` returns `202 Accepted` with a `planId` + `reviewRequestId`, and the reviewer's decision drives approve / edit / reject / replan / clarify through a durable checkpoint store (ADR-014).
+- **Optional cloud knowledge & safety.** In-memory BM25 knowledge is the default and needs no cloud dependency. Azure AI Search (ADR-012), Azure AI Foundry IQ (ADR-013), and Azure AI Content Safety + Prompt Shields (ADR-010) are all opt-in — clone + `dotnet build` demonstrates the platform without them.
+
+**Built with:** .NET Aspire 13.3, Microsoft Agent Framework (`Microsoft.Agents.AI` / `.Abstractions` / `.OpenAI` / `.Workflows` 1.18.0), Microsoft.Extensions.AI 10.9.0, Model Context Protocol (MCP), React 19 + Vite, Azure Container Apps, Azure Static Web Apps, Azure Bot Framework, and Azure API Management (AI Gateway).
+
+## Required vs Optional Azure Resources
+
+Retail Pulse is designed to demo locally from a fresh clone without any optional cloud dependency. The table below is the authoritative "what must exist vs what is opt-in" for the platform itself; see [docs/deployment-azd.md](docs/deployment-azd.md) for the Bicep parameters that toggle each optional resource.
+
+### Required (any deployment)
+
+| Resource | Purpose | How it is provisioned |
+|----------|---------|-----------------------|
+| **Azure OpenAI + APIM AI Gateway** | Chat completions for every LLM call (router, specialists, planner, council). APIM enforces token-per-minute limits, emits usage metrics, and authenticates to Azure OpenAI with managed identity. | `infra/modules/apim.bicep` + `infra/modules/apim-openai-api.bicep`, verified live by `scripts/Verify-ApimAiGateway.ps1`. |
+| **Azure Container Apps + Container Apps Environment** | Hosts `RetailPulse.Api`, `RetailPulse.McpServer`, and `RetailPulse.TeamsBot` with managed identities and scale-to-zero. | `infra/modules/aca-environment.bicep`, `infra/modules/aca-app.bicep`. |
+| **Azure Container Registry (Basic)** | Stores the three backend images. Container Apps pull with managed identity — no admin secrets. | `infra/modules/acr.bicep`. |
+| **Azure Static Web Apps** | Serves the React/Vite build; the SPA calls the Container Apps API directly for long-running chat / SignalR. | `infra/modules/static-web-app.bicep`. |
+| **Application Insights + Log Analytics** | OpenTelemetry sink for traces, metrics, and logs. | `infra/modules/monitoring.bicep`. |
+| **Entra ID app registration** | Only auth mode ever deployed to production (`Authentication__Mode = Entra`, single-tenant, PKCE). | `infra/modules/entra-*.bicep` and `scripts/Setup-EntraApp.ps1`. |
+
+### Optional (opt-in — the platform still runs without any of them)
+
+| Resource | Enables | Enabled by |
+|----------|---------|------------|
+| **Azure AI Search** | Vector + BM25 knowledge over your corpus (ADR-012). | `Knowledge:Provider:Mode=AzureAISearch` and `Knowledge:AzureAISearch:Endpoint` set. Default degradation is `FailLoud`; set `Degradation=FallbackToInMemory` to soft-fail. |
+| **Azure AI Foundry IQ (Azure AI Projects)** | Foundry-hosted retrieval agent (ADR-013). | `Knowledge:Provider:Mode=FoundryIQ` and `Knowledge:FoundryIQ:ProjectEndpoint` set. |
+| **Azure AI Content Safety + Prompt Shields** | Prompt-injection + harmful-content filtering on inputs and outputs (ADR-010). | `Security:ContentSafety:Enabled=true` and the endpoint / API version set. |
+| **Azure AI Foundry Agent Service** | Foundry-hosted persistent shipment specialist (bespoke). | `FoundryAgent:Enabled=true` + project endpoint / agent name. |
+| **Azure Files durable mount** | Cross-replica persistence of the SQLite stores (`memory.db`, `approvals.db`, `sessions.db`, `plans.db`, `audit.db`, `costs.db`, `alerts.db`). | Currently blocked by tenant governance policy (see [docs/deployment-azd.md](docs/deployment-azd.md)); the deployed demo runs with `RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true`. |
+
+> **Local demo (zero optional resources).** `dotnet build RetailPulse.slnx` succeeds with no
+> optional cloud resource configured. `dotnet run --project src/RetailPulse.AppHost`
+> then launches the full stack — see [Quick Start](#quick-start) for the
+> `OpenAI:Endpoint` requirement, the pre-built frontend prerequisite (`npm ci`
+> against the internal proxy), and the exact honest limits.
+
+**Built with:** .NET Aspire, Microsoft Agent Framework (MAF), Model Context Protocol (MCP), React + Vite, Azure Container Apps, Azure Static Web Apps, Azure Bot Framework, and Azure API Management (AI Gateway).
 
 ---
 
@@ -40,12 +78,16 @@ Retail Pulse is an AI-powered brand intelligence platform that uses agentic AI t
 
 ### Key Patterns
 
-- **Tenant config** (`tenant.yaml`) drives everything - prompts, data seeding, UI branding. Loaded by `FileTenantProvider`, injected into system prompts.
-- **AI Gateway** - APIM fronts Azure OpenAI/Foundry with token limiting, metrics, managed identity auth. Deployed via Bicep.
-- **Real-time telemetry** - SignalR hub broadcasts agent spans to the frontend. Dashboard shows live tool calls, agent thoughts, and timing.
-- **MCP tools** - SQLite-backed retail metrics (depletions, shipments, field sentiment) shaped by tenant brands/regions. Agent can **read and write** data via `UpdateMetrics` tool.
-- **Foundry delegation** - can hand off to persistent Azure AI Foundry agents for deeper analysis.
-- **Frontend** - single-page dashboard with ChatPanel, suggested retail prompts (grocery, QSR, home improvement, office supply, furniture), chart rendering, and span timeline.
+- **Content packs** (`packs/<pack>/`) bundle tenant model, agent roster, knowledge corpus, and starting tasks. `Packs:Active` selects one at boot; adding a specialist or a starting task is a YAML edit. See [Tenant Configuration Guide](docs/tenant-configuration.md) and ADR-008.
+- **Shared MAF invocation seam** — every LLM call (router, specialists, planner, council) goes through `MafAgentInvoker` → `ChatClientAgent` with `UseProvidedChatClientAsIs = true`, preserving the ADR-006 function-invocation cap, OpenTelemetry, and MCP resilience decorators. Proven by `MafPrimitivesCharacterizationTests`. See ADR-007.
+- **Hybrid execution admission** — `HybridExecutionDecider` chooses Fast / Plan / Council per turn using router confidence, `DetectedIntents`, an explicit user override, and configured advisory phrases (ADR-014).
+- **Plan-first with review gate** — multi-domain turns run through `PlanExecutor` (Microsoft.Agents.AI.Workflows `InProcessExecution` with framework checkpoints). When `PlanReview:Enabled=true`, `/api/chat` returns `202 Accepted` and the reviewer's approve / edit / reject / clarify decision drives the workflow (ADR-014).
+- **AI Gateway** — APIM fronts Azure OpenAI/Foundry with token limiting, metrics, managed identity auth. Deployed via Bicep and verified live by `Verify-ApimAiGateway.ps1`.
+- **Real-time telemetry** — SignalR hub broadcasts agent spans to the frontend. Dashboard shows live tool calls, agent thoughts, and timing.
+- **Pluggable knowledge providers** — InMemory BM25 by default; Azure AI Search (ADR-012) and Foundry IQ (ADR-013) are opt-in via `Knowledge:Provider:Mode` and per-agent `use_knowledge_base` / `knowledge_base_name` bindings.
+- **MCP tools** — SQLite-backed retail metrics (depletions, shipments, field sentiment) shaped by the pack's tenant. Agents can **read and write** data via the `UpdateMetrics` tool.
+- **Optional Foundry delegation** — hand off to persistent Azure AI Foundry agents for deeper analysis when `FoundryAgent:Enabled=true`.
+- **Frontend** — single-page dashboard with ChatPanel, pack-sourced suggested starting tasks, chart rendering, and span timeline.
 
 ### Three-Tier Distribution Model
 
@@ -58,8 +100,8 @@ Retail Pulse is designed for industries using a Three-Tier distribution model (m
 ### Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
-- [Node.js 20+](https://nodejs.org/)
-- An OpenAI API key (or Azure OpenAI endpoint)
+- [Node.js 20+](https://nodejs.org/) — required for the frontend build. The AppHost launches `npm ci` + `npm run dev` for `src/RetailPulse.Web` on startup, so an unusable npm environment blocks the full-stack demo.
+- An **Azure OpenAI endpoint** (or an OpenAI-compatible endpoint). The API requires both `OpenAI:Endpoint` and a valid deployment name (`OpenAI:Deployment`) to start.
 
 ### 1. Clone the repo
 
@@ -68,25 +110,34 @@ git clone https://github.com/swigerb/retail-pulse.git
 cd retail-pulse
 ```
 
-### 2. Configure tenant.yaml (or use the included Apex Retail Group sample)
+### 2. Pick a content pack (or use the shipped `default` Apex Retail Group pack)
 
-The repo ships with a sample `tenant.yaml` for **Apex Retail Group**, a fictional multi-category retail conglomerate with 12 brands across 6 categories. To customize for your own brand, see the [Tenant Configuration Guide](docs/tenant-configuration.md).
+Retail Pulse ships three content packs under `packs/`:
+
+- `default` — **Apex Retail Group** (multi-category retail conglomerate, 12 brands, 6 categories, 6 regions). Loaded by default.
+- `halcyon-pet-supply` — a specialty pet-supply retailer example.
+- `prairiehearth-craft-supply` — a craft-supply retailer example.
+
+Each pack bundles its tenant model, agent roster (`agents.yaml`), starting tasks (`starting-tasks.yaml`), and knowledge corpus (`knowledge/*.md`) in one directory. Select a pack at boot with `Packs:Active`. See the [Tenant Configuration Guide](docs/tenant-configuration.md) for the schema and worked examples.
 
 ### 3. Set up Azure OpenAI credentials
 
+The API needs an endpoint + deployment name; the API key falls back to `demo-key` in Development but the endpoint has no fallback and the deployment must resolve non-empty (a missing `OpenAI:Deployment` with a specialist that also has no `model` in `agents.yaml` will fail startup at `AzureOpenAIClient.GetChatClient("")`).
+
 ```bash
+dotnet user-secrets set "OpenAI:Endpoint" "<your-azure-openai-or-apim-endpoint>" --project src/RetailPulse.Api
+dotnet user-secrets set "OpenAI:Deployment" "<your-deployment-name>" --project src/RetailPulse.Api
 dotnet user-secrets set "OpenAI:ApiKey" "<your-api-key>" --project src/RetailPulse.Api
 ```
 
-> To use Azure OpenAI directly (bypassing APIM), also set the endpoint:
-> ```bash
-> dotnet user-secrets set "OpenAI:Endpoint" "<your-azure-openai-endpoint>" --project src/RetailPulse.Api
-> ```
+> To point directly at Azure OpenAI (bypassing APIM), set `OpenAI:Endpoint` to the account URL. To route through the APIM AI Gateway, use the gateway URL emitted by `azd env get-values` after `azd provision`.
 
 > **Every setting in one place:** [`src/RetailPulse.Api/appsettings.json`](src/RetailPulse.Api/appsettings.json)
 > is the checked-in reference config — loaded in every environment and
-> documenting all sections (OpenAI, Security, FoundryAgent, ToolCache,
-> TokenPricing, Observability, …) with safe defaults. Edit it directly for
+> documenting all sections (`OpenAI`, `Packs`, `Knowledge`, `Guardrails`,
+> `PlanPersistence`, `SessionPersistence`, `Approval`, `RealtimeResilience`,
+> `ChatTimeout`, `Security`, `FoundryAgent`, `ToolCache`, `TokenPricing`,
+> `Observability`, …) with safe defaults. Edit it directly for
 > non-secret tweaks; keep real secrets in user-secrets, **not** in this
 > committed file. For deployment, see
 > [`appsettings.Production.json`](src/RetailPulse.Api/appsettings.Production.json),
@@ -243,14 +294,15 @@ All brands operate across **6 regions**: Northeast, Southeast, Midwest, Southwes
 |-------|-----------|---------|---------|
 | **Orchestration** | .NET Aspire | 13.3.0 | Service discovery, health checks, dashboard |
 | **Runtime** | .NET | 10 | Backend services |
-| **Agent** | Microsoft AI Framework (MAF) | — | AI agent with tool calling |
+| **Agent Framework** | Microsoft Agent Framework (`Microsoft.Agents.AI` + `.Abstractions` + `.OpenAI` + `.Workflows`) | 1.18.0 | `ChatClientAgent` for router/specialists/planner/council + `Microsoft.Agents.AI.Workflows.InProcessExecution` for plan-first orchestration (ADR-007, ADR-014). Contract test `MafPackageVersionContractTests` fails CI on downgrades. |
+| **AI Middleware** | Microsoft.Extensions.AI | 10.9.0 | `IChatClient`, function invocation, OpenTelemetry — preserved end-to-end via `UseProvidedChatClientAsIs = true`. |
 | **Model** | GPT-5.4-mini (via APIM AI Gateway) | — | Reasoning and natural language |
 | **Tools** | Model Context Protocol (MCP) | — | Standardized tool access |
-| **Data** | SQLite (Microsoft.Data.Sqlite) | — | Mutable tenant-seeded metrics store |
+| **Data** | SQLite (Microsoft.Data.Sqlite) | — | Mutable tenant-seeded metrics store + durable session/plan/approval/audit stores |
 | **Frontend** | React + Vite + TypeScript | 19 / 8 / 6 | Interactive dashboard |
 | **UI Components** | Fluent UI React | 9.x | Design system |
 | **Real-time** | SignalR | 10.x | Live telemetry streaming |
-| **Multi-Agent** | Azure AI Foundry Agent Service | — | Foundry-hosted Shipment Specialist (optional) |
+| **Foundry-hosted agents** | Azure AI Foundry Agent Service (optional) | — | Bespoke shipment specialist when `FoundryAgent:Enabled=true`. Foundry IQ knowledge is a separate opt-in provider (ADR-013). |
 | **Observability** | OpenTelemetry + Aspire Dashboard | — | Distributed traces, metrics, logs |
 | **Monitoring** | Azure Application Insights | — | Production telemetry and traces |
 | **Gateway** | Azure API Management | — | Token metering, rate limiting, audit |
@@ -582,31 +634,48 @@ The web app navigation is intentionally minimal by default: Chat, Real-Time Tele
 
 ## Configuration
 
-### User Secrets
+### User Secrets & core configuration
 
-| Setting | User Secret Key | Default |
-|---------|----------------|---------|
-| API Key | `OpenAI:ApiKey` | *(required)* |
-| LLM Endpoint | `OpenAI:Endpoint` | APIM gateway URL |
-| API Version | `OpenAI:ApiVersion` | `2025-03-01-preview` |
-| MCP Server URL | `McpServer:BaseUrl` | `http://localhost:5200` |
-| Foundry Enabled | `FoundryAgent:Enabled` | `false` |
-| Foundry Project Endpoint | `FoundryAgent:ProjectEndpoint` | *(set by deploy script)* |
-| Foundry Agent Name | `FoundryAgent:ShipmentAgentName` | `Distribution Analysis Specialist` |
-| App Insights | `APPLICATIONINSIGHTS_CONNECTION_STRING` | *(set in AppHost)* |
+`src/RetailPulse.Api/appsettings.json` is the checked-in reference config with safe defaults for every section. The table below is a per-surface quick reference; edit `appsettings.json` for non-secret tweaks and keep secrets in user-secrets or environment variables.
 
-### tenant.yaml
+| Setting | Key | Default | Purpose |
+|---------|-----|---------|---------|
+| API Key | `OpenAI:ApiKey` | *(Development falls back to `demo-key`)* | Bearer credential passed to the OpenAI-compatible endpoint. |
+| LLM Endpoint | `OpenAI:Endpoint` | *(required, no fallback)* | Azure OpenAI account URL or APIM AI Gateway URL. Startup fails if unset. |
+| Deployment Name | `OpenAI:Deployment` | *(must resolve non-empty)* | Deployment / model name for the default agent when the pack does not override `agents.<key>.model`. |
+| API Version | `OpenAI:ApiVersion` | `2025-03-01-preview` | Azure OpenAI REST API version. |
+| Active Pack | `Packs:Active` | `default` | Content pack selected at boot. Values: any directory name under `packs/`. |
+| Pack Root | `Packs:Root` | `packs` | Filesystem root scanned for content packs. |
+| Knowledge Provider | `Knowledge:Provider:Mode` | `InMemory` | `InMemory` (BM25, no cloud dep) \| `AzureAISearch` \| `FoundryIQ`. |
+| Knowledge Degradation | `Knowledge:Provider:Degradation` | `FailLoud` | `FailLoud` \| `FallbackToInMemory` when the optional cloud provider is unreachable. |
+| Azure AI Search Endpoint | `Knowledge:AzureAISearch:Endpoint` | *(empty)* | Enables ADR-012 provider when set. |
+| Foundry IQ Project | `Knowledge:FoundryIQ:ProjectEndpoint` | *(empty)* | Enables ADR-013 provider when set. |
+| Content Safety | `Security:ContentSafety:Enabled` | `false` | ADR-010 opt-in for Prompt Shields + harmful-content classification. |
+| Agent-def guardrails | `Guardrails:AgentDefinition:OnValidationFailure` | `RefuseStartup` (prod) | ADR-011 load-time validator; refuses startup on any violation in prod. |
+| Plan persistence | `PlanPersistence:Enabled` | `false` | Enables `/api/plans/*`, plan review, `HybridExecutionDecider` plan path (ADR-014). |
+| Session persistence | `SessionPersistence:Enabled` | `false` | Enables `/api/sessions/*` durable conversation store. |
+| SignalR heartbeat | `RealtimeResilience:ApplicationHeartbeatEnabled` | `true` | Server-side keep-alive tick emitted by the telemetry hub. |
+| Fast timeout | `ChatTimeout:SingleShot` | `00:01:30` | Hard timeout for a single-shot chat turn. |
+| Plan timeout | `ChatTimeout:Plan` | `00:06:00` | Hard timeout for a full plan execution. |
+| MCP Server URL | `McpServer:BaseUrl` | `http://localhost:5200` | Local MCP server address. |
+| Foundry Enabled | `FoundryAgent:Enabled` | `false` | Enables the bespoke Foundry shipment specialist. |
+| Foundry Project | `FoundryAgent:ProjectEndpoint` | *(set by deploy script)* | Azure AI Foundry project endpoint. |
+| Foundry Agent | `FoundryAgent:ShipmentAgentName` | `Distribution Analysis Specialist` | Persistent agent name. |
+| App Insights | `APPLICATIONINSIGHTS_CONNECTION_STRING` | *(set in AppHost)* | Distributed traces + custom metrics sink. |
 
-All tenant configuration lives in `tenant.yaml` at the repo root. Changes take effect on restart — no code changes required.
+### Content packs (`packs/<pack>/`)
 
-| Key | Purpose |
-|-----|---------|
-| `company` / `industry` | Company identity, injected into agent system prompts |
-| `brands[]` | Brand definitions with category, variants, and price segment |
-| `regions[]` | Geographic regions for data segmentation |
-| `channels[]` | Distribution channels (On-Premise, Off-Premise, E-Commerce) |
-| `theme` | UI branding (primary/accent colors, logo, font) |
-| `distribution` | Distribution model config (Three-Tier, distributor types) |
+Retail Pulse loads a **content pack** at boot (`Packs:Active`, default `default`) instead of a single monolithic `tenant.yaml`. A pack bundles the tenant model, agent roster, starting tasks, and knowledge corpus in one directory so a whole scenario can be swapped in place. Changes take effect on restart — no code changes required.
+
+| File | Purpose |
+|------|---------|
+| `pack.yaml` | Pack manifest: id, display name, industry, company, brands, regions, channels, theme, distribution model. Injected into agent system prompts. |
+| `agents.yaml` | Specialist roster: keys, intents, model, temperature, tool bindings, `use_knowledge_base` / `knowledge_base_name`. Adding a specialist is an edit here (ADR-008). |
+| `starting-tasks.yaml` | Suggested chat prompts surfaced by the SPA. |
+| `knowledge/*.md` | Grounding corpus indexed by the active knowledge provider (default InMemory BM25). |
+| `seed/scenario.yaml` | Optional deterministic seed data for the SQLite store. |
+
+See the [Tenant Configuration Guide](docs/tenant-configuration.md) for the full schema, live validation rules, and a worked example of adding a specialist by configuration only.
 
 ## Ports
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -667,9 +667,19 @@ Detect margin-destructive patterns across brands.
 
 ---
 
-### POST /api/escalate
+### POST /api/escalate  *(deprecated — compatibility only)*
 
-Escalate a query through the L1→L2→L3 escalation pipeline. Routes through progressively senior agent layers.
+> **Deprecated.** The `/api/chat` pipeline no longer routes multi-domain
+> requests through this endpoint. Admission for cross-domain analysis is
+> owned by `HybridExecutionDecider` (issue #95), which lifts qualifying
+> turns onto the plan-first path (`ADR-014`, `/api/chat` → **HTTP 202
+> Accepted** with `planId`/`reviewRequestId`). `/api/escalate` is retained
+> for explicit legacy callers only; new integrations should use `/api/chat`
+> and observe the 202 handoff. See the class documentation on
+> [`EscalationEndpoints`](../src/RetailPulse.Api/Endpoints/EscalationEndpoints.cs)
+> and [`EscalationOrchestrator`](../src/RetailPulse.Api/Escalation/EscalationOrchestrator.cs).
+
+Escalate a query through the legacy L1→L2→L3 escalation pipeline. Routes through progressively senior agent layers.
 
 **Request Body:** Same as `POST /api/chat`
 
@@ -685,6 +695,85 @@ Escalate a query through the L1→L2→L3 escalation pipeline. Routes through pr
   "escalationReason": "Cross-domain query requiring multi-agent synthesis"
 }
 ```
+
+---
+
+## Plan store & execution control  *(opt-in — `PlanPersistence:Enabled=true`)*
+
+These endpoints are only mapped when `PlanPersistence:Enabled` is `true` and
+the caller is authenticated. Anonymous callers are refused at entry and
+cross-subject reads collapse into `404` so a plan id cannot be probed. All
+routes below are wired by
+[`PlanEndpoints`](../src/RetailPulse.Api/Endpoints/PlanEndpoints.cs) and
+[`ExecutionControlEndpoints`](../src/RetailPulse.Api/Endpoints/ExecutionControlEndpoints.cs).
+
+### GET /api/plans
+
+List the caller's persisted plans, newest activity first.
+
+**Response (200):** array of `PlanSummaryDto` (`planId`, `sessionId`,
+`intent`, `status`, `stepCount`, `updatedAt`, …).
+
+### GET /api/plans/{planId}
+
+Rehydrate one persisted plan with its ordered steps.
+
+**Response (200):** `PlanDetailDto` — plan header plus `steps[]`
+(`stepIndex`, `specialistKey`, `intent`, `action`, `status`, `output`,
+`tokens`, `startedAt`, `completedAt`).
+
+**Errors:** `403` for anonymous callers, `404` for unknown or cross-subject
+plan ids.
+
+### DELETE /api/plans/{planId}
+
+Remove one persisted plan (and every step under it) owned by the caller.
+Cascades in a single transaction.
+
+**Response:** `204 No Content` on success, `404` if the plan does not exist
+or belongs to a different subject.
+
+### POST /api/chat/{sessionId}/cancel
+
+Cancel the caller's in-flight `/api/chat` (fast-path or streaming) run for
+`sessionId`. Ownership-scoped through `IExecutionCancellationRegistry`.
+
+**Response:** `204 No Content` on cancel; `404` for no active run OR a
+foreign owner (foreign owners collapse to `404` so live sessions of other
+callers cannot be probed).
+
+### POST /api/plans/{planId}/cancel
+
+Cancel the caller's in-flight plan orchestration keyed on `planId`. Same
+ownership contract as `/api/chat/{sessionId}/cancel`.
+
+**Response:** `204 No Content`, `403` for anonymous callers, `404`
+otherwise.
+
+### GET /api/plans/{planId}/reconcile
+
+Rehydrate durable plan state after a reconnect. Accepts an optional
+`afterStepIndex` query parameter — the response only includes steps whose
+`stepIndex > afterStepIndex`, so a reconnecting client can render just the
+ones it missed.
+
+**Response (200):**
+
+```json
+{
+  "planId": "...",
+  "sessionId": "...",
+  "status": "in_progress",
+  "failureReason": null,
+  "updatedAt": "2026-...",
+  "totalStepCount": 3,
+  "afterStepIndex": 0,
+  "steps": [ { "stepIndex": 1, "specialistKey": "demand-forecasting", "status": "completed", "output": "…" } ]
+}
+```
+
+**Errors:** `403` for anonymous callers, `404` for unknown or cross-subject
+plan ids.
 
 ---
 

--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -1,6 +1,6 @@
 # MCP Tool Reference
 
-The Retail Pulse MCP (Model Context Protocol) Server exposes domain-specific tools that specialist agents invoke via function calling. The MCP server runs at `http://localhost:5200` and is backed by a SQLite database seeded from `tenant.yaml`.
+The Retail Pulse MCP (Model Context Protocol) Server exposes domain-specific tools that specialist agents invoke via function calling. The MCP server runs at `http://localhost:5200` and is backed by a SQLite database seeded from the active content pack (`Packs:Active`, default `default`).
 
 All tools are registered as `[McpServerTool]` classes and are accessible both through the MCP protocol and via proxy REST endpoints on the API server.
 

--- a/docs/adr/001-multi-agent-routing.md
+++ b/docs/adr/001-multi-agent-routing.md
@@ -59,5 +59,6 @@ We implement a **specialist agent routing architecture** where:
   turns onto the plan path (ADR-014). `/api/escalate` is retained only as a
   deprecated compatibility endpoint.
 - Confidence threshold tuning is now the
-  `Planning:MinConfidenceForFastPath` setting evaluated by
-  `HybridExecutionDecider`, not a router-internal constant.
+  `PlanPersistence:MinConfidenceForFastPath` setting evaluated by
+  `HybridExecutionDecider` (bound via `PlanPersistenceOptions.SectionName =
+  "PlanPersistence"`), not a router-internal constant.

--- a/docs/adr/001-multi-agent-routing.md
+++ b/docs/adr/001-multi-agent-routing.md
@@ -2,7 +2,21 @@
 
 ## Status
 
-Accepted
+Superseded by:
+- **ADR-008** (data-driven agent definitions) — specialists are no longer
+  one-class-per-agent; they are declared in `packs/<pack>/agents.yaml` and
+  materialised by `ConfiguredSpecialistAgent`.
+- **ADR-014** (plan-first orchestration using MAF Workflows) — the router's
+  `DetectedIntents` is no longer discarded after the first hit; multi-domain
+  requests are lifted onto a `PlanExecutor` workflow.
+- **ADR-007** (MAF agent primitives) — every specialist invocation, including
+  the router itself, now runs through `MafAgentInvoker` /
+  `Microsoft.Agents.AI.ChatClientAgent` instead of a bespoke chat loop.
+
+The original intent classification / confidence-threshold / fallback shape
+recorded below is still what happens on the fast single-shot path, but the
+admission decision (fast vs. plan vs. council) is owned by
+`HybridExecutionDecider`, not the router.
 
 ## Context
 
@@ -30,3 +44,20 @@ We implement a **specialist agent routing architecture** where:
 - Misrouting can occur when user intent is ambiguous; the confidence threshold must be tuned.
 - Adding a new specialist requires updating the router prompt with the new intent category.
 - Memory context is loaded before routing, which adds latency even if the agent doesn't need it (addressed in Sprint 5.6).
+
+## Why superseded
+
+- "Adding a specialist requires implementing `ISpecialistAgent`" is no longer
+  true. Adding a specialist is now a `packs/<pack>/agents.yaml` edit —
+  `ConfiguredSpecialistAgent` binds the definition to a shared MAF invoker
+  (ADR-008). Bespoke C# specialists (`MemoryManagement`,
+  `CompetitiveIntel`, `PromoPlanning`) still exist for behaviour that cannot
+  be expressed as prompt + tool bindings.
+- "Router chooses one specialist" understates the current pipeline. The
+  router still classifies, but `HybridExecutionDecider` inspects
+  `DetectedIntents`, confidence, and advisory phrasing to lift multi-domain
+  turns onto the plan path (ADR-014). `/api/escalate` is retained only as a
+  deprecated compatibility endpoint.
+- Confidence threshold tuning is now the
+  `Planning:MinConfidenceForFastPath` setting evaluated by
+  `HybridExecutionDecider`, not a router-internal constant.

--- a/docs/adr/006-tool-context-budget.md
+++ b/docs/adr/006-tool-context-budget.md
@@ -77,5 +77,9 @@ tool is added without a bounded-output classification.
 ## Related
 
 - ADR-002 (MCP tool server), ADR-004 (caching strategy)
+- ADR-014 (plan-first orchestration) — a plan is opened once as the outer
+  `RequestToolContext` scope so the dedup map, distinct-call counter, and
+  cumulative-chars ceiling accumulate across every step of a plan instead of
+  resetting per specialist call.
 - `docs/tool-context-budget.md`
 - `src/RetailPulse.Api/Budget/*`, `tests/RetailPulse.Tests/Budget/*`

--- a/docs/adr/014-plan-first-orchestration.md
+++ b/docs/adr/014-plan-first-orchestration.md
@@ -1,4 +1,4 @@
-# ADR-011: Plan-first orchestration using MAF Workflows
+# ADR-014: Plan-first orchestration using MAF Workflows
 
 ## Status
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ The component diagram shows the five-service architecture orchestrated by .NET A
 
 - **React Frontend** — Chat UI, telemetry dashboard, agent routing indicators, streaming message display, collaborative cards
 - **RetailPulse API** — Composition root with endpoint group extensions (`Endpoints/*.cs`), multi-agent router pipeline, guardrails/cache/streaming middleware, bounded telemetry and memory channels, rate limiting (4 tiers), observability suite (cost tracking, audit log, conversation export)
-- **MCP Server** — REST + MCP dual endpoints for all domain tools (depletions, shipments, sentiment, demand, promo, competitive, store ops, margin), SQLite data store with deterministic seeding from `tenant.yaml`
+- **MCP Server** — REST + MCP dual endpoints for all domain tools (depletions, shipments, sentiment, demand, promo, competitive, store ops, margin), SQLite data store with deterministic seeding from the active content pack (`packs/<Packs:Active>/pack.yaml` + `packs/<Packs:Active>/seed/scenario.yaml`, loaded by `PackTenantLoader.LoadFromPackDirectory` in `RetailPulse.McpServer.Program.cs`)
 - **Teams Bot** — Adaptive Card rendering, SSO via `TeamsSsoHandler` with `StrictTenantValidation`, configurable health checks (`HealthMode: fail-fast | degraded`), `DevelopmentAuthHandler` bypass in local dev
 - **Aspire AppHost** — Non-containerized orchestration, OpenTelemetry, service discovery, health endpoints
 
@@ -44,12 +44,12 @@ Browser (ChatPanel) → POST /api/chat → RetailPulseAgent
 | Step | Component | What Happens |
 |------|-----------|-------------|
 | **1. User sends message** | `ChatPanel.tsx` | Frontend sends `POST /api/chat` with `{ message, sessionId, history }`. Conversation history (up to 10 turns) is included for context continuity. |
-| **2. Agent builds prompt** | `RetailPulseAgent.cs` | Assembles a message array: system prompt (from `src/RetailPulse.Api/prompts.yaml`) + conversation history + current user message. Starts a `Stopwatch` to measure wall-clock duration. |
+| **2. Agent builds prompt** | `RetailPulseAgent.cs` | Assembles a message array: system prompt (resolved by `PromptTemplateEngine` from the active content pack's `agents.yaml` — the roster loaded into `PromptConfiguration` via `activePack.Agents` in `Program.cs`) + conversation history + current user message. Starts a `Stopwatch` to measure wall-clock duration. |
 | **3. Model inference** | Azure OpenAI via APIM | The `IChatClient` (backed by `AzureOpenAIClient`) sends the messages to APIM. APIM applies token limiting (default **80,000 TPM** per subscription — configurable via the `tokensPerMinute` param in `infra/modules/apim-openai-api.bicep`), emits metrics, and forwards to Azure OpenAI using managed identity. Model: `gpt-5.4-mini` (shipped deployment `gpt-5.4-mini-2026-03-17`). |
 | **4. Tool selection** | Azure OpenAI | The model examines the user's question and the available tool schemas, then decides which tools to call and with what parameters. For a portfolio-wide question, it may call `GetPortfolioDepletionStats`; for a single brand, `GetDepletionStats`. |
 | **5. Tool execution loop** | MAF (`UseFunctionInvocation`) | Microsoft.Extensions.AI middleware intercepts each tool call. It invokes the registered `AITool` implementation, captures the result, and sends it back to the model. The model may call additional tools or generate its final response. Tools execute sequentially within a single turn. |
 | **6. API proxy call** | e.g., `DepletionStatsTool.cs` | Each tool is an HTTP proxy. It calls the MCP Server's REST endpoint (e.g., `GET /api/depletion-stats?brand=X&region=Y&period=Z`). If the MCP Server is unreachable, the tool returns hardcoded fallback data and logs a warning. |
-| **7. Data retrieval** | `RetailPulseDb.cs` | The MCP Server's singleton SQLite service queries (or updates) the data. Data is seeded from `tenant.yaml` configuration (12 brands, 6 regions, 3 channels) using deterministic algorithms. The `UpdateMetrics` tool can also write to the database, enabling real-time data mutations by the agent. |
+| **7. Data retrieval** | `RetailPulseDb.cs` | The MCP Server's singleton SQLite service queries (or updates) the data. Data is seeded from the active content pack (`packs/<Packs:Active>/pack.yaml` for the tenant model — 12 brands, 6 regions, 3 channels in the shipped `default` pack — plus `packs/<Packs:Active>/seed/scenario.yaml` for deterministic starting metrics) using deterministic algorithms. The `UpdateMetrics` tool can also write to the database, enabling real-time data mutations by the agent. |
 | **8. Response assembly** | `RetailPulseAgent.cs` | After the model produces its final text response, the agent packages it with telemetry spans, chart data (if any), and `TotalDurationMs` (from the `Stopwatch`). |
 | **9. Frontend rendering** | `ChatPanel.tsx` | The response is displayed as formatted markdown. Charts render via `ChartRenderer` (Recharts). Telemetry spans stream to `TelemetryPanel` via SignalR for real-time display. |
 
@@ -57,14 +57,14 @@ Browser (ChatPanel) → POST /api/chat → RetailPulseAgent
 
 | Data | Location | Persistence |
 |------|----------|-------------|
-| **Depletion metrics** (sales velocity, YoY trends, inventory) | `RetailPulseDb` → SQLite `Depletions` table, keyed by `(Brand, Region)` | On disk (`data/retailpulse.db`). Seeded from `tenant.yaml` on first run; persists AI mutations across restarts. |
+| **Depletion metrics** (sales velocity, YoY trends, inventory) | `RetailPulseDb` → SQLite `Depletions` table, keyed by `(Brand, Region)` | On disk (`%TEMP%/retailpulse/retailpulse.db`). Seeded from the active content pack (`packs/<Packs:Active>/pack.yaml` + `packs/<Packs:Active>/seed/scenario.yaml`) on first run; persists AI mutations across restarts. |
 | **Shipment data** (distribution, fill rates) | `RetailPulseDb` → SQLite `Shipments` table | Same as above. |
 | **Field sentiment** (rep feedback, scores) | `RetailPulseDb` → SQLite `Sentiment` table | Same as above. |
-| **Tenant configuration** (brands, regions, channels) | `tenant.yaml` at repo root → loaded by `FileTenantProvider` | On disk. Single source of truth for the business domain. Changing this file triggers a database re-seed on next restart. |
+| **Tenant configuration** (brands, regions, channels) | `packs/<Packs:Active>/pack.yaml` (`tenant:` block) → loaded by `PackTenantProvider` (constructed with the `LoadedPack` returned by `PackLoader.ForDirectory(...).Load(activePack)` in `Program.cs`) | On disk. Single source of truth for the business domain. Editing the active pack's `pack.yaml` or any file under `packs/<Packs:Active>/seed/` changes the content-hash the MCP server records and triggers a database re-seed on next restart. The legacy root `tenant.yaml` is retained for byte-equivalence tests only and is not read at runtime. |
 | **Conversation history** | Frontend state (`ChatPanel.tsx`) → sent with each request; optionally mirrored to the durable server-side session store when `SessionPersistence:Enabled=true` (issue #90). | Browser session only by default. When enabled, sessions and turns for **authenticated** subjects are persisted to `data/sessions.db` via `SqliteSessionStore`, so a browser refresh can rehydrate the last conversation. Anonymous sessions are **never** persisted (see Session Persistence below). |
 | **Telemetry spans** | Frontend state (`Dashboard.tsx`) via SignalR | Browser session only. Resets on "Clear Telemetry" or "+ New Chat". |
 
-> **Key insight:** The analytics dataset lives in a SQLite database (`data/retailpulse.db`), seeded deterministically from `tenant.yaml`. Unlike the earlier in-memory approach, the agent can now **read and write** data via the `UpdateMetrics` MCP tool — enabling real-time scenario modeling, what-if analysis, and live data updates during demos. The database re-seeds automatically when `tenant.yaml` changes (tracked via content hash). To reset to baseline, delete the database file and restart. Swapping to production data sources requires only replacing the MCP Server tool implementations.
+> **Key insight:** The analytics dataset lives in a SQLite database (`%TEMP%/retailpulse/retailpulse.db` in the MCP server), seeded deterministically from the active content pack. Unlike the earlier in-memory approach, the agent can now **read and write** data via the `UpdateMetrics` MCP tool — enabling real-time scenario modeling, what-if analysis, and live data updates during demos. The database re-seeds automatically when the active `packs/<Packs:Active>/pack.yaml` or any file under `packs/<Packs:Active>/seed/` changes (tracked via a content hash covering both). Switching `Packs:Active` resolves to a different pack directory and therefore a different hash, so the store re-seeds against the new tenant. To reset to baseline, delete the database file and restart. Swapping to production data sources requires only replacing the MCP Server tool implementations.
 
 ---
 
@@ -83,7 +83,7 @@ Browser (ChatPanel) → POST /api/chat → RetailPulseAgent
 | Decision | Rationale |
 |----------|-----------|
 | **Why MAF over LangChain/Semantic Kernel?** | Native .NET integration. Built on `Microsoft.Extensions.AI` abstraction — works with any `IChatClient` implementation. OpenTelemetry tracing is built in, not bolted on. |
-| **Why GPT-5.4-mini?** | Best balance of reasoning quality, speed, and cost for tool-calling scenarios. Architecture is model-agnostic — swap via `prompts.yaml`. |
+| **Why GPT-5.4-mini?** | Best balance of reasoning quality, speed, and cost for tool-calling scenarios. Architecture is model-agnostic — swap via the `model:` field on an entry in the active pack's `packs/<pack>/agents.yaml`. |
 | **Prompt configuration in YAML** | Separates prompt engineering from code. Non-developers can iterate on prompts without touching C#. Supports multiple agent definitions. |
 
 #### MAF & Microsoft.Extensions.AI package versions
@@ -145,7 +145,7 @@ captured in [`ADR-007: MAF agent primitives for specialist/router/council execut
 |----------|-----------|
 | **Why MCP over direct HTTP calls?** | MCP is an emerging standard. Today's tools query a SQLite database; tomorrow, swap to real APIs without changing agent code. Any MCP-compatible agent can use these tools. |
 | **REST + MCP dual endpoints** | MCP SSE for agent communication. REST endpoints (`/api/depletion-stats`) for direct testing and integration. Same backing data, two access patterns. |
-| **SQLite data store** | Enables demo without real data dependencies. Seeded from `tenant.yaml` with rich, realistic patterns. Supports **read + write** — the agent can update data in real time via the `UpdateMetrics` tool. |
+| **SQLite data store** | Enables demo without real data dependencies. Seeded from the active content pack (`packs/<Packs:Active>/pack.yaml` + `packs/<Packs:Active>/seed/scenario.yaml`) with rich, realistic patterns. Supports **read + write** — the agent can update data in real time via the `UpdateMetrics` tool. |
 
 ### React + Vite + TypeScript — Frontend
 
@@ -926,7 +926,7 @@ var hydrated = engine.Hydrate(agentDefinition);
 // Replaces {tenant.company}, {tenant.brands}, {tenant.regions}, etc.
 ```
 
-This replaced 8 repetitive `.Replace()` chains in Program.cs with a single DRY call. The engine loads `prompts.yaml` and applies tenant configuration from `FileTenantProvider`.
+This replaced 8 repetitive `.Replace()` chains in Program.cs with a single DRY call. The engine consumes the hydrated `PromptConfiguration` loaded from the active content pack (`activePack.Agents`) and applies tenant configuration from `PackTenantProvider(activePack)`. The legacy root `tenant.yaml` and `src/RetailPulse.Api/prompts.yaml` files are retained on disk for byte-equivalence tests only — the engine no longer reads them.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -310,58 +310,135 @@ tool added to the agent must log first, then fall back.
 
 ## Multi-Agent Router Architecture
 
-Retail Pulse uses a three-layer multi-agent system: a **Router** classifies user intent, **Specialist Agents** handle domain-specific queries, and an **Escalation Orchestrator** coordinates cross-domain analysis.
+Retail Pulse routes every `/api/chat` turn through three layers that are wired together at startup: the LLM-based **Router**, the pure **HybridExecutionDecider** admission gate, and a pool of **specialists** (data-driven + a handful of bespoke ones). A dedicated **Portfolio Health Council** and the durable **plan-first orchestrator** (ADR-014) sit alongside the fast single-shot path — the admission gate chooses between them.
 
-### Router → Specialist Dispatch Flow
+### Router → HybridExecutionDecider → Fast / Plan / Council
 
 ```
 User Message → GuardrailsMiddleware (input filter)
   → Cache Check (SHA256 key of normalized query)
   → ConversationMemoryMiddleware (inject prior context)
   → RetailOpsRouter (LLM classification, temp 0.1)
-      ├── confidence ≥ 0.6 → Specialist Agent (domain-specific tools + prompt)
-      └── confidence < 0.6 → GeneralAgent (all 7 original tools, fallback)
+        → RoutingDecision { agentKey, intent, confidence, detectedIntents[] }
+  → HybridExecutionDecider.Decide(decision, message, ctx, options)
+        ├── Fast    → single specialist via AgentExecutionPipeline → MafAgentInvoker
+        ├── Plan    → PlanOrchestrator → planner → (optional plan review, ADR-014) → PlanExecutor
+        └── Council → ConsensusOrchestrator (portfolio-health dedicated trigger)
   → Response Assembly (charts, telemetry, cost tracking)
   → GuardrailsMiddleware (output PII redaction)
   → Cache Store (deterministic queries only)
-  → Return
+  → Return   (fast: 200 OK; plan-with-review: 202 Accepted)
 ```
 
-The `RetailOpsRouter` uses a dedicated low-temperature classification prompt (`agents.router` in `prompts.yaml`) that returns JSON with `intent`, `confidence`, and `reasoning` fields. Intent strings use slash-separated format (e.g., `demand/forecasting`) for future sub-categorization.
+The `RetailOpsRouter` uses a dedicated low-temperature classification prompt (`agents.router` in the active pack's `agents.yaml`) that returns JSON with `intent`, `confidence`, and — critically — `detectedIntents` (every domain the LLM found in the message). Intent strings use slash-separated format (e.g., `demand/forecasting`) for future sub-categorization.
 
-### Specialist Agent Registry
+`HybridExecutionDecider` (`src/RetailPulse.Api/Agents/Routing/HybridExecutionDecider.cs`) is a pure static function on the hot path. Its precedence, top to bottom:
 
-| Agent Key | Display Name | Intents | Temperature | Tools |
-|-----------|-------------|---------|-------------|-------|
-| `demand-forecasting` | Demand Forecast | `demand/forecasting` | 0.3 | GetHistoricalDemand, GenerateForecast, GetSeasonalityFactors, IdentifyDemandRisks |
-| `promo-planning` | Promo Planning | `promo/planning` | 0.3 | GetPromoHistory, CalculateLift, EvaluateTiming, EstimateROI |
-| `competitive-intel` | Competitive Intel | `competitive/intelligence` | 0.4 | GetCompetitorPricing, GetMarketShare, DetectThreats, GetCompetitiveLandscape |
-| `supply-chain` | Supply Chain | `supply/analysis` | 0.3 | GetShipmentStats + supply-specific tools |
-| `store-ops` | Store Operations | `store/operations` | 0.3 | GetStorePerformance, PredictStockout |
-| `planogram` | Planogram | `planogram/optimization` | 0.3 | GetShelfLayout, OptimizePlanogram |
-| `margin` | Margin Analysis | `margin/analysis` | 0.3 | GetMarginByBrand, GetMarginDrivers, GetMarginTrend, DetectMarginRisks |
-| `general` | General | All unmatched intents | 0.7 | All 7 original tools (depletions, shipments, sentiment, etc.) |
+1. **Explicit user override** — an authenticated caller may force `Fast` or `Plan`, but only when the requested path is reachable (a `Plan` force with no planner registered is ignored).
+2. **Council intent** — the portfolio-health intent always resolves to `Council` when no valid override wins.
+3. **Planner unavailable** — anonymous callers, plan orchestrator not registered, or empty `DetectedIntents` → `Fast`. The plan path simply is not a destination for that request.
+4. **Multi-domain** — `DetectedIntents.Count >= PlanPersistence:MinDetectedIntentsForPlan` (default 2) → `Plan`.
+5. **Low confidence** — router confidence strictly below `PlanPersistence:MinConfidenceForFastPath` (default 0.6) → `Plan`.
+6. **Advisory / diagnostic phrases** — configured phrases in `PlanPersistence:AdvisoryPhrases` → `Plan`.
+7. Otherwise → `Fast`.
 
-All specialists implement `ISpecialistAgent` (in `RetailPulse.Contracts.Routing`) and register via DI through the `AddAgentRouting()` extension method. Adding a new specialist requires one class implementing the interface and one DI registration line.
+### Specialist Registry (data-driven — ADR-008)
 
-> **Architecture note (Sprint 2):** The specialist agent pipeline was identified for consolidation into a shared `SpecialistAgentBase` to reduce copy/paste duplication of message construction, history truncation, chart extraction, and token accounting across agents. This refactoring is tracked but not yet implemented — each specialist currently repeats the common orchestration logic in its `HandleAsync` method.
+Specialists are no longer one-class-per-domain. The active content pack's `packs/<pack>/agents.yaml` declares each specialist with a `key`, `intents[]`, `model`, `temperature`, prompt bindings, and — for domains that use tools — `tool_bindings`. `ConfiguredSpecialistAgent` (`src/RetailPulse.Api/Agents/Specialists/ConfiguredSpecialistAgent.cs`) binds a definition to the shared `MafAgentInvoker` at startup. Adding a new specialist is a config change: append a new entry to `agents.yaml`, restart, and the new key is discovered by the router and by `IEnumerable<ISpecialistAgent>` DI. See `docs/tenant-configuration.md` for the schema and a worked example.
 
-### Registration Pattern
+The shipped `default` pack registers the following specialists (see `packs/default/agents.yaml` for the authoritative list; each also declares its intents and tool bindings):
 
-```csharp
-// In RoutingServiceExtensions.cs
-services.AddScoped<ISpecialistAgent>(sp => new DemandForecastAgent(...));
-services.AddScoped<ISpecialistAgent>(sp => new PromoPlanningAgent(...));
-// ... each specialist auto-discovered by IEnumerable<ISpecialistAgent>
-```
+| Agent Key | Purpose | Path |
+|-----------|---------|------|
+| `router` | Intent classification (JSON output) | data-driven |
+| `demand-forecasting` | Demand forecasts, seasonality, demand risk | data-driven |
+| `promo-planning` | Promo lift, ROI, timing evaluation | data-driven (bespoke helper for lift math) |
+| `competitive-intel` | Competitor pricing, market share, threats | data-driven (bespoke helper for landscape rollup) |
+| `supply-chain` | Shipment health, disruptions, fulfilment | data-driven |
+| `store-ops` | Store performance, stockout risk | data-driven |
+| `planogram` | Shelf layout, planogram optimisation | data-driven |
+| `margin` | Margin drivers, trends, risks | data-driven |
+| `memory-management` | User-facing memory ("forget everything") | bespoke (`MemoryManagementAgent`) |
+| `general` | Fallback when no specialist matches | data-driven |
 
-The router discovers all specialists via `IEnumerable<ISpecialistAgent>` — no manual mapping required. The `GeneralAgent` catches all intent categories as the fallback handler.
+Bespoke C# specialists remain for behaviour that cannot be expressed as a
+prompt + tool binding (memory GDPR flows, some competitive/promo helper
+math). Every specialist — data-driven or bespoke — goes through
+`MafAgentInvoker` on invocation, so token accounting, tracing, tool
+budgets, and content safety apply uniformly.
+
+### Agent-definition safety validation (ADR-011)
+
+`AgentDefinitionValidator` runs at load time and scans every parsed
+`AgentDefinition` against `Guardrails:AgentDefinition:*`
+(allowed-models list, allowed-tools list, privileged-tools list,
+temperature bounds, max system-prompt length, max keyword-fast-path
+length, optional Content Safety pre-flight on the system prompt). The
+default policy is `RefuseStartup` — the API refuses to start with a
+violation. See `docs/adr/011-agent-definition-safety-validation.md`.
 
 ---
 
-## Escalation Chain (L1 → L2 → L3)
+## Plan-first orchestration + review gate (ADR-014)
 
-When a query exceeds what a single specialist can handle, the `EscalationOrchestrator` coordinates multi-agent resolution:
+When `HybridExecutionDecider` returns `Plan` and `PlanPersistence:Enabled=true`,
+the request is lifted onto the plan-first orchestrator instead of running a
+single specialist inline.
+
+```
+POST /api/chat (multi-domain / low-confidence / advisory)
+  → PlanOrchestrator → planner (MAF ChatClientAgent) → typed Plan { steps[] }
+  → PlanStore.PersistAsync — status = awaiting_review (or ready_to_run)
+
+  If PlanReview:Enabled=true:
+    → PlanReviewCoordinator.OpenRoundAsync
+        ├── writes a genuine Microsoft.Agents.AI.Workflows checkpoint
+        │   (ICheckpointStore<JsonElement>, JSON store rooted at
+        │    {data-dir}/plan-reviews)
+        └── opens a Pending approval row (Kind = "plan_review")
+    → /api/chat returns 202 Accepted { planId, reviewRequestId, round, sessionId }
+    → Reviewer decides via POST /api/plans/{planId}/reviews/{requestId}/decision
+        ├── approve / edit → PlanExecutor runs the effective plan
+        ├── reject         → planner replans, new checkpoint, next review round
+        └── timeout        → PlanReviewTimeoutBackgroundService trips the row
+  Else:
+    → PlanExecutor runs the plan directly (200 OK envelope)
+
+PlanExecutor
+  = Microsoft.Agents.AI.Workflows.InProcessExecution
+  + CheckpointManager (JSON checkpoint per step)
+  + step edges wired 1 → 2 → ... → 5 (max plan width per ADR-014)
+  + each step invokes the target specialist through the same MafAgentInvoker seam
+  + [[CLARIFY]] / [[REPLAN]] markers pause the workflow durably
+```
+
+The 202 handoff, review decision, mid-plan clarification, and replan
+lifecycle are exhaustively documented in `docs/API.md` (see
+"Non-blocking suspend/resume" and `POST /api/plans/{planId}/reviews/{requestId}/decision`).
+
+The pre-#94 hot path is preserved byte-for-byte when `PlanReview:Enabled = false`:
+the plan runs inline and `/api/chat` returns the standard `200 OK`
+`ChatResponse` envelope. When `PlanPersistence:Enabled = false`, the plan
+path is unreachable — `HybridExecutionDecider` treats the planner as
+unavailable and always returns `Fast`.
+
+### Related durable state
+
+- `data/plans.db` — plans, steps, review rows, clarifications
+- `{data-dir}/plan-reviews/*.json` — framework checkpoints for suspend/resume
+- `data/approvals.db` — Wave-1 approval gate (see below), also carries `Kind = "plan_review"` and `Kind = "clarification"` rows
+
+---
+
+## Escalation Chain (legacy — compatibility only)
+
+> **Deprecated.** `/api/chat` no longer routes through this path. Multi-domain
+> admission is owned by `HybridExecutionDecider` and lifted onto the
+> plan-first orchestrator (see the section above and ADR-014). `/api/escalate`
+> is retained for callers that opt in explicitly.
+
+Historically, when a query exceeded what a single specialist could handle,
+the `EscalationOrchestrator` coordinated a legacy L1→L2→L3 fan-out:
 
 ```
 User Query → Router → L1 (Single Specialist)
@@ -381,7 +458,11 @@ User Query → Router → L1 (Single Specialist)
 | **L2** | Multiple specialists fan out in parallel | 15 seconds | When L1 times out, or query explicitly spans domains |
 | **L3** | Flags for human review | N/A | When L2 cannot reach confident resolution |
 
-The escalation endpoint is `POST /api/escalate`. Each level's activity is traced as OTel spans with escalation metadata.
+The escalation endpoint is `POST /api/escalate`. Each level's activity is
+traced as OTel spans with escalation metadata. See
+[`EscalationEndpoints`](../src/RetailPulse.Api/Endpoints/EscalationEndpoints.cs)
+— the class documentation explicitly labels this path legacy and points at
+`HybridExecutionDecider` for the current admission logic.
 
 ---
 

--- a/docs/demo-walkthrough.md
+++ b/docs/demo-walkthrough.md
@@ -359,7 +359,7 @@ A competitor just launched a massive Memorial Day sale in the Southwest. Decreas
 
 > *"What you've just seen is a fundamental shift. The AI isn't just reading data — it's a collaborator that can update, analyze, and advise. And every single change is traceable in the telemetry. You can see exactly what was updated, when, and by whom. That's enterprise-grade agentic AI."*
 
-> **Pro tip:** To reset the data for the next demo, simply delete the SQLite database file (`data/retailpulse.db`) and restart the MCP Server. It will re-seed from `tenant.yaml` automatically.
+> **Pro tip:** To reset the data for the next demo, simply delete the SQLite database file (`%TEMP%/retailpulse/retailpulse.db`) and restart the MCP Server. It will re-seed from the active content pack (`packs/<Packs:Active>/pack.yaml` + `packs/<Packs:Active>/seed/scenario.yaml`) automatically.
 
 ---
 
@@ -644,7 +644,7 @@ Forget everything
 
 > *"Enterprise AI isn't just about intelligence — it's about trust. Guardrails prevent misuse. Streaming delivers UX parity with consumer AI. Caching cuts costs without sacrificing freshness. Memory creates continuity. And the observability suite gives compliance and finance complete visibility. Every one of these features is running right now, on every message, in real time."*
 
-> **Pro tip:** To reset the data for the next demo, simply delete the SQLite database file (`data/retailpulse.db`) and restart the MCP Server. It will re-seed from `tenant.yaml` automatically.
+> **Pro tip:** To reset the data for the next demo, simply delete the SQLite database file (`%TEMP%/retailpulse/retailpulse.db`) and restart the MCP Server. It will re-seed from the active content pack (`packs/<Packs:Active>/pack.yaml` + `packs/<Packs:Active>/seed/scenario.yaml`) automatically.
 
 ---
 
@@ -688,11 +688,11 @@ Forget everything
 
 ### "What model does it use?"
 
-> GPT-5.4-mini via Azure AI Foundry (through APIM AI Gateway). The architecture is model-agnostic — swap to GPT-4.1, Claude, or any `IChatClient`-compatible model by changing one line in `prompts.yaml`.
+> GPT-5.4-mini via Azure AI Foundry (through APIM AI Gateway). The architecture is model-agnostic — swap to GPT-4.1, Claude, or any `IChatClient`-compatible model by changing the `model:` field on an entry in the active pack's `packs/<pack>/agents.yaml`.
 
 ### "Does the agent actually change the data?"
 
-> Yes. The `UpdateMetrics` MCP tool writes directly to the SQLite database. Changes persist across queries within the same session and survive MCP Server restarts (the database file is on disk). To reset to the original state, delete `data/retailpulse.db` and restart — it re-seeds automatically from `tenant.yaml`.
+> Yes. The `UpdateMetrics` MCP tool writes directly to the SQLite database. Changes persist across queries within the same session and survive MCP Server restarts (the database file is on disk). To reset to the original state, delete `%TEMP%/retailpulse/retailpulse.db` and restart — it re-seeds automatically from the active content pack (`packs/<Packs:Active>/pack.yaml` + `packs/<Packs:Active>/seed/scenario.yaml`).
 
 ### "How long did this take to build?"
 
@@ -775,10 +775,10 @@ Northeast, Southeast, Midwest, Southwest, West Coast, Pacific Northwest
 | Aspire Dashboard not loading | The dashboard URL is dynamic; check the terminal for `Login to the dashboard at...` |
 | SignalR connection fails | Verify the API is running; check browser console for WebSocket errors |
 | Telemetry shows "Disconnected" | This is expected before the first query. Send a message and it will connect. |
-| MCP tools return empty data | Diacritics are handled automatically - "Anejo" matches "Añejo". Check brand/region spelling against tenant.yaml. |
-| MCP tools return no data | Verify brand name matches tenant.yaml exactly. Check region spelling. |
+| MCP tools return empty data | Diacritics are handled automatically - "Anejo" matches "Añejo". Check brand/region spelling against the active pack's `packs/<Packs:Active>/pack.yaml` (`tenant.brands` / `tenant.regions`). |
+| MCP tools return no data | Verify brand name matches the active pack's `packs/<Packs:Active>/pack.yaml` (`tenant.brands`) exactly. Check region spelling. |
 | No data in App Insights | Allow 2-5 minutes for telemetry to appear. Check the connection string in AppHost.cs. |
-| Data not resetting between demos | Delete `data/retailpulse.db` and restart the MCP Server. It will re-seed from `tenant.yaml`. |
+| Data not resetting between demos | Delete `%TEMP%/retailpulse/retailpulse.db` and restart the MCP Server. It will re-seed from the active content pack (`packs/<Packs:Active>/pack.yaml` + `packs/<Packs:Active>/seed/scenario.yaml`). |
 | UpdateMetrics returns "Invalid field" | Check field spelling against valid fields: Depletions (`DepletionsYoY`, `SellThroughYoY`, `InventoryWeeks`, `Status`, `SentimentSummary`), Shipments (`ShipmentsYoY`, `CasesShipped`, `CasesDepleted`, `AnomalyType`, `RiskLevel`), Sentiment (`Sentiment`). |
 | HTTP 429 Too Many Requests | Rate limiting is active. `strict` policy allows 10/min on chat routes. Wait a few seconds or adjust rate limiter config for demo. |
 | Bot SSO not working in Emulator | Expected — Bot Framework Emulator does not support SSO. Use `DevelopmentAuthHandler` (automatic in Development environment). See [Testing Guide](testing-guide.md). |

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -2,6 +2,43 @@
 
 Retail Pulse supports one-command deployment to Azure using the [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/).
 
+## Required vs Optional Azure resources
+
+The table below is the authoritative "what must exist vs what is opt-in" for
+an Azure deployment. Optional resources default off; a fresh `azd up` will
+deploy a working, secured stack without them, and the platform demos locally
+with none of them (see the top-level [README](../README.md#required-vs-optional-azure-resources)
+for the local-only walkthrough).
+
+### Required
+
+| Component | Azure Service | Bicep module | Notes |
+|-----------|--------------|--------------|-------|
+| API | Azure Container Apps | `infra/modules/aca-app.bicep` | .NET minimal API + agent host (`RetailPulse.Api`) |
+| MCP Server | Azure Container Apps | `infra/modules/aca-app.bicep` | Retail metrics tool host (`RetailPulse.McpServer`) |
+| Teams Bot | Azure Container Apps | `infra/modules/aca-app.bicep` | Microsoft Agents SDK (`RetailPulse.TeamsBot`) |
+| Container Apps Environment | Managed environment | `infra/modules/aca-environment.bicep` | Shared network + log analytics workspace binding |
+| Container Registry | Azure Container Registry (Basic) | `infra/modules/acr.bicep` | Dedicated registry; Container Apps pull with `AcrPull` on the managed identity — no admin secrets |
+| Frontend | Azure Static Web Apps | `infra/modules/static-web-app.bicep` | React/Vite build (Standard SKU); the SPA calls the Container Apps API directly for chat/SignalR |
+| Monitoring | Application Insights + Log Analytics | `infra/modules/monitoring.bicep` | OpenTelemetry sink |
+| App data storage | Container-local temp (no durable volume) | — | See "App data storage" note below. |
+| AI Gateway | Azure API Management (Developer) | `infra/modules/apim.bicep`, `infra/modules/apim-openai-api.bicep` | Token limits, metrics, managed-identity auth to Azure OpenAI; verified live by `scripts/Verify-ApimAiGateway.ps1` |
+| Authentication | Microsoft Entra ID (single-tenant, MSAL PKCE) | `infra/modules/entra-*.bicep`, `scripts/Setup-EntraApp.ps1` | Only auth mode ever deployed to production — see [ADR-005](./adr/005-provider-neutral-authentication.md) and [authentication-entra.md](./authentication-entra.md). |
+
+### Optional (opt-in — every one is off by default)
+
+| Feature | Azure Service | How to enable | ADR |
+|---------|--------------|---------------|-----|
+| Vector + BM25 knowledge | Azure AI Search | `Knowledge:Provider:Mode = AzureAISearch` + `Knowledge:AzureAISearch:Endpoint`. Default degradation is `FailLoud`; set `Degradation = FallbackToInMemory` to soft-fail. | [ADR-012](adr/012-azure-ai-search-provider.md) |
+| Foundry retrieval agent | Azure AI Foundry IQ (Azure AI Projects) | `Knowledge:Provider:Mode = FoundryIQ` + `Knowledge:FoundryIQ:ProjectEndpoint`, plus vector store id / retrieval agent name from the pack. | [ADR-013](adr/013-foundry-iq-knowledge-provider.md) |
+| Prompt injection + harmful content filtering | Azure AI Content Safety + Prompt Shields | `Security:ContentSafety:Enabled = true` + endpoint/API version. Bicep helper: `infra/modules/content-safety.bicep`. | [ADR-010](adr/010-content-safety-layering.md) |
+| Persistent Foundry shipment specialist | Azure AI Foundry Agent Service | `FoundryAgent:Enabled = true` + `FoundryAgent:ProjectEndpoint` + agent name. | — |
+| Durable SQLite mount | Azure Files SMB mount on the API Container App | Currently **not enabled** — this tenant's governance policy forces new storage accounts to `allowSharedKeyAccess=false` and blocks key-based CIFS mounts. The API therefore ships with `RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true`. See the "App data storage" note below for the incident detail and the future durable path. | — |
+
+The rest of this document describes the required stack in detail — jump to
+["Optional cloud knowledge providers"](#optional-cloud-knowledge-providers)
+below for worked examples of enabling Azure AI Search and Foundry IQ.
+
 ## Architecture
 
 | Component | Azure Service | Notes |

--- a/docs/deployment-azd.md
+++ b/docs/deployment-azd.md
@@ -36,8 +36,8 @@ for the local-only walkthrough).
 | Durable SQLite mount | Azure Files SMB mount on the API Container App | Currently **not enabled** — this tenant's governance policy forces new storage accounts to `allowSharedKeyAccess=false` and blocks key-based CIFS mounts. The API therefore ships with `RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true`. See the "App data storage" note below for the incident detail and the future durable path. | — |
 
 The rest of this document describes the required stack in detail — jump to
-["Optional cloud knowledge providers"](#optional-cloud-knowledge-providers)
-below for worked examples of enabling Azure AI Search and Foundry IQ.
+["Optional features (opt-in, disabled by default)"](#optional-features-opt-in-disabled-by-default)
+below for worked examples of enabling Azure AI Search and Content Safety.
 
 ## Architecture
 
@@ -411,8 +411,9 @@ fail-closed path is **not** weakened — a future policy-compatible durable back
 options below) can drop the opt-out and set a real durable path instead.
 
 The **MCP server** still writes its seeded retail dataset (`retailpulse.db`) under
-the OS temp directory. That is intentional and safe: it **re-seeds from
-`tenant.yaml` on first run**, so the demo data regenerates automatically and needs
+the OS temp directory. That is intentional and safe: it **re-seeds from the
+active content pack (`packs/<Packs:Active>/pack.yaml` + `packs/<Packs:Active>/seed/scenario.yaml`)
+on first run**, so the demo data regenerates automatically and needs
 no durable volume.
 
 **Single writer & SMB-safe pragmas (retained helper).** The API keeps
@@ -568,10 +569,15 @@ since the old origin is already compiled into the previously deployed bundle.
 
 ### Content-file packaging
 
-`tenant.yaml` is now packaged into the API and MCP server publish output
-(`CopyToPublishDirectory`), and both resolve it from the content root first, falling back
-to the repo-relative path for local `dotnet run`. This is required because the container
-image does not contain the repository layout.
+The active content-pack tree (`packs/**` — `pack.yaml`, `agents.yaml`,
+`starting-tasks.yaml`, `knowledge/**`, `seed/**`) is packaged into both the API
+and MCP server publish output (`CopyToPublishDirectory`, linked under `packs/`
+in `RetailPulse.Api.csproj` and `RetailPulse.McpServer.csproj`). Both hosts
+resolve the active pack directory from `ContentRootPath\packs\<Packs:Active>`
+first, falling back to the repo-relative path for local `dotnet run`. This is
+required because the container image does not contain the repository layout.
+The legacy root `tenant.yaml` and `src/RetailPulse.Api/prompts.yaml` are still
+copied for byte-equivalence tests but are not consulted by the runtime.
 
 ### Cross-platform provision hooks
 

--- a/docs/tenant-configuration.md
+++ b/docs/tenant-configuration.md
@@ -348,6 +348,184 @@ represent any real retailer, cooperative, or supplier.
 
 ---
 
+## Worked example: add a specialist by configuration only (ADR-008)
+
+This section walks through the whole "add a new analyst-style agent
+without touching C#" surface end-to-end, on the shipped `default` pack.
+It demonstrates the ADR-008 promise: a specialist entry is a YAML edit;
+`ConfiguredSpecialistAgent` binds the definition to `MafAgentInvoker` at
+startup so tracing, tool budgets, and content safety apply uniformly.
+
+### 1. Append the specialist entry to `packs/default/agents.yaml`
+
+Add a new top-level entry under `agents:` — do **not** rewrite an
+existing one:
+
+```yaml
+agents:
+  # ...existing entries...
+  shrink-analysis:
+    name: "Shrink Analysis Agent"
+    model: "gpt-5.4-mini"
+    key: "shrink-analysis"
+    use_knowledge_base: false
+    display_name: "Shrink Analysis"
+    role: "specialist"
+    intents:
+      - "shrink/analysis"
+    keyword_fast_paths:
+      - "inventory shrink"
+      - "shrinkage report"
+    fallback_reply: "I couldn't run a shrink analysis for that scope."
+    system_prompt: |
+      You are a Shrink Analysis specialist for {tenant.company}.
+      You quantify inventory shrinkage patterns by store, category, and week.
+
+      ## Available Tools
+      - GetStorePerformance: rolled-up store KPI snapshots.
+      - PredictStockout: forward-looking stockout risk (bounded by category).
+
+      ## Rules
+      1. Always report an absolute shrink figure alongside the % of category.
+      2. Never claim a driver you cannot cite from a tool response.
+```
+
+Only tools listed in
+`AgentDefinitionValidatorToolCatalog.KnownToolNames` are accepted — the
+ADR-011 safety validator will refuse startup with
+`agent-definition-policy` otherwise. To use knowledge grounding, set
+`use_knowledge_base: true` and `knowledge_base_name: "<source>"` where
+`<source>` is a key defined in `Knowledge:Sources:Named` in
+`appsettings.json` (or a document `Source` under the pack's `knowledge/`
+directory).
+
+### 2. Add the intent to the router prompt (same file)
+
+Router intent classification is data-driven. Add the new intent to the
+`router` agent's `system_prompt`:
+
+```yaml
+  router:
+    # ...existing keys...
+    system_prompt: |
+      # ...existing category list...
+      - "shrink/analysis" — Questions about inventory shrinkage, loss
+        prevention, damage, and category-level shrink comparisons.
+      # ...
+```
+
+### 3. (Optional) Surface a starting task
+
+Append an entry under an existing category in
+`packs/default/starting-tasks.yaml` so the SPA offers it as a quick
+prompt:
+
+```yaml
+categories:
+  - id: store-ops
+    label: "Store Operations"
+    prompts:
+      - "Show me shrink trends for our grocery brands in the Midwest"
+```
+
+### 4. Restart the API
+
+No project or DI change is needed. On restart, the pack loader will:
+
+1. Parse the new entry, defaulting `key` to `shrink-analysis`.
+2. Register a `ConfiguredSpecialistAgent` bound to `MafAgentInvoker`.
+3. Run `AgentDefinitionValidator` (ADR-011). The API logs
+   `AgentDefinitionValidator scanned N definition(s) with 0 violation(s)`
+   on success or refuses to start on any policy violation
+   (`Guardrails:AgentDefinition:OnValidationFailure = RefuseStartup`
+   is the shipped default in production).
+4. Expose the specialist via `GET /api/info` and `IEnumerable<ISpecialistAgent>`.
+
+The router's LLM classification now emits `shrink/analysis` for matching
+questions, `HybridExecutionDecider` routes single-domain shrink questions
+to the new specialist on the fast path, and multi-domain requests (for
+example "shrink + margin") get lifted onto the plan path with
+`shrink-analysis` as one of the plan's steps.
+
+### 5. Verify
+
+```bash
+# From repo root, with the API pointed at your OpenAI:Endpoint:
+curl -s http://localhost:5100/api/info | jq '.specialists[] | select(.key=="shrink-analysis")'
+
+# Or ask the router directly:
+curl -s -X POST http://localhost:5100/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"how bad is our shrink in the Midwest last quarter","sessionId":"demo"}'
+```
+
+`ShippedPackContractTests` will fail if the new entry is malformed;
+`AgentDefinitionPolicyTests` will fail if you referenced a
+non-catalogued tool or exceeded the temperature bounds. Both catch the
+mistake before it reaches CI.
+
+---
+
+## Worked example: enable Azure AI Search knowledge (ADR-012)
+
+Retail Pulse defaults to the in-memory BM25 knowledge provider and needs
+no cloud dependency to demo. To route retrieval through Azure AI Search
+in production without touching code:
+
+### 1. Flip the provider mode
+
+`src/RetailPulse.Api/appsettings.Production.json` (or an environment
+override):
+
+```json
+{
+  "Knowledge": {
+    "Provider": {
+      "Mode": "AzureAISearch",
+      "Degradation": "FailLoud"
+    },
+    "AzureAISearch": {
+      "Endpoint": "https://<your-search>.search.windows.net",
+      "IndexName": "retail-pulse-knowledge",
+      "SchemaVersion": "v1",
+      "Embeddings": {
+        "Endpoint": "https://<your-openai>.openai.azure.com",
+        "Deployment": "text-embedding-3-large"
+      }
+    }
+  }
+}
+```
+
+Leave `Knowledge:AzureAISearch:Endpoint` empty and the provider stays
+unmaterialised — even with `Mode = AzureAISearch` set, the composition
+root treats it as unconfigured. That is intentional: a copy-paste of the
+schema shape into `appsettings.json` does not silently activate the
+optional dependency.
+
+### 2. Bind agents to a named source
+
+`Knowledge:Sources:Named` in `appsettings.json` defines the source keys
+each agent references via `knowledge_base_name`. Named entries scope
+retrieval to a subset of the indexed corpus.
+
+### 3. Degradation
+
+`Degradation = FailLoud` (default) surfaces a knowledge failure to the
+caller so operators notice a broken index. `FallbackToInMemory` allows
+the provider to degrade to the shipped in-memory corpus if the cloud
+provider is unreachable — pick one deliberately per environment.
+
+### 4. Foundry IQ alternative
+
+The same pattern works for the Azure AI Foundry IQ provider (ADR-013):
+set `Knowledge:Provider:Mode = FoundryIQ` and populate
+`Knowledge:FoundryIQ:ProjectEndpoint`, `VectorStoreName` /
+`VectorStoreId`, `RetrievalAgentName`, and `Model`. The composition
+root selects exactly one active provider at boot.
+
+---
+
 ## Legacy `tenant.yaml` and `prompts.yaml`
 
 The pre-pack `tenant.yaml` at the repo root and

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -755,7 +755,7 @@ on every run. CI also uploads this file as the `eval-harness-report` artifact.
 
 1. Add a new case to `Eval/Data/golden-dataset.json`. Every case needs a unique id,
    a category, a fictional prompt consistent with the seeded Apex Retail Group tenant
-   (see `tenant.yaml`), and an `expectations` block with:
+   (see the `tenant:` block in `packs/default/pack.yaml`), and an `expectations` block with:
    - `explicit_chart` (bool) + `chart_type` (canonical `ChartSpec.Type` or `null`)
    - `routing_mode`: `keyword-fast-path` (deterministically graded) or `llm-required`
      (routing recorded but not graded — the deterministic scorer only gates on the

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -38,6 +38,15 @@ Retail Pulse behaves differently depending on where you're testing. Understandin
 
 ## Running Unit Tests
 
+> **Golden-dataset answer-quality gate (deterministic).** The offline
+> deterministic case set in `tests/RetailPulse.Tests/Eval/` runs on every
+> PR through `EvaluationHarnessTests.OfflineDeterministicGate_PassesAllCases`
+> and asserts every deterministic golden case still routes to the right
+> specialist, produces the right chart shape, and stays under the per-run
+> cost cap. See ["Answer-Quality Evaluation Harness"](#answer-quality-evaluation-harness-issue-110)
+> below for the dataset schema, per-category pass-rate report, and refresh
+> workflow.
+
 ### Run All Tests
 
 ```bash
@@ -48,6 +57,13 @@ dotnet test
 
 ```bash
 dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj
+```
+
+### Run the offline eval gate alone
+
+```bash
+dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj \
+  --filter "FullyQualifiedName~EvaluationHarnessTests"
 ```
 
 ### Run Tests with Detailed Output

--- a/src/RetailPulse.Api/Budget/RequestToolContext.cs
+++ b/src/RetailPulse.Api/Budget/RequestToolContext.cs
@@ -57,7 +57,7 @@ public sealed class RequestToolContext
     {
         // If a caller already opened an outer budget scope (for example the
         // plan-first orchestrator wrapping a whole plan around per-step
-        // specialist invocations — see issue #93 and ADR-011), reuse it so the
+        // specialist invocations — see issue #93 and ADR-014), reuse it so the
         // returned-character counter, dedup map, and distinct-call counter
         // accumulate cumulatively across the whole plan instead of resetting
         // per step. The nested scope is a no-op on dispose in that case so

--- a/tests/RetailPulse.Tests/Planning/PlanExecutorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanExecutorTests.cs
@@ -453,7 +453,7 @@ public sealed class PlanExecutorTests
     [Fact]
     public async Task Full_width_five_step_plan_executes_every_edge_in_declared_order()
     {
-        // ADR-011 pins the plan width at 5. This test proves the workflow
+        // ADR-014 pins the plan width at 5. This test proves the workflow
         // graph really wires all five edges (step_i -> step_{i+1}) and each
         // step runs exactly once, in order, when nothing fails.
         var store = new RecordingPlanStore();


### PR DESCRIPTION
Closes #111
Working as Kroger (Lead)

## What changed and why

Documentation and ADR pass to make every claim about the agentic platform evolution match the code as it stands today. No product behaviour changes; only doc/ADR content and two ADR-rename follow-on comment fixes (one in `Budget/RequestToolContext.cs`, one in `Planning/PlanExecutorTests.cs`).

### ADR house-keeping

- **Renumber duplicate ADR-011.** The tree shipped with two `011-*.md` files: the safety-validation ADR (kept as ADR-011) and a plan-first orchestration ADR that landed later. Rename the plan-first file to `docs/adr/014-plan-first-orchestration.md`, retitle its H1, and update the two live cross-references (`RequestToolContext.cs` scope comment, `PlanExecutorTests.cs` plan-width comment).
- **Supersede ADR-001.** Explicitly mark ADR-001 (multi-agent routing) as superseded by ADR-008 (data-driven agent definitions), ADR-014 (plan-first orchestration), and ADR-007 (MAF agent primitives). The original decision/consequences are preserved verbatim per ADR conventions; a "Why superseded" section explains each invariant the code has moved past.
- **Cross-link ADR-006 to ADR-014.** ADR-006 (tool-context budget) now points at ADR-014's plan-scope semantics so readers see that a plan opens the outer `RequestToolContext` once and every step accumulates against the same budget.
- ADR-007..013 are already accurate; no changes needed. Issue #111 asked for ADR-007..010; audit showed 008, 009, 010, 011, 012, 013 were already delivered, so this PR only fills the real gap (ADR-014 rename) and marks the actual invalidations (ADR-001).

### `README.md`

- **Overview** rewrite: replaces the generic "powered by MAF" fluff with the concrete `Microsoft.Agents.AI 1.18.0` + `MafAgentInvoker` + `ChatClientAgent` seam and the `Microsoft.Agents.AI.Workflows` plan-first pipeline actually used by `PlanExecutor`. Enumerates the four shipped differentiators (data-driven specialists ADR-008, content-pack tenanting, plan-first + review-gated ADR-014, opt-in cloud knowledge/safety ADR-010/012/013).
- **Required vs Optional Azure Resources** table added near the top so the opt-in surface is unmistakable inside a minute. Required = Azure OpenAI + APIM, ACA + environment, ACR, Static Web Apps, App Insights + Log Analytics, Entra ID. Optional = Azure AI Search, Foundry IQ, Content Safety + Prompt Shields, Foundry Agent Service, Azure Files durable mount (currently blocked by tenant policy).
- **Quick Start** made honest: `OpenAI:Endpoint` is required with no fallback; `OpenAI:Deployment` must resolve non-empty; Node.js 20+ is a genuine prerequisite because the AppHost launches `npm ci` + `npm run dev` for the frontend. Step 2 now points at content packs (`packs/default`, `packs/halcyon-pet-supply`, `packs/prairiehearth-craft-supply`).
- **Configuration** table expanded from 8 rows to 20 with the newer keys (`Packs:*`, `Knowledge:Provider:*`, `Knowledge:AzureAISearch:*`, `Knowledge:FoundryIQ:*`, `Security:ContentSafety:Enabled`, `Guardrails:AgentDefinition:OnValidationFailure`, `PlanPersistence:Enabled`, `SessionPersistence:Enabled`, `RealtimeResilience:ApplicationHeartbeatEnabled`, `ChatTimeout:SingleShot|Plan`). Replaces the old `tenant.yaml` subsection with a Content Packs reference table.
- **Technology stack** table splits the single "Agent - MAF" row into `Microsoft.Agents.AI 1.18.0` + `Microsoft.Extensions.AI 10.9.0` with the actual roles and cross-refs to ADR-007/014.
- Refreshed **Key Patterns** around content packs, `MafAgentInvoker`, `HybridExecutionDecider`, plan-first + 202 review handoff, pluggable knowledge providers, optional Foundry delegation.

### `docs/architecture.md`

- Rewrites the **Multi-Agent Router Architecture** section around `Router → HybridExecutionDecider → {Fast | Plan | Council}`, enumerates the decider's seven-step precedence exactly as encoded in `HybridExecutionDecider.Decide`, and replaces the specialist registry table with the data-driven roster the `default` pack ships (`ConfiguredSpecialistAgent` + bespoke `MemoryManagementAgent`).
- Adds a dedicated **Plan-first orchestration + review gate (ADR-014)** section with the actual `PlanOrchestrator` / `PlanReviewCoordinator` / `PlanExecutor` pipeline, framework `ICheckpointStore<JsonElement>` locations, the `[[CLARIFY]]` / `[[REPLAN]]` durable pause markers, and the fail-safe when `PlanReview:Enabled=false` or `PlanPersistence:Enabled=false`.
- **Escalation Chain** section demoted with a leading callout as legacy compatibility-only, cross-linking `EscalationEndpoints`.
- Cross-links **ADR-011** (agent-definition safety validation) for the load-time validator.

### `docs/API.md`

- Adds a **Plan store & execution control** section documenting the endpoints that were completely undocumented despite being wired in code:
  - `GET /api/plans`, `GET /api/plans/{planId}`, `DELETE /api/plans/{planId}` (from `PlanEndpoints`).
  - `POST /api/chat/{sessionId}/cancel`, `POST /api/plans/{planId}/cancel`, `GET /api/plans/{planId}/reconcile` (from `ExecutionControlEndpoints`).
- **`POST /api/escalate`** header now marks the endpoint deprecated compatibility-only with a callout pointing readers at `/api/chat` + the 202 handoff for new integrations. Matches the class documentation on `EscalationEndpoints`.

### `docs/tenant-configuration.md`

- Adds an end-to-end **worked example: add a specialist by configuration only (ADR-008)** covering `packs/default/agents.yaml` shape, the router-intent update, the `ConfiguredSpecialistAgent` + `MafAgentInvoker` + `AgentDefinitionValidator` (ADR-011) load-time contract, and a curl-based verification.
- Adds a **worked example: enable Azure AI Search knowledge (ADR-012)** covering the exact `Knowledge:Provider:*` and `Knowledge:AzureAISearch:*` keys and the `FailLoud | FallbackToInMemory` degradation choice. Notes the Foundry IQ variant (ADR-013) uses the same pattern.

### `docs/deployment-azd.md`

- Adds a leading **Required vs Optional Azure resources** block mirroring the top-level README table so the opt-in surface is unmistakable inside a minute for readers who land in the deployment doc first. Names Bicep modules per required resource and the exact enable flags per optional resource.

### `docs/testing-guide.md`

- Promotes the offline deterministic golden-dataset gate (`EvaluationHarnessTests.OfflineDeterministicGate_PassesAllCases`) with a callout at the top of "Running Unit Tests" and a copy-paste `dotnet test --filter` selector so readers hit it before scrolling 700+ lines to the full harness reference.

### `docs/MCP-TOOLS.md`

- Intro corrected: the MCP server's SQLite seed source is now the active content pack (`Packs:Active`), not a monolithic `tenant.yaml`.

## Testing / verification executed on this machine

All commands run against branch `squad/111-docs-adr-pass` on Windows, `dotnet` version 10.0.400-preview from the pinned SDK.

| Check | Command | Result |
|-------|---------|--------|
| Whole-solution build | `dotnet build RetailPulse.slnx --verbosity quiet` | **PASS** — 0 warnings, 0 errors, ~17s |
| API project rebuild after `RequestToolContext.cs` comment tweak | `dotnet build src/RetailPulse.Api/RetailPulse.Api.csproj --verbosity quiet` | **PASS** — 0/0 in ~21s |
| PlanExecutor tests (touched comment) | `dotnet test tests/RetailPulse.Tests --filter "FullyQualifiedName~PlanExecutor" --no-build` | **PASS** — 17/17 |
| Golden-dataset eval gate | `dotnet test tests/RetailPulse.Tests --filter "FullyQualifiedName~EvaluationHarnessTests" --no-build` | **PASS** — 2/2 |
| Data-driven specialists + packs + MAF primitives | `dotnet test tests/RetailPulse.Tests --filter "FullyQualifiedName~MafPrimitives\|FullyQualifiedName~DataDrivenSpecialistTests\|FullyQualifiedName~Pack" --no-build` | **PASS** — 102/102 |
| Plan / hybrid / knowledge / content-safety | `dotnet test tests/RetailPulse.Tests --filter "FullyQualifiedName~PlanExecutor\|FullyQualifiedName~PlanFirst\|FullyQualifiedName~HybridExecutionDecider\|FullyQualifiedName~KnowledgeProvider\|FullyQualifiedName~ContentSafety" --no-build` | **PASS** — 163/163 |
| Full test-list count sanity | `dotnet test --list-tests` | 3,323 tests discovered — README "3,200+ tests" claim is accurate |
| MCP server standalone | `dotnet run --project src/RetailPulse.McpServer` (async) + `GET /health` | **200 OK** |
| Pre-commit hook enforcement | Every commit ran `.githooks/pre-commit` (`dotnet format --verify-no-changes` on staged C#) | **PASS** — 0 files reformatted |
| Pre-push hook (matches CI `lint`) | `dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic` on push | **PASS** — 0 of 722 reformatted |

### AppHost / frontend / clean-slate boot — honest limits

The task explicitly forbids running `npm` (frontend validation lives in GitHub Actions), and `RetailPulse.AppHost` invokes `AddNpmApp("frontend", "../RetailPulse.Web", "dev")` at startup, which shells to `npm`. I therefore did NOT execute the full AppHost end-to-end here; I updated the README Quick Start to state the npm prerequisite honestly instead of claiming zero-configuration.

Booting `RetailPulse.Api` standalone against a synthetic `OpenAI:Endpoint` + `OpenAI:Deployment` reproduces a **pre-existing** startup failure that is unrelated to this PR: `SqliteApprovalGate.InitializeSchemaAsync` fails on a fresh `%TEMP%\retailpulse\approvals.db` with `SQLite Error 1: 'no such column: AgentInstanceId'`. The multi-statement `CREATE TABLE ... ; CREATE INDEX ... ON ApprovalRequests (Decision, AgentInstanceId) ; ...` batch inside `SqliteApprovalGate.cs:144` appears to parse all `CREATE INDEX` statements before the `CREATE TABLE` populates the schema visible to the prepare pass. This is:

- Reproducible on a fully clean `%TEMP%\retailpulse\` (I deleted the dir; no other approvals.db anywhere on disk).
- Not something to fix in a docs-only PR.
- The reason the README Quick Start now says the AppHost path is the recommended demo (Aspire wires MCP + frontend automatically, and Aspire's per-service temp dirs sidestep this specific reproducer), not that `dotnet run --project src/RetailPulse.Api` alone is a zero-config path.

## Files changed

```
docs/API.md                                                    | +91  -2
docs/MCP-TOOLS.md                                              | +1   -1
docs/README.md                                                 | +116 -47
docs/adr/001-multi-agent-routing.md                            | +23  -1
docs/adr/006-tool-context-budget.md                            | +3   -0
docs/adr/{011 => 014}-plan-first-orchestration.md              | rename
docs/adr/014-plan-first-orchestration.md                       | +1   -1  (H1 retitle)
docs/architecture.md                                           | +111 -30
docs/deployment-azd.md                                         | +34  -0
docs/testing-guide.md                                          | +16  -0
docs/tenant-configuration.md                                   | +181 -0
src/RetailPulse.Api/Budget/RequestToolContext.cs               | +1   -1  (ADR-011 → ADR-014 comment ref)
tests/RetailPulse.Tests/Planning/PlanExecutorTests.cs          | +1   -1  (ADR-011 → ADR-014 comment ref)
```

## Known limitations

1. **Frontend build / AppHost end-to-end not executed here** — CI (`frontend`, `provider-matrix`) owns that.
2. **`SqliteApprovalGate` schema init bug** — reproducible pre-existing defect independent of this PR; documented above so a future issue can pick it up. This PR intentionally does not touch it.
