### PR TITLE
fix(#154): deterministic approval endpoint-vs-timeout race test via TimeProvider timer registration

### DIFF
--- a/tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs
+++ b/tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs
@@ -32,6 +32,26 @@ public sealed class ApprovalLifecycleTests : IDisposable
     private SqliteApprovalGate CreateGate(TimeProvider clock, TimeSpan? defaultTimeout = null)
         => new(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(), defaultTimeout ?? TimeSpan.FromMinutes(5), clock);
 
+    /// <summary>
+    /// Polls <paramref name="condition"/> on a small logical cadence until it
+    /// returns true or <paramref name="timeout"/> elapses. Tests use this to wait
+    /// for a background task (typically the exponential-backoff waiter inside
+    /// <see cref="SqliteApprovalGate.WaitForApprovalAsync"/>) to reach
+    /// <see cref="Task.Delay(TimeSpan, TimeProvider, CancellationToken)"/> and
+    /// register a timer with the fake clock — the pre-condition for
+    /// <see cref="FakeClock.Advance"/> to deterministically wake it.
+    /// </summary>
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(10);
+        }
+        return condition();
+    }
+
     private static ApprovalContext MakeContext(
         string agentId = "agent-1",
         string userId = "user-1",
@@ -199,7 +219,14 @@ public sealed class ApprovalLifecycleTests : IDisposable
 
         Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
 
-        await Task.Yield();
+        // Determinism (issue #154 sibling audit): the fake clock only wakes an
+        // already-parked Task.Delay. Wait for the waiter to register its timer
+        // BEFORE the human response so the sequence is fully deterministic —
+        // waiter parked → human writes Approved → Advance wakes waiter → waiter
+        // re-reads the row and returns the human's Approved decision.
+        bool parked = await WaitUntilAsync(() => clock.TimerCount >= 1, TimeSpan.FromSeconds(5));
+        parked.Should().BeTrue("the waiter must park at Task.Delay(_timeProvider) before the human responds");
+
         await gate.RespondAsync(req.RequestId, ApprovalDecision.Approved, "green-lit");
 
         // Advance clock enough to release the next backoff tick without crossing the deadline.
@@ -256,6 +283,10 @@ public sealed class ApprovalLifecycleTests : IDisposable
         // maximise the odds of an interleaving; assert the invariant on every
         // iteration: the row and the waiter always report one and only one
         // terminal decision and it is one of {Approved, TimedOut}.
+        //
+        // Determinism (issue #154 sibling audit): the FakeClock's Advance only
+        // wakes an already-parked Task.Delay. Wait for the waiter to register
+        // its timer before Advance so the deadline check is guaranteed to run.
         for (int trial = 0; trial < 15; trial++)
         {
             string dbPath = Path.Combine(Path.GetTempPath(), $"approval_race_{Guid.NewGuid():N}.db");
@@ -266,6 +297,10 @@ public sealed class ApprovalLifecycleTests : IDisposable
                 ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
 
                 Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+
+                bool parked = await WaitUntilAsync(() => clock.TimerCount >= 1, TimeSpan.FromSeconds(5));
+                parked.Should().BeTrue($"trial {trial}: the waiter must park at Task.Delay(_timeProvider) before Advance is called");
+
                 var humanTask = Task.Run(async () =>
                 {
                     // Give the waiter a moment to see Pending once, then race the
@@ -301,12 +336,19 @@ public sealed class ApprovalLifecycleTests : IDisposable
         // Two waiters (e.g., a retry) observing the same request must both return
         // the same terminal outcome — the conditional UPDATE guarantees at most one
         // writer flips Pending, and the other side re-reads the actual winner.
+        //
+        // Determinism (issue #154 sibling audit): wait for BOTH waiters to park at
+        // Task.Delay(_timeProvider) before Advance, so each waiter is guaranteed
+        // to be woken by the fake clock's advance.
         var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
         SqliteApprovalGate gate = CreateGate(clock, TimeSpan.FromSeconds(60));
         ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
 
         Task<ApprovalResult> a = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
         Task<ApprovalResult> b = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+
+        bool bothParked = await WaitUntilAsync(() => clock.TimerCount >= 2, TimeSpan.FromSeconds(5));
+        bothParked.Should().BeTrue("both waiters must park at Task.Delay(_timeProvider) before Advance is called");
 
         clock.Advance(TimeSpan.FromSeconds(120));
         ApprovalResult[] results = await Task.WhenAll(a, b).WaitAsync(TimeSpan.FromSeconds(5));
@@ -331,6 +373,13 @@ public sealed class ApprovalLifecycleTests : IDisposable
         (req.ExpiresAt - req.CreatedAt).Should().Be(TimeSpan.FromSeconds(45));
 
         Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId);
+
+        // Determinism (issue #154 sibling audit): the fake clock only wakes an
+        // already-parked Task.Delay, so wait for the waiter to register its
+        // timer before advancing past the deadline.
+        bool parked = await WaitUntilAsync(() => clock.TimerCount >= 1, TimeSpan.FromSeconds(5));
+        parked.Should().BeTrue("the waiter must park at Task.Delay(_timeProvider) before Advance is called");
+
         clock.Advance(TimeSpan.FromSeconds(90));
 
         ApprovalResult result = await waitTask.WaitAsync(TimeSpan.FromSeconds(5));
@@ -501,6 +550,15 @@ public sealed class ApprovalLifecycleTests : IDisposable
         // Concurrent human-vs-timeout at the endpoint boundary. RespondAsync (the
         // endpoint call) and WaitForApprovalAsync (the agent's blocking waiter) must
         // return the same terminal decision, matching the durable row exactly.
+        //
+        // Determinism protocol (issue #154): the FakeClock only wakes an already-
+        // parked Task.Delay. If we Advance before the waiter has reached
+        // Task.Delay(backoff, _timeProvider, ct) and registered its timer, Advance
+        // fires on an empty timer list and the waiter is stranded — the outer
+        // WaitAsync(5s) then trips a real TimeoutException (~1 in 9 full-suite
+        // runs). Wait for TimerCount to observe the waiter has parked, THEN kick
+        // the endpoint and Advance so the timeout branch and the endpoint's
+        // conditional UPDATE genuinely race for the single Pending row.
         for (int trial = 0; trial < 15; trial++)
         {
             string dbPath = Path.Combine(Path.GetTempPath(), $"approval_endpoint_race_{Guid.NewGuid():N}.db");
@@ -511,6 +569,14 @@ public sealed class ApprovalLifecycleTests : IDisposable
                 ApprovalRequest req = await gate.RequestApprovalAsync(MakeContext());
 
                 Task<ApprovalResult> waitTask = gate.WaitForApprovalAsync(req.RequestId, timeout: TimeSpan.FromSeconds(60));
+
+                // The waiter's first loop iteration reads Pending, heartbeats,
+                // checks the deadline (not yet crossed), then awaits Task.Delay
+                // against the injected clock. Only after that Task.Delay lands
+                // does TimerCount reach 1.
+                bool parked = await WaitUntilAsync(() => clock.TimerCount >= 1, TimeSpan.FromSeconds(5));
+                parked.Should().BeTrue($"trial {trial}: the waiter must park at Task.Delay(_timeProvider) before Advance is called");
+
                 Task<ApprovalResult> endpointTask = Task.Run(async () =>
                 {
                     await Task.Yield();
@@ -589,6 +655,20 @@ public sealed class ApprovalLifecycleTests : IDisposable
         public override DateTimeOffset GetUtcNow()
         {
             lock (_lock) return _now;
+        }
+
+        /// <summary>
+        /// Count of currently-registered (undisposed) timers. Tests await
+        /// <see cref="TimerCount"/> reaching an expected value before calling
+        /// <see cref="Advance"/> so the advance is guaranteed to wake at least
+        /// one parked <see cref="Task.Delay(TimeSpan, TimeProvider, CancellationToken)"/>
+        /// — otherwise Advance can fire on an empty timer list and the waiter
+        /// registers its timer after time has already moved, leaving it
+        /// stranded until the outer WaitAsync wall-clock timeout trips.
+        /// </summary>
+        public int TimerCount
+        {
+            get { lock (_lock) return _timers.Count; }
         }
 
         public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)


### PR DESCRIPTION
## Summary

Closes #154
Working as Publix (Tester)

`ApprovalLifecycleTests.Race_ConcurrentEndpointRespondVsWaiterTimeout_EndpointAndWaiterAgreeExactlyOnce` failed with `System.TimeoutException` in roughly 1 of 9 full-suite runs. Root cause was a test-determinism gap, not a production defect: `FakeClock.Advance` only wakes an *already-parked* `Task.Delay(TimeSpan, TimeProvider, CancellationToken)`. When the test called `clock.Advance(120s)` before the waiter reached `Task.Delay(backoff, _timeProvider, ct)` inside `SqliteApprovalGate.WaitForApprovalAsync`, Advance ran against an empty timer list; the waiter then registered a timer with `dueTime = 250ms` and nothing ever ticked it. The outer `WaitAsync(TimeSpan.FromSeconds(5))` guard then tripped a real wall-clock TimeoutException.

Fix follows the exact deterministic pattern PR #153 established for issue #152 (heartbeat cadence): expose `FakeClock.TimerCount`, add `WaitUntilAsync`, and wait for `TimerCount >= expected` before Advance. The endpoint's `RespondAsync` and the waiter's timeout branch still race for the single conditional UPDATE from `Pending`, so the exactly-once invariant is exercised end-to-end. No production behaviour change, no retries, no widened timeouts, no new packages.

## Sibling audit under `tests/RetailPulse.Tests/Approval/`

Applied the same `TimerCount` gate to every test in the folder that Advances once against a pending waiter:

| Test | Fix |
|---|---|
| `Race_ConcurrentEndpointRespondVsWaiterTimeout_EndpointAndWaiterAgreeExactlyOnce` (target) | `WaitUntilAsync(() => clock.TimerCount >= 1, 5s)` before starting endpoint task and Advance |
| `Race_HumanApproveAndWaiterTimeout_InterleavedFireOnce_ExactlyOneWinner` | Same TimerCount>=1 gate — identical single-shot Advance shape |
| `Race_TwoWaitersOnSameRequest_SameTerminalOutcome` | `TimerCount >= 2` before Advance (two independent waiters must both park) |
| `ConfiguredDefaultTimeout_IsUsedByRequestAndWait` | `TimerCount >= 1` before Advance |
| `InjectedClock_HumanResponseBeforeDeadline_WinsAndAgreesWithRow` | Replaced fragile `await Task.Yield()` with `TimerCount >= 1` gate BEFORE `RespondAsync` so the human write always lands while the waiter is asleep |

Tests already using the iterative `Yield + Advance(slice)` loop are intentionally left alone (each iteration re-Yields, so the waiter has multiple opportunities to park):
- `InjectedClock_TimeoutFires_Deterministically` (5 × Yield+Advance)
- `Respond_LateHumanResponseAfterTimeout_ReturnsPersistedTimedOutResult` (5 × Yield+Advance)
- `PlanReviewCoordinatorTests.Timeout_advances_deterministically_via_injected_clock` (20 × Advance+Yield)

## Meaningful-test proof (invariant break)

After the fix was committed as `aef5dec`, I temporarily broke the exactly-once invariant in production code (uncommitted mutation only — restored byte-for-byte before this PR):

`src/RetailPulse.Api/Approval/SqliteApprovalGate.cs`, `TryConditionalTransitionAsync`, dropped the `AND Decision = 'Pending'` guard from the UPDATE:

```diff
-            WHERE RequestId = @id AND Decision = 'Pending'
+            WHERE RequestId = @id
```

Ran the target test:

```
Failed RetailPulse.Tests.Approval.ApprovalLifecycleTests.Race_ConcurrentEndpointRespondVsWaiterTimeout_EndpointAndWaiterAgreeExactlyOnce [364 ms]
  Error Message:
   Expected endpoint.Decision to be ApprovalDecision.TimedOut {value: 4} because the endpoint MUST report the same terminal outcome the waiter observes, but found ApprovalDecision.Approved {value: 1}.
  Stack Trace:
     at FluentAssertions.Primitives.EnumAssertions`2.Be(TEnum expected, String because, Object[] becauseArgs)
   at RetailPulse.Tests.Approval.ApprovalLifecycleTests.Race_ConcurrentEndpointRespondVsWaiterTimeout_EndpointAndWaiterAgreeExactlyOnce()
     in C:\src\rp-b\tests\RetailPulse.Tests\Approval\ApprovalLifecycleTests.cs:line 594

Failed!  - Failed: 1, Passed: 0, Skipped: 0, Total: 1, Duration: 370 ms
```

The test catches the double-resolution deterministically: without the conditional guard, both writers (endpoint's Approved UPDATE and waiter's TimedOut UPDATE) succeed and the row ends up in the second-writer state, so the endpoint and the waiter disagree. `git diff` after restore returned zero (production file identical to the committed good state), then the target test passed again on the restored code.

## 15-run full-suite ledger

Full-suite command per the CI workflow (`dotnet test RetailPulse.slnx`). All 15 runs used the SAME built binaries; every run stood on its own (no `--filter`, no test-project subsetting). Ledger persisted at `.scout/copilot/session-state/.../files/154-run-ledger.txt`:

| Run | Result | Total | Passed | Failed | Skipped | Duration (s) | Failed tests |
|---:|---|---:|---:|---:|---:|---:|---|
| 1 | PASS | 3399 | 3387 | 0 | 12 | 95.92 | — |
| 2 | PASS | 3399 | 3387 | 0 | 12 | 93.09 | — |
| 3 | PASS | 3399 | 3387 | 0 | 12 | 93.37 | — |
| 4 | PASS | 3399 | 3387 | 0 | 12 | 100.78 | — |
| 5 | PASS | 3399 | 3387 | 0 | 12 | 92.90 | — |
| 6 | PASS | 3399 | 3387 | 0 | 12 | 92.38 | — |
| 7 | PASS | 3399 | 3387 | 0 | 12 | 93.59 | — |
| 8 | PASS | 3399 | 3387 | 0 | 12 | 91.41 | — |
| 9 | PASS | 3399 | 3387 | 0 | 12 | 98.51 | — |
| 10 | PASS | 3399 | 3387 | 0 | 12 | 93.61 | — |
| 11 | PASS | 3399 | 3387 | 0 | 12 | 92.43 | — |
| 12 | PASS | 3399 | 3387 | 0 | 12 | 83.90 | — |
| 13 | PASS | 3399 | 3387 | 0 | 12 | 93.58 | — |
| 14 | PASS | 3399 | 3387 | 0 | 12 | 92.62 | — |
| 15 | PASS | 3399 | 3387 | 0 | 12 | 94.40 | — |

**Result: 15/15 consecutive full-suite PASS.** Every run reported identical totals across both test projects (`RetailPulse.LoadTests` — 3 skipped, `RetailPulse.Tests` — 3387 passed / 9 skipped). No unrelated tests failed at any point; the consecutive-success counter never had to restart. Fifteen runs is what this PR proves; I make no broader stability claim beyond that.

## Targeted tests

Prior to the 15-run sweep, targeted checks all PASS on the fix:

- `Race_ConcurrentEndpointRespondVsWaiterTimeout_EndpointAndWaiterAgreeExactlyOnce` × 5 iterations — all PASS
- All 19 `ApprovalLifecycleTests` — PASS (`Failed: 0, Passed: 19, Skipped: 0, Total: 19`)

## Formatting

```
dotnet format RetailPulse.slnx --verify-no-changes
```
Exit code 0. No format changes needed.

## Files changed

- `tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs` (+81, −1)

Commit: `aef5dec`

## Notes for reviewer (Kroger)

- Production code (`SqliteApprovalGate.cs`) is byte-for-byte unchanged on this branch — the invariant break was purely local and never committed.
- The `WaitUntilAsync` helper polls with `Task.Delay(10)` on the wall clock (matches PR #153); it is a *readiness signal* between tests and the waiter, not a timeout tolerance.
- No timeouts were raised. No retries were added. No new dependencies.
