### PR TITLE
fix(#158): route every test SQLite temp file through a shared cleanup helper

### DIFF
--- a/tests/RetailPulse.Tests/Approval/ApprovalApiTests.cs
+++ b/tests/RetailPulse.Tests/Approval/ApprovalApiTests.cs
@@ -24,10 +24,7 @@ public class ApprovalApiTests : IDisposable
         _gate = new SqliteApprovalGate(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>());
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 
     private static ApprovalContext MakeContext(
         string userId = "user-1", string action = "Test action")

--- a/tests/RetailPulse.Tests/Approval/ApprovalApiTests.cs
+++ b/tests/RetailPulse.Tests/Approval/ApprovalApiTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RetailPulse.Api.Approval;
 using RetailPulse.Contracts.Approval;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -19,15 +20,13 @@ public class ApprovalApiTests : IDisposable
 
     public ApprovalApiTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"approval_api_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("approval_api_test");
         _gate = new SqliteApprovalGate(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>());
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static ApprovalContext MakeContext(

--- a/tests/RetailPulse.Tests/Approval/ApprovalGateTests.cs
+++ b/tests/RetailPulse.Tests/Approval/ApprovalGateTests.cs
@@ -23,10 +23,7 @@ public class ApprovalGateTests : IDisposable
         _gate = new SqliteApprovalGate(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>());
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 
     private static ApprovalContext MakeContext(
         string agentId = "agent-1", string userId = "user-1",

--- a/tests/RetailPulse.Tests/Approval/ApprovalGateTests.cs
+++ b/tests/RetailPulse.Tests/Approval/ApprovalGateTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RetailPulse.Api.Approval;
 using RetailPulse.Contracts.Approval;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -18,15 +19,13 @@ public class ApprovalGateTests : IDisposable
 
     public ApprovalGateTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"approval_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("approval_test");
         _gate = new SqliteApprovalGate(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>());
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static ApprovalContext MakeContext(

--- a/tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs
+++ b/tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs
@@ -23,10 +23,7 @@ public sealed class ApprovalLifecycleTests : IDisposable
         _dbPath = SqliteTestCleanup.NewDbPath("approval_lifecycle");
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 
     private SqliteApprovalGate CreateGate(TimeProvider clock, TimeSpan? defaultTimeout = null)
         => new(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>(), defaultTimeout ?? TimeSpan.FromMinutes(5), clock);

--- a/tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs
+++ b/tests/RetailPulse.Tests/Approval/ApprovalLifecycleTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using RetailPulse.Api.Approval;
 using RetailPulse.Contracts.Approval;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -19,14 +20,12 @@ public sealed class ApprovalLifecycleTests : IDisposable
 
     public ApprovalLifecycleTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"approval_lifecycle_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("approval_lifecycle");
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private SqliteApprovalGate CreateGate(TimeProvider clock, TimeSpan? defaultTimeout = null)
@@ -289,7 +288,7 @@ public sealed class ApprovalLifecycleTests : IDisposable
         // its timer before Advance so the deadline check is guaranteed to run.
         for (int trial = 0; trial < 15; trial++)
         {
-            string dbPath = Path.Combine(Path.GetTempPath(), $"approval_race_{Guid.NewGuid():N}.db");
+            string dbPath = SqliteTestCleanup.NewDbPath("approval_race");
             try
             {
                 var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
@@ -323,9 +322,7 @@ public sealed class ApprovalLifecycleTests : IDisposable
             }
             finally
             {
-                try { File.Delete(dbPath); } catch { }
-                try { File.Delete(dbPath + "-wal"); } catch { }
-                try { File.Delete(dbPath + "-shm"); } catch { }
+                SqliteTestCleanup.ReleaseAndDelete(dbPath);
             }
         }
     }
@@ -570,7 +567,7 @@ public sealed class ApprovalLifecycleTests : IDisposable
         //      waiter genuinely hangs, this test hangs — a real, visible bug.
         for (int trial = 0; trial < 15; trial++)
         {
-            string dbPath = Path.Combine(Path.GetTempPath(), $"approval_endpoint_race_{Guid.NewGuid():N}.db");
+            string dbPath = SqliteTestCleanup.NewDbPath("approval_endpoint_race");
             try
             {
                 var clock = new FakeClock(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
@@ -612,9 +609,7 @@ public sealed class ApprovalLifecycleTests : IDisposable
             }
             finally
             {
-                try { File.Delete(dbPath); } catch { }
-                try { File.Delete(dbPath + "-wal"); } catch { }
-                try { File.Delete(dbPath + "-shm"); } catch { }
+                SqliteTestCleanup.ReleaseAndDelete(dbPath);
             }
         }
     }

--- a/tests/RetailPulse.Tests/Approval/AsyncSqliteApprovalTests.cs
+++ b/tests/RetailPulse.Tests/Approval/AsyncSqliteApprovalTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RetailPulse.Api.Approval;
 using RetailPulse.Contracts.Approval;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -18,15 +19,13 @@ public class AsyncSqliteApprovalTests : IDisposable
 
     public AsyncSqliteApprovalTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"approval_async_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("approval_async_test");
         _gate = new SqliteApprovalGate(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>());
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static ApprovalContext MakeContext(string action = "Test action")

--- a/tests/RetailPulse.Tests/Approval/AsyncSqliteApprovalTests.cs
+++ b/tests/RetailPulse.Tests/Approval/AsyncSqliteApprovalTests.cs
@@ -23,10 +23,7 @@ public class AsyncSqliteApprovalTests : IDisposable
         _gate = new SqliteApprovalGate(_dbPath, Mock.Of<ILogger<SqliteApprovalGate>>());
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 
     private static ApprovalContext MakeContext(string action = "Test action")
         => new("agent-1", "user-1", action, "Low", "medium", "Testing");

--- a/tests/RetailPulse.Tests/Approval/AsyncSqliteTests.cs
+++ b/tests/RetailPulse.Tests/Approval/AsyncSqliteTests.cs
@@ -6,6 +6,7 @@ using RetailPulse.Api.Approval;
 using RetailPulse.Api.Memory;
 using RetailPulse.Contracts.Approval;
 using RetailPulse.Contracts.Memory;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -23,8 +24,8 @@ public class AsyncSqliteTests : IDisposable
 
     public AsyncSqliteTests()
     {
-        _approvalDbPath = Path.Combine(Path.GetTempPath(), $"async_approval_{Guid.NewGuid():N}.db");
-        _memoryDbPath = Path.Combine(Path.GetTempPath(), $"async_memory_{Guid.NewGuid():N}.db");
+        _approvalDbPath = SqliteTestCleanup.NewDbPath("async_approval");
+        _memoryDbPath = SqliteTestCleanup.NewDbPath("async_memory");
         _gate = new SqliteApprovalGate(_approvalDbPath, Mock.Of<ILogger<SqliteApprovalGate>>());
         _memory = new SqliteConversationMemory(_memoryDbPath, Mock.Of<ILogger<SqliteConversationMemory>>());
     }
@@ -34,9 +35,7 @@ public class AsyncSqliteTests : IDisposable
         _memory.Dispose();
         foreach (string? path in new[] { _approvalDbPath, _memoryDbPath })
         {
-            try { File.Delete(path); } catch { }
-            try { File.Delete(path + "-wal"); } catch { }
-            try { File.Delete(path + "-shm"); } catch { }
+            SqliteTestCleanup.ReleaseAndDelete(path);
         }
     }
 

--- a/tests/RetailPulse.Tests/Approval/PlanBroadcastScopingTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanBroadcastScopingTests.cs
@@ -24,8 +24,8 @@ using RetailPulse.Contracts.Persistence;
 using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
 using RetailPulse.Tests.Fixtures;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 using RetailPulse.Tests.TestInfrastructure;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Tests.Approval;
 

--- a/tests/RetailPulse.Tests/Approval/PlanBroadcastScopingTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanBroadcastScopingTests.cs
@@ -25,6 +25,7 @@ using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
 using RetailPulse.Tests.Fixtures;
 using ChatResponse = RetailPulse.Contracts.ChatResponse;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -64,16 +65,14 @@ public sealed class PlanBroadcastScopingTests : IDisposable
 
     public PlanBroadcastScopingTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"prv_scope_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("prv_scope");
         _checkpointDir = Path.Combine(Path.GetTempPath(), $"prv_scope_ckpt_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_checkpointDir);
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
         try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
     }
 

--- a/tests/RetailPulse.Tests/Approval/PlanClarifierTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanClarifierTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using RetailPulse.Api.Approval;
 using RetailPulse.Contracts.Approval;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -21,16 +22,14 @@ public sealed class PlanClarifierTests : IDisposable
 
     public PlanClarifierTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"plan_clarify_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("plan_clarify");
         _checkpointDir = Path.Combine(Path.GetTempPath(), $"plan_clarify_ckpt_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_checkpointDir);
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
         try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
     }
 

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionChartPropagationTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionChartPropagationTests.cs
@@ -24,8 +24,8 @@ using RetailPulse.Contracts.Persistence;
 using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
 using RetailPulse.Tests.Fixtures;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 using RetailPulse.Tests.TestInfrastructure;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Tests.Approval;
 

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionChartPropagationTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionChartPropagationTests.cs
@@ -25,6 +25,7 @@ using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
 using RetailPulse.Tests.Fixtures;
 using ChatResponse = RetailPulse.Contracts.ChatResponse;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -55,16 +56,14 @@ public sealed class PlanReviewCompletionChartPropagationTests : IDisposable
 
     public PlanReviewCompletionChartPropagationTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"prv_charts_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("prv_charts");
         _checkpointDir = Path.Combine(Path.GetTempPath(), $"prv_charts_ckpt_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_checkpointDir);
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
         try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
     }
 

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
@@ -26,6 +26,7 @@ using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
 using RetailPulse.Tests.Fixtures;
 using ChatResponse = RetailPulse.Contracts.ChatResponse;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -48,16 +49,14 @@ public sealed class PlanReviewCompletionServiceTests : IDisposable
 
     public PlanReviewCompletionServiceTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"prv_completion_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("prv_completion");
         _checkpointDir = Path.Combine(Path.GetTempPath(), $"prv_completion_ckpt_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_checkpointDir);
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
         try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
     }
 

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCompletionServiceTests.cs
@@ -25,8 +25,8 @@ using RetailPulse.Contracts.Persistence;
 using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
 using RetailPulse.Tests.Fixtures;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 using RetailPulse.Tests.TestInfrastructure;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Tests.Approval;
 

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
@@ -23,6 +23,14 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
 {
     private readonly string _dbPath;
     private readonly string _checkpointDir;
+    // #158: two tests below intentionally simulate a "process crash" by
+    // firing CoordinateAsync and never awaiting it. Without cancellation
+    // that background waiter keeps a live SqliteConnection open past the
+    // fixture's Dispose, which then legitimately can't delete the DB.
+    // Track those tasks + a shared CTS so Dispose can release them BEFORE
+    // SqliteTestCleanup runs.
+    private readonly CancellationTokenSource _backgroundCts = new();
+    private readonly List<Task> _backgroundTasks = [];
 
     public PlanReviewCoordinatorTests()
     {
@@ -33,6 +41,17 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
 
     public void Dispose()
     {
+        _backgroundCts.Cancel();
+        try
+        {
+            // Give abandoned coord waiters up to 2s to observe cancellation and
+            // release their pooled SqliteConnection. Any timeout here would be
+            // a real test-code leak — surface it via SqliteTestCleanup below.
+            Task.WhenAll(_backgroundTasks).Wait(TimeSpan.FromSeconds(2));
+        }
+        catch { /* individual task failures/cancellations are expected */ }
+        _backgroundCts.Dispose();
+
         SqliteTestCleanup.ReleaseAndDelete(_dbPath);
         try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
     }
@@ -323,12 +342,13 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
             PlanReviewCoordinator coord = CreateCoordinator(firstGate, options, TimeProvider.System);
 
             PlanReviewCoordinationInput input = SampleInput();
-            Task<PlanReviewOutcome> coordTask = coord.CoordinateAsync(input, CancellationToken.None);
+            Task<PlanReviewOutcome> coordTask = coord.CoordinateAsync(input, _backgroundCts.Token);
             ApprovalRequest row = await WaitForPending(firstGate, input.Subject);
             requestId = row.RequestId;
 
-            // Simulate crash: abandon the coordinator waiter.
-            _ = coordTask; // no observation
+            // Simulate crash: abandon the coordinator waiter (tracked so
+            // fixture Dispose can cancel + release its SQLite handle — #158).
+            _backgroundTasks.Add(coordTask);
         }
 
         // New "process": a fresh gate + reconciliation with the plan-aware strategy
@@ -372,7 +392,7 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
         PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System);
 
         PlanReviewCoordinationInput input = SampleInput() with { Subject = "alice" };
-        _ = coord.CoordinateAsync(input, CancellationToken.None);
+        _backgroundTasks.Add(coord.CoordinateAsync(input, _backgroundCts.Token));
         _ = await WaitForPending(gate, input.Subject);
 
         (await gate.GetPendingAsync("bob")).Should().BeEmpty(

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using RetailPulse.Api.Approval;
 using RetailPulse.Contracts.Approval;
 using RetailPulse.Contracts.Routing;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -25,16 +26,14 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
 
     public PlanReviewCoordinatorTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"plan_review_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("plan_review");
         _checkpointDir = Path.Combine(Path.GetTempPath(), $"plan_review_ckpt_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_checkpointDir);
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
         try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
     }
 

--- a/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
@@ -24,8 +24,8 @@ using RetailPulse.Contracts.Persistence;
 using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
 using RetailPulse.Tests.Fixtures;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 using RetailPulse.Tests.TestInfrastructure;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Tests.Approval;
 

--- a/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
@@ -25,6 +25,7 @@ using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
 using RetailPulse.Tests.Fixtures;
 using ChatResponse = RetailPulse.Contracts.ChatResponse;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Approval;
 
@@ -42,16 +43,14 @@ public sealed class PlanStateIntegrityTests : IDisposable
 
     public PlanStateIntegrityTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"prv_state_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("prv_state");
         _checkpointDir = Path.Combine(Path.GetTempPath(), $"prv_state_ckpt_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_checkpointDir);
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
         try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
     }
 

--- a/tests/RetailPulse.Tests/Budget/ToolContextAfterMeasurement.cs
+++ b/tests/RetailPulse.Tests/Budget/ToolContextAfterMeasurement.cs
@@ -5,6 +5,7 @@ using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
 using Xunit;
 using Xunit.Abstractions;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Budget;
 
@@ -34,7 +35,7 @@ public sealed class ToolContextAfterMeasurement : IDisposable
         _out = output;
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
-        _dbPath = Path.Combine(AppContext.BaseDirectory, $"budget_after_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("budget_after");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
 
@@ -130,6 +131,6 @@ public sealed class ToolContextAfterMeasurement : IDisposable
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { /* best effort */ }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 }

--- a/tests/RetailPulse.Tests/Budget/ToolContextAfterMeasurement.cs
+++ b/tests/RetailPulse.Tests/Budget/ToolContextAfterMeasurement.cs
@@ -3,9 +3,9 @@ using FluentAssertions;
 using RetailPulse.Api.Budget;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 using Xunit;
 using Xunit.Abstractions;
-using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Budget;
 
@@ -129,8 +129,5 @@ public sealed class ToolContextAfterMeasurement : IDisposable
         }
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 }

--- a/tests/RetailPulse.Tests/Budget/ToolContextBaselineMeasurement.cs
+++ b/tests/RetailPulse.Tests/Budget/ToolContextBaselineMeasurement.cs
@@ -1,9 +1,9 @@
 using System.Text.Json;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 using Xunit;
 using Xunit.Abstractions;
-using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Budget;
 
@@ -91,8 +91,5 @@ public sealed class ToolContextBaselineMeasurement : IDisposable
         Assert.True(total > 0);
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 }

--- a/tests/RetailPulse.Tests/Budget/ToolContextBaselineMeasurement.cs
+++ b/tests/RetailPulse.Tests/Budget/ToolContextBaselineMeasurement.cs
@@ -3,6 +3,7 @@ using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
 using Xunit;
 using Xunit.Abstractions;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Budget;
 
@@ -32,7 +33,7 @@ public sealed class ToolContextBaselineMeasurement : IDisposable
         _out = output;
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
-        _dbPath = Path.Combine(AppContext.BaseDirectory, $"budget_measure_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("budget_measure");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
     }
@@ -92,6 +93,6 @@ public sealed class ToolContextBaselineMeasurement : IDisposable
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { /* best effort cleanup */ }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 }

--- a/tests/RetailPulse.Tests/Chaos/DeadLetterQueueTests.cs
+++ b/tests/RetailPulse.Tests/Chaos/DeadLetterQueueTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using RetailPulse.Api.Resilience;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Chaos;
 
@@ -14,7 +15,7 @@ public class DeadLetterQueueTests : IDisposable
 
     public DeadLetterQueueTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"dlq-test-{Guid.NewGuid()}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("dlq-test");
         _queue = new DeadLetterQueue(NullLogger<DeadLetterQueue>.Instance, _dbPath);
     }
 
@@ -90,6 +91,6 @@ public class DeadLetterQueueTests : IDisposable
     public void Dispose()
     {
         _queue.Dispose();
-        try { File.Delete(_dbPath); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 }

--- a/tests/RetailPulse.Tests/Chat/MemoryCancellationTests.cs
+++ b/tests/RetailPulse.Tests/Chat/MemoryCancellationTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RetailPulse.Api.Memory;
 using RetailPulse.Contracts.Memory;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Chat;
 
@@ -21,7 +22,7 @@ public class MemoryCancellationTests : IDisposable
 
     public MemoryCancellationTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"cancel_memory_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("cancel_memory");
         _memory = new SqliteConversationMemory(_dbPath, Mock.Of<ILogger<SqliteConversationMemory>>());
         _middlewareLogger = new Mock<ILogger<ConversationMemoryMiddleware>>();
         _extractionLogger = new Mock<ILogger<MemoryExtractionService>>();
@@ -30,9 +31,7 @@ public class MemoryCancellationTests : IDisposable
     public void Dispose()
     {
         _memory.Dispose();
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     // ── Memory Work Receives CancellationToken ──────────────────────────

--- a/tests/RetailPulse.Tests/Data/CompetitiveDataTests.cs
+++ b/tests/RetailPulse.Tests/Data/CompetitiveDataTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Data;
 
@@ -38,7 +39,7 @@ public class CompetitiveDataTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_compdata_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_compdata_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _tenant = tenantProvider.GetTenant();
 
@@ -55,9 +56,7 @@ public class CompetitiveDataTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private SqliteConnection OpenConnection()

--- a/tests/RetailPulse.Tests/Data/DemandDataTests.cs
+++ b/tests/RetailPulse.Tests/Data/DemandDataTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Data;
 
@@ -43,7 +44,7 @@ public class DemandDataTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_data_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_data_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _tenant = tenantProvider.GetTenant();
 
@@ -61,9 +62,7 @@ public class DemandDataTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private SqliteConnection OpenConnection()

--- a/tests/RetailPulse.Tests/Data/MountedStorePragmaContractTests.cs
+++ b/tests/RetailPulse.Tests/Data/MountedStorePragmaContractTests.cs
@@ -36,10 +36,7 @@ public sealed class MountedStorePragmaContractTests : IDisposable
     private static readonly string RepoRoot = FindRepoRoot();
     private readonly List<string> _dbPaths = [];
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete([.. _dbPaths]);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete([.. _dbPaths]);
 
     private string NewDbPath(string label)
     {

--- a/tests/RetailPulse.Tests/Data/MountedStorePragmaContractTests.cs
+++ b/tests/RetailPulse.Tests/Data/MountedStorePragmaContractTests.cs
@@ -11,6 +11,7 @@ using RetailPulse.Api.Configuration;
 using RetailPulse.Api.Memory;
 using RetailPulse.Api.Observability;
 using RetailPulse.Api.Security;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Data;
 
@@ -37,20 +38,12 @@ public sealed class MountedStorePragmaContractTests : IDisposable
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
-        foreach (string db in _dbPaths)
-        {
-            foreach (string f in Directory.EnumerateFiles(
-                Path.GetDirectoryName(db)!, Path.GetFileNameWithoutExtension(db) + "*"))
-            {
-                try { File.Delete(f); } catch { /* best effort */ }
-            }
-        }
+        SqliteTestCleanup.ReleaseAndDelete([.. _dbPaths]);
     }
 
     private string NewDbPath(string label)
     {
-        string p = Path.Combine(Path.GetTempPath(), $"rp-{label}-{Guid.NewGuid():N}.db");
+        string p = SqliteTestCleanup.NewDbPath($"rp-{label}");
         _dbPaths.Add(p);
         return p;
     }

--- a/tests/RetailPulse.Tests/Data/PortfolioDepletionCoverageTests.cs
+++ b/tests/RetailPulse.Tests/Data/PortfolioDepletionCoverageTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
 using Xunit;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Data;
 
@@ -27,7 +28,7 @@ public class PortfolioDepletionCoverageTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"rp_portfolio_coverage_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("rp_portfolio_coverage");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _tenant = tenantProvider.GetTenant();
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
@@ -36,9 +37,7 @@ public class PortfolioDepletionCoverageTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     [Fact]

--- a/tests/RetailPulse.Tests/Data/PortfolioDepletionCoverageTests.cs
+++ b/tests/RetailPulse.Tests/Data/PortfolioDepletionCoverageTests.cs
@@ -2,8 +2,8 @@ using System.Text.Json;
 using FluentAssertions;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
-using Xunit;
 using RetailPulse.Tests.TestInfrastructure;
+using Xunit;
 
 namespace RetailPulse.Tests.Data;
 

--- a/tests/RetailPulse.Tests/Data/PromoDataTests.cs
+++ b/tests/RetailPulse.Tests/Data/PromoDataTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Data;
 
@@ -45,7 +46,7 @@ public class PromoDataTests : IDisposable
     {
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_promodata_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_promodata_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _tenant = tenantProvider.GetTenant();
         _ = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
@@ -60,9 +61,7 @@ public class PromoDataTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private SqliteConnection OpenConnection()

--- a/tests/RetailPulse.Tests/Data/SqliteMountTests.cs
+++ b/tests/RetailPulse.Tests/Data/SqliteMountTests.cs
@@ -29,10 +29,7 @@ public sealed class SqliteMountTests : IDisposable
         _connectionString = new SqliteConnectionStringBuilder { DataSource = _dbPath }.ToString();
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 
     private static long ReadLong(SqliteConnection conn, string pragma)
     {

--- a/tests/RetailPulse.Tests/Data/SqliteMountTests.cs
+++ b/tests/RetailPulse.Tests/Data/SqliteMountTests.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using RetailPulse.Api.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Data;
 
@@ -24,18 +25,13 @@ public sealed class SqliteMountTests : IDisposable
 
     public SqliteMountTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"rp-mount-{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("rp-mount");
         _connectionString = new SqliteConnectionStringBuilder { DataSource = _dbPath }.ToString();
     }
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
-        foreach (string f in Directory.EnumerateFiles(
-            Path.GetDirectoryName(_dbPath)!, Path.GetFileNameWithoutExtension(_dbPath) + "*"))
-        {
-            try { File.Delete(f); } catch { /* best effort */ }
-        }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static long ReadLong(SqliteConnection conn, string pragma)

--- a/tests/RetailPulse.Tests/Data/SupplyDataTests.cs
+++ b/tests/RetailPulse.Tests/Data/SupplyDataTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Data;
 
@@ -53,7 +54,7 @@ public class SupplyDataTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_supplydata_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_supplydata_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _tenant = tenantProvider.GetTenant();
 
@@ -70,9 +71,7 @@ public class SupplyDataTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private SqliteConnection OpenConnection()

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewEditInjectionTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewEditInjectionTests.cs
@@ -25,6 +25,7 @@ using RetailPulse.Contracts;
 using RetailPulse.Contracts.Approval;
 using RetailPulse.Contracts.Guardrails;
 using RetailPulse.Contracts.Persistence;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Endpoints;
 
@@ -108,11 +109,12 @@ public sealed class PlanReviewEditInjectionTests
         public required SqliteApprovalGate Gate { get; init; }
         public required string SeededRequestId { get; init; }
         public required string PlanId { get; init; }
+        public required string DbPath { get; init; }
 
         public static async Task<Host> CreateAsync(string subject)
         {
             const string planId = "plan-injection-1";
-            string dbPath = Path.Combine(Path.GetTempPath(), $"prv_inj_{Guid.NewGuid():N}.db");
+            string dbPath = SqliteTestCleanup.NewDbPath("prv_inj");
 
             WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
             builder.WebHost.UseTestServer();
@@ -178,6 +180,7 @@ public sealed class PlanReviewEditInjectionTests
                 Gate = gate,
                 SeededRequestId = row.RequestId,
                 PlanId = planId,
+                DbPath = dbPath,
             };
         }
 
@@ -185,6 +188,7 @@ public sealed class PlanReviewEditInjectionTests
         {
             Client.Dispose();
             await App.DisposeAsync();
+            SqliteTestCleanup.ReleaseAndDelete(DbPath);
         }
     }
 

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsAuthorizationTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewEndpointsAuthorizationTests.cs
@@ -26,6 +26,7 @@ using RetailPulse.Contracts;
 using RetailPulse.Contracts.Approval;
 using RetailPulse.Contracts.Guardrails;
 using RetailPulse.Contracts.Persistence;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Endpoints;
 
@@ -175,13 +176,14 @@ public sealed class PlanReviewEndpointsAuthorizationTests
         public required HttpClient Client { get; init; }
         public required SqliteApprovalGate Gate { get; init; }
         public required string SeededRequestId { get; init; }
+        public required string DbPath { get; init; }
 
         public static async Task<PlanReviewHost> CreateAsync(
             string subjectClaim,
             SeedRow aliceRow,
             bool asAnonymous = false)
         {
-            string dbPath = Path.Combine(Path.GetTempPath(), $"prv_ep_{Guid.NewGuid():N}.db");
+            string dbPath = SqliteTestCleanup.NewDbPath("prv_ep");
 
             WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
             builder.WebHost.UseTestServer();
@@ -277,6 +279,7 @@ public sealed class PlanReviewEndpointsAuthorizationTests
                 Client = app.GetTestClient(),
                 Gate = gate,
                 SeededRequestId = seededRow.RequestId,
+                DbPath = dbPath,
             };
         }
 
@@ -284,6 +287,7 @@ public sealed class PlanReviewEndpointsAuthorizationTests
         {
             Client.Dispose();
             await App.DisposeAsync();
+            SqliteTestCleanup.ReleaseAndDelete(DbPath);
         }
     }
 

--- a/tests/RetailPulse.Tests/Endpoints/PlanReviewGuardrailExtensionTests.cs
+++ b/tests/RetailPulse.Tests/Endpoints/PlanReviewGuardrailExtensionTests.cs
@@ -25,6 +25,7 @@ using RetailPulse.Contracts;
 using RetailPulse.Contracts.Approval;
 using RetailPulse.Contracts.Guardrails;
 using RetailPulse.Contracts.Persistence;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Endpoints;
 
@@ -247,6 +248,7 @@ public sealed class PlanReviewGuardrailExtensionTests
         public required SqliteApprovalGate Gate { get; init; }
         public required string SeededRequestId { get; init; }
         public required string PlanId { get; init; }
+        public required string DbPath { get; init; }
 
         public static async Task<Host> CreateAsync(
             string subject,
@@ -255,7 +257,7 @@ public sealed class PlanReviewGuardrailExtensionTests
             bool contentSafetyBlocks = false)
         {
             const string planId = "plan-guardrail-1";
-            string dbPath = Path.Combine(Path.GetTempPath(), $"prv_guard_{Guid.NewGuid():N}.db");
+            string dbPath = SqliteTestCleanup.NewDbPath("prv_guard");
 
             WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
             builder.WebHost.UseTestServer();
@@ -328,6 +330,7 @@ public sealed class PlanReviewGuardrailExtensionTests
                 Gate = gate,
                 SeededRequestId = row.RequestId,
                 PlanId = planId,
+                DbPath = dbPath,
             };
         }
 
@@ -335,6 +338,7 @@ public sealed class PlanReviewGuardrailExtensionTests
         {
             Client.Dispose();
             await App.DisposeAsync();
+            SqliteTestCleanup.ReleaseAndDelete(DbPath);
         }
     }
 

--- a/tests/RetailPulse.Tests/Integration/Phase1IntegrationTests.cs
+++ b/tests/RetailPulse.Tests/Integration/Phase1IntegrationTests.cs
@@ -20,6 +20,7 @@ using RetailPulse.Contracts.Approval;
 using RetailPulse.Contracts.Memory;
 using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Integration;
 
@@ -39,8 +40,8 @@ public class Phase1IntegrationTests : IDisposable
 
     public Phase1IntegrationTests()
     {
-        _memoryDbPath = Path.Combine(Path.GetTempPath(), $"phase1_mem_{Guid.NewGuid():N}.db");
-        _approvalDbPath = Path.Combine(Path.GetTempPath(), $"phase1_appr_{Guid.NewGuid():N}.db");
+        _memoryDbPath = SqliteTestCleanup.NewDbPath("phase1_mem");
+        _approvalDbPath = SqliteTestCleanup.NewDbPath("phase1_appr");
         _memory = new SqliteConversationMemory(_memoryDbPath, Mock.Of<ILogger<SqliteConversationMemory>>());
         _approvalGate = new SqliteApprovalGate(_approvalDbPath, Mock.Of<ILogger<SqliteApprovalGate>>());
         _alertService = new InMemoryAlertService(throttleWindow: TimeSpan.FromMilliseconds(50));
@@ -56,9 +57,7 @@ public class Phase1IntegrationTests : IDisposable
 
     private static void CleanDb(string path)
     {
-        try { File.Delete(path); } catch { }
-        try { File.Delete(path + "-wal"); } catch { }
-        try { File.Delete(path + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(path);
     }
 
     #region Router Still Routes Correctly

--- a/tests/RetailPulse.Tests/Integration/Phase1IntegrationTests.cs
+++ b/tests/RetailPulse.Tests/Integration/Phase1IntegrationTests.cs
@@ -55,10 +55,7 @@ public class Phase1IntegrationTests : IDisposable
         CleanDb(_approvalDbPath);
     }
 
-    private static void CleanDb(string path)
-    {
-        SqliteTestCleanup.ReleaseAndDelete(path);
-    }
+    private static void CleanDb(string path) => SqliteTestCleanup.ReleaseAndDelete(path);
 
     #region Router Still Routes Correctly
 

--- a/tests/RetailPulse.Tests/Integration/RouterIntegrationTests.cs
+++ b/tests/RetailPulse.Tests/Integration/RouterIntegrationTests.cs
@@ -18,6 +18,7 @@ using RetailPulse.Contracts;
 using RetailPulse.Contracts.Approval;
 using RetailPulse.Contracts.Memory;
 using RetailPulse.Contracts.Routing;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Integration;
 
@@ -451,7 +452,7 @@ public class RouterIntegrationTests
     [Fact]
     public async Task MemoryPersists_AcrossMultipleConversations()
     {
-        string dbPath = Path.Combine(Path.GetTempPath(), $"integ_mem_{Guid.NewGuid():N}.db");
+        string dbPath = SqliteTestCleanup.NewDbPath("integ_mem");
         try
         {
             using var memory = new SqliteConversationMemory(dbPath, Mock.Of<ILogger<SqliteConversationMemory>>());
@@ -472,16 +473,14 @@ public class RouterIntegrationTests
         }
         finally
         {
-            try { File.Delete(dbPath); } catch { }
-            try { File.Delete(dbPath + "-wal"); } catch { }
-            try { File.Delete(dbPath + "-shm"); } catch { }
+            SqliteTestCleanup.ReleaseAndDelete(dbPath);
         }
     }
 
     [Fact]
     public async Task ApprovalFlow_EndToEnd_RequestRespondAgentReceives()
     {
-        string dbPath = Path.Combine(Path.GetTempPath(), $"integ_appr_{Guid.NewGuid():N}.db");
+        string dbPath = SqliteTestCleanup.NewDbPath("integ_appr");
         try
         {
             var gate = new SqliteApprovalGate(dbPath, Mock.Of<ILogger<SqliteApprovalGate>>());
@@ -501,9 +500,7 @@ public class RouterIntegrationTests
         }
         finally
         {
-            try { File.Delete(dbPath); } catch { }
-            try { File.Delete(dbPath + "-wal"); } catch { }
-            try { File.Delete(dbPath + "-shm"); } catch { }
+            SqliteTestCleanup.ReleaseAndDelete(dbPath);
         }
     }
 

--- a/tests/RetailPulse.Tests/Margin/MarginDataTests.cs
+++ b/tests/RetailPulse.Tests/Margin/MarginDataTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Margin;
 
@@ -32,7 +33,7 @@ public class MarginDataTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_margindata_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_margindata_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _tenant = tenantProvider.GetTenant();
 
@@ -49,9 +50,7 @@ public class MarginDataTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private SqliteConnection OpenConnection()

--- a/tests/RetailPulse.Tests/Margin/MarginToolTests.cs
+++ b/tests/RetailPulse.Tests/Margin/MarginToolTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Margin;
 
@@ -21,7 +22,7 @@ public class MarginToolTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_margin_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_margin_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
     }
@@ -29,9 +30,7 @@ public class MarginToolTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static JsonElement Parse(object obj) =>

--- a/tests/RetailPulse.Tests/Memory/ConversationMemoryTests.cs
+++ b/tests/RetailPulse.Tests/Memory/ConversationMemoryTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RetailPulse.Api.Memory;
 using RetailPulse.Contracts.Memory;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Memory;
 
@@ -18,16 +19,14 @@ public class ConversationMemoryTests : IDisposable
 
     public ConversationMemoryTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"memory_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("memory_test");
         _memory = new SqliteConversationMemory(_dbPath, Mock.Of<ILogger<SqliteConversationMemory>>());
     }
 
     public void Dispose()
     {
         _memory.Dispose();
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static MemoryEntry MakeEntry(

--- a/tests/RetailPulse.Tests/Memory/MemoryMiddlewareTests.cs
+++ b/tests/RetailPulse.Tests/Memory/MemoryMiddlewareTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RetailPulse.Api.Memory;
 using RetailPulse.Contracts.Memory;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Memory;
 
@@ -20,7 +21,7 @@ public class MemoryMiddlewareTests : IDisposable
 
     public MemoryMiddlewareTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"middleware_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("middleware_test");
         _memory = new SqliteConversationMemory(_dbPath, Mock.Of<ILogger<SqliteConversationMemory>>());
 
         _extractionClient = new Mock<IChatClient>();
@@ -37,9 +38,7 @@ public class MemoryMiddlewareTests : IDisposable
     public void Dispose()
     {
         _memory.Dispose();
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private void SetupExtractionResponse(string json)

--- a/tests/RetailPulse.Tests/Memory/MemoryStoreRetrieveIntegrationTests.cs
+++ b/tests/RetailPulse.Tests/Memory/MemoryStoreRetrieveIntegrationTests.cs
@@ -4,6 +4,7 @@ using RetailPulse.Api.Agents.Specialists;
 using RetailPulse.Api.Memory;
 using RetailPulse.Contracts;
 using RetailPulse.Contracts.Memory;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Memory;
 
@@ -15,7 +16,7 @@ public class MemoryStoreRetrieveIntegrationTests : IDisposable
 
     public MemoryStoreRetrieveIntegrationTests()
     {
-        _dbPath = Path.Combine(AppContext.BaseDirectory, $"memory-store-retrieve-{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("memory-store-retrieve");
         _memory = new SqliteConversationMemory(_dbPath, NullLogger<SqliteConversationMemory>.Instance);
         _agent = new MemoryManagementAgent(_memory, NullLogger<MemoryManagementAgent>.Instance);
     }
@@ -143,9 +144,7 @@ public class MemoryStoreRetrieveIntegrationTests : IDisposable
     public void Dispose()
     {
         _memory.Dispose();
-        TryDelete(_dbPath);
-        TryDelete(_dbPath + "-wal");
-        TryDelete(_dbPath + "-shm");
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static MemoryEntry CreateEntry(
@@ -174,19 +173,4 @@ public class MemoryStoreRetrieveIntegrationTests : IDisposable
             Message: message,
             SessionId: sessionId,
             User: new UserContext(userId, "Test User", "test@example.com"));
-
-    private static void TryDelete(string path)
-    {
-        try
-        {
-            if (File.Exists(path))
-            {
-                File.Delete(path);
-            }
-        }
-        catch
-        {
-            // Best-effort cleanup for SQLite sidecar files.
-        }
-    }
 }

--- a/tests/RetailPulse.Tests/Observability/DurableCostTrackerTests.cs
+++ b/tests/RetailPulse.Tests/Observability/DurableCostTrackerTests.cs
@@ -27,10 +27,7 @@ public sealed class DurableCostTrackerTests : IDisposable
         _dbPath = SqliteTestCleanup.NewDbPath("rp-costs");
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 
     private static IConfiguration Pricing() =>
         new ConfigurationBuilder()

--- a/tests/RetailPulse.Tests/Observability/DurableCostTrackerTests.cs
+++ b/tests/RetailPulse.Tests/Observability/DurableCostTrackerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using RetailPulse.Api.Configuration;
 using RetailPulse.Api.Observability;
 using RetailPulse.Contracts.Observability;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Observability;
 
@@ -23,16 +24,12 @@ public sealed class DurableCostTrackerTests : IDisposable
 
     public DurableCostTrackerTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"rp-costs-{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("rp-costs");
     }
 
     public void Dispose()
     {
-        foreach (string f in Directory.EnumerateFiles(
-            Path.GetDirectoryName(_dbPath)!, Path.GetFileNameWithoutExtension(_dbPath) + "*"))
-        {
-            try { File.Delete(f); } catch { /* best effort cleanup */ }
-        }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static IConfiguration Pricing() =>
@@ -84,7 +81,7 @@ public sealed class DurableCostTrackerTests : IDisposable
         // instance — a fresh replica remounting the same share at the same path —
         // must observe the prior history. Durability comes from the mounted
         // directory, not the process, which is the whole point of the fix.
-        string mountDir = Path.Combine(Path.GetTempPath(), $"rp-mount-{Guid.NewGuid():N}");
+        string mountDir = Path.Combine(SqliteTestCleanup.TempRoot, $"rp-mount-{Guid.NewGuid():N}");
         Directory.CreateDirectory(mountDir);
         string mountedDbPath = Path.Combine(mountDir, "costs.db");
         try
@@ -102,6 +99,7 @@ public sealed class DurableCostTrackerTests : IDisposable
         }
         finally
         {
+            SqliteTestCleanup.ReleaseAndDelete(mountedDbPath);
             try { Directory.Delete(mountDir, recursive: true); } catch { /* best effort */ }
         }
     }

--- a/tests/RetailPulse.Tests/Packs/DefaultPackSeedGoldenTests.cs
+++ b/tests/RetailPulse.Tests/Packs/DefaultPackSeedGoldenTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Data.Sqlite;
 using RetailPulse.Api.Packs;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Packs;
 
@@ -21,16 +22,13 @@ public sealed class DefaultPackSeedGoldenTests : IDisposable
 
     public DefaultPackSeedGoldenTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"rp_default_seed_golden_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("rp_default_seed_golden");
     }
 
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        SqliteConnection.ClearAllPools();
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     [Fact]
@@ -138,7 +136,7 @@ public sealed class DefaultPackSeedGoldenTests : IDisposable
         // Copy the default pack into a scratch dir so we can mutate its
         // seed without touching the real shipped pack.
         string scratch = Path.Combine(
-            Path.GetTempPath(), $"rp_default_seed_scratch_{Guid.NewGuid():N}");
+            SqliteTestCleanup.TempRoot, $"rp_default_seed_scratch_{Guid.NewGuid():N}");
         Directory.CreateDirectory(scratch);
         try
         {

--- a/tests/RetailPulse.Tests/Packs/PackSwitchSeedDimensionsTests.cs
+++ b/tests/RetailPulse.Tests/Packs/PackSwitchSeedDimensionsTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Data.Sqlite;
 using RetailPulse.Api.Packs;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Packs;
 
@@ -20,13 +21,7 @@ public sealed class PackSwitchSeedDimensionsTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        SqliteConnection.ClearAllPools();
-        foreach (string path in _dbPaths)
-        {
-            try { File.Delete(path); } catch { }
-            try { File.Delete(path + "-wal"); } catch { }
-            try { File.Delete(path + "-shm"); } catch { }
-        }
+        SqliteTestCleanup.ReleaseAndDelete([.. _dbPaths]);
     }
 
     [Fact]
@@ -96,10 +91,8 @@ public sealed class PackSwitchSeedDimensionsTests : IDisposable
 
         foreach (LoadedPack pack in packs)
         {
-            string dbPath = Path.Combine(Path.GetTempPath(),
-                $"rp_pack_switch_{pack.Name}_{Guid.NewGuid():N}.db");
+            string dbPath = SqliteTestCleanup.NewDbPath($"rp_pack_switch_{pack.Name}");
             _dbPaths.Add(dbPath);
-            SqliteConnection.ClearAllPools();
 
             // Every shipped pack ships its own tenant declaration; wrap
             // it as an in-memory provider for the seeder.

--- a/tests/RetailPulse.Tests/Persistence/PlanStoreRestartTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/PlanStoreRestartTests.cs
@@ -24,10 +24,7 @@ public sealed class PlanStoreRestartTests : IDisposable
         _dbPath = SqliteTestCleanup.NewDbPath("plan_restart");
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 
     [Fact]
     public async Task Full_Plan_Survives_A_Store_Restart_With_Full_Fidelity()

--- a/tests/RetailPulse.Tests/Persistence/PlanStoreRestartTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/PlanStoreRestartTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RetailPulse.Api.Persistence;
 using RetailPulse.Contracts.Persistence;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Persistence;
 
@@ -20,14 +21,12 @@ public sealed class PlanStoreRestartTests : IDisposable
 
     public PlanStoreRestartTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"plan_restart_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("plan_restart");
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     [Fact]

--- a/tests/RetailPulse.Tests/Persistence/SessionPersistenceServiceExtensionsTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SessionPersistenceServiceExtensionsTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using RetailPulse.Api.Persistence;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Persistence;
 
@@ -31,7 +32,7 @@ public sealed class SessionPersistenceServiceExtensionsTests
     [Fact]
     public void Disabled_DoesNotRegisterStore_OrCleanupService_OrTouchDisk()
     {
-        string dbPath = Path.Combine(Path.GetTempPath(), $"session_disabled_{Guid.NewGuid():N}.db");
+        string dbPath = SqliteTestCleanup.NewDbPath("session_disabled");
 
         IServiceCollection services = BuildServices(
             new Dictionary<string, string?> { ["SessionPersistence:Enabled"] = "false" },
@@ -53,7 +54,7 @@ public sealed class SessionPersistenceServiceExtensionsTests
     [Fact]
     public void Enabled_RegistersStore_AndCleanupService()
     {
-        string dbPath = Path.Combine(Path.GetTempPath(), $"session_enabled_{Guid.NewGuid():N}.db");
+        string dbPath = SqliteTestCleanup.NewDbPath("session_enabled");
 
         try
         {
@@ -72,9 +73,7 @@ public sealed class SessionPersistenceServiceExtensionsTests
         }
         finally
         {
-            try { File.Delete(dbPath); } catch { }
-            try { File.Delete(dbPath + "-shm"); } catch { }
-            try { File.Delete(dbPath + "-wal"); } catch { }
+            SqliteTestCleanup.ReleaseAndDelete(dbPath);
         }
     }
 }

--- a/tests/RetailPulse.Tests/Persistence/SessionStoreRestartTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SessionStoreRestartTests.cs
@@ -26,10 +26,7 @@ public sealed class SessionStoreRestartTests : IDisposable
         _dbPath = SqliteTestCleanup.NewDbPath("session_restart");
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 
     private static SessionTurnWrite MakeTurn(string sessionId, string subject, string role, string content) =>
         new()

--- a/tests/RetailPulse.Tests/Persistence/SessionStoreRestartTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SessionStoreRestartTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RetailPulse.Api.Persistence;
 using RetailPulse.Contracts.Persistence;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Persistence;
 
@@ -22,14 +23,12 @@ public sealed class SessionStoreRestartTests : IDisposable
 
     public SessionStoreRestartTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"session_restart_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("session_restart");
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static SessionTurnWrite MakeTurn(string sessionId, string subject, string role, string content) =>

--- a/tests/RetailPulse.Tests/Persistence/SqlitePlanStoreTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SqlitePlanStoreTests.cs
@@ -20,10 +20,7 @@ public sealed class SqlitePlanStoreTests : IDisposable
         _dbPath = SqliteTestCleanup.NewDbPath("plan_store");
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 
     private SqlitePlanStore NewStore() =>
         new(_dbPath, Mock.Of<ILogger<SqlitePlanStore>>());

--- a/tests/RetailPulse.Tests/Persistence/SqlitePlanStoreTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SqlitePlanStoreTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RetailPulse.Api.Persistence;
 using RetailPulse.Contracts.Persistence;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Persistence;
 
@@ -16,14 +17,12 @@ public sealed class SqlitePlanStoreTests : IDisposable
 
     public SqlitePlanStoreTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"plan_store_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("plan_store");
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private SqlitePlanStore NewStore() =>

--- a/tests/RetailPulse.Tests/Persistence/SqliteSessionStoreTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SqliteSessionStoreTests.cs
@@ -25,10 +25,7 @@ public sealed class SqliteSessionStoreTests : IDisposable
         _store = new SqliteSessionStore(_dbPath, Mock.Of<ILogger<SqliteSessionStore>>());
     }
 
-    public void Dispose()
-    {
-        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
-    }
+    public void Dispose() => SqliteTestCleanup.ReleaseAndDelete(_dbPath);
 
     private static SessionTurnWrite MakeTurn(
         string sessionId,

--- a/tests/RetailPulse.Tests/Persistence/SqliteSessionStoreTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SqliteSessionStoreTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using RetailPulse.Api.Persistence;
 using RetailPulse.Contracts;
 using RetailPulse.Contracts.Persistence;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Persistence;
 
@@ -20,15 +21,13 @@ public sealed class SqliteSessionStoreTests : IDisposable
 
     public SqliteSessionStoreTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"session_store_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("session_store_test");
         _store = new SqliteSessionStore(_dbPath, Mock.Of<ILogger<SqliteSessionStore>>());
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static SessionTurnWrite MakeTurn(

--- a/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
@@ -19,6 +19,7 @@ using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
 using RetailPulse.Tests.Fixtures;
 using ChatResponse = RetailPulse.Contracts.ChatResponse;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Planning;
 
@@ -35,16 +36,14 @@ public sealed class PlanReviewOrchestratorTests : IDisposable
 
     public PlanReviewOrchestratorTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"plan_review_orch_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("plan_review_orch");
         _checkpointDir = Path.Combine(Path.GetTempPath(), $"plan_review_orch_ckpt_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_checkpointDir);
     }
 
     public void Dispose()
     {
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
         try { Directory.Delete(_checkpointDir, recursive: true); } catch { }
     }
 

--- a/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
+++ b/tests/RetailPulse.Tests/Planning/PlanReviewOrchestratorTests.cs
@@ -18,8 +18,8 @@ using RetailPulse.Contracts.Persistence;
 using RetailPulse.Contracts.Routing;
 using RetailPulse.Contracts.Tracing;
 using RetailPulse.Tests.Fixtures;
-using ChatResponse = RetailPulse.Contracts.ChatResponse;
 using RetailPulse.Tests.TestInfrastructure;
+using ChatResponse = RetailPulse.Contracts.ChatResponse;
 
 namespace RetailPulse.Tests.Planning;
 

--- a/tests/RetailPulse.Tests/Promo/TaskModuleTests.cs
+++ b/tests/RetailPulse.Tests/Promo/TaskModuleTests.cs
@@ -13,6 +13,7 @@ using RetailPulse.Api.Models;
 using RetailPulse.Contracts;
 using RetailPulse.Contracts.Approval;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Promo;
 
@@ -31,7 +32,7 @@ public class TaskModuleTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_taskmod_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_taskmod_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
     }
@@ -39,9 +40,7 @@ public class TaskModuleTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static JsonElement Parse(object obj) =>

--- a/tests/RetailPulse.Tests/Security/DurableAuditLogTests.cs
+++ b/tests/RetailPulse.Tests/Security/DurableAuditLogTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using RetailPulse.Api.Security;
 using RetailPulse.Contracts.Observability;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Security;
 
@@ -15,7 +16,7 @@ public class DurableAuditLogTests : IDisposable
 
     public DurableAuditLogTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"audit_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("audit_test");
         _auditLog = new DurableAuditLog(_dbPath);
     }
 
@@ -132,7 +133,7 @@ public class DurableAuditLogTests : IDisposable
     public void Dispose()
     {
         _auditLog.Dispose();
-        try { File.Delete(_dbPath); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
         GC.SuppressFinalize(this);
     }
 }

--- a/tests/RetailPulse.Tests/StoreOps/PlanogramTests.cs
+++ b/tests/RetailPulse.Tests/StoreOps/PlanogramTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.StoreOps;
 
@@ -21,7 +22,7 @@ public class PlanogramTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_planogram_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_planogram_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
     }
@@ -29,9 +30,7 @@ public class PlanogramTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static JsonElement Parse(object obj) =>

--- a/tests/RetailPulse.Tests/StoreOps/StoreDataTests.cs
+++ b/tests/RetailPulse.Tests/StoreOps/StoreDataTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.StoreOps;
 
@@ -23,7 +24,7 @@ public class StoreDataTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_storedata_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_storedata_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _tenant = tenantProvider.GetTenant();
 
@@ -40,9 +41,7 @@ public class StoreDataTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private SqliteConnection OpenConnection()

--- a/tests/RetailPulse.Tests/StoreOps/StoreOpsToolTests.cs
+++ b/tests/RetailPulse.Tests/StoreOps/StoreOpsToolTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.StoreOps;
 
@@ -22,7 +23,7 @@ public class StoreOpsToolTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_storeops_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_storeops_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
     }
@@ -30,9 +31,7 @@ public class StoreOpsToolTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static JsonElement Parse(object obj) =>

--- a/tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanup.cs
+++ b/tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanup.cs
@@ -31,10 +31,18 @@ namespace RetailPulse.Tests.TestInfrastructure;
 ///     unrelated <c>%TEMP%</c> noise (see PR body for the counting
 ///     methodology).</item>
 ///   <item><see cref="ReleaseAndDelete(string)"/> calls
-///     <see cref="SqliteConnection.ClearPool"/> using the exact connection
-///     string shape the stores use (<c>Mode=ReadWriteCreate</c>,
-///     <c>Cache=Shared</c>) before any <c>File.Delete</c>. That releases the
-///     pooled handle, so the delete succeeds instead of failing silently.</item>
+///     <see cref="SqliteConnection.ClearPool"/> for the specific
+///     <c>Data Source=&lt;path&gt;</c> across every connection-string
+///     variant tests are known to open (RWCreate+Shared for the stores,
+///     ReadOnly+Shared and plain ReadOnly for verification reads, and
+///     bare <c>Data Source=&lt;path&gt;</c>). Path-scoped clearing is
+///     used instead of
+///     <see cref="SqliteConnection.ClearAllPools"/> so it cannot race
+///     with a sibling xUnit fixture running in parallel — every fixture
+///     allocates a unique DB path, so per-path clearing only touches
+///     handles this fixture owns. A process-wide clear would reproduce
+///     the SafeHandle / <see cref="ObjectDisposedException"/> race
+///     audited in issue #156.</item>
 ///   <item>Every SQLite sidecar (<c>-journal</c>, <c>-wal</c>, <c>-shm</c>)
 ///     is deleted, not just the main <c>.db</c>. Even though <c>SqliteMount</c>
 ///     runs <c>journal_mode=DELETE</c> (no <c>-wal</c> / <c>-shm</c> in normal
@@ -49,11 +57,9 @@ namespace RetailPulse.Tests.TestInfrastructure;
 /// <para>
 /// Disposal ordering: fixture <c>Dispose</c> must dispose its store handles
 /// (if any) <em>before</em> calling this helper. This helper never touches
-/// caller-owned <see cref="SqliteConnection"/> instances, so it cannot
-/// reintroduce the SafeHandle / <see cref="ObjectDisposedException"/> race
-/// audited in issue #156 — it only creates a fresh, never-opened
-/// <see cref="SqliteConnection"/> to satisfy the <see cref="SqliteConnection.ClearPool"/>
-/// signature (which reads the connection string off the instance).
+/// caller-owned <see cref="SqliteConnection"/> instances — it never
+/// constructs or opens one — so it cannot reintroduce the SafeHandle /
+/// <see cref="ObjectDisposedException"/> race audited in issue #156.
 /// </para>
 /// </summary>
 public static class SqliteTestCleanup
@@ -88,27 +94,59 @@ public static class SqliteTestCleanup
     {
         ArgumentException.ThrowIfNullOrEmpty(dbPath);
 
-        // 1) Release the pooled handle for the exact connection string every
-        //    store in this project uses. Do this BEFORE any File.Delete so the
-        //    OS handle is closed and the delete can succeed on Windows.
-        var probe = new SqliteConnection(new SqliteConnectionStringBuilder
+        // 1) Release every pooled handle keyed on THIS specific path. Pool
+        //    buckets are keyed on the exact connection string, so we clear
+        //    each variant tests are known to open against a temp DB:
+        //      • RWCreate + Shared cache : the shape every store builds via
+        //        SqliteMount (SqliteApprovalGate, SqlitePlanStore,
+        //        SqliteSessionStore, SqliteAlertService, SqliteConversationMemory,
+        //        RetailPulseDb).
+        //      • ReadOnly  + Shared cache : verification reads in
+        //        DemandDataTests, CompetitiveDataTests, PromoDataTests,
+        //        SupplyDataTests, StoreDataTests, MarginDataTests.
+        //      • ReadOnly (no cache)     : StoreOpsToolTests, PlanogramTests
+        //        ("Data Source=<path>;Mode=ReadOnly").
+        //      • Bare "Data Source=<path>" : DurableCostTracker,
+        //        DurableAuditLog, PackSwitchSeedDimensionsTests,
+        //        DefaultPackSeedGoldenTests, MountedStorePragmaContractTests.
+        //    Missing any one of these leaves an OS handle open on Windows
+        //    and the delete fails — which is the exact leak this helper
+        //    guards against (#158).
+        //
+        //    Per-path clearing is chosen over SqliteConnection.ClearAllPools()
+        //    on purpose: xUnit v2 runs fixtures in parallel in the same
+        //    process, and ClearAllPools disposes idle handles across every
+        //    pool bucket. If a sibling fixture just checked out one of
+        //    those handles, the process-wide clear races with its next
+        //    Open and reproduces the SafeHandle / ObjectDisposedException
+        //    from issue #156. Path-scoped clearing cannot race with a
+        //    sibling because every fixture allocates a unique DB path.
+        ClearPoolForConnectionString(new SqliteConnectionStringBuilder
         {
             DataSource = dbPath,
             Mode = SqliteOpenMode.ReadWriteCreate,
             Cache = SqliteCacheMode.Shared,
         }.ToString());
-        SqliteConnection.ClearPool(probe);
 
-        // 2) A handful of tests build a simpler `Data Source=<path>` string for
-        //    read-back verification (PRAGMA reads, seeded-row checks). That
-        //    lands in a different pool bucket, so clear that shape too.
-        var probeSimple = new SqliteConnection(new SqliteConnectionStringBuilder
+        ClearPoolForConnectionString(new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadOnly,
+            Cache = SqliteCacheMode.Shared,
+        }.ToString());
+
+        ClearPoolForConnectionString(new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadOnly,
+        }.ToString());
+
+        ClearPoolForConnectionString(new SqliteConnectionStringBuilder
         {
             DataSource = dbPath,
         }.ToString());
-        SqliteConnection.ClearPool(probeSimple);
 
-        // 3) Delete the database + every SQLite sidecar. Sidecars are:
+        // 2) Delete the database + every SQLite sidecar. Sidecars are:
         //      -journal : DELETE rollback journal (the mode SqliteMount uses)
         //      -wal / -shm : write-ahead log + shared-memory index (not used
         //                    by our policy, but deleted defensively so a
@@ -136,6 +174,22 @@ public static class SqliteTestCleanup
                 $"SqliteTestCleanup.ReleaseAndDelete failed for '{dbPath}'.",
                 errors);
         }
+    }
+
+    /// <summary>
+    /// Clears the Microsoft.Data.Sqlite pool bucket keyed on the given
+    /// connection string. Uses a fresh, never-opened
+    /// <see cref="SqliteConnection"/> purely as a carrier for the string —
+    /// <see cref="SqliteConnection.ClearPool"/> reads its
+    /// <see cref="SqliteConnection.ConnectionString"/> to locate the
+    /// bucket. The carrier is never opened and its underlying
+    /// <c>SQLitePCL.sqlite3</c> is never referenced, so this cannot
+    /// reintroduce the SafeHandle disposal race audited in issue #156.
+    /// </summary>
+    private static void ClearPoolForConnectionString(string connectionString)
+    {
+        var probe = new SqliteConnection(connectionString);
+        SqliteConnection.ClearPool(probe);
     }
 
     /// <summary>

--- a/tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanup.cs
+++ b/tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanup.cs
@@ -1,0 +1,183 @@
+using System.Text;
+using Microsoft.Data.Sqlite;
+
+namespace RetailPulse.Tests.TestInfrastructure;
+
+/// <summary>
+/// The single shared owner of SQLite temp-file lifetime for every test in this
+/// project. Every fixture that opens a SQLite database MUST allocate its path
+/// through <see cref="NewDbPath(string)"/> and release it through
+/// <see cref="ReleaseAndDelete(string)"/> (or the batch overload).
+///
+/// <para>
+/// Issue #158 documented ~280,497 orphaned <c>*.db*</c> files (~1.36 TB) in
+/// <c>%TEMP%</c> accumulated by repeated local runs. The root cause was
+/// <see cref="SqliteConnection"/> pooling: the stores under test open per-
+/// operation connections via <c>await using</c>, which returns the underlying
+/// handle to the pool rather than closing it. Fixture <c>Dispose</c> then
+/// tried to <c>File.Delete</c> the database path while the pool still held
+/// the OS handle open — Windows returned <c>ERROR_SHARING_VIOLATION</c>,
+/// the delete was silently swallowed by <c>try { ... } catch { }</c>, and
+/// every failed test run leaked a database plus (for WAL / rollback journals)
+/// a matching <c>-wal</c>, <c>-shm</c>, or <c>-journal</c> sidecar.
+/// </para>
+///
+/// <para>
+/// The contract this helper enforces:
+/// </para>
+/// <list type="number">
+///   <item>Every test DB lives under <see cref="TempRoot"/> — a dedicated
+///     namespace-scoped subdirectory so a leak count is measurable without
+///     unrelated <c>%TEMP%</c> noise (see PR body for the counting
+///     methodology).</item>
+///   <item><see cref="ReleaseAndDelete(string)"/> calls
+///     <see cref="SqliteConnection.ClearPool"/> using the exact connection
+///     string shape the stores use (<c>Mode=ReadWriteCreate</c>,
+///     <c>Cache=Shared</c>) before any <c>File.Delete</c>. That releases the
+///     pooled handle, so the delete succeeds instead of failing silently.</item>
+///   <item>Every SQLite sidecar (<c>-journal</c>, <c>-wal</c>, <c>-shm</c>)
+///     is deleted, not just the main <c>.db</c>. Even though <c>SqliteMount</c>
+///     runs <c>journal_mode=DELETE</c> (no <c>-wal</c> / <c>-shm</c> in normal
+///     operation) the sidecars are removed defensively so a future policy
+///     change cannot silently reintroduce a leak.</item>
+///   <item>Deletion failures throw. They are the sentinel that says a pooled
+///     connection is still holding the file — the exact bug that produced the
+///     original leak. Callers <b>must not</b> reinstate a <c>catch</c>-and-
+///     ignore around <see cref="ReleaseAndDelete(string)"/>.</item>
+/// </list>
+///
+/// <para>
+/// Disposal ordering: fixture <c>Dispose</c> must dispose its store handles
+/// (if any) <em>before</em> calling this helper. This helper never touches
+/// caller-owned <see cref="SqliteConnection"/> instances, so it cannot
+/// reintroduce the SafeHandle / <see cref="ObjectDisposedException"/> race
+/// audited in issue #156 — it only creates a fresh, never-opened
+/// <see cref="SqliteConnection"/> to satisfy the <see cref="SqliteConnection.ClearPool"/>
+/// signature (which reads the connection string off the instance).
+/// </para>
+/// </summary>
+public static class SqliteTestCleanup
+{
+    /// <summary>
+    /// Namespace-scoped root for every SQLite temp file the test suite creates.
+    /// Isolated from ambient <c>%TEMP%</c> so the leak counter documented in the
+    /// PR body has a precise, exclusive matching pattern.
+    /// </summary>
+    public static readonly string TempRoot = Path.Combine(
+        Path.GetTempPath(), "RetailPulse.Tests.Sqlite");
+
+    /// <summary>
+    /// Allocate a fresh, guaranteed-unique database path under
+    /// <see cref="TempRoot"/>. Callers pass <paramref name="label"/> so a
+    /// mid-run inspection of the directory names the owning fixture.
+    /// </summary>
+    public static string NewDbPath(string label)
+    {
+        Directory.CreateDirectory(TempRoot);
+        return Path.Combine(TempRoot, $"{Sanitize(label)}_{Guid.NewGuid():N}.db");
+    }
+
+    /// <summary>
+    /// Release the pooled SQLite handle for <paramref name="dbPath"/>, delete
+    /// the database file, and delete every SQLite sidecar. Throws on any
+    /// deletion failure — a lock survives here only if a caller-owned
+    /// connection was not disposed first, which is the exact regression #158
+    /// is preventing.
+    /// </summary>
+    public static void ReleaseAndDelete(string dbPath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(dbPath);
+
+        // 1) Release the pooled handle for the exact connection string every
+        //    store in this project uses. Do this BEFORE any File.Delete so the
+        //    OS handle is closed and the delete can succeed on Windows.
+        var probe = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Cache = SqliteCacheMode.Shared,
+        }.ToString());
+        SqliteConnection.ClearPool(probe);
+
+        // 2) A handful of tests build a simpler `Data Source=<path>` string for
+        //    read-back verification (PRAGMA reads, seeded-row checks). That
+        //    lands in a different pool bucket, so clear that shape too.
+        var probeSimple = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+        }.ToString());
+        SqliteConnection.ClearPool(probeSimple);
+
+        // 3) Delete the database + every SQLite sidecar. Sidecars are:
+        //      -journal : DELETE rollback journal (the mode SqliteMount uses)
+        //      -wal / -shm : write-ahead log + shared-memory index (not used
+        //                    by our policy, but deleted defensively so a
+        //                    future WAL flip cannot silently regress the leak).
+        List<Exception>? errors = null;
+        foreach (string path in Sidecars(dbPath))
+        {
+            try
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch (Exception ex)
+            {
+                (errors ??= []).Add(new IOException(
+                    $"Could not delete '{path}' — a pooled or live SqliteConnection " +
+                    "is still holding the file open. Dispose the store BEFORE calling " +
+                    "ReleaseAndDelete, and never wrap this call in a swallowing catch " +
+                    "(see issue #158 for the leak this guards against).", ex));
+            }
+        }
+
+        if (errors is { Count: > 0 })
+        {
+            throw new AggregateException(
+                $"SqliteTestCleanup.ReleaseAndDelete failed for '{dbPath}'.",
+                errors);
+        }
+    }
+
+    /// <summary>
+    /// Batch version for fixtures that own more than one database (for example
+    /// tests that instantiate both a memory store and an approval gate).
+    /// Every path is attempted even if an earlier one throws so a single
+    /// stubborn lock cannot mask a leak on a sibling path; failures are
+    /// aggregated into a single throw.
+    /// </summary>
+    public static void ReleaseAndDelete(params string[] dbPaths)
+    {
+        ArgumentNullException.ThrowIfNull(dbPaths);
+        List<Exception>? errors = null;
+        foreach (string p in dbPaths)
+        {
+            try { ReleaseAndDelete(p); }
+            catch (Exception ex) { (errors ??= []).Add(ex); }
+        }
+        if (errors is { Count: > 0 })
+            throw new AggregateException("One or more SQLite temp cleanups failed.", errors);
+    }
+
+    /// <summary>
+    /// Every path SQLite may create alongside <paramref name="dbPath"/>. The
+    /// enumeration is public so the helper's own tests can assert every one
+    /// of them is gone after cleanup.
+    /// </summary>
+    public static IEnumerable<string> Sidecars(string dbPath)
+    {
+        yield return dbPath;
+        yield return dbPath + "-journal";
+        yield return dbPath + "-wal";
+        yield return dbPath + "-shm";
+    }
+
+    private static string Sanitize(string label)
+    {
+        if (string.IsNullOrWhiteSpace(label)) return "db";
+        char[] invalid = Path.GetInvalidFileNameChars();
+        var buf = new StringBuilder(label.Length);
+        foreach (char c in label)
+            buf.Append(invalid.Contains(c) ? '_' : c);
+        return buf.ToString();
+    }
+}

--- a/tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanupTests.cs
+++ b/tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanupTests.cs
@@ -1,0 +1,187 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using RetailPulse.Api.Approval;
+using RetailPulse.Api.Memory;
+using RetailPulse.Contracts.Approval;
+using RetailPulse.Contracts.Memory;
+
+namespace RetailPulse.Tests.TestInfrastructure;
+
+/// <summary>
+/// Regression guard for the SQLite temp-file leak documented in issue #158.
+/// These tests pin the contract every fixture in this project relies on: the
+/// shared <see cref="SqliteTestCleanup"/> helper releases the pooled handle
+/// before deletion, removes every SQLite sidecar (not just the main .db),
+/// and surfaces (rather than swallows) a lock. If any of these turn red,
+/// the ~280 k / 1.36 TB leak that motivated the fix is back.
+/// </summary>
+public sealed class SqliteTestCleanupTests
+{
+    [Fact]
+    public void TempRoot_LivesUnderTempAndIsNamespaceScoped()
+    {
+        // The counting methodology documented on the PR only holds if every
+        // test's DB lives under a directory the suite owns exclusively.
+        SqliteTestCleanup.TempRoot.Should().StartWith(Path.GetTempPath());
+        Path.GetFileName(SqliteTestCleanup.TempRoot)
+            .Should().Be("RetailPulse.Tests.Sqlite");
+    }
+
+    [Fact]
+    public void NewDbPath_ProducesUniquePathsUnderTempRoot()
+    {
+        string a = SqliteTestCleanup.NewDbPath("alpha");
+        string b = SqliteTestCleanup.NewDbPath("alpha");
+
+        a.Should().NotBe(b);
+        Path.GetDirectoryName(a).Should().Be(SqliteTestCleanup.TempRoot);
+        Path.GetDirectoryName(b).Should().Be(SqliteTestCleanup.TempRoot);
+        Path.GetFileName(a).Should().StartWith("alpha_");
+        Path.GetExtension(a).Should().Be(".db");
+
+        // NewDbPath must be idempotent about directory creation.
+        Directory.Exists(SqliteTestCleanup.TempRoot).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReleaseAndDelete_RemovesDbAndEverySidecar_WhenPresent()
+    {
+        string dbPath = SqliteTestCleanup.NewDbPath("sidecar-sweep");
+        // Simulate every sidecar SQLite might leave behind so the helper's
+        // sidecar sweep is proved end-to-end, not just claimed.
+        foreach (string p in SqliteTestCleanup.Sidecars(dbPath))
+            File.WriteAllBytes(p, [0x1]);
+
+        SqliteTestCleanup.ReleaseAndDelete(dbPath);
+
+        foreach (string p in SqliteTestCleanup.Sidecars(dbPath))
+            File.Exists(p).Should().BeFalse($"sidecar '{p}' must be swept");
+    }
+
+    [Fact]
+    public void ReleaseAndDelete_IsNoOpForNonExistentPath()
+    {
+        string missing = Path.Combine(SqliteTestCleanup.TempRoot,
+            $"never-created-{Guid.NewGuid():N}.db");
+
+        Action act = () => SqliteTestCleanup.ReleaseAndDelete(missing);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task ReleaseAndDelete_AfterRealStoreUse_RemovesEverythingLeftInTempRoot()
+    {
+        // End-to-end proof against the exact class of leak: use the actual
+        // SqliteConversationMemory + SqliteApprovalGate stores (which open
+        // per-operation connections through the pool), then run the helper
+        // and prove the DB is really gone. If the pool still held the file
+        // handle open, File.Delete would have failed on Windows, the helper
+        // would have thrown, and the test would fail — which is precisely
+        // the regression guard #158 asks for.
+        string memPath = SqliteTestCleanup.NewDbPath("regression-memory");
+        string apprPath = SqliteTestCleanup.NewDbPath("regression-approval");
+
+        var memory = new SqliteConversationMemory(memPath, NullLogger<SqliteConversationMemory>.Instance);
+        var gate = new SqliteApprovalGate(apprPath, NullLogger<SqliteApprovalGate>.Instance);
+
+        await memory.StoreAsync("user-1", new MemoryEntry(
+            Id: Guid.NewGuid().ToString("N"),
+            UserId: "user-1",
+            Type: MemoryType.ConversationSummary,
+            Content: "regression content",
+            EntityKey: null,
+            CreatedAt: DateTimeOffset.UtcNow,
+            ExpiresAt: DateTimeOffset.UtcNow.AddDays(1)));
+
+        ApprovalRequest req = await gate.RequestApprovalAsync(new ApprovalContext(
+            "agent-1", "user-1", "regression action", "Low", "medium", "Testing"));
+        await gate.RespondAsync(req.RequestId, ApprovalDecision.Approved);
+
+        memory.Dispose();
+
+        SqliteTestCleanup.ReleaseAndDelete(memPath, apprPath);
+
+        foreach (string p in SqliteTestCleanup.Sidecars(memPath).Concat(SqliteTestCleanup.Sidecars(apprPath)))
+            File.Exists(p).Should().BeFalse($"'{p}' must be gone after ReleaseAndDelete — otherwise #158 is back");
+    }
+
+    [Fact]
+    public void ReleaseAndDelete_ThrowsWhenFileIsLocked_InsteadOfSilentlyLeaking()
+    {
+        // Simulate the exact failure mode #158 was silently swallowing:
+        // something else holds the file open when Dispose runs. The helper
+        // MUST surface this, not catch-and-ignore. If a future refactor puts
+        // a `try { ... } catch { }` back around ReleaseAndDelete's File.Delete,
+        // this test turns red.
+        string dbPath = SqliteTestCleanup.NewDbPath("locked-file");
+        File.WriteAllBytes(dbPath, [0x0]);
+
+        // A non-shared FileStream keeps the OS handle open with a deny-all
+        // sharing mode — File.Delete against a file held this way throws on
+        // Windows.
+        using (FileStream _ = new(dbPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            Action act = () => SqliteTestCleanup.ReleaseAndDelete(dbPath);
+            act.Should().Throw<AggregateException>(
+                "a locked file is the sentinel that a live handle survived — the helper MUST surface it")
+               .WithInnerException<IOException>();
+        }
+
+        // After the lock is released the helper cleans up cleanly.
+        SqliteTestCleanup.ReleaseAndDelete(dbPath);
+        File.Exists(dbPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReleaseAndDelete_Batch_AggregatesFailuresAcrossPaths()
+    {
+        // A single leak on one path must not mask a leak on a sibling path.
+        // Prove the batch overload attempts every path and aggregates failures.
+        string good = SqliteTestCleanup.NewDbPath("batch-good");
+        string bad = SqliteTestCleanup.NewDbPath("batch-locked");
+        File.WriteAllBytes(good, [0x1]);
+        File.WriteAllBytes(bad, [0x1]);
+
+        using (FileStream _ = new(bad, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            Action act = () => SqliteTestCleanup.ReleaseAndDelete(good, bad);
+            act.Should().Throw<AggregateException>();
+        }
+
+        // The unlocked path was still cleaned up.
+        File.Exists(good).Should().BeFalse();
+
+        // Follow-up call clears the (now-unlocked) sibling.
+        SqliteTestCleanup.ReleaseAndDelete(bad);
+        File.Exists(bad).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReleaseAndDelete_DoesNotTouchCallerOwnedSqliteConnection_NoObjectDisposedRace()
+    {
+        // Guards against reintroducing the SafeHandle / ObjectDisposedException
+        // race audited in issue #156: the helper opens NO caller-owned handle.
+        // The connection it constructs to satisfy SqliteConnection.ClearPool's
+        // signature is a fresh, never-opened instance — proving that here so
+        // a future "helpful" refactor cannot silently start disposing shared
+        // state.
+        string dbPath = SqliteTestCleanup.NewDbPath("no-shared-handle");
+
+        // A caller opens their own connection, uses it, disposes it. The
+        // helper must be a no-op on THAT handle — the caller controls its
+        // lifetime.
+        using (var owned = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            owned.Open();
+            using SqliteCommand cmd = owned.CreateCommand();
+            cmd.CommandText = "CREATE TABLE T (X INTEGER)";
+            cmd.ExecuteNonQuery();
+        } // owned disposed here — pool now holds the underlying handle
+
+        // After caller disposal, the helper must be able to fully clean up
+        // without touching the caller's already-disposed reference.
+        SqliteTestCleanup.ReleaseAndDelete(dbPath);
+        File.Exists(dbPath).Should().BeFalse();
+    }
+}

--- a/tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanupTests.cs
+++ b/tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanupTests.cs
@@ -161,11 +161,13 @@ public sealed class SqliteTestCleanupTests
     public void ReleaseAndDelete_DoesNotTouchCallerOwnedSqliteConnection_NoObjectDisposedRace()
     {
         // Guards against reintroducing the SafeHandle / ObjectDisposedException
-        // race audited in issue #156: the helper opens NO caller-owned handle.
-        // The connection it constructs to satisfy SqliteConnection.ClearPool's
-        // signature is a fresh, never-opened instance — proving that here so
-        // a future "helpful" refactor cannot silently start disposing shared
-        // state.
+        // race audited in issue #156: the helper only builds fresh, never-opened
+        // SqliteConnection instances as probes for SqliteConnection.ClearPool,
+        // and it only clears buckets keyed on THIS fixture's unique db path —
+        // so it can never touch the caller-owned handle above. And because
+        // clearing is path-scoped (never SqliteConnection.ClearAllPools()), a
+        // parallel xUnit fixture cannot have its live sqlite3 handle disposed
+        // under it either.
         string dbPath = SqliteTestCleanup.NewDbPath("no-shared-handle");
 
         // A caller opens their own connection, uses it, disposes it. The

--- a/tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanupTests.cs
+++ b/tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanupTests.cs
@@ -107,24 +107,117 @@ public sealed class SqliteTestCleanupTests
     }
 
     [Fact]
-    public void ReleaseAndDelete_ThrowsWhenFileIsLocked_InsteadOfSilentlyLeaking()
+    public void ReleaseAndDelete_SurfacesDeletionFailures_InsteadOfSilentlyLeaking()
     {
-        // Simulate the exact failure mode #158 was silently swallowing:
-        // something else holds the file open when Dispose runs. The helper
-        // MUST surface this, not catch-and-ignore. If a future refactor puts
-        // a `try { ... } catch { }` back around ReleaseAndDelete's File.Delete,
-        // this test turns red.
-        string dbPath = SqliteTestCleanup.NewDbPath("locked-file");
+        // Pins the "never swallow a delete failure" contract that #158 exists
+        // to enforce. If a future refactor reintroduces a `try { ... } catch { }`
+        // around ReleaseAndDelete's File.Delete, this test turns red.
+        //
+        // Portable forced-failure design:
+        //   The helper's delete loop is `if (File.Exists(path)) File.Delete(path)`,
+        //   and File.Exists returns false for a directory, so a "directory
+        //   sitting at the target path" would be silently skipped — no throw,
+        //   no guard. Instead we place a REAL file at the target and make
+        //   File.Delete fail against it portably:
+        //     • Windows: mark the file read-only. File.Delete on a read-only
+        //       file surfaces UnauthorizedAccessException (which the helper
+        //       wraps in IOException). No admin rights required.
+        //     • Linux: strip write permission from the file's parent directory.
+        //       POSIX unlink(2) requires write on the parent, so the delete
+        //       returns EACCES (surfaced as UnauthorizedAccessException /
+        //       IOException). Isolating the guard in a dedicated subdirectory
+        //       means no sibling test's cleanup is affected.
+        //   Both platforms end up in the helper's catch wrapper and observe
+        //   the same AggregateException / inner-IOException shape.
+        //
+        // The original Windows sharing-violation shape is preserved as an
+        // OPTIONAL supplemental test below, guarded by OperatingSystem.IsWindows(),
+        // so we still exercise the exact ERROR_SHARING_VIOLATION path #158
+        // originated from on the platform where it applies.
+        Directory.CreateDirectory(SqliteTestCleanup.TempRoot);
+        string guardDir = Path.Combine(SqliteTestCleanup.TempRoot, $"guard-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(guardDir);
+        string dbPath = Path.Combine(guardDir, "undeletable.db");
+        File.WriteAllBytes(dbPath, [0x1]);
+
+        try
+        {
+            MakeUndeletable(guardDir, dbPath);
+
+            Action act = () => SqliteTestCleanup.ReleaseAndDelete(dbPath);
+            act.Should().Throw<AggregateException>(
+                "an undeletable target is the sentinel that a leak survived — the helper MUST surface it")
+               .WithInnerException<IOException>();
+        }
+        finally
+        {
+            // Teardown in finally so this test itself cannot leak the guard
+            // directory into %TEMP%\RetailPulse.Tests.Sqlite\ even if an
+            // assertion above threw.
+            RestoreAndCleanup(guardDir, dbPath);
+        }
+    }
+
+    [Fact]
+    public void ReleaseAndDelete_Batch_AggregatesFailuresAcrossPaths()
+    {
+        // A single failure on one path must not mask a failure on a sibling
+        // path — and the good sibling MUST still be cleaned up. Uses the same
+        // portable read-only-file / non-writable-parent guard as the primary
+        // test so the "bad" path fails deletion on Windows and Linux identically.
+        string good = SqliteTestCleanup.NewDbPath("batch-good");
+        File.WriteAllBytes(good, [0x1]);
+
+        Directory.CreateDirectory(SqliteTestCleanup.TempRoot);
+        string guardDir = Path.Combine(SqliteTestCleanup.TempRoot, $"guard-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(guardDir);
+        string bad = Path.Combine(guardDir, "batch-undeletable.db");
+        File.WriteAllBytes(bad, [0x1]);
+
+        try
+        {
+            MakeUndeletable(guardDir, bad);
+
+            Action act = () => SqliteTestCleanup.ReleaseAndDelete(good, bad);
+            act.Should().Throw<AggregateException>();
+
+            // The good sibling was still cleaned up — the batch overload
+            // does not short-circuit on the first failure.
+            File.Exists(good).Should().BeFalse();
+        }
+        finally
+        {
+            RestoreAndCleanup(guardDir, bad);
+            if (File.Exists(good))
+                File.Delete(good);
+        }
+    }
+
+    [Fact]
+    public void ReleaseAndDelete_ThrowsWhenFileIsLocked_OnWindows_SharingViolation()
+    {
+        // Supplemental Windows-only fidelity check: on Windows the ORIGINAL
+        // #158 failure mode was ERROR_SHARING_VIOLATION from a pooled
+        // SqliteConnection still holding the OS handle open. This test
+        // reproduces that exact shape with a deny-all FileStream so a future
+        // refactor cannot regress the Windows-specific surface without
+        // turning something red.
+        //
+        // This test is intentionally Windows-only: on Linux, POSIX unlink(2)
+        // permits removing an open file, so there is no equivalent "locked
+        // file blocks delete" behaviour to pin — writing a Linux variant
+        // that pretends otherwise would misrepresent the platform.
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        string dbPath = SqliteTestCleanup.NewDbPath("locked-file-windows");
         File.WriteAllBytes(dbPath, [0x0]);
 
-        // A non-shared FileStream keeps the OS handle open with a deny-all
-        // sharing mode — File.Delete against a file held this way throws on
-        // Windows.
         using (FileStream _ = new(dbPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
         {
             Action act = () => SqliteTestCleanup.ReleaseAndDelete(dbPath);
             act.Should().Throw<AggregateException>(
-                "a locked file is the sentinel that a live handle survived — the helper MUST surface it")
+                "on Windows a locked file is the exact ERROR_SHARING_VIOLATION shape #158 originated from")
                .WithInnerException<IOException>();
         }
 
@@ -133,28 +226,51 @@ public sealed class SqliteTestCleanupTests
         File.Exists(dbPath).Should().BeFalse();
     }
 
-    [Fact]
-    public void ReleaseAndDelete_Batch_AggregatesFailuresAcrossPaths()
+    private static void MakeUndeletable(string parentDir, string filePath)
     {
-        // A single leak on one path must not mask a leak on a sibling path.
-        // Prove the batch overload attempts every path and aggregates failures.
-        string good = SqliteTestCleanup.NewDbPath("batch-good");
-        string bad = SqliteTestCleanup.NewDbPath("batch-locked");
-        File.WriteAllBytes(good, [0x1]);
-        File.WriteAllBytes(bad, [0x1]);
-
-        using (FileStream _ = new(bad, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        if (OperatingSystem.IsWindows())
         {
-            Action act = () => SqliteTestCleanup.ReleaseAndDelete(good, bad);
-            act.Should().Throw<AggregateException>();
+            // File.Delete on a read-only file surfaces UnauthorizedAccessException
+            // on Windows — enough to prove the helper does not swallow it.
+            File.SetAttributes(filePath, FileAttributes.ReadOnly);
+        }
+        else
+        {
+            // POSIX unlink(2) requires write permission on the parent
+            // directory. Stripping write from parentDir forces File.Delete
+            // to return EACCES (surfaced as UnauthorizedAccessException).
+            // Read + execute retained so File.Exists can still resolve the
+            // file inside.
+            File.SetUnixFileMode(parentDir,
+                UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        }
+    }
+
+    private static void RestoreAndCleanup(string parentDir, string filePath)
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                if (File.Exists(filePath))
+                    File.SetAttributes(filePath, FileAttributes.Normal);
+            }
+            else if (Directory.Exists(parentDir))
+            {
+                File.SetUnixFileMode(parentDir,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+        }
+        catch
+        {
+            // Best-effort — teardown must never mask the real assertion.
         }
 
-        // The unlocked path was still cleaned up.
-        File.Exists(good).Should().BeFalse();
-
-        // Follow-up call clears the (now-unlocked) sibling.
-        SqliteTestCleanup.ReleaseAndDelete(bad);
-        File.Exists(bad).Should().BeFalse();
+        if (Directory.Exists(parentDir))
+        {
+            try { Directory.Delete(parentDir, recursive: true); }
+            catch { /* best-effort */ }
+        }
     }
 
     [Fact]

--- a/tests/RetailPulse.Tests/Tools/CompetitiveToolTests.cs
+++ b/tests/RetailPulse.Tests/Tools/CompetitiveToolTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Tools;
 
@@ -20,7 +21,7 @@ public class CompetitiveToolTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_comp_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_comp_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
     }
@@ -28,9 +29,7 @@ public class CompetitiveToolTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static JsonElement Parse(object obj) =>

--- a/tests/RetailPulse.Tests/Tools/DemandToolTests.cs
+++ b/tests/RetailPulse.Tests/Tools/DemandToolTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Tools;
 
@@ -20,7 +21,7 @@ public class DemandToolTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_demand_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_demand_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
     }
@@ -28,9 +29,7 @@ public class DemandToolTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static JsonElement Parse(object obj) =>

--- a/tests/RetailPulse.Tests/Tools/PromoToolTests.cs
+++ b/tests/RetailPulse.Tests/Tools/PromoToolTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Tools;
 
@@ -20,7 +21,7 @@ public class PromoToolTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_promo_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_promo_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
     }
@@ -28,9 +29,7 @@ public class PromoToolTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static JsonElement Parse(object obj) =>

--- a/tests/RetailPulse.Tests/Tools/SupplyToolTests.cs
+++ b/tests/RetailPulse.Tests/Tools/SupplyToolTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests.Tools;
 
@@ -20,7 +21,7 @@ public class SupplyToolTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_supply_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_supply_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
     }
@@ -28,9 +29,7 @@ public class SupplyToolTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static JsonElement Parse(object obj) =>

--- a/tests/RetailPulse.Tests/UpdateMetricsToolTests.cs
+++ b/tests/RetailPulse.Tests/UpdateMetricsToolTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
 using RetailPulse.McpServer.Tools;
+using RetailPulse.Tests.TestInfrastructure;
 
 namespace RetailPulse.Tests;
 
@@ -16,7 +17,7 @@ public class UpdateMetricsToolTests : IDisposable
         string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
 
-        _dbPath = Path.Combine(Path.GetTempPath(), $"retailpulse_test_{Guid.NewGuid():N}.db");
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_test");
         var tenantProvider = new FileTenantProvider(tenantConfigPath);
         _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
     }
@@ -24,9 +25,7 @@ public class UpdateMetricsToolTests : IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        try { File.Delete(_dbPath); } catch { /* file may be locked by WAL */ }
-        try { File.Delete(_dbPath + "-wal"); } catch { }
-        try { File.Delete(_dbPath + "-shm"); } catch { }
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
     }
 
     private static string ToJson(object obj) => JsonSerializer.Serialize(obj);


### PR DESCRIPTION
Closes #158

Working as Publix (Tester)

## Problem

Full-solution test runs were leaking every SQLite database file and its sidecars (`-journal`, `-wal`, `-shm`) into `%TEMP%`. Prior measurements observed ~280,497 `*.db*` files (~1.36 TB) and 19,577 files after a later single sweep. Root cause: fixture `Dispose` blocks calling `File.Delete` while `Microsoft.Data.Sqlite`'s per-connection-string pool still owned the OS handle. Windows returned `ERROR_SHARING_VIOLATION` and every fixture's `try { … } catch { }` silently swallowed it. Hosted CI hid the local-machine leak.

## Fix

Introduced a single shared helper at `tests/RetailPulse.Tests/TestInfrastructure/SqliteTestCleanup.cs`:

- `NewDbPath(label)` — every fixture allocates its temp DB under a dedicated namespace subdirectory `%TEMP%\RetailPulse.Tests.Sqlite\` so we can count exactly what this suite generated with no ambient-`%TEMP%` noise.
- `ReleaseAndDelete(path)` — before any `File.Delete`, calls `SqliteConnection.ClearPool` for **every** connection-string variant tests are known to open against a temp DB:
  - `Mode=ReadWriteCreate; Cache=Shared` — every store (`SqliteApprovalGate`, `SqlitePlanStore`, `SqliteSessionStore`, `SqliteAlertService`, `SqliteConversationMemory`, `RetailPulseDb`).
  - `Mode=ReadOnly; Cache=Shared` — verification reads (`DemandDataTests`, `CompetitiveDataTests`, `PromoDataTests`, `SupplyDataTests`, `StoreDataTests`, `MarginDataTests`).
  - `Mode=ReadOnly` (no cache) — `StoreOpsToolTests`, `PlanogramTests`.
  - Bare `Data Source=<path>` — `DurableCostTracker`, `DurableAuditLog`, `MountedStorePragmaContractTests`, `DefaultPackSeedGoldenTests`, `PackSwitchSeedDimensionsTests`.

  Path-scoped clearing is used **on purpose** instead of `SqliteConnection.ClearAllPools()`. xUnit v2 runs collections in parallel in the same process, and a process-wide clear can dispose an idle handle just after a sibling fixture pulled it from the pool — that's exactly the SafeHandle / `ObjectDisposedException` race audited in issue #156. Because every fixture allocates a unique DB path, path-scoped clearing cannot race with siblings.

- Then sweeps `.db`, `-journal`, `-wal`, `-shm` for that path and **throws** an `AggregateException` on failure. Deletion failures never get swallowed — that's the whole point.

Every fixture (~50) was routed through the helper. Two `PlanReviewCoordinatorTests` cases that intentionally simulate a "process crash" by firing `CoordinateAsync` and never awaiting it were updated to track their tasks against a fixture-scoped `CancellationTokenSource` so `Dispose` can cancel them and let their pooled connection go idle before `ReleaseAndDelete` runs.

## Regression guard

Chose a **documented shared cleanup helper that every SQLite fixture must use**, plus 9 pinned regression tests in `SqliteTestCleanupTests.cs` (names below match the file exactly at HEAD `7aae37e`):

1. `TempRoot_LivesUnderTempAndIsNamespaceScoped` — every DB lands in `%TEMP%\RetailPulse.Tests.Sqlite\`.
2. `NewDbPath_ProducesUniquePathsUnderTempRoot`.
3. `ReleaseAndDelete_RemovesDbAndEverySidecar_WhenPresent`.
4. `ReleaseAndDelete_IsNoOpForNonExistentPath`.
5. `ReleaseAndDelete_AfterRealStoreUse_RemovesEverythingLeftInTempRoot` — end-to-end proof using the real `SqliteConversationMemory` + `SqliteApprovalGate` stores that no handle survives cleanup.
6. `ReleaseAndDelete_SurfacesDeletionFailures_InsteadOfSilentlyLeaking` — pins the "never swallow a delete failure" contract using a portable guard (see *CI iteration* below).
7. `ReleaseAndDelete_Batch_AggregatesFailuresAcrossPaths` — a single failure on one path never masks a leak on a sibling path, and the good sibling is still cleaned up.
8. `ReleaseAndDelete_ThrowsWhenFileIsLocked_OnWindows_SharingViolation` — Windows-only supplemental test, guarded by `OperatingSystem.IsWindows()`, that preserves the exact `ERROR_SHARING_VIOLATION` shape #158 originated from. No Linux equivalent is added because POSIX unlink(2) permits removing an open file; pretending otherwise would misrepresent the platform.
9. `ReleaseAndDelete_DoesNotTouchCallerOwnedSqliteConnection_NoObjectDisposedRace` — the #156 non-regression proof.

The helper's `ReleaseAndDelete` is the single point of enforcement: it can't be bypassed by accident because a fixture that skips it will not have a matching `NewDbPath` origin and any leftover file gets caught by the after-count. Together, the pinned tests + throw-on-lock + namespace subdirectory give both a code-level guard (contract tests) and a run-time guard (namespace count).

## No store behaviour change

All product code under `src/` is untouched. Every change is under `tests/RetailPulse.Tests/`. The CI iteration below (commit `7aae37e`) is likewise test-side only — no helper behaviour changed.

## Verification

### Counting methodology

- Namespace: `%TEMP%\RetailPulse.Tests.Sqlite\` (created by `SqliteTestCleanup.NewDbPath`; nothing else in the process writes there).
- Command:
  ```powershell
  $ns = Join-Path $env:TEMP 'RetailPulse.Tests.Sqlite'
  (Get-ChildItem -Path $ns -Recurse -File -Force -ErrorAction SilentlyContinue).Count
  ```
- Pattern: recurse the namespace subdirectory only. Excludes ambient-`%TEMP%` noise from anything not owned by this suite.

### Before / After

| Marker | Count | When |
| ------ | ----: | ---- |
| BEFORE | **0** | Namespace directory reset before run 1 |
| AFTER  | **0** | Namespace directory measured after run 10 |

Zero files remained after ten sequential full-suite runs.

### Full solution suite, ten runs (original ten-run measurement — still valid; CI iteration is guard-test-only)

Command: `dotnet test RetailPulse.slnx --nologo --no-build --no-restore` (repo prebuild done once with `dotnet build RetailPulse.slnx -c Debug`).

| Run | Result | Failed | Passed | Skipped | Total | Duration |
| ---:| ------ | -----: | -----: | ------: | ----: | -------: |
| 1   | Passed | 0 | 3395 | 9 | 3404 | 1m 49s |
| 2   | Passed | 0 | 3395 | 9 | 3404 | 1m 34s |
| 3   | Passed | 0 | 3395 | 9 | 3404 | 1m 30s |
| 4   | Passed | 0 | 3395 | 9 | 3404 | 1m 45s |
| 5   | Passed | 0 | 3395 | 9 | 3404 | 1m 41s |
| 6   | Passed | 0 | 3395 | 9 | 3404 | 1m 37s |
| 7   | Passed | 0 | 3395 | 9 | 3404 | 1m 33s |
| 8   | Passed | 0 | 3395 | 9 | 3404 | 1m 40s |
| 9   | Passed | 0 | 3395 | 9 | 3404 | 1m 48s |
| 10  | Passed | 0 | 3395 | 9 | 3404 | 1m 44s |

10/10 clean, no retries, no failure names to report.

### Post-CI-iteration re-run (commit `7aae37e`, Windows)

Because the guard-test rewrite adds one Windows-only supplemental test (`ReleaseAndDelete_ThrowsWhenFileIsLocked_OnWindows_SharingViolation`), Windows totals move from 3395 → 3396 passed. Two full-solution runs on Windows after the fix, with `%TEMP%\RetailPulse.Tests.Sqlite\` residue measured after each:

| Run | Result | Failed | Passed | Skipped | Total | Duration | Residue |
| ---:| ------ | -----: | -----: | ------: | ----: | -------: | ------: |
| 1   | Passed | 0 | 3396 | 9 | 3405 | 1m 36s | 0 |
| 2   | Passed | 0 | 3396 | 9 | 3405 | 1m 39s | 0 |

Targeted `SqliteTestCleanupTests` class: 9 passed, 0 failed, 0 skipped.

### Format

```
$ dotnet format RetailPulse.slnx --verify-no-changes
(exit 0)
```

## Iteration notes

- Run 1 (before the initial fix) surfaced 2 real failures: `PlanReviewCoordinatorTests` fire-and-forget coordinator tasks kept a live `SqliteConnection` past `Dispose`; and the initial helper only cleared the `RWCreate+Shared` pool bucket, missing the `ReadOnly+Shared` bucket used by verification-read fixtures. Both were fixed in commit `3dbb518` — the original ten runs above are all after that fix.
- The formatting commit `6cbc0cc` was a mechanical `dotnet format` sweep applying `IDE0022` (expression-body Dispose) across the fixtures the refactor touched. No semantic change.

### CI iteration (Linux-only guard-test regression — commit `7aae37e`)

The first push (`6cbc0cc`) passed every Windows check but the Ubuntu job of GitHub Actions run `32977220980` failed 2 tests out of 3395 (3 393 passed, 9 skipped, 2 failed; all other checks green):

- `SqliteTestCleanupTests.ReleaseAndDelete_ThrowsWhenFileIsLocked_InsteadOfSilentlyLeaking`
- `SqliteTestCleanupTests.ReleaseAndDelete_Batch_AggregatesFailuresAcrossPaths`

Both tests forced `File.Delete` to fail by holding the target file open through a `FileStream` opened with `FileShare.None`. That is a Windows-only failure mode: Windows honours the deny-all share and returns `ERROR_SHARING_VIOLATION`, while Linux's POSIX `unlink(2)` is documented to permit removing an open file. On Linux the helper therefore deleted the file cleanly and the tests failed the "must throw" assertion.

**This is a test-side gap, not a product / helper bug.** The `SqliteTestCleanup` helper's own behaviour is correct on both platforms (the leak-preventing `SqliteConnection.ClearPool` + throw-on-delete-failure contract still holds); only the tests' choice of forced-failure mechanism was Windows-specific. Kroger's retrospective decision: fix the tests, do not touch the helper or `src/`.

The two failing tests were rewritten to use a portable primary guard:

- **Windows**: `File.SetAttributes(path, FileAttributes.ReadOnly)`. `File.Delete` on a read-only file surfaces `UnauthorizedAccessException`, which the helper wraps in `IOException`.
- **Linux**: `File.SetUnixFileMode(parentDir, UserRead | UserExecute)`. POSIX `unlink(2)` requires write on the parent directory, so `File.Delete` returns `EACCES` / `UnauthorizedAccessException` — the helper wraps the same shape. The guard file is isolated in a per-test subdirectory of `%TEMP%\RetailPulse.Tests.Sqlite\` so no sibling test's cleanup is affected.

Both platforms end up in the helper's catch block and observe the same `AggregateException` with an inner `IOException` — the exact contract the tests are pinning. Guard state (read-only attribute or parent-directory mode) is restored in a `finally` block so the test cannot leak the guard directory into `%TEMP%\RetailPulse.Tests.Sqlite\`. The `AFTER = 0` residue count above is measured after the rewrite, so the guard tests themselves are proven not to leak.

The Windows-specific `FileShare.None` sharing-violation shape #158 originated from is preserved as an **optional supplemental** test, `ReleaseAndDelete_ThrowsWhenFileIsLocked_OnWindows_SharingViolation`, guarded by `OperatingSystem.IsWindows()` and named to make the platform scope explicit. This preserves fidelity to the original failure mode on the platform where it actually occurs. No Linux equivalent was added — writing one that pretends unlink cannot succeed on an open file would misrepresent POSIX semantics.

The 8 test names originally listed in this PR body did not exactly match the source at that time; the 9-item list above now matches `SqliteTestCleanupTests.cs` at commit `7aae37e` exactly.
