### PR TITLE
docs(#160): record merge gate rule — verdicts on PR, never merge on CI alone

### DIFF
--- a/.github/skills/reviewer-protocol/SKILL.md
+++ b/.github/skills/reviewer-protocol/SKILL.md
@@ -10,7 +10,37 @@ source: "extracted"
 
 When a team member has a **Reviewer** role (e.g., Tester, Code Reviewer, Lead), they may approve or reject work from other agents. On rejection, the coordinator enforces strict lockout rules to ensure the original author does NOT self-revise. This prevents defensive feedback loops and ensures independent review.
 
+Reviewers also gate merge. CI green means the code compiled and the tests that ran passed — it does not mean the change is correct and it does not mean the suite is stable. The merge gate rules below are non-negotiable.
+
 ## Patterns
+
+### Merge Gate — Verdicts, Not CI Alone
+
+These rules bind every PR in this repository, including docs-only PRs.
+
+1. **Never merge on CI status alone.** Before merging, confirm an explicit **APPROVE** verdict for the **current head SHA**. Green checks are necessary but not sufficient.
+2. **REJECT blocks merge**, regardless of check status. Do not merge a PR whose most recent verdict for the current head is REJECT, even if every check is green. Merge only after the reviewer posts a fresh APPROVE against the current head.
+3. **Verdicts must be posted as PR comments.** Both APPROVE and REJECT are recorded as comments on the pull request itself. A verdict that exists only in an agent session transcript is not a verdict for gate purposes.
+4. **Read the diff before merging a defect fix.** For any PR that claims to fix a bug or regression, inspect the diff and confirm the change actually does what the PR description says.
+5. **Re-measure stability claims on the merge target.** Stability sweeps ("N consecutive passes", flake reproduction attempts) must be run against the PR's mergeable head with the target merged in — not against the working branch under different load. Report **raw per-run output**. If any run fails during a stability sequence — target or not — **name the failing test**. Do not report a clean sweep that omits observed failures.
+
+#### Why verdicts are comments — the single-identity constraint
+
+Author and reviewer in this repository share the same GitHub identity, **`swigerb`**. GitHub blocks formal self-approval, so a reviewer running under `swigerb` **cannot** submit a Files-changed → Approve review on a PR authored by `swigerb`. Verdicts are therefore recorded as **PR comments**. A merge gate that only reads formal GitHub review state (`APPROVED` / `CHANGES_REQUESTED`) will see zero verdicts on every PR and will let REJECTs through. The gate — human or tooling — must read the **verdict comment for the current head SHA**, not the formal review state and not the CI status.
+
+#### Verdict staleness
+
+An APPROVE applies to the exact head SHA it was posted against. Any new commit invalidates it — the PR must receive a fresh APPROVE against the new head before it may merge. A REJECT similarly applies until the reviewer posts a new verdict against a newer head.
+
+#### Anti-patterns for the merge gate
+
+- ❌ Merging because checks are green without locating an APPROVE comment for the current head
+- ❌ Merging over a REJECT comment because CI is green or because the reviewer's concerns "seem minor"
+- ❌ Leaving a verdict in a session transcript instead of posting it to the PR
+- ❌ Merging a defect fix without reading the diff to confirm the change matches the PR description
+- ❌ Reporting a clean stability sweep run on the working branch instead of the merge target
+- ❌ Reporting a clean stability sweep that silently drops runs where a test failed — every observed failure must be named
+- ❌ Inferring a verdict from formal GitHub review state alone (self-approval is blocked by the shared `swigerb` identity, so formal state is always empty)
 
 ### Reviewer Rejection Protocol
 

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -351,3 +351,30 @@ The dashboard now refreshes every 10 seconds while mounted and shows empty state
 - **Frontend / Chick:** Observability summary endpoints must not be assumed to contain nested dashboard collections; call the dedicated endpoints and map fields explicitly.
 - **QA / Publix:** Contract validation for observability dashboards should include idle/empty states and cross-endpoint field names.
 
+### 2026-08-26T14:07-04:00: Merge gate — never merge on CI alone; verdicts live on the PR
+
+**By:** Kroger (Lead)
+
+**Rule (operational, binds every PR including this one):**
+
+1. **Never merge on CI status alone.** Confirm an explicit **APPROVE** verdict for the **current head SHA** before merging. Green checks mean the code compiled and the tests that ran passed — nothing more.
+2. **A REJECT verdict blocks merge**, however green the checks are. Merge only after the reviewer posts a fresh APPROVE against the current head.
+3. **Verdicts must be posted as PR comments** (APPROVE and REJECT alike). A verdict that exists only in an agent session transcript did not happen for gate purposes.
+4. **Read the diff before merging** any change that claims to fix a defect. Confirm the change actually does what the PR says.
+5. **Re-measure stability claims on the merge target** (post-merge `main`, or the PR's mergeable head with the target merged in), not on the working branch under different load. Report **raw per-run output**. If any run fails during a stability sequence — target or not — **name the failing test** rather than reporting a clean sweep.
+
+**Why (both incidents, preserved so the reasoning survives the rule):**
+
+- **Incident 1 — REJECT was ignored and merged.** A PR was merged while its reviewer verdict was REJECT. The merge gate checked `state=OPEN`, `mergeable=MERGEABLE`, and `0 failing checks` — but never looked at the verdict. Three reviewer blockers reached `main`, including a P0 cross-session data leak where plan completion broadcast `subject`, `reply`, and `charts` to `Clients.All`.
+- **Incident 2 — stability claims failed independent re-measurement, twice.** PR #155 reported "15 consecutive full-suite passes, 0 failed"; independent measurement on merged `main` showed that exact test still failing. A separate PR reported a clean 10-run sweep that also did not reproduce.
+
+**Root cause of Incident 1 — the single-identity constraint (call it out, it is the whole reason the gate misses):**
+
+Author and reviewer share the same GitHub identity, **`swigerb`**. GitHub blocks formal self-approval, so a reviewer running under `swigerb` **cannot** submit a Files-changed → Approve review on a PR authored by `swigerb`. The squad therefore records verdicts as **PR comments**. Any merge gate that only reads formal GitHub review state (`APPROVED` / `CHANGES_REQUESTED`) will see zero verdicts on every PR and will let REJECTs through. The gate must read the **verdict comment for the current head**, not the formal review state.
+
+**Team impact:**
+- **All authors:** Do not merge your own PR on CI status alone. Wait for the reviewer's APPROVE comment against the current head SHA. If you push a new commit after APPROVE, the prior approval is stale — request a fresh one.
+- **All reviewers:** Post the verdict — APPROVE or REJECT — as a **PR comment**, and name the head SHA it applies to. Do not leave the verdict in your session transcript. Re-measure stability claims on the merge target with raw per-run output; if any run fails, name the test.
+- **Coordinator / gate tooling:** Treat a REJECT comment as a hard merge block regardless of CI. Treat an APPROVE comment as stale once a new commit is pushed. Never infer a verdict from CI or from formal review state alone.
+- **This PR:** Docs-only, but the rule it records applies to itself — it merges only after an APPROVE comment against its current head.
+


### PR DESCRIPTION
Closes #160

## Summary

Docs-only. Records the merge gate rule so it binds future work.

- **`.squad/decisions.md`** — appends a decision entry (`2026-08-26T14:07-04:00: Merge gate — never merge on CI alone; verdicts live on the PR`) with the operational rule, rationale from both incidents (REJECT-ignored merge that shipped a P0 cross-session data leak; two failed stability re-measurements), the single-identity constraint, and team impact.
- **`.github/skills/reviewer-protocol/SKILL.md`** — new **Merge Gate — Verdicts, Not CI Alone** section ahead of the existing rejection/lockout protocol. Requires: APPROVE for the **current head SHA** before merge; REJECT blocks merge even with green CI; both verdicts must be **PR comments**; verdicts go stale on any new commit; the diff must be read before merging a defect fix; stability claims must be re-measured on the merge target with **raw per-run output** and every observed failing test named.

## Single-identity constraint (called out explicitly, per acceptance criterion)

Author and reviewer share the `swigerb` identity. GitHub blocks formal self-approval, so verdicts live in **PR comments**. Any gate that only reads formal review state (`APPROVED`/`CHANGES_REQUESTED`) sees zero verdicts on every PR and lets REJECTs through. The gate must read the verdict comment for the current head SHA.

## Meta

**This PR is subject to the rule it records.** It merges only after an APPROVE comment posted against its current head SHA. A REJECT comment blocks merge regardless of CI status.

## Validation

- `dotnet format RetailPulse.slnx --verify-no-changes` — clean (exit 0).
- No behavioural code changes. `scripts/`, `docs/testing/`, and `README.md` untouched.

## Files changed

- `.squad/decisions.md` (+27)
- `.github/skills/reviewer-protocol/SKILL.md` (+30)