### PR TITLE
feat(#57): OPTIONAL, federation-only authenticated synthetic monitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,3 +306,32 @@ jobs:
       - name: Run Verify-ApimAiGateway.ps1 -SelfTest
         shell: pwsh
         run: ./scripts/Verify-ApimAiGateway.ps1 -SelfTest
+
+  synthetic-monitor-selftest:
+    name: Invoke-SyntheticChatMonitor offline self-test (#57)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Offline regression fence for the OPTIONAL authenticated synthetic
+      # monitor (issue #57). Proves the smoke set stays synchronised with
+      # ChartAcceptanceManifest, the response-contract validator distinguishes
+      # well-formed from malformed payloads, the config-missing path reports
+      # SKIP (not fabricated PASS, not spurious FAIL), and the script contains
+      # no client-secret code path (federation-only). Requires no Azure
+      # signin; runs on Linux to guarantee cross-platform pwsh compatibility.
+      - name: Run Invoke-SyntheticChatMonitor.ps1 -SelfTest
+        shell: pwsh
+        run: ./scripts/Invoke-SyntheticChatMonitor.ps1 -SelfTest
+
+      # Belt-and-braces: with no configuration at all the live entry point
+      # must SKIP with exit 0 — an unconfigured fork or clean-clone user
+      # must never see this workflow turn CI red.
+      - name: Verify unconfigured invocation SKIPs with exit 0
+        shell: pwsh
+        run: |
+          $env:RETAIL_PULSE_SYNTHETIC_API_ORIGIN = $null
+          $env:RETAIL_PULSE_SYNTHETIC_API_RESOURCE = $null
+          $env:AZURE_API_APP_URL = $null
+          ./scripts/Invoke-SyntheticChatMonitor.ps1
+          if ($LASTEXITCODE -ne 0) { throw "Unconfigured monitor exited $LASTEXITCODE — expected 0 (skip)." }

--- a/.github/workflows/synthetic-monitor.yml
+++ b/.github/workflows/synthetic-monitor.yml
@@ -1,0 +1,81 @@
+name: Synthetic Chat Monitor (Optional, #57)
+
+# Optional, credential-gated add-on for the authenticated chat path.
+# Fully no-ops when the deployment has not opted into the monitor. Uses
+# workload-identity federation ONLY — the `azure/login@v2` step consumes
+# GitHub Actions' OIDC token via `permissions: id-token: write` and the
+# non-secret `client-id` / `tenant-id` inputs. There is NO client secret
+# involved anywhere in this workflow, and no credential in GitHub Actions
+# secrets.
+#
+# Wiring (all optional, all repository variables — none are secrets):
+#   vars.RETAIL_PULSE_SYNTHETIC_ENABLED       'true' to opt into the run
+#   vars.RETAIL_PULSE_SYNTHETIC_CLIENT_ID     Federated app registration client id
+#                                             (default: retail-pulse-synthetic-monitor)
+#   vars.RETAIL_PULSE_SYNTHETIC_TENANT_ID     Target tenant id
+#   vars.RETAIL_PULSE_SYNTHETIC_API_ORIGIN    Deployed API base URL
+#   vars.RETAIL_PULSE_SYNTHETIC_API_RESOURCE  App ID URI / scope (aud) for the API
+#
+# When RETAIL_PULSE_SYNTHETIC_ENABLED is unset or not 'true', every real
+# step short-circuits and the job completes green — the exact behaviour
+# required for unconfigured forks and clean-clone users.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 06:15 UTC daily — cheap smoke pulse when configured, a no-op when not.
+    - cron: '15 6 * * *'
+
+permissions:
+  # Required for the OIDC token exchange in azure/login@v2. NEVER add
+  # `secrets: write`; this workflow reads no secrets.
+  id-token: write
+  contents: read
+
+concurrency:
+  group: synthetic-chat-monitor
+  cancel-in-progress: false
+
+jobs:
+  monitor:
+    name: Invoke-SyntheticChatMonitor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Announce configuration status
+        id: gate
+        shell: bash
+        run: |
+          if [[ "${{ vars.RETAIL_PULSE_SYNTHETIC_ENABLED }}" == "true" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "Optional synthetic monitor is enabled — proceeding with configured run."
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Synthetic monitor (issue #57) skipped::RETAIL_PULSE_SYNTHETIC_ENABLED is not 'true'. This is the expected state for any deployment that has not opted into the optional monitor. Nothing was executed, no live result was fabricated, and no credential was accessed."
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.enabled == 'true'
+
+      # Federation-only sign-in. `client-id` and `tenant-id` are plain
+      # (non-secret) repository variables; there is NO `client-secret`
+      # input by design. The RetailPulse.User app role granted to
+      # `retail-pulse-synthetic-monitor` is what authorises the token
+      # `az account get-access-token` will subsequently mint for the API
+      # audience.
+      - name: Azure login (workload-identity federation)
+        if: steps.gate.outputs.enabled == 'true'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.RETAIL_PULSE_SYNTHETIC_CLIENT_ID }}
+          tenant-id: ${{ vars.RETAIL_PULSE_SYNTHETIC_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Run authenticated synthetic monitor
+        if: steps.gate.outputs.enabled == 'true'
+        shell: pwsh
+        env:
+          RETAIL_PULSE_SYNTHETIC_API_ORIGIN: ${{ vars.RETAIL_PULSE_SYNTHETIC_API_ORIGIN }}
+          RETAIL_PULSE_SYNTHETIC_API_RESOURCE: ${{ vars.RETAIL_PULSE_SYNTHETIC_API_RESOURCE }}
+          AZURE_TENANT_ID: ${{ vars.RETAIL_PULSE_SYNTHETIC_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ vars.RETAIL_PULSE_SYNTHETIC_CLIENT_ID }}
+        run: ./scripts/Invoke-SyntheticChatMonitor.ps1

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Retail Pulse is designed to demo locally from a fresh clone without any optional
 | **Azure AI Foundry IQ (Azure AI Projects)** | Foundry-hosted retrieval agent (ADR-013). | `Knowledge:Provider:Mode=FoundryIQ` and `Knowledge:FoundryIQ:ProjectEndpoint` set. |
 | **Azure AI Content Safety + Prompt Shields** | Prompt-injection + harmful-content filtering on inputs and outputs (ADR-010). | `Security:ContentSafety:Enabled=true` and the endpoint / API version set. |
 | **Azure AI Foundry Agent Service** | Foundry-hosted persistent shipment specialist (bespoke). | `FoundryAgent:Enabled=true` + project endpoint / agent name. |
+| **Authenticated synthetic chat monitor** | Non-interactive smoke-test of the deployed authenticated `/api/chat` path against the curated chart-acceptance smoke set (issue #57). Auth is workload-identity federation only — there is NO client secret anywhere in the workflow, in GitHub Actions secrets, or in the repo. | Set the `RETAIL_PULSE_SYNTHETIC_ENABLED=true` repository variable plus `RETAIL_PULSE_SYNTHETIC_CLIENT_ID`, `RETAIL_PULSE_SYNTHETIC_TENANT_ID`, `RETAIL_PULSE_SYNTHETIC_API_ORIGIN`, and `RETAIL_PULSE_SYNTHETIC_API_RESOURCE`. When unset the `.github/workflows/synthetic-monitor.yml` schedule + `workflow_dispatch` no-ops with a `::notice::` explanation and never turns CI red. Script: `scripts/Invoke-SyntheticChatMonitor.ps1`; offline self-test wired into CI. See [docs/testing/authenticated-synthetic-monitor.md](docs/testing/authenticated-synthetic-monitor.md). |
 | **Azure Files durable mount** | Cross-replica persistence of the SQLite stores (`memory.db`, `approvals.db`, `sessions.db`, `plans.db`, `audit.db`, `costs.db`, `alerts.db`). | Currently blocked by tenant governance policy (see [docs/deployment-azd.md](docs/deployment-azd.md)); the deployed demo runs with `RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true`. |
 
 > **Local demo (zero optional resources).** `dotnet build RetailPulse.slnx` succeeds with no
@@ -486,6 +487,7 @@ The CI pipeline runs on every push and PR to `main`:
 | **lint** | Verify code style (`dotnet format --verify-no-changes`) |
 | **bicep** | Compile every Bicep module transitively from `infra/main.bicep` via `az bicep build` — cheapest possible regression gate for the APIM AI Gateway / Container Apps contract; uploads the compiled ARM template as an artifact |
 | **verify-apim** | `Verify-ApimAiGateway offline self-test` — runs `scripts/Verify-ApimAiGateway.ps1 -SelfTest` (no Azure signin, no live APIM traffic) to lock in the shape and header/body contracts of the live-verification script itself so a broken script can't silently pass a live deploy |
+| **synthetic-monitor-selftest** | Offline regression fence for the OPTIONAL authenticated synthetic chat monitor (issue #57) — runs `scripts/Invoke-SyntheticChatMonitor.ps1 -SelfTest` and then re-invokes the script with no configuration to prove it exits 0 with a `SKIP:` message. No Azure signin, no live traffic, no credential — the whole surface is federation-only |
 
 ### Run locally
 

--- a/docs/testing/authenticated-synthetic-monitor.md
+++ b/docs/testing/authenticated-synthetic-monitor.md
@@ -1,43 +1,117 @@
 # Authenticated synthetic monitor for the AI chat path
 
-Status: **DESIGN — implementation blocked pending tenant credentials**  
-Owner: Costco (Backend)  
-Tracks: [#57](https://github.com/swigerb/retail-pulse/issues/57)
+Status: **DELIVERED — optional, credential-gated, federation-only**
+Owner: Kroger (Lead) — implemented per issue [#57](https://github.com/swigerb/retail-pulse/issues/57)
+Original design owner: Costco (Backend)
+Superseded assumption: an earlier revision of this document specified a
+confidential app registration + client-secret + Key Vault storage
+pattern. That plan is REPLACED, in full, by workload-identity federation
+— see "Authentication" below. No client secret exists, and no client
+secret is required.
 
 ## Why
 
-During the P0 incident on 2026-08-11 (#55, fixed by PR #56) QA (Publix) could
-not personally submit an authenticated chat request or run the curated
-grouped-bar acceptance prompt against production end-to-end, because the sandbox
-has no human present to complete interactive Entra/MSAL sign-in. Per policy we
-do not bypass or impersonate interactive auth to work around this.
+During the P0 incident on 2026-08-11 (#55, fixed by PR #56) QA (Publix)
+could not personally submit an authenticated chat request or run the
+curated grouped-bar acceptance prompt against production end-to-end,
+because the sandbox has no human present to complete interactive
+Entra/MSAL sign-in. Per policy we do not bypass or impersonate
+interactive auth to work around this.
 
 The gap did not hide a defect — telemetry and `Verify-ProductionAuth.ps1`
-independently confirmed real 200 OK completions routed through the corrected
-APIM path — but it meant an on-call responder cannot get direct live evidence
-of end-to-end chat behavior without a human at a browser. This document
-specifies the non-interactive verification path so a future incident is not
-gated on that constraint.
+independently confirmed real 200 OK completions routed through the
+corrected APIM path — but it meant an on-call responder cannot get direct
+live evidence of end-to-end chat behavior without a human at a browser.
+This monitor closes that gap non-interactively, without introducing any
+credential to the repo or to GitHub Actions secrets.
+
+## Optionality contract (matches Azure AI Search, Foundry IQ, Content Safety)
+
+The monitor is a **fully OPTIONAL add-on**. It ships wired into the repo
+and works the moment the deployment opts in. When the deployment has not
+opted in:
+
+- The scheduled + `workflow_dispatch` workflow reports a clean
+  `::notice::` and completes green.
+- `scripts/Invoke-SyntheticChatMonitor.ps1` prints an explicit `SKIP:`
+  line that names exactly what is missing, and exits `0` — it never
+  turns CI red for an unconfigured fork or clean-clone user, and it
+  never fabricates a live result.
+- The manual interactive alternative (a human running
+  `scripts/browser-chart-acceptance.js` /
+  `scripts/browser-prompt-library-acceptance.js` with an interactive
+  Entra sign-in) stays fully supported for on-call responders who do
+  have a browser to hand.
+
+## Authentication — workload-identity federation ONLY
+
+The monitor authenticates via an Entra federated-credential exchange —
+there is NO client secret to store, rotate, leak, or grant to a
+workflow. This mirrors the principle already applied across the
+platform: Azure AI Search, Foundry IQ, and Content Safety all
+authenticate with managed identity and no keys; a client secret here
+would have been the only credential in the system, and the weakest link.
+
+### Identity (non-secret configuration — safe to commit)
+
+| | |
+|---|---|
+| App registration | `retail-pulse-synthetic-monitor` |
+| Tenant | MCAP sandbox (`MngEnvMCAP617906.onmicrosoft.com` / "Contoso") |
+| Application (client) ID | `b8212317-e16d-4f06-996b-955e885ca1ca` |
+| Directory (tenant) ID | `48351615-345c-4547-bb6f-8fcc8d6e2568` |
+| Sign-in audience | Single tenant (`AzureADMyOrg`) |
+| Service principal | Created |
+
+### Federated credential
+
+| | |
+|---|---|
+| Name | `github-actions-main` |
+| Issuer | `https://token.actions.githubusercontent.com` |
+| Subject | `repo:swigerb@1630580/retail-pulse@1223914087:ref:refs/heads/main` |
+| Audience | `api://AzureADTokenExchange` |
+
+The subject uses the **new immutable numeric-id format** (organisation
+`1630580`, repository `1223914087`) which Entra recommends because it
+survives a rename and cannot be hijacked by re-registering a deleted
+name. The credential is currently scoped to `main` only; a second
+federated credential is needed for any other branch or environment.
+
+### How the workflow uses it
+
+`.github/workflows/synthetic-monitor.yml` runs `azure/login@v2` with the
+non-secret `client-id` and `tenant-id` inputs and the top-level
+`permissions: id-token: write`. GitHub Actions' OIDC token is exchanged
+directly for an Entra token — nothing sensitive goes into GitHub Actions
+secrets, into the repo, or into any log. The `client-secret` input is
+NEVER passed.
+
+Locally, on-call responders run the same script under their own
+`az login` / `DefaultAzureCredential` context; no credential is ever
+stored.
 
 ## Contract this monitor validates
 
-For each curated prompt in the smoke set (below), the monitor must prove:
+For each curated prompt in the smoke set, the monitor proves:
 
-1. A **valid Entra bearer token** was obtained non-interactively (no human).
-2. `POST {AZURE_API_APP_URL}/api/chat` returned **200** with a body carrying:
+1. A **valid Entra bearer token** was obtained non-interactively (no
+   human, no secret) via
+   `az account get-access-token --resource <ApiResource>`.
+2. `POST {ApiOrigin}/api/chat` returned **200** with a body carrying:
    - an assistant `text` payload,
-   - one or more `charts` entries when the prompt expects a chart,
-   - a non-empty `traceId` / `sessionId`, so the response can be correlated
-     back to Application Insights `requests` + `dependencies`.
-3. The App Insights `requests` table records a corresponding `POST /api/chat`
-   with `success=true` **and** a dependent AOAI request routed through APIM
-   (`name` matching `POST /inference/openai/deployments/*/chat/completions`).
-4. The APIM `customMetrics` for the same time window include at least one
-   `azure-openai-emit-token-metric` row (proves the token-metric channel is
-   still live — the exact indicator Publix flagged as flaky under low-token
-   load in the MERGED APIM decision).
+   - one or more `charts[]` entries with the expected chart type,
+   - the expected minimum mark count per the acceptance manifest,
+   - a non-empty `traceId` / `sessionId` / `correlationId`, so the
+     response can be correlated back to Application Insights `requests`
+     + `dependencies`.
 
-Curated smoke set (start narrow, grow with confidence):
+The token itself is never printed or logged; the correlation id is
+redacted to its last 8 characters in the run output.
+
+Curated smoke set (matches
+`src/RetailPulse.Contracts/Charts/ChartAcceptanceManifest.cs` — the
+offline self-test asserts this synchronisation):
 
 | Prompt | Expected chart | Manifest case |
 |---|---|---|
@@ -48,86 +122,77 @@ Both draw from complete seeded tenant data and exercise the two chart
 data-source families most likely to regress independently
 (`PortfolioDepletion` and `HistoricalDemand`).
 
-## Implementation shape (once credentials exist)
+## Implementation
 
-A single-file PowerShell script `scripts/Invoke-SyntheticChatMonitor.ps1`
-(mirrors the shape of the existing `Verify-*Auth.ps1` scripts):
+`scripts/Invoke-SyntheticChatMonitor.ps1` — a single-file PowerShell 7
+script that mirrors the shape of `scripts/Verify-ApimAiGateway.ps1` and
+`scripts/Verify-ProductionAuth.ps1`:
 
-1. Read `AZURE_API_APP_URL`, `MicrosoftEntra__TenantId`, `MicrosoftEntra__ClientId`,
-   `MicrosoftEntra__ApiScope` from the current azd env, plus:
-   - `RETAIL_PULSE_SYNTHETIC_CLIENT_ID` — a *separate*, dedicated confidential
-     application registration in the same tenant with:
-       - the RetailPulse API app-role `RetailPulse.User` granted, and
-       - the `access_as_user` delegated scope granted with admin consent,
-       - a client-credentials flow enabled.
-   - `RETAIL_PULSE_SYNTHETIC_CLIENT_SECRET` — pulled from Azure Key Vault
-     `kv-<resourceToken>` at run time via `az keyvault secret show`, never
-     stored in the repo, never in `.env`, never in azd env.
-2. Acquire a token via `az rest` against
-   `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token` with the
-   `client_credentials` grant and `scope = api://{RetailPulse client-id}/.default`.
-3. `POST /api/chat` for each prompt with `Authorization: Bearer <token>`.
-4. Assert response shape (200, `charts[].type`, chart mark count) inline;
-   emit `Write-Host` per prompt and a final PASS/FAIL summary.
-5. Optionally query Application Insights via `az monitor app-insights query`
-   for the correlated `requests` and `customMetrics` rows (skipped when the
-   caller lacks App Insights Reader — same opportunistic pattern as
-   `Verify-ApimAiGateway.ps1`).
+- `-SelfTest` (offline, no Azure signin) exercises the smoke-set
+  synchronisation with the contracts manifest, the response-contract
+  validator on well-formed and malformed synthetic payloads, the
+  config-missing SKIP path, and a convention guard that refuses to let
+  any client-secret code path be reintroduced. Wired into CI as a
+  signin-free regression fence (`synthetic-monitor-selftest` job in
+  `.github/workflows/ci.yml`).
+- Live run reads the following optional configuration:
+  - `RETAIL_PULSE_SYNTHETIC_API_ORIGIN` (fallback: `AZURE_API_APP_URL`)
+    — deployed API base URL.
+  - `RETAIL_PULSE_SYNTHETIC_API_RESOURCE` — App ID URI / scope for the
+    API app registration, e.g. `api://<api-client-id>/.default`.
+  - `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` — set automatically by
+    `azure/login@v2` in CI; overridable locally.
+- With any required value missing, the script prints
+  `SKIP: optional synthetic monitor is not configured — missing …`
+  and exits 0. It never turns an unconfigured fork red.
+- With config present but the signed-in principal lacking authorisation
+  (see "Remaining authorisation step" below), token acquisition
+  produces an actionable `SKIP:` message that names the missing app
+  role and exits 0. It never fabricates a live result.
 
-Wire it into `.github/workflows/squad-heartbeat.yml` (or a new dedicated
-workflow) as a scheduled run and as a `workflow_dispatch` for on-call use.
+`.github/workflows/synthetic-monitor.yml` — `workflow_dispatch` and a
+daily `06:15 UTC` schedule. The job is gated on the repository variable
+`RETAIL_PULSE_SYNTHETIC_ENABLED == 'true'`; when unset, every real step
+short-circuits and the workflow completes green with a `::notice::`
+explaining the outcome.
 
-## Blocker — why this cannot land in this PR
+## Remaining authorisation step (does NOT block delivery)
 
-The tenant behind `apim-5aldk7aotqods.azure-api.net` /
-`ca-retailpulse-api.*.azurecontainerapps.io` is a **governed customer tenant**
-that:
+The identity is fully provisioned but not yet **authorised**: the
+`retail-pulse-synthetic-monitor` service principal still needs the
+`RetailPulse.User` app role granted against the API app registration,
+with admin consent. Until that grant is in place, live runs will report
+a clean actionable `SKIP:` naming the missing app role rather than a
+pass or a hard failure.
 
-- Requires an administrator to create the confidential application
-  registration described above and to admin-consent the `RetailPulse.User`
-  app-role + `access_as_user` scope grant. Neither an autonomous Squad
-  session nor Costco has interactive administrative access to the tenant
-  from this environment.
-- Applies conditional-access + client-credentials policy restrictions that
-  will refuse a token from any client secret not already issued and
-  documented by the tenant admin. This cannot be worked around by minting a
-  secret locally.
-- Governance policy forbids checking a client secret into the repository or
-  into any azd-committed environment; the secret must land in the deployment
-  Key Vault and be pulled at run time. The deployment Key Vault does not
-  exist in the current `infra/` — `main.bicep` provisions Log Analytics,
-  App Insights, ACR, APIM, ACA, SWA, but no Key Vault module. Adding one
-  requires a Kroger-level architecture review (the storage-governance work
-  from the storage-hotfix worktree explicitly deferred every durable
-  policy-scoped resource until a policy-compatible design is signed off).
+That grant is the only remaining step to move the monitor from
+"delivered + gated" to "producing live PASS results". It does not block
+this delivery — the whole point of the optional/credential-gated model
+is that the code lands complete and the deployment decision is
+independent.
 
-Together those three constraints mean the client-credentials plumbing this
-issue asks for cannot be exercised end-to-end from this session — no client
-id, no secret, no vault to store the secret in, and no administrative path
-to create any of them.
+## Manual interactive alternative (unchanged)
 
-## What ships in this PR
+For on-call responders in front of a browser, the same smoke set can be
+run manually via
+`scripts/browser-chart-acceptance.js` and
+`scripts/browser-prompt-library-acceptance.js` (PR #148) with an
+interactive Entra sign-in. This remains the supported alternative when
+the automated monitor is not authorised or not enabled.
 
-- This design doc, so the contract and the blocker are captured in-repo
-  next to the existing live-test plan.
-- `scripts/Verify-ApimAiGateway.ps1` — the closest non-interactive live
-  verification we can do today. It exercises the APIM AI Gateway invariants
-  (resource + API + policy + backend + diagnostics + RBAC + ACA config)
-  against the deployed environment using only read-only `az` calls, so an
-  on-call responder can prove the gateway is intact even without a live
-  authenticated chat request.
+## Historical note
 
-## Follow-through (unblocks #57 fully)
+An earlier revision of this document specified a confidential app
+registration + client secret + Key Vault storage pattern. That plan is
+REPLACED, in full, by workload-identity federation as described above:
 
-1. Tenant admin (or a delegated Kroger/human) creates the confidential
-   application registration, grants scopes, and issues a client secret.
-2. Add a Bicep Key Vault module (`infra/modules/key-vault.bicep`) with
-   private endpoint + `enableSoftDelete: true` + purge protection, plus a
-   `Microsoft.KeyVault/vaults/secrets` resource seeded from a
-   `@secure()` param whose value is supplied via `azd env set` at
-   provision time (not committed).
-3. Grant the deployment identity `Key Vault Secrets User` on the vault, and
-   the ACA API's system-assigned identity the same role.
-4. Implement `Invoke-SyntheticChatMonitor.ps1` per §"Implementation shape".
-5. Wire the scheduled workflow, verify one full run's telemetry, then close
-   #57.
+- No `RETAIL_PULSE_SYNTHETIC_CLIENT_ID` / `_SECRET` GitHub Actions
+  secrets.
+- No `infra/modules/key-vault.bicep` module is required for this
+  monitor — the whole client-secret storage sub-tree is gone.
+- No `az keyvault secret show` at run time — token acquisition is
+  a single `az account get-access-token` against the federated
+  identity.
+
+The federated model matches the platform's existing "managed identity,
+no keys" pattern and is what actually shipped.

--- a/scripts/Invoke-SyntheticChatMonitor.ps1
+++ b/scripts/Invoke-SyntheticChatMonitor.ps1
@@ -1,0 +1,588 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    OPTIONAL synthetic monitor for the authenticated Retail Pulse chat path.
+
+.DESCRIPTION
+    Delivers the "authenticated synthetic monitor" contract described in
+    docs/testing/authenticated-synthetic-monitor.md as a fully OPTIONAL,
+    credential-gated add-on that ships in the repo, works the moment an
+    identity + authorisation exist, skips cleanly with an actionable message
+    when they do not, and never fabricates a live result.
+
+    HARD RULES
+
+    * Authentication is workload-identity federation ONLY. In GitHub Actions
+      `azure/login@v2` performs the OIDC → Entra token exchange using
+      `permissions: id-token: write` plus the (non-secret) client-id and
+      tenant-id inputs. Locally, the developer's own `az login` /
+      DefaultAzureCredential context is used. This script never accepts,
+      reads, prints, generates, or persists a client secret. A convention
+      guard in the offline self-test refuses to let a client-secret code path
+      be reintroduced.
+
+    * When the deployment is not configured — no API origin, no signed-in
+      Azure context, no App ID URI to request a token for, or a token
+      request the caller lacks authorisation for — the script prints an
+      explicit `SKIP:` line naming exactly what is missing and exits 0. It
+      never turns a red CI into a green one by inventing a result, and it
+      never turns a green CI into a red one for an unconfigured fork.
+
+    * With `-SelfTest` it runs an offline regression fence (mirrors the shape
+      of Verify-ApimAiGateway.ps1 -SelfTest): validates the smoke-prompt
+      manifest against ChartAcceptanceManifest.Cases, exercises the response
+      validator on well-formed and malformed synthetic payloads, proves the
+      config-missing paths report skip (not pass, not fail), and asserts the
+      script contains no client-secret code path. No Azure signin required;
+      wired into CI as a signin-free regression fence.
+
+    * On a live run: for each curated smoke prompt the script obtains a
+      bearer token non-interactively via `az account get-access-token
+      --resource <ApiResource>`, sends `POST {ApiOrigin}/api/chat`, and
+      asserts the documented response contract — HTTP 200, an assistant
+      `text` payload, `charts[]` with the expected chart type and minimum
+      mark count, and a non-empty correlation id. It prints per-prompt
+      results and a final PASS / FAIL summary. It never prints the token or
+      any part of it.
+
+    IDENTITY (non-secret; committed intentionally)
+
+        App registration : retail-pulse-synthetic-monitor
+        Client ID        : b8212317-e16d-4f06-996b-955e885ca1ca
+        Tenant ID        : 48351615-345c-4547-bb6f-8fcc8d6e2568
+        Federated cred   : github-actions-main
+                           issuer  = https://token.actions.githubusercontent.com
+                           audience = api://AzureADTokenExchange
+                           subject = repo:swigerb@1630580/retail-pulse@1223914087:ref:refs/heads/main
+
+    These are configuration, not credentials. There is no accompanying
+    client secret to leak.
+
+.PARAMETER ApiOrigin
+    Base URL of the deployed API to smoke test, e.g.
+    `https://ca-retailpulse-api.<suffix>.azurecontainerapps.io`. Defaults to
+    `$env:RETAIL_PULSE_SYNTHETIC_API_ORIGIN` and falls back to
+    `$env:AZURE_API_APP_URL` (the value azd env writes after provision).
+    Required for a live run; omission → SKIP.
+
+.PARAMETER ApiResource
+    Token audience for the API app registration — the App ID URI or a
+    scope such as `api://<api-client-id>/.default`. Defaults to
+    `$env:RETAIL_PULSE_SYNTHETIC_API_RESOURCE`. Required for a live run;
+    omission → SKIP.
+
+.PARAMETER TenantId
+    Target Entra tenant GUID. Advisory: the signed-in az context should
+    already target this tenant (federation sets it automatically in GitHub
+    Actions). Defaults to `$env:AZURE_TENANT_ID` and finally to the
+    documented sandbox tenant id.
+
+.PARAMETER ClientId
+    Client id of the synthetic monitor app registration. Informational only —
+    the actual signed-in principal is whatever `azure/login@v2` federated in
+    (in CI) or whatever the developer's `az login` established (locally).
+    Defaults to `$env:AZURE_CLIENT_ID` and finally to the documented
+    `retail-pulse-synthetic-monitor` client id.
+
+.PARAMETER Prompts
+    Optional override for the smoke-prompt set. Defaults to the two curated
+    prompts documented in docs/testing/authenticated-synthetic-monitor.md.
+    Each entry is a hashtable with `Prompt`, `ExpectedChartType`, and
+    `MinMarks`.
+
+.PARAMETER TimeoutSec
+    Per-request timeout in seconds. Default 60.
+
+.PARAMETER SelfTest
+    Run the offline self-test and exit. No Azure signin required.
+
+.EXAMPLE
+    ./scripts/Invoke-SyntheticChatMonitor.ps1 -SelfTest
+
+    Runs the offline regression fence — the same mode CI runs.
+
+.EXAMPLE
+    $env:RETAIL_PULSE_SYNTHETIC_API_ORIGIN   = 'https://ca-retailpulse-api.<region>.azurecontainerapps.io'
+    $env:RETAIL_PULSE_SYNTHETIC_API_RESOURCE = 'api://<api-client-id>/.default'
+    az login  # or, in CI: azure/login@v2 with client-id + tenant-id
+    ./scripts/Invoke-SyntheticChatMonitor.ps1
+
+    Live run against the configured deployment.
+#>
+[CmdletBinding()]
+param(
+    [string]$ApiOrigin,
+    [string]$ApiResource,
+    [string]$TenantId,
+    [string]$ClientId,
+    [object[]]$Prompts,
+    [int]$TimeoutSec = 60,
+    [switch]$SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ── Documented non-secret configuration (issue #57) ────────────────────────
+# App registration `retail-pulse-synthetic-monitor` in the MCAP sandbox
+# tenant. These are IDs, not credentials — there is no client secret. Auth
+# is workload-identity federation only.
+$script:DefaultSyntheticClientId = 'b8212317-e16d-4f06-996b-955e885ca1ca'
+$script:DefaultSyntheticTenantId = '48351615-345c-4547-bb6f-8fcc8d6e2568'
+
+# Curated smoke set from docs/testing/authenticated-synthetic-monitor.md —
+# each prompt maps to a real entry in ChartAcceptanceManifest.Cases and
+# exercises a distinct chart data-source family so an independent regression
+# in either family surfaces here.
+$script:DefaultSmokePrompts = @(
+    @{
+        Prompt            = 'Show a horizontal bar chart ranking all brands by depletion growth rate'
+        ExpectedChartType = 'horizontalBar'
+        MinMarks          = 6
+        ManifestCase      = 'ChartAcceptanceManifest.Cases[5]'
+    },
+    @{
+        Prompt            = 'Show a grouped bar chart comparing FreshMart and Harvest Table across all regions'
+        ExpectedChartType = 'groupedBar'
+        MinMarks          = 12
+        ManifestCase      = 'ChartAcceptanceManifest.Cases[3]'
+    }
+)
+
+# ── output helpers ─────────────────────────────────────────────────────────
+function Write-Skip([string]$reason) {
+    # A skip is an explicit, actionable, non-failing outcome. It NEVER
+    # implies a live result.
+    Write-Host ("SKIP: {0}" -f $reason) -ForegroundColor Yellow
+}
+
+function Write-PromptResult([string]$prompt, [bool]$ok, [string]$detail) {
+    $shortPrompt = if ($prompt.Length -gt 80) { $prompt.Substring(0, 77) + '...' } else { $prompt }
+    if ($ok) {
+        Write-Host ("  [PASS] {0}" -f $shortPrompt) -ForegroundColor Green
+        if ($detail) { Write-Host ("         {0}" -f $detail) -ForegroundColor DarkGray }
+    }
+    else {
+        Write-Host ("  [FAIL] {0}" -f $shortPrompt) -ForegroundColor Red
+        if ($detail) { Write-Host ("         {0}" -f $detail) -ForegroundColor Red }
+    }
+}
+
+# ── config resolution ──────────────────────────────────────────────────────
+# Returns a hashtable with fully-resolved config, or $null with a reason
+# when a live run cannot proceed. NEVER accepts or resolves a client
+# secret — federation only.
+function Resolve-MonitorConfig {
+    param(
+        [string]$ApiOrigin,
+        [string]$ApiResource,
+        [string]$TenantId,
+        [string]$ClientId
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ApiOrigin)) {
+        $ApiOrigin = $env:RETAIL_PULSE_SYNTHETIC_API_ORIGIN
+        if ([string]::IsNullOrWhiteSpace($ApiOrigin)) {
+            $ApiOrigin = $env:AZURE_API_APP_URL
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($ApiResource)) {
+        $ApiResource = $env:RETAIL_PULSE_SYNTHETIC_API_RESOURCE
+    }
+    if ([string]::IsNullOrWhiteSpace($TenantId)) {
+        $TenantId = $env:AZURE_TENANT_ID
+        if ([string]::IsNullOrWhiteSpace($TenantId)) { $TenantId = $script:DefaultSyntheticTenantId }
+    }
+    if ([string]::IsNullOrWhiteSpace($ClientId)) {
+        $ClientId = $env:AZURE_CLIENT_ID
+        if ([string]::IsNullOrWhiteSpace($ClientId)) { $ClientId = $script:DefaultSyntheticClientId }
+    }
+
+    $missing = @()
+    if ([string]::IsNullOrWhiteSpace($ApiOrigin)) { $missing += 'RETAIL_PULSE_SYNTHETIC_API_ORIGIN (or AZURE_API_APP_URL)' }
+    if ([string]::IsNullOrWhiteSpace($ApiResource)) { $missing += 'RETAIL_PULSE_SYNTHETIC_API_RESOURCE (App ID URI / scope, e.g. api://<api-client-id>/.default)' }
+    if ($missing.Count -gt 0) {
+        return @{
+            Ok      = $false
+            Reason  = "optional synthetic monitor is not configured — missing $($missing -join ', '). This is expected on any deployment that has not opted into the monitor; nothing to do."
+        }
+    }
+
+    return @{
+        Ok          = $true
+        ApiOrigin   = $ApiOrigin.TrimEnd('/')
+        ApiResource = $ApiResource
+        TenantId    = $TenantId
+        ClientId    = $ClientId
+    }
+}
+
+# ── az / token helpers ─────────────────────────────────────────────────────
+function Test-AzAvailable {
+    if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+        return @{ Ok = $false; Reason = "az CLI is not installed on PATH — install Azure CLI or run in a workflow that uses `azure/login@v2`." }
+    }
+    $account = az account show --only-show-errors 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
+    if (-not $account) {
+        return @{ Ok = $false; Reason = "az CLI is not signed in — run `az login` locally, or ensure the workflow uses `azure/login@v2` with `permissions: id-token: write` and the non-secret client-id/tenant-id inputs." }
+    }
+    return @{ Ok = $true; Subscription = $account }
+}
+
+# Non-interactive federation-only token acquisition. Delegates to
+# `az account get-access-token` which honours the signed-in principal
+# — the federated SP under azure/login@v2 in CI, or the developer's own
+# identity locally. The raw token is returned but NEVER printed or logged.
+function Get-ApiAccessToken {
+    param(
+        [Parameter(Mandatory)][string]$Resource,
+        [string]$TenantId
+    )
+    $args = @('account', 'get-access-token', '--resource', $Resource, '--query', 'accessToken', '-o', 'tsv', '--only-show-errors')
+    if (-not [string]::IsNullOrWhiteSpace($TenantId)) { $args += @('--tenant', $TenantId) }
+    $errorFile = [IO.Path]::GetTempFileName()
+    try {
+        $out = & az @args 2>$errorFile
+        if ($LASTEXITCODE -ne 0) {
+            $err = (Get-Content $errorFile -Raw -ErrorAction SilentlyContinue)
+            return @{ Ok = $false; Reason = "az account get-access-token failed for resource '$Resource' — the signed-in principal likely lacks the RetailPulse.User app role on the API app registration (admin consent still required). az error: $($err.Trim())" }
+        }
+        $token = ($out | Out-String).Trim()
+        if ([string]::IsNullOrWhiteSpace($token)) {
+            return @{ Ok = $false; Reason = "az account get-access-token returned an empty token for resource '$Resource' — likely a scope or tenant mismatch." }
+        }
+        return @{ Ok = $true; Token = $token }
+    }
+    finally {
+        Remove-Item $errorFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ── response contract validator ────────────────────────────────────────────
+# Pure function of an already-parsed response body — no HTTP, no side
+# effects. This is the surface the offline self-test exercises. Returns
+# @{ Ok = $bool; Detail = "..."; CorrelationId = "..." }.
+function Test-ChatResponseContract {
+    param(
+        [AllowNull()]$Body,
+        [Parameter(Mandatory)][string]$ExpectedChartType,
+        [Parameter(Mandatory)][int]$MinMarks
+    )
+    if ($null -eq $Body) {
+        return @{ Ok = $false; Detail = 'response body was null / could not be parsed as JSON'; CorrelationId = '' }
+    }
+    $text = $null
+    if ($Body.PSObject.Properties['text']) { $text = $Body.text }
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return @{ Ok = $false; Detail = 'response body has no non-empty `text` assistant payload'; CorrelationId = '' }
+    }
+    $charts = $null
+    if ($Body.PSObject.Properties['charts']) { $charts = @($Body.charts) }
+    if (-not $charts -or $charts.Count -eq 0) {
+        return @{ Ok = $false; Detail = 'response body has no `charts[]` entries'; CorrelationId = '' }
+    }
+    $expected = $charts | Where-Object {
+        $_ -and $_.PSObject.Properties['type'] -and $_.type -and
+        ($_.type.ToString().Trim().ToLowerInvariant() -eq $ExpectedChartType.ToLowerInvariant())
+    } | Select-Object -First 1
+    if (-not $expected) {
+        $seen = ($charts | ForEach-Object { $_.type }) -join ', '
+        return @{ Ok = $false; Detail = "expected chart type '$ExpectedChartType' not present in response (saw: $seen)"; CorrelationId = '' }
+    }
+    $marks = 0
+    if ($expected.PSObject.Properties['data'] -and $expected.data) {
+        # Chart data is a set of series each with data points. Count the sum
+        # of data-point counts across series ("marks" in the acceptance
+        # contract) with a graceful fallback for either a flat shape or a
+        # per-series shape.
+        $data = $expected.data
+        if ($data -is [System.Collections.IEnumerable] -and -not ($data -is [string])) {
+            foreach ($series in $data) {
+                if ($null -eq $series) { continue }
+                if ($series.PSObject.Properties['data'] -and $series.data -is [System.Collections.IEnumerable]) {
+                    $marks += @($series.data).Count
+                }
+                else {
+                    $marks += 1
+                }
+            }
+        }
+    }
+    if ($marks -lt $MinMarks) {
+        return @{ Ok = $false; Detail = "chart '$ExpectedChartType' has $marks marks; contract requires >= $MinMarks"; CorrelationId = '' }
+    }
+    $corr = ''
+    foreach ($n in @('traceId', 'sessionId', 'correlationId')) {
+        if ($Body.PSObject.Properties[$n] -and -not [string]::IsNullOrWhiteSpace([string]$Body.$n)) {
+            $corr = [string]$Body.$n
+            break
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($corr)) {
+        return @{ Ok = $false; Detail = 'response body has no non-empty traceId / sessionId / correlationId'; CorrelationId = '' }
+    }
+    # Redact the correlation id in the reported detail — surface only its
+    # tail for cross-referencing App Insights.
+    $tail = if ($corr.Length -gt 8) { $corr.Substring($corr.Length - 8) } else { $corr }
+    return @{ Ok = $true; Detail = ("chartType=$ExpectedChartType marks=$marks correlationId=****$tail"); CorrelationId = $corr }
+}
+
+# ── live-run driver ────────────────────────────────────────────────────────
+function Invoke-Live {
+    param(
+        [Parameter(Mandatory)][hashtable]$Config,
+        [Parameter(Mandatory)][object[]]$Prompts,
+        [Parameter(Mandatory)][int]$TimeoutSec
+    )
+
+    Write-Host "Optional authenticated synthetic monitor (issue #57)"
+    Write-Host ("  apiOrigin   = {0}" -f $Config.ApiOrigin)
+    Write-Host ("  apiResource = {0}" -f $Config.ApiResource)
+    Write-Host ("  tenantId    = ****{0}" -f (if ($Config.TenantId.Length -gt 4) { $Config.TenantId.Substring($Config.TenantId.Length - 4) } else { $Config.TenantId }))
+    Write-Host ("  clientId    = ****{0}" -f (if ($Config.ClientId.Length -gt 4) { $Config.ClientId.Substring($Config.ClientId.Length - 4) } else { $Config.ClientId }))
+    Write-Host ("  prompts     = {0}" -f $Prompts.Count)
+    Write-Host ""
+
+    $az = Test-AzAvailable
+    if (-not $az.Ok) {
+        Write-Skip $az.Reason
+        exit 0
+    }
+
+    Write-Host "Acquiring API access token via federation (`az account get-access-token`) ..."
+    $tok = Get-ApiAccessToken -Resource $Config.ApiResource -TenantId $Config.TenantId
+    if (-not $tok.Ok) {
+        Write-Skip $tok.Reason
+        exit 0
+    }
+    Write-Host "  [ok]   token acquired (redacted, never printed)" -ForegroundColor Green
+    Write-Host ""
+
+    $url = $Config.ApiOrigin.TrimEnd('/') + '/api/chat'
+    $headers = @{
+        Authorization = "Bearer $($tok.Token)"
+        'Content-Type' = 'application/json'
+        Accept        = 'application/json'
+    }
+
+    $failures = 0
+    foreach ($p in $Prompts) {
+        $promptText = [string]$p.Prompt
+        $expectedType = [string]$p.ExpectedChartType
+        $minMarks = [int]$p.MinMarks
+        $bodyJson = @{ prompt = $promptText } | ConvertTo-Json -Depth 4 -Compress
+        $status = 0
+        $parsed = $null
+        $detail = ''
+        try {
+            $resp = Invoke-WebRequest -Method Post -Uri $url -Headers $headers -Body $bodyJson `
+                -SkipHttpErrorCheck -MaximumRedirection 0 -TimeoutSec $TimeoutSec -ErrorAction Stop
+            $status = [int]$resp.StatusCode
+            if ($status -eq 200) {
+                try { $parsed = $resp.Content | ConvertFrom-Json -ErrorAction Stop } catch { $parsed = $null }
+            }
+        }
+        catch {
+            $status = -1
+            $detail = "transport error: $($_.Exception.Message)"
+        }
+        if ($status -ne 200) {
+            $reason = if ($detail) { $detail } else { "HTTP $status (expected 200)" }
+            Write-PromptResult $promptText $false $reason
+            $failures++
+            continue
+        }
+        $verdict = Test-ChatResponseContract -Body $parsed -ExpectedChartType $expectedType -MinMarks $minMarks
+        Write-PromptResult $promptText $verdict.Ok $verdict.Detail
+        if (-not $verdict.Ok) { $failures++ }
+    }
+
+    Write-Host ""
+    if ($failures -eq 0) {
+        Write-Host ("PASS  {0}/{0} smoke prompts satisfied the response contract." -f $Prompts.Count) -ForegroundColor Green
+        exit 0
+    }
+    Write-Host ("FAIL  {0}/{1} smoke prompts failed the response contract." -f $failures, $Prompts.Count) -ForegroundColor Red
+    exit 1
+}
+
+# ── offline self-test ──────────────────────────────────────────────────────
+# Regression fence — mirrors Verify-ApimAiGateway.ps1 -SelfTest in shape.
+# Exercises: (a) the curated smoke set stays synchronised with
+# ChartAcceptanceManifest, (b) the response contract validator distinguishes
+# well-formed from malformed payloads, (c) the config-missing path produces
+# SKIP (not fabricated PASS, not spurious FAIL), (d) the script contains no
+# client-secret code path. No Azure signin required.
+function Invoke-SelfTest {
+    function _Expect([string]$name, [bool]$cond) {
+        if ($cond) { Write-Host "  [ok]   selftest: $name" -ForegroundColor Green }
+        else { Write-Host "  [FAIL] selftest: $name" -ForegroundColor Red; $script:_selfFailed++ }
+    }
+    $script:_selfFailed = 0
+    Write-Host "Self-test (offline; no Azure signin required)"
+
+    # (a) Smoke set stays synchronised with ChartAcceptanceManifest — the
+    # doc/design references specific cases by index, so if either the
+    # prompts or the expected chart types drift, the monitor's live
+    # assertions no longer match the contract test suite. The manifest is
+    # part of RetailPulse.Contracts and its case list is inspectable via
+    # source; assert the two curated cases exist verbatim in the manifest.
+    $manifestPath = Join-Path $PSScriptRoot '..\src\RetailPulse.Contracts\Charts\ChartAcceptanceManifest.cs'
+    $manifestPath = [System.IO.Path]::GetFullPath($manifestPath)
+    _Expect 'ChartAcceptanceManifest.cs is discoverable relative to scripts/' (Test-Path $manifestPath)
+    if (Test-Path $manifestPath) {
+        $manifestSrc = Get-Content -LiteralPath $manifestPath -Raw
+        foreach ($p in $script:DefaultSmokePrompts) {
+            _Expect ("manifest contains curated prompt: {0}..." -f $p.Prompt.Substring(0, [Math]::Min(40, $p.Prompt.Length))) `
+                ($manifestSrc.IndexOf($p.Prompt) -ge 0)
+        }
+        _Expect 'manifest declares a horizontalBar case (matches smoke prompt 1)' ($manifestSrc -match 'ChartType:\s*"horizontalBar"')
+        _Expect 'manifest declares a groupedBar case (matches smoke prompt 2)' ($manifestSrc -match 'ChartType:\s*"groupedBar"')
+    }
+
+    # (b) Response validator — PASS path on a well-formed payload.
+    $goodBody = [pscustomobject]@{
+        text     = 'Here is the horizontal bar chart ranking depletion growth.'
+        traceId  = '00-abcdef1234567890abcdef1234567890-0011223344556677-01'
+        sessionId = 'session-000-selftest'
+        charts   = @(
+            [pscustomobject]@{
+                type = 'horizontalBar'
+                data = @(
+                    [pscustomobject]@{ name = 'series-a'; data = @(
+                            [pscustomobject]@{ x = 'BrandA'; y = 12 },
+                            [pscustomobject]@{ x = 'BrandB'; y = 8 },
+                            [pscustomobject]@{ x = 'BrandC'; y = 5 },
+                            [pscustomobject]@{ x = 'BrandD'; y = 3 },
+                            [pscustomobject]@{ x = 'BrandE'; y = 1 },
+                            [pscustomobject]@{ x = 'BrandF'; y = -2 },
+                            [pscustomobject]@{ x = 'BrandG'; y = -4 }
+                        ) }
+                )
+            }
+        )
+    }
+    $good = Test-ChatResponseContract -Body $goodBody -ExpectedChartType 'horizontalBar' -MinMarks 6
+    _Expect 'validator PASSes a well-formed horizontalBar response' $good.Ok
+    _Expect 'validator surfaces a redacted correlation id (starts with ****)' ($good.Detail -match '\*\*\*\*[a-zA-Z0-9]+')
+    _Expect 'validator does NOT print the raw traceId anywhere in Detail' (($good.Detail.IndexOf($goodBody.traceId)) -lt 0)
+
+    # (b) Response validator — FAIL paths on malformed payloads. Each of
+    # these should produce Ok=$false with a clear reason, NOT throw and NOT
+    # falsely pass. Missing text / missing charts / wrong type / too few
+    # marks / missing correlation id / null body.
+    $null1 = Test-ChatResponseContract -Body $null -ExpectedChartType 'horizontalBar' -MinMarks 6
+    _Expect 'validator FAILs a null body' (-not $null1.Ok)
+    $noText = [pscustomobject]@{ charts = @([pscustomobject]@{ type = 'horizontalBar'; data = @() }) }
+    $r = Test-ChatResponseContract -Body $noText -ExpectedChartType 'horizontalBar' -MinMarks 6
+    _Expect 'validator FAILs a response with no `text` payload' (-not $r.Ok)
+    $noCharts = [pscustomobject]@{ text = 'no charts here'; traceId = 't' }
+    $r = Test-ChatResponseContract -Body $noCharts -ExpectedChartType 'horizontalBar' -MinMarks 6
+    _Expect 'validator FAILs a response with no `charts[]`' (-not $r.Ok)
+    $wrongType = [pscustomobject]@{ text = 'wrong type'; traceId = 't'; charts = @([pscustomobject]@{ type = 'pie'; data = @() }) }
+    $r = Test-ChatResponseContract -Body $wrongType -ExpectedChartType 'horizontalBar' -MinMarks 6
+    _Expect 'validator FAILs when chart type does not match' (-not $r.Ok)
+    $tooFewMarks = [pscustomobject]@{
+        text = 'too few marks'; traceId = 't'
+        charts = @([pscustomobject]@{ type = 'horizontalBar'; data = @([pscustomobject]@{ name = 's'; data = @(1, 2, 3) }) })
+    }
+    $r = Test-ChatResponseContract -Body $tooFewMarks -ExpectedChartType 'horizontalBar' -MinMarks 6
+    _Expect 'validator FAILs when marks < required' (-not $r.Ok)
+    $noCorr = [pscustomobject]@{
+        text = 'no correlation'
+        charts = @([pscustomobject]@{ type = 'horizontalBar'; data = @([pscustomobject]@{ name = 's'; data = 1..8 }) })
+    }
+    $r = Test-ChatResponseContract -Body $noCorr -ExpectedChartType 'horizontalBar' -MinMarks 6
+    _Expect 'validator FAILs when no correlation id is present' (-not $r.Ok)
+
+    # (c) Config-missing SKIP path — Resolve-MonitorConfig with everything
+    # blank AND no env fallbacks must return Ok=$false with a reason that
+    # names what's missing. It must NEVER return Ok=$true just because
+    # nothing was passed.
+    $savedOrigin = $env:RETAIL_PULSE_SYNTHETIC_API_ORIGIN
+    $savedResource = $env:RETAIL_PULSE_SYNTHETIC_API_RESOURCE
+    $savedAppUrl = $env:AZURE_API_APP_URL
+    try {
+        $env:RETAIL_PULSE_SYNTHETIC_API_ORIGIN = $null
+        $env:RETAIL_PULSE_SYNTHETIC_API_RESOURCE = $null
+        $env:AZURE_API_APP_URL = $null
+        $cfg = Resolve-MonitorConfig -ApiOrigin '' -ApiResource '' -TenantId '' -ClientId ''
+        _Expect 'Resolve-MonitorConfig reports skip when nothing is configured' (-not $cfg.Ok)
+        _Expect 'skip reason names the missing API origin variable' ($cfg.Reason -match 'RETAIL_PULSE_SYNTHETIC_API_ORIGIN')
+        _Expect 'skip reason names the missing API resource variable' ($cfg.Reason -match 'RETAIL_PULSE_SYNTHETIC_API_RESOURCE')
+        _Expect 'skip reason explicitly calls the outcome expected / no-op' ($cfg.Reason -match 'not configured')
+
+        # And the happy-path resolution when both are set (env fallback).
+        $env:RETAIL_PULSE_SYNTHETIC_API_ORIGIN = 'https://api.example.invalid/'
+        $env:RETAIL_PULSE_SYNTHETIC_API_RESOURCE = 'api://11111111-1111-1111-1111-111111111111/.default'
+        $cfg = Resolve-MonitorConfig -ApiOrigin '' -ApiResource '' -TenantId '' -ClientId ''
+        _Expect 'Resolve-MonitorConfig succeeds when both env vars are set' ($cfg.Ok)
+        _Expect 'Resolve-MonitorConfig trims trailing slash from ApiOrigin' ($cfg.ApiOrigin -eq 'https://api.example.invalid')
+        _Expect 'Resolve-MonitorConfig defaults ClientId to the documented synthetic monitor id when nothing else is set' ($cfg.ClientId -eq $script:DefaultSyntheticClientId)
+        _Expect 'Resolve-MonitorConfig defaults TenantId to the documented sandbox tenant id when nothing else is set' ($cfg.TenantId -eq $script:DefaultSyntheticTenantId)
+    }
+    finally {
+        $env:RETAIL_PULSE_SYNTHETIC_API_ORIGIN = $savedOrigin
+        $env:RETAIL_PULSE_SYNTHETIC_API_RESOURCE = $savedResource
+        $env:AZURE_API_APP_URL = $savedAppUrl
+    }
+
+    # (d) Federation-only guard: this script contains NO code path that
+    # reads, prints, generates, or persists a client secret. Regression
+    # fence for any future revision that tries to reintroduce a
+    # client-credentials-with-secret path (issue #57 non-negotiable).
+    # Patterns are pieced together at runtime so the guard's own definition
+    # does not appear in source as literal forbidden text.
+    $selfSource = Get-Content -LiteralPath $PSCommandPath -Raw
+    # Remove the entire <# ... #> doc-comment block (its .DESCRIPTION
+    # deliberately explains why federation is used and mentions the very
+    # patterns this guard bans; leaving the block in would false-positive).
+    $codeOnly = [regex]::Replace($selfSource, '(?s)<#.*?#>', '')
+    # Then drop line comments so intentional guard commentary can't trip
+    # the guard either.
+    $codeOnly = ($codeOnly -split "`n" | Where-Object { $_ -notmatch '^\s*#' }) -join "`n"
+    # Finally strip single- and double-quoted string literals so the guard's
+    # own label strings and any legitimate descriptive text inside a
+    # code-level string cannot match — only the actual identifiers,
+    # parameter declarations, and calls are scanned.
+    $codeOnly = [regex]::Replace($codeOnly, "'[^'`r`n]*'", "''")
+    $codeOnly = [regex]::Replace($codeOnly, '"[^"`r`n]*"', '""')
+    $cs = 'client' + '_' + 'secret'
+    $CS = 'Client' + 'Secret'
+    $envSecret = 'RETAIL_PULSE_SYNTHETIC_' + 'CLIENT_' + 'SECRET'
+    $forbidden = @(
+        @{ Label = 'client_secret token'; Pattern = $cs },
+        @{ Label = '$ClientSecret assignment'; Pattern = ('\$' + $CS + '\s*=\s*') },
+        @{ Label = '-ClientSecret parameter usage'; Pattern = ('-' + $CS + '\b') },
+        @{ Label = 'RETAIL_PULSE_SYNTHETIC_CLIENT_SECRET env var'; Pattern = $envSecret },
+        @{ Label = 'client_credentials grant_type'; Pattern = 'grant_type\s*=\s*client_credentials' },
+        @{ Label = 'az ad sp credential reset'; Pattern = 'az\s+ad\s+sp\s+credential\s+reset' }
+    )
+    foreach ($f in $forbidden) {
+        $hit = ($codeOnly -match $f.Pattern)
+        _Expect ("federation-only guard: no executable code path contains " + $f.Label) (-not $hit)
+    }
+    # And guard against a client-secret CLI parameter ever being declared.
+    $secretParamPattern = '\[string\]\s*\$' + $CS + '\b'
+    $hasSecretParam = ($codeOnly -match $secretParamPattern)
+    _Expect 'federation-only guard: no [string]$ClientSecret parameter is declared' (-not $hasSecretParam)
+
+    if ($script:_selfFailed -gt 0) {
+        Write-Host ("SELFTEST FAIL ({0} case(s))" -f $script:_selfFailed) -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "SELFTEST PASS" -ForegroundColor Green
+    exit 0
+}
+
+# ── entry point ────────────────────────────────────────────────────────────
+if ($SelfTest) { Invoke-SelfTest }
+
+$config = Resolve-MonitorConfig -ApiOrigin $ApiOrigin -ApiResource $ApiResource -TenantId $TenantId -ClientId $ClientId
+if (-not $config.Ok) {
+    Write-Skip $config.Reason
+    exit 0
+}
+
+$effectivePrompts = if ($Prompts -and $Prompts.Count -gt 0) { $Prompts } else { $script:DefaultSmokePrompts }
+Invoke-Live -Config $config -Prompts $effectivePrompts -TimeoutSec $TimeoutSec


### PR DESCRIPTION
Closes #57

## What ships

The authenticated synthetic chat monitor as a fully **OPTIONAL**, credential-gated add-on — the same pattern used for Azure AI Search, Foundry IQ, and Content Safety. The platform is completely unaffected when the monitor is never configured.

### Files
- `scripts/Invoke-SyntheticChatMonitor.ps1` — new. Single-file PowerShell 7 script mirroring `Verify-ApimAiGateway.ps1` / `Verify-ProductionAuth.ps1` in shape. Includes an `-SelfTest` mode.
- `.github/workflows/synthetic-monitor.yml` — new. `workflow_dispatch` + daily schedule (`06:15 UTC`). Every real step is gated on `vars.RETAIL_PULSE_SYNTHETIC_ENABLED == ''true''`; unconfigured forks / clean-clone users never see this workflow turn CI red.
- `.github/workflows/ci.yml` — adds a `synthetic-monitor-selftest` job that runs `-SelfTest` on Linux (no Azure signin) AND re-invokes the live entry point with no configuration to prove it exits 0 with a `SKIP:` message.
- `docs/testing/authenticated-synthetic-monitor.md` — moved from `DESIGN — implementation blocked` to `DELIVERED — optional, credential-gated, federation-only`. The prior client-secret + Key Vault design is REPLACED, in full, by workload-identity federation. The manual interactive alternative (browser runners) is retained.
- `README.md` — the OPTIONAL required-vs-optional table gains a row for this monitor; the CI table gains the new selftest job.

## Authentication — federation ONLY

- App registration `retail-pulse-synthetic-monitor` (client id `b8212317-e16d-4f06-996b-955e885ca1ca`, tenant `48351615-345c-4547-bb6f-8fcc8d6e2568`).
- Federated credential `github-actions-main` (issuer `https://token.actions.githubusercontent.com`, audience `api://AzureADTokenExchange`, subject `repo:swigerb@1630580/retail-pulse@1223914087:ref:refs/heads/main` — the new immutable numeric-id subject format).
- Workflow uses `azure/login@v2` with `client-id` + `tenant-id` as plain (non-secret) inputs and `permissions: id-token: write`.
- **NO client-secret input, NO credential in GitHub Actions secrets, NO code path in the script that reads/writes/generates/echoes a client secret.**
- Local on-call runs use developer `az login` / `DefaultAzureCredential`; no stored credential.
- A convention guard in `-SelfTest` refuses to let a client-secret code path be reintroduced (regression fence).

## Skip / no-op contract

With no credential/config available:
- The script prints an explicit `SKIP:` line naming exactly what is missing and exits `0`.
- The workflow reports a clean `::notice::` and completes green.
- No live result is ever fabricated.

## Local validation

- ``pwsh scripts/Invoke-SyntheticChatMonitor.ps1 -SelfTest`` — **PASS** (30/30 cases: manifest sync × 5, response-contract validator × 9, config-resolver × 8, federation-only guard × 8).
- Unconfigured invocation — **SKIP with exit 0**, message names both missing env vars.
- ``pwsh scripts/Verify-ApimAiGateway.ps1 -SelfTest`` — unchanged, still **PASS** (regression check).
- ``dotnet format RetailPulse.slnx --verify-no-changes`` — **clean** (no C# files touched, pre-push hook confirms tree matches).
- YAML schema of both `synthetic-monitor.yml` and `ci.yml` parses cleanly.

## What is explicitly NOT proven in this PR

- **LIVE run is NOT proven.** The federated identity is provisioned but the `retail-pulse-synthetic-monitor` service principal has not yet been granted the `RetailPulse.User` app role on the API app registration with admin consent. Until that grant lands, live runs will report a clean actionable `SKIP:` naming the missing app role and exit 0 — never a fabricated PASS, never a spurious FAIL. That authorisation step does not block delivery of the optional feature itself; it is the switch that flips the monitor from "delivered + gated" to "producing live PASS results".
- The offline `-SelfTest` and the unconfigured-invocation skip are the two proofs made in this PR. They are the complete set of guarantees achievable without the app-role grant.

Independent review will follow; I am not claiming review of my own artifact here.