### PR TITLE
Add opt-in app-only (client-credentials) token acceptance (#163)

### DIFF
--- a/docs/authentication-matrix.md
+++ b/docs/authentication-matrix.md
@@ -70,7 +70,11 @@ regardless of what the UI renders).
 
 ## Runtime authorization matrix (Entra mode)
 
-Behavior for the `Entra` mode is identical to the pre-foundation implementation.
+Behavior for the `Entra` mode is identical to the pre-foundation implementation
+for delegated (user) tokens. Optionally, a deployment may opt in to accepting
+app-only (client-credentials) tokens for machine callers such as the synthetic
+monitor — see [App-only (client-credentials) tokens](#app-only-client-credentials-tokens-entra-mode)
+below. The opt-in is **off by default** and never widens the delegated path.
 
 | Request | Credential | Expected result |
 |---------|-----------|-----------------|
@@ -81,6 +85,42 @@ Behavior for the `Entra` mode is identical to the pre-foundation implementation.
 | `/hubs/*` | no token | 401 |
 | REST endpoint | token via `?access_token` query string only | 401 (query token is honored only on `/hubs/*`) |
 | `/health`, `/alive` | none | 200 (anonymous by design — health-only invariant) |
+
+### App-only (client-credentials) tokens (Entra mode)
+
+App-only acceptance is an **opt-in, fail-closed** capability. It is **off by
+default**: an unset deployment behaves exactly as it did before this feature
+existed and rejects every client-credentials token with `403`. The opt-in never
+touches the delegated (user) path — a delegated token is authorized byte-for-byte
+identically whether the opt-in is on or off. There is no reusable scope-bypass:
+both SignalR hubs and every REST endpoint remain protected, anonymous-session
+hardening is unchanged, and a misconfigured opt-in fails startup rather than
+silently falling through to a weaker policy.
+
+**Configuration keys** (all under the `MicrosoftEntra:` section — env vars
+`MicrosoftEntra__...`):
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `AllowAppOnlyTokens` | bool | `false` | Master opt-in. When `false`, app-only tokens are rejected 403 regardless of role. When `true`, an app-only token bearing the required app role is accepted (subject to the optional allow-list below). |
+| `AllowedAppClientIds` | string[] (config-array) | *empty* | Optional allow-list of application (client) IDs permitted to authenticate via app-only tokens. When empty, no client-ID restriction (the app role itself is the gate). When populated, the token's `azp` (v2) or `appid` (v1) claim MUST match one of the listed GUIDs — enforced case-insensitively via GUID normalization. |
+| `AppRole` | string | `RetailPulse.User` | Existing key. The app-only path is authorized on this role alone (no `scp`); a blank/placeholder value fails startup when the opt-in is on. |
+| `ApiScope` | string | `access_as_user` | Existing key. Delegated-only. Not consulted for app-only tokens. |
+
+| Request | Credential | `AllowAppOnlyTokens` | `AllowedAppClientIds` | Expected result |
+|---------|-----------|----------------------|-----------------------|-----------------|
+| Protected REST/hub | app-only token (`roles=RetailPulse.User`, no `scp`) | `false` (default) | — | **403** — the default policy rejects every app-only token, matching pre-#163 behaviour |
+| Protected REST/hub | app-only token bearing the required app role | `true` | *empty* | **200** — accepted; the app role is the gate |
+| Protected REST/hub | app-only token bearing the required app role and an allow-listed `azp` (v2) | `true` | `[<monitor-app-id>]` | **200** — accepted; both the role and the allow-list are satisfied |
+| Protected REST/hub | app-only token bearing the required app role and an allow-listed `appid` (v1) | `true` | `[<monitor-app-id>]` | **200** — v1 tokens surface the caller as `appid` and match the same allow-list |
+| Protected REST/hub | app-only token bearing the required app role but no `azp`/`appid` | `true` | `[<monitor-app-id>]` | **403** — no claim to match against the allow-list; fail closed |
+| Protected REST/hub | app-only token bearing the required app role and a non-allow-listed `azp` | `true` | `[<monitor-app-id>]` | **403** — another admin-consented app in the tenant cannot piggy-back onto the role |
+| Protected REST/hub | app-only token with the wrong role or no `roles` claim | `true` | any | **403** — `RequireRole` fails; the role is the primary app-only gate |
+| Protected REST/hub | signed token carrying neither `scp` nor `roles` | any | any | **403** — no authorization signal at all |
+| Delegated (user) token with role + scope | valid delegated token | any | any | **200** — byte-for-byte unchanged from the delegated behaviour above |
+| Delegated (user) token missing scope or role | valid delegated token | any | any | **403** — the delegated path always requires the exact scope and role |
+| Startup with `AllowAppOnlyTokens=true` and a placeholder / non-GUID in `AllowedAppClientIds` | — | `true` | malformed | **Startup fails** — `InvalidOperationException`; no fallback to a weaker policy |
+| Startup with `AllowAppOnlyTokens=true` and a blank `AppRole` on the resolved options | — | `true` | any | **Startup fails** — the app role is the only app-only gate; it cannot be empty |
 
 ## Runtime authorization matrix (Anonymous mode)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -571,6 +571,106 @@ attack surface. The live build stays `Entra`.
 - **Managed Identity:** For Azure OpenAI (via APIM) and other Azure resources — no client
   secrets in code.
 
+### App-only (client-credentials) tokens — opt-in, fail-closed
+
+By default the API accepts only **delegated** (user) tokens — a token bearing the
+`RetailPulse.User` app role AND the `access_as_user` scope. An **app-only**
+(client-credentials) token — which carries `roles` but no `scp` — is rejected
+`403`. This is the pre-#163 behaviour and is preserved bit-for-bit for every
+unset deployment. It matches the ADR-005 / epic #27 guardrails: **"Live
+production stays Entra only and fails closed"**, **"No silent downgrade"**.
+
+Machine callers (for example the optional synthetic monitor in `#57`) need an
+app-only token, so the Entra boundary now supports an **opt-in** app-only path.
+It is additive, narrow, and fail-closed:
+
+- **Disabled by default.** Unset configuration behaves exactly as it did
+  before this feature existed.
+- **Delegated behaviour unchanged.** Enabling the flag does not alter the
+  delegated (user) path in any way — same role check, same scope check, same
+  claim shapes.
+- **Narrow scope.** Only tokens bearing the configured app role are accepted,
+  and both SignalR hubs plus every REST endpoint remain protected. The
+  anonymous-session hardening is untouched. There is no reusable general
+  scope-bypass path that a future endpoint could inherit unintentionally.
+- **Fail closed.** A malformed or incomplete opt-in configuration (placeholder
+  or non-GUID entry in the allow-list, blank app role) fails startup — never a
+  warning-and-continue, never a fallback to a weaker policy.
+- **Client-ID allow-list is optional but supported.** Populating
+  `MicrosoftEntra:AllowedAppClientIds` requires the token's `azp` (v2) or
+  `appid` (v1) claim to match one of the listed GUIDs, so consenting an
+  unrelated application to `RetailPulse.User` does not automatically grant it
+  API access.
+
+#### Configuration keys
+
+All keys live in the `MicrosoftEntra` section (env-var form
+`MicrosoftEntra__...`). Existing `AppRole` and `ApiScope` values are unchanged.
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `MicrosoftEntra:AllowAppOnlyTokens` | bool | **`false`** | Master opt-in. When `false`, every app-only token is rejected `403` (this matches the shipped Bicep and preserves pre-#163 behaviour). When `true`, an app-only token bearing the required app role is accepted — subject to the optional allow-list below. |
+| `MicrosoftEntra:AllowedAppClientIds` | string[] (config-array) | **empty** | Optional allow-list of application (client) IDs (Entra service-principal client IDs) permitted to authenticate via app-only tokens. Empty means the app role alone gates access. When populated, the token's `azp` (v2) or `appid` (v1) claim MUST match one of the listed GUIDs. |
+| `MicrosoftEntra:AppRole` | string | `RetailPulse.User` | The role required on **every** authenticated request. In the app-only path this is the primary gate — a blank or placeholder value fails startup when the opt-in is on. |
+
+#### Startup validation (fail-closed)
+
+`EntraAuthOptions.FromConfiguration` runs `ValidateAppOnlyOptIn()` whenever
+`AllowAppOnlyTokens=true`, in **every** environment (Development included). Any
+of the following throws `InvalidOperationException` before authentication is
+registered:
+
+- A blank `AppRole` on the resolved options (a documentation placeholder is
+  scrubbed and the default `RetailPulse.User` kicks in — this catches the
+  direct-construction case).
+- Any entry in `AllowedAppClientIds` that is blank or looks like a
+  documentation placeholder (`<...>`).
+- Any entry in `AllowedAppClientIds` that is not a valid GUID.
+
+Development is not exempt: a typo that slips past a local build would otherwise
+propagate to a deployed environment. The opt-in must be spelled right or the
+process refuses to start.
+
+#### How each token shape is evaluated
+
+The dual-mode assertion (`AuthenticationSetup.IsAuthorizedPrincipal`) is a
+strict branch on token type — there is no fallback and no "or":
+
+- Token carries `scp` (delegated) → require the configured API scope
+  (`HasRequiredScope`). Behaviour is byte-for-byte identical to pre-#163.
+- Token carries `roles` and NO `scp` (app-only) → require
+  `AllowAppOnlyTokens=true` AND, if the allow-list is populated, the token's
+  `azp`/`appid` matches an allow-listed GUID. The `RequireRole` requirement
+  on the policy handles the role check for both branches.
+- Token carries neither `scp` nor `roles` → deny.
+
+#### Client-ID / object-ID allow-list decision (recorded per #163)
+
+**Decision:** support an **optional** `MicrosoftEntra:AllowedAppClientIds`
+allow-list keyed on the token's `azp` (v2) / `appid` (v1) claim, with an empty
+list meaning "no client-ID restriction". Object-ID (`oid`) allow-listing was
+considered and deliberately not adopted.
+
+**Reasoning:**
+
+- Entra emits `azp` on v2 tokens and `appid` on v1 tokens; both are the
+  Microsoft-documented "authorized party" identifier — the client ID of the
+  application that obtained the token. Matching on this claim maps directly to
+  the identity a tenant admin registers and consents in Entra, so operators can
+  reason about who is on the allow-list without decoding token internals.
+- The service-principal object ID (`oid`) also uniquely identifies the caller
+  within a tenant, but it is one indirection removed from the identity operators
+  actually manage (the app registration). Using `azp`/`appid` keeps the
+  configuration and audit trail aligned with the Entra admin experience.
+- Making the list optional preserves the single-tenant default (role assignment
+  + admin consent is already tenant-admin-gated), while giving deployments
+  defense-in-depth when they want it — critical because the `RetailPulse.User`
+  app role now allows `Users/Groups,Applications` and any admin-consented app in
+  the tenant could otherwise gain API access silently.
+- Any entry that is not a valid GUID fails startup, so a typo can never silently
+  disable the restriction. Comparison is GUID-normalized so case/format
+  differences cannot bypass the check.
+
 ---
 
 ## Rate Limiting

--- a/src/RetailPulse.Api/Security/AuthenticationSetup.cs
+++ b/src/RetailPulse.Api/Security/AuthenticationSetup.cs
@@ -21,7 +21,10 @@ namespace RetailPulse.Api.Security;
 ///     <c>/hubs</c> requests (browsers cannot set Authorization headers on WebSocket
 ///     handshakes); all other endpoints require the Authorization header.</item>
 ///   <item>Every protected endpoint/hub requires an authenticated user, the required app
-///     role (<c>roles</c> claim), and the delegated API scope (<c>scp</c> claim).</item>
+///     role (<c>roles</c> claim), and either the delegated API scope (<c>scp</c> claim) or
+///     — only when <see cref="EntraAuthOptions.AllowAppOnlyTokens"/> is opted in — an
+///     app-only (client-credentials) token bearing the required app role and, if
+///     configured, an allow-listed <c>azp</c>/<c>appid</c>.</item>
 ///   <item>Development uses the synthetic <see cref="DevelopmentAuthHandler"/> so the demo
 ///     runs locally without real tokens — never available outside Development.</item>
 /// </list>
@@ -102,7 +105,7 @@ public static class AuthenticationSetup
         {
             builder
                 .RequireRole(options.AppRole)
-                .RequireAssertion(ctx => HasRequiredScope(ctx.User, options.ApiScope));
+                .RequireAssertion(ctx => IsAuthorizedPrincipal(ctx.User, options));
         }
 
         return builder.Build();
@@ -160,6 +163,43 @@ public static class AuthenticationSetup
     }
 
     /// <summary>
+    /// Returns true when the principal is authorized under the dual-mode token policy:
+    /// <list type="bullet">
+    ///   <item>Delegated tokens (carrying <c>scp</c>) MUST carry the configured API scope.
+    ///     Behaviour is byte-for-byte unchanged from before the app-only opt-in existed —
+    ///     and is unaffected by whether the opt-in is on or off.</item>
+    ///   <item>App-only tokens (carrying <c>roles</c> but NO <c>scp</c>) are accepted ONLY
+    ///     when <see cref="EntraAuthOptions.AllowAppOnlyTokens"/> is <c>true</c>. The
+    ///     required app role is already enforced by <c>RequireRole</c> on the policy; if
+    ///     <see cref="EntraAuthOptions.AllowedAppClientIds"/> is populated, the token's
+    ///     <c>azp</c>/<c>appid</c> must additionally match one of the listed client IDs.</item>
+    ///   <item>Tokens carrying neither <c>scp</c> nor <c>roles</c> are rejected.</item>
+    /// </list>
+    /// </summary>
+    public static bool IsAuthorizedPrincipal(ClaimsPrincipal principal, EntraAuthOptions options)
+    {
+        if (HasScopeClaim(principal))
+        {
+            // Delegated (user) token — behaviour unchanged: require the configured scope.
+            return HasRequiredScope(principal, options.ApiScope);
+        }
+
+        if (HasRolesClaim(principal))
+        {
+            // App-only (client-credentials) token. The required app role is already
+            // enforced by RequireRole on the policy. This branch decides whether the
+            // opt-in accepts app-only at all and, if configured, whether the calling
+            // client is on the allow-list.
+            return options.AllowAppOnlyTokens
+                && (options.AllowedAppClientIds.Length == 0
+                    || HasAllowedAppClientId(principal, options.AllowedAppClientIds));
+        }
+
+        // Neither scp nor roles → no authorization signal at all → reject.
+        return false;
+    }
+
+    /// <summary>
     /// Returns true when the principal carries the required delegated scope. The <c>scp</c>
     /// claim is a space-delimited list, so a single claim can contain several scopes.
     /// </summary>
@@ -195,6 +235,71 @@ public static class AuthenticationSetup
         foreach (string scope in scopeClaimValue.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
             if (string.Equals(scope, requiredScope, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Returns true when the principal has any <c>scp</c>-style claim (v1 short or v2 long form).</summary>
+    private static bool HasScopeClaim(ClaimsPrincipal principal) =>
+        principal.HasClaim(c =>
+            c.Type is "scp" or "http://schemas.microsoft.com/identity/claims/scope");
+
+    /// <summary>Returns true when the principal has any <c>roles</c> claim.</summary>
+    private static bool HasRolesClaim(ClaimsPrincipal principal) =>
+        principal.HasClaim(c => c.Type == "roles");
+
+    /// <summary>
+    /// Returns true when the token's <c>azp</c> (v2) or <c>appid</c> (v1) claim matches
+    /// one of the allow-listed application (client) IDs. Comparison is GUID-normalized so
+    /// case, formatting, and braces cannot bypass the check.
+    /// </summary>
+    private static bool HasAllowedAppClientId(ClaimsPrincipal principal, IReadOnlyList<string> allowedClientIds)
+    {
+        var allowed = new Guid[allowedClientIds.Count];
+        for (int i = 0; i < allowedClientIds.Count; i++)
+        {
+            if (!Guid.TryParse(allowedClientIds[i], out allowed[i]))
+            {
+                // Startup validation already rejects non-GUID entries — an unparseable
+                // entry here means someone bypassed FromConfiguration/Validate. Fail
+                // closed rather than treating it as a match.
+                return false;
+            }
+        }
+
+        foreach (Claim claim in principal.FindAll("azp"))
+        {
+            if (MatchesAny(claim.Value, allowed))
+            {
+                return true;
+            }
+        }
+
+        foreach (Claim claim in principal.FindAll("appid"))
+        {
+            if (MatchesAny(claim.Value, allowed))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MatchesAny(string tokenClientId, Guid[] allowed)
+    {
+        if (!Guid.TryParse(tokenClientId, out Guid parsed))
+        {
+            return false;
+        }
+
+        foreach (Guid candidate in allowed)
+        {
+            if (candidate == parsed)
             {
                 return true;
             }

--- a/src/RetailPulse.Api/Security/EntraAuthOptions.cs
+++ b/src/RetailPulse.Api/Security/EntraAuthOptions.cs
@@ -42,6 +42,24 @@ public sealed class EntraAuthOptions
     /// <summary>App role name required on every protected endpoint/hub (roles claim).</summary>
     public string AppRole { get; init; } = DefaultAppRole;
 
+    /// <summary>
+    /// When true, app-only (client-credentials) tokens — those carrying a <c>roles</c>
+    /// claim and NO <c>scp</c> claim — are accepted, provided the required app role is
+    /// present. Delegated (user) tokens are unaffected. Defaults to <c>false</c>: unset
+    /// configuration behaves exactly as before this flag existed and rejects app-only
+    /// tokens.
+    /// </summary>
+    public bool AllowAppOnlyTokens { get; init; }
+
+    /// <summary>
+    /// Optional allow-list of application (client) IDs that may authenticate via
+    /// app-only tokens when <see cref="AllowAppOnlyTokens"/> is <c>true</c>. An empty
+    /// list means no client-ID restriction — every app-only token bearing the required
+    /// app role is accepted. When populated, the token's <c>azp</c> (v2) or
+    /// <c>appid</c> (v1) claim MUST match one of the listed GUIDs.
+    /// </summary>
+    public string[] AllowedAppClientIds { get; init; } = [];
+
     /// <summary>When true, real JWT bearer validation is enforced. Defaults to true outside Development.</summary>
     public bool RequireAuth { get; init; } = true;
 
@@ -100,6 +118,12 @@ public sealed class EntraAuthOptions
         string? clientId = Clean(entra["ClientId"]);
         string? audience = Clean(entra["Audience"]) ?? legacyAudience;
 
+        // Opt-in: accept app-only (client-credentials) tokens. Default false — an unset
+        // deployment behaves exactly as before this feature existed. See docs/security.md
+        // §"App-only (client-credentials) tokens" and docs/authentication-matrix.md.
+        bool allowAppOnly = configuration.GetValue($"{SectionName}:AllowAppOnlyTokens", false);
+        string[] allowedAppClientIds = ReadAllowedAppClientIds(entra);
+
         var options = new EntraAuthOptions
         {
             Instance = Clean(entra["Instance"]) ?? "https://login.microsoftonline.com/",
@@ -108,8 +132,18 @@ public sealed class EntraAuthOptions
             Audience = audience,
             ApiScope = Clean(entra["ApiScope"]) ?? DefaultApiScope,
             AppRole = Clean(entra["AppRole"]) ?? DefaultAppRole,
+            AllowAppOnlyTokens = allowAppOnly,
+            AllowedAppClientIds = allowedAppClientIds,
             RequireAuth = requireAuth,
         };
+
+        // Fail-closed validation for the opt-in runs in EVERY environment (Development
+        // included). If a deployment opts in, it must do so correctly regardless of where
+        // it runs — no silent fallback to a weaker policy on a misconfigured opt-in.
+        if (allowAppOnly)
+        {
+            options.ValidateAppOnlyOptIn();
+        }
 
         // Validation runs for ALL non-Development environments, regardless of the flag.
         if (nonDevelopment)
@@ -141,6 +175,43 @@ public sealed class EntraAuthOptions
         }
     }
 
+    /// <summary>
+    /// Fail-fast validation for the app-only opt-in. Runs whenever
+    /// <see cref="AllowAppOnlyTokens"/> is <c>true</c> so a misconfigured opt-in never
+    /// silently falls through to a weaker policy — it fails startup instead.
+    /// </summary>
+    public void ValidateAppOnlyOptIn()
+    {
+        if (string.IsNullOrWhiteSpace(AppRole) || IsPlaceholder(AppRole))
+        {
+            throw new InvalidOperationException(
+                "MicrosoftEntra:AppRole is required (and must not be a placeholder) when " +
+                "MicrosoftEntra:AllowAppOnlyTokens=true. App-only tokens are authorized " +
+                "solely by the configured app role, so leaving it unset would grant access " +
+                "to any client-credentials caller.");
+        }
+
+        foreach (string entry in AllowedAppClientIds)
+        {
+            if (string.IsNullOrWhiteSpace(entry) || IsPlaceholder(entry))
+            {
+                throw new InvalidOperationException(
+                    "MicrosoftEntra:AllowedAppClientIds contains a blank or placeholder " +
+                    "entry. Every allow-list entry must be a real application (client) ID " +
+                    "so a typo cannot silently disable the restriction.");
+            }
+
+            if (!Guid.TryParse(entry, out _))
+            {
+                throw new InvalidOperationException(
+                    $"MicrosoftEntra:AllowedAppClientIds contains '{entry}', which is not a " +
+                    "valid GUID. Every entry must be an application (client) ID from the " +
+                    "Entra tenant so app-only requests can be matched against the token's " +
+                    "azp/appid claim.");
+            }
+        }
+    }
+
     /// <summary>Detects documentation placeholders such as "&lt;your-tenant-id&gt;".</summary>
     private static bool IsPlaceholder(string? value) =>
         !string.IsNullOrWhiteSpace(value) && (value.Contains('<') || value.Contains('>'));
@@ -168,5 +239,38 @@ public sealed class EntraAuthOptions
         return Uri.TryCreate(authority, UriKind.Absolute, out Uri? uri) && uri.Segments.Length >= 2
             ? uri.Segments[1].TrimEnd('/')
             : null;
+    }
+
+    /// <summary>
+    /// Reads the optional <c>MicrosoftEntra:AllowedAppClientIds</c> configuration array,
+    /// preserving raw values so <see cref="ValidateAppOnlyOptIn"/> can reject placeholders
+    /// and malformed GUIDs at startup. Blank entries are dropped so a trailing empty slot
+    /// in configuration is treated as absent (not as a validation failure).
+    /// </summary>
+    private static string[] ReadAllowedAppClientIds(IConfigurationSection entra)
+    {
+        IConfigurationSection section = entra.GetSection("AllowedAppClientIds");
+        if (!section.Exists())
+        {
+            return [];
+        }
+
+        List<string> entries = [];
+        foreach (IConfigurationSection child in section.GetChildren())
+        {
+            string? raw = child.Value;
+            if (raw is null)
+            {
+                continue;
+            }
+
+            string trimmed = raw.Trim();
+            if (trimmed.Length > 0)
+            {
+                entries.Add(trimmed);
+            }
+        }
+
+        return [.. entries];
     }
 }

--- a/tests/RetailPulse.Tests/Security/AppOnlyTokenAuthenticationTests.cs
+++ b/tests/RetailPulse.Tests/Security/AppOnlyTokenAuthenticationTests.cs
@@ -1,0 +1,415 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using RetailPulse.Api.Security;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// End-to-end HTTP contract tests for the app-only (client-credentials) token opt-in
+/// added by issue #163.
+///
+/// The behaviour under test is deliberately narrow — the same real
+/// <see cref="AuthenticationSetup"/> + <see cref="EntraAuthOptions"/> stack Production
+/// uses, wired up in an in-process <see cref="TestServer"/>, with a symmetric signing
+/// key so tests can mint tokens offline. Every assertion the security review card in
+/// #163 calls out is covered:
+/// <list type="bullet">
+///   <item>App-only token <b>rejected</b> when the feature is disabled (the default)
+///     — the most important test; proves an accidental token acceptance can only
+///     happen when someone deliberately opts in.</item>
+///   <item>App-only token <b>accepted</b> when enabled and the required app role is
+///     present, whether or not an allow-list is configured.</item>
+///   <item>App-only token <b>rejected</b> when enabled but the wrong role, no role,
+///     or a non-allow-listed <c>azp</c>/<c>appid</c> is presented.</item>
+///   <item>Delegated token behaviour <b>byte-for-byte unchanged</b> whether the flag
+///     is off (the default) or on — both success and the missing-scope/missing-role
+///     failure modes.</item>
+///   <item>Token carrying <b>neither</b> <c>scp</c> nor <c>roles</c> is rejected.</item>
+///   <item>Both SignalR hub surfaces still reject anonymous connections and negotiate
+///     requests exactly as they did before this opt-in existed.</item>
+/// </list>
+/// </summary>
+public sealed class AppOnlyTokenAuthenticationTests
+{
+    private const string TenantId = "11111111-1111-1111-1111-111111111111";
+    private const string ClientId = "33333333-3333-3333-3333-333333333333";
+    private const string MonitorAppId = "b8212317-e16d-4f06-996b-955e885ca1ca";
+    private const string OtherAppId = "44444444-4444-4444-4444-444444444444";
+    private const string AppRole = "RetailPulse.User";
+    private const string ApiScope = "access_as_user";
+    private const string Issuer = "https://login.microsoftonline.com/" + TenantId + "/v2.0";
+
+    private static readonly SymmetricSecurityKey SigningKey = new(
+        System.Text.Encoding.UTF8.GetBytes("retail-pulse-test-signing-key-0123456789ABCDEF"));
+
+    // ── App-only token REJECTED when the feature is off (the default) ─────────
+    //
+    // This is the single most important assertion in the whole file: an existing
+    // deployment that has not opted in must behave exactly as it does today and MUST
+    // return 403 for a service-principal token, even if that token carries the right
+    // app role. #163 explicitly names this as the top test.
+
+    [Fact]
+    public async Task AppOnlyToken_WhenFeatureDisabled_Returns403()
+    {
+        using TestFixture fx = CreateServer(allowAppOnly: false);
+        string token = CreateToken(Issuer, ClientId, AppOnlyClaims(MonitorAppId));
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "app-only acceptance is opt-in; the default policy must reject client-credentials tokens");
+    }
+
+    [Fact]
+    public async Task AppOnlyToken_WhenFeatureDisabled_IsRejectedOnHubs_ViaQueryToken()
+    {
+        using TestFixture fx = CreateServer(allowAppOnly: false);
+        string token = CreateToken(Issuer, ClientId, AppOnlyClaims(MonitorAppId));
+
+        HttpResponseMessage response = await fx.Client.GetAsync($"/hubs/telemetry?access_token={token}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "both hubs must reject app-only callers when the opt-in is off");
+    }
+
+    // ── App-only token ACCEPTED when enabled and role present ────────────────
+
+    [Fact]
+    public async Task AppOnlyToken_WhenFeatureEnabled_WithRequiredRole_Returns200()
+    {
+        using TestFixture fx = CreateServer(allowAppOnly: true);
+        string token = CreateToken(Issuer, ClientId, AppOnlyClaims(MonitorAppId));
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "an app-only token carrying the required app role must be accepted when the opt-in is on");
+    }
+
+    [Fact]
+    public async Task AppOnlyToken_WhenFeatureEnabled_WithRequiredRole_ConnectsToHub()
+    {
+        using TestFixture fx = CreateServer(allowAppOnly: true);
+        string token = CreateToken(Issuer, ClientId, AppOnlyClaims(MonitorAppId));
+
+        HttpResponseMessage response = await fx.Client.GetAsync($"/hubs/telemetry?access_token={token}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "a role-carrying app-only token must be accepted on both REST and hub surfaces when the opt-in is on");
+    }
+
+    // ── App-only token REJECTED when enabled but wrong role / no role ────────
+
+    [Fact]
+    public async Task AppOnlyToken_WhenFeatureEnabled_MissingRole_Returns403()
+    {
+        using TestFixture fx = CreateServer(allowAppOnly: true);
+        // No "roles" claim at all — a service-principal token with no application permission.
+        string token = CreateToken(Issuer, ClientId, [new Claim("azp", MonitorAppId)]);
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an app-only token without the required app role must be rejected even when the opt-in is on");
+    }
+
+    [Fact]
+    public async Task AppOnlyToken_WhenFeatureEnabled_WrongRole_Returns403()
+    {
+        using TestFixture fx = CreateServer(allowAppOnly: true);
+        string token = CreateToken(Issuer, ClientId,
+            [new Claim("roles", "Some.Other.Role"), new Claim("azp", MonitorAppId)]);
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an app-only token with an unrelated role must be rejected — no general scope-bypass");
+    }
+
+    // ── Delegated behaviour is BYTE-FOR-BYTE UNCHANGED in either configuration ─
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DelegatedToken_WithRoleAndScope_Returns200_InBothConfigurations(bool allowAppOnly)
+    {
+        using TestFixture fx = CreateServer(allowAppOnly);
+        string token = CreateToken(Issuer, ClientId,
+            [new Claim("roles", AppRole), new Claim("scp", ApiScope)]);
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "a valid delegated token must be accepted whether or not the app-only opt-in is on");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DelegatedToken_MissingScope_Returns403_InBothConfigurations(bool allowAppOnly)
+    {
+        using TestFixture fx = CreateServer(allowAppOnly);
+        // Delegated token (has scp="") but missing the required scope value.
+        string token = CreateToken(Issuer, ClientId,
+            [new Claim("roles", AppRole), new Claim("scp", "some.other.scope")]);
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "delegated tokens still require the exact configured API scope — behaviour unchanged");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DelegatedToken_MissingRole_Returns403_InBothConfigurations(bool allowAppOnly)
+    {
+        using TestFixture fx = CreateServer(allowAppOnly);
+        string token = CreateToken(Issuer, ClientId, [new Claim("scp", ApiScope)]);
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "delegated tokens still require the app role — behaviour unchanged");
+    }
+
+    // ── Token with neither scp nor roles → REJECTED ──────────────────────────
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TokenWithNeitherScpNorRoles_Returns403_InBothConfigurations(bool allowAppOnly)
+    {
+        using TestFixture fx = CreateServer(allowAppOnly);
+        // Signature/issuer/audience are all valid — but the token carries no authorization
+        // signal at all. It must be rejected regardless of the opt-in state.
+        string token = CreateToken(Issuer, ClientId, []);
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a signed token with no scp and no roles gives the policy nothing to authorize on — deny");
+    }
+
+    // ── Optional azp/appid allow-list ────────────────────────────────────────
+
+    [Fact]
+    public async Task AppOnlyToken_WhenAllowlistConfigured_MatchesAzp_Returns200()
+    {
+        using TestFixture fx = CreateServer(allowAppOnly: true, allowlist: [MonitorAppId]);
+        string token = CreateToken(Issuer, ClientId,
+            [new Claim("roles", AppRole), new Claim("azp", MonitorAppId)]);
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "an allow-listed azp must be accepted");
+    }
+
+    [Fact]
+    public async Task AppOnlyToken_WhenAllowlistConfigured_MatchesAppId_Returns200()
+    {
+        // v1 tokens use "appid" instead of "azp" — allow-list must match on either.
+        using TestFixture fx = CreateServer(allowAppOnly: true, allowlist: [MonitorAppId]);
+        string token = CreateToken(Issuer, ClientId,
+            [new Claim("roles", AppRole), new Claim("appid", MonitorAppId)]);
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "a v1-style appid must match the allow-list");
+    }
+
+    [Fact]
+    public async Task AppOnlyToken_WhenAllowlistConfigured_UnknownAzp_Returns403()
+    {
+        using TestFixture fx = CreateServer(allowAppOnly: true, allowlist: [MonitorAppId]);
+        string token = CreateToken(Issuer, ClientId,
+            [new Claim("roles", AppRole), new Claim("azp", OtherAppId)]);
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a non-allow-listed azp must be rejected even with the correct role");
+    }
+
+    [Fact]
+    public async Task AppOnlyToken_WhenAllowlistConfigured_NoAzpOrAppId_Returns403()
+    {
+        using TestFixture fx = CreateServer(allowAppOnly: true, allowlist: [MonitorAppId]);
+        // No azp, no appid — the allow-list has no claim to match against.
+        string token = CreateToken(Issuer, ClientId, [new Claim("roles", AppRole)]);
+
+        HttpResponseMessage response = await Post(fx, "/api/chat", token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an app-only token with no azp/appid cannot satisfy an allow-list");
+    }
+
+    // ── Hub anonymous surfaces stay closed on both configurations ────────────
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AnonymousHubNegotiate_Returns401_InBothConfigurations(bool allowAppOnly)
+    {
+        using TestFixture fx = CreateServer(allowAppOnly);
+
+        HttpResponseMessage telemetry = await fx.Client.PostAsync(
+            "/hubs/telemetry/negotiate", new StringContent(string.Empty));
+        HttpResponseMessage streaming = await fx.Client.PostAsync(
+            "/hubs/streaming/negotiate", new StringContent(string.Empty));
+
+        telemetry.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "anonymous hub negotiate must remain closed regardless of the app-only opt-in");
+        streaming.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "anonymous hub negotiate must remain closed regardless of the app-only opt-in");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static Claim[] AppOnlyClaims(string clientAppId) =>
+        [new Claim("roles", AppRole), new Claim("azp", clientAppId)];
+
+    private static async Task<HttpResponseMessage> Post(TestFixture fx, string path, string bearerToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, path);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+        return await fx.Client.SendAsync(request);
+    }
+
+    private static string CreateToken(string issuer, string audience, IEnumerable<Claim> claims)
+    {
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = issuer,
+            Audience = audience,
+            Subject = new ClaimsIdentity(claims),
+            NotBefore = DateTime.UtcNow.AddMinutes(-1),
+            Expires = DateTime.UtcNow.AddMinutes(30),
+            SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.HmacSha256),
+        };
+
+        var handler = new JsonWebTokenHandler { SetDefaultTimesOnTokenCreation = false };
+        return handler.CreateToken(descriptor);
+    }
+
+    private static TestFixture CreateServer(bool allowAppOnly, string[]? allowlist = null)
+    {
+        Dictionary<string, string?> settings = new()
+        {
+            ["Security:RequireAuth"] = "true",
+            ["MicrosoftEntra:Instance"] = "https://login.microsoftonline.com/",
+            ["MicrosoftEntra:TenantId"] = TenantId,
+            ["MicrosoftEntra:ClientId"] = ClientId,
+            ["MicrosoftEntra:ApiScope"] = ApiScope,
+            ["MicrosoftEntra:AppRole"] = AppRole,
+            ["MicrosoftEntra:AllowAppOnlyTokens"] = allowAppOnly ? "true" : "false",
+        };
+
+        if (allowlist is not null)
+        {
+            for (int i = 0; i < allowlist.Length; i++)
+            {
+                settings[$"MicrosoftEntra:AllowedAppClientIds:{i}"] = allowlist[i];
+            }
+        }
+
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        IHostBuilder builder = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices((context, services) =>
+                {
+                    services.AddRouting();
+
+                    // Force the production (non-Development) branch so the real JwtBearer
+                    // scheme is registered — HostBuilder defaults to Production.
+                    EntraAuthOptions options = services.AddRetailPulseAuthentication(
+                        config, context.HostingEnvironment);
+                    services.AddRetailPulseAuthorization(options);
+
+                    // Symmetric-key override so tests can validate self-signed tokens
+                    // offline while keeping issuer/audience/lifetime validation on.
+                    services.PostConfigure<JwtBearerOptions>(
+                        JwtBearerDefaults.AuthenticationScheme,
+                        jwt =>
+                        {
+                            jwt.Authority = null;
+                            jwt.MetadataAddress = null!;
+                            jwt.ConfigurationManager = null;
+                            jwt.RequireHttpsMetadata = false;
+                            jwt.TokenValidationParameters.IssuerSigningKey = SigningKey;
+                            jwt.TokenValidationParameters.ValidateIssuerSigningKey = true;
+                        });
+                });
+                webHost.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseAuthentication();
+                    app.UseAuthorization();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapPost("/api/chat", static () => Results.Ok(new { reply = "ok" }))
+                            .RequireAuthorization();
+
+                        // Both hub connection and negotiate endpoints for BOTH hubs, so
+                        // the tests can assert that neither hub is widened by this opt-in.
+                        endpoints.MapGet("/hubs/telemetry", static () => Results.Ok(new { hub = "telemetry" }))
+                            .RequireAuthorization();
+                        endpoints.MapPost("/hubs/telemetry/negotiate", static () => Results.Ok(new { negotiated = true }))
+                            .RequireAuthorization();
+                        endpoints.MapGet("/hubs/streaming", static () => Results.Ok(new { hub = "streaming" }))
+                            .RequireAuthorization();
+                        endpoints.MapPost("/hubs/streaming/negotiate", static () => Results.Ok(new { negotiated = true }))
+                            .RequireAuthorization();
+
+                        endpoints.MapGet("/health", static () => Results.Ok(new { status = "ok" })).AllowAnonymous();
+                        endpoints.MapGet("/alive", static () => Results.Ok(new { status = "alive" })).AllowAnonymous();
+                    });
+                });
+            });
+
+        IHost host = builder.Build();
+        host.Start();
+        return new TestFixture(host);
+    }
+
+    private sealed class TestFixture : IDisposable
+    {
+        private readonly IHost _host;
+
+        public TestFixture(IHost host)
+        {
+            _host = host;
+            Client = host.GetTestClient();
+        }
+
+        public HttpClient Client { get; }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            _host.StopAsync().GetAwaiter().GetResult();
+            _host.Dispose();
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Security/EntraAuthOptionsTests.cs
+++ b/tests/RetailPulse.Tests/Security/EntraAuthOptionsTests.cs
@@ -215,4 +215,135 @@ public sealed class EntraAuthOptionsTests
         // RequireAuthenticatedUser + RequireRole + a scope assertion → at least 3 requirements.
         policy.Requirements.Should().HaveCountGreaterThanOrEqualTo(3);
     }
+
+    // ── #163: app-only opt-in — configuration contract ────────────────────────
+
+    [Fact]
+    public void AllowAppOnlyTokens_DefaultsToFalse()
+    {
+        IConfiguration config = Config(
+            ("MicrosoftEntra:TenantId", TenantId),
+            ("MicrosoftEntra:ClientId", ClientId));
+
+        var options = EntraAuthOptions.FromConfiguration(config, Env("Production"));
+
+        options.AllowAppOnlyTokens.Should().BeFalse(
+            "unset MicrosoftEntra:AllowAppOnlyTokens must behave exactly as it did before the opt-in existed");
+        options.AllowedAppClientIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AllowAppOnlyTokens_WhenTrue_WithoutAllowlist_IsAccepted()
+    {
+        IConfiguration config = Config(
+            ("MicrosoftEntra:TenantId", TenantId),
+            ("MicrosoftEntra:ClientId", ClientId),
+            ("MicrosoftEntra:AllowAppOnlyTokens", "true"));
+
+        var options = EntraAuthOptions.FromConfiguration(config, Env("Production"));
+
+        options.AllowAppOnlyTokens.Should().BeTrue();
+        options.AllowedAppClientIds.Should().BeEmpty(
+            "the client-ID allow-list is optional — an empty list means no additional restriction");
+    }
+
+    [Fact]
+    public void AllowAppOnlyTokens_WithValidAllowlist_IsAccepted()
+    {
+        const string MonitorAppId = "b8212317-e16d-4f06-996b-955e885ca1ca";
+
+        IConfiguration config = Config(
+            ("MicrosoftEntra:TenantId", TenantId),
+            ("MicrosoftEntra:ClientId", ClientId),
+            ("MicrosoftEntra:AllowAppOnlyTokens", "true"),
+            ("MicrosoftEntra:AllowedAppClientIds:0", MonitorAppId));
+
+        var options = EntraAuthOptions.FromConfiguration(config, Env("Production"));
+
+        options.AllowAppOnlyTokens.Should().BeTrue();
+        options.AllowedAppClientIds.Should().ContainSingle().Which.Should().Be(MonitorAppId);
+    }
+
+    [Fact]
+    public void AllowAppOnlyTokens_WithPlaceholderInAllowlist_ThrowsAtStartup()
+    {
+        IConfiguration config = Config(
+            ("MicrosoftEntra:TenantId", TenantId),
+            ("MicrosoftEntra:ClientId", ClientId),
+            ("MicrosoftEntra:AllowAppOnlyTokens", "true"),
+            ("MicrosoftEntra:AllowedAppClientIds:0", "<your-monitor-client-id>"));
+
+        Action act = () => EntraAuthOptions.FromConfiguration(config, Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*AllowedAppClientIds*placeholder*");
+    }
+
+    [Fact]
+    public void AllowAppOnlyTokens_WithNonGuidInAllowlist_ThrowsAtStartup()
+    {
+        IConfiguration config = Config(
+            ("MicrosoftEntra:TenantId", TenantId),
+            ("MicrosoftEntra:ClientId", ClientId),
+            ("MicrosoftEntra:AllowAppOnlyTokens", "true"),
+            ("MicrosoftEntra:AllowedAppClientIds:0", "not-a-guid"));
+
+        Action act = () => EntraAuthOptions.FromConfiguration(config, Env("Production"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not a valid GUID*");
+    }
+
+    [Fact]
+    public void AllowAppOnlyTokens_WithPlaceholderAppRole_FallsBackToDefault()
+    {
+        // A placeholder AppRole is scrubbed by FromConfiguration and the default takes
+        // effect, so the opt-in validation is satisfied. This proves the option validation
+        // interacts correctly with the placeholder-cleaning rules — a copy-pasted
+        // documentation placeholder cannot silently pin the app role to "".
+        IConfiguration config = Config(
+            ("MicrosoftEntra:TenantId", TenantId),
+            ("MicrosoftEntra:ClientId", ClientId),
+            ("MicrosoftEntra:AllowAppOnlyTokens", "true"),
+            ("MicrosoftEntra:AppRole", "<your-app-role>"));
+
+        var options = EntraAuthOptions.FromConfiguration(config, Env("Production"));
+
+        options.AppRole.Should().Be(EntraAuthOptions.DefaultAppRole);
+    }
+
+    [Fact]
+    public void AllowAppOnlyTokens_WithExplicitlyEmptyAppRole_ThrowsAtStartup()
+    {
+        // Direct-object misuse: someone bypasses FromConfiguration and constructs the
+        // options with a blank AppRole. ValidateAppOnlyOptIn must still refuse to accept
+        // that shape — an app-only token would otherwise be authorized on role alone with
+        // an empty role name.
+        var options = new EntraAuthOptions
+        {
+            RequireAuth = true,
+            TenantId = TenantId,
+            ClientId = ClientId,
+            AllowAppOnlyTokens = true,
+            AppRole = "",
+        };
+
+        Action act = options.ValidateAppOnlyOptIn;
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*AppRole*");
+    }
+
+    [Fact]
+    public void AllowAppOnlyTokens_MisconfigurationFailsStartupEvenInDevelopment()
+    {
+        // Opt-in misconfig fails EVERYWHERE — Development included. Otherwise a dev-only
+        // typo would silently pass local build and then trip the deployed environment.
+        IConfiguration config = Config(
+            ("MicrosoftEntra:AllowAppOnlyTokens", "true"),
+            ("MicrosoftEntra:AllowedAppClientIds:0", "<placeholder>"));
+
+        Action act = () => EntraAuthOptions.FromConfiguration(config, Env("Development"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
 }


### PR DESCRIPTION
Closes #163.

## Summary

Adds an **opt-in, fail-closed** app-only (client-credentials) token acceptance path to the Entra authorization policy. The delegated (user) path is byte-for-byte unchanged in every configuration — a deployment that does not set the new flag behaves exactly as it does today and rejects app-only tokens with `403`.

This unblocks the synthetic monitor in #57 (its Entra identity is fully provisioned) without weakening the production security boundary.

## Security posture

Aligned with ADR-005 / epic #27 (**"Live production stays Entra only and fails closed"**, **"No silent downgrade"**):

- **Disabled by default.** `MicrosoftEntra:AllowAppOnlyTokens` defaults to `false`. Existing shipped Bicep is unchanged; existing deployments continue to reject every client-credentials token, matching pre-#163 behaviour.
- **Delegated path unchanged.** Enabling the flag does not touch the delegated (`scp`) branch. Role check and scope check are byte-for-byte identical whether the opt-in is on or off. Proven by `AppOnlyTokenAuthenticationTests.DelegatedToken_*_InBothConfigurations` tests running under `[Theory][InlineData(false)][InlineData(true)]`.
- **Narrow scope.** No general scope-bypass. The dual-mode assertion is a strict branch:
  - `scp` present → delegated → require `access_as_user` (existing `HasRequiredScope`).
  - `roles` present and no `scp` → app-only → require `AllowAppOnlyTokens=true` AND (if allow-list populated) matching `azp`/`appid`.
  - Neither → deny.
- Both SignalR hubs and every REST endpoint remain protected via the same `RequireRole(AppRole)` + assertion combination. The anonymous-session hardening is untouched.
- **Fail-closed startup validation.** `EntraAuthOptions.ValidateAppOnlyOptIn()` runs in every environment (Development included) whenever `AllowAppOnlyTokens=true`. It throws `InvalidOperationException` for:
  - Blank/placeholder `AppRole` on the resolved options.
  - Blank / placeholder-looking entry in `AllowedAppClientIds`.
  - Non-GUID entry in `AllowedAppClientIds`.
  No warning-and-continue, no fallback to a weaker policy.

## Exact configuration & default

| Key | Type | Default | Purpose |
|-----|------|---------|---------|
| `MicrosoftEntra:AllowAppOnlyTokens` | bool | **`false`** | Master opt-in. False = every app-only token → 403 (pre-#163 behaviour). True = app-only tokens bearing the required app role are accepted. |
| `MicrosoftEntra:AllowedAppClientIds` | string[] (config-array) | **empty** | Optional allow-list keyed on the token's `azp` (v2) / `appid` (v1) claim. Empty = no client-ID restriction (role is the gate). Populated = `azp`/`appid` must match one of the listed GUIDs. |

Env-var form: `MicrosoftEntra__AllowAppOnlyTokens`, `MicrosoftEntra__AllowedAppClientIds__0`, `MicrosoftEntra__AllowedAppClientIds__1`, …

Documented in `docs/security.md` §"App-only (client-credentials) tokens — opt-in, fail-closed" and `docs/authentication-matrix.md` §"App-only (client-credentials) tokens (Entra mode)".

## Client-ID / object-ID allow-list decision

**Decision: support an *optional* allow-list keyed on `azp` (v2) / `appid` (v1), with an empty list meaning "no client-ID restriction". Object-ID (`oid`) allow-listing was considered and deliberately not adopted.**

**Reasoning (evidence-based on Entra claim surface, per #163):**

- Entra emits `azp` on v2 tokens and `appid` on v1 tokens; both are the Microsoft-documented "authorized party" identifier — the client ID of the application that obtained the token. Matching on this claim maps directly to the identity a tenant admin registers and consents in Entra, so operators can reason about who is on the allow-list without decoding token internals.
- The service-principal object ID (`oid`) also uniquely identifies the caller within a tenant, but it is one indirection removed from the identity operators actually manage (the app registration). Using `azp`/`appid` keeps configuration and audit trails aligned with the Entra admin experience.
- Making the list optional preserves the single-tenant default (role assignment + admin consent is already tenant-admin-gated), while giving deployments defense-in-depth when they want it — critical because the `RetailPulse.User` app role now allows `Users/Groups,Applications` per #57 and any admin-consented app in the tenant could otherwise gain API access silently. Brian's preference for an optional allow-list is honoured by the evidence.
- Any allow-list entry that is not a valid GUID fails startup, so a typo can never silently disable the restriction. Comparison is GUID-normalized so case/format differences cannot bypass the check.

## Test evidence

All required tests from #163 are present and green.

**New — `tests/RetailPulse.Tests/Security/AppOnlyTokenAuthenticationTests.cs`** (in-process TestServer wiring the real `AuthenticationSetup` + `EntraAuthOptions` stack; symmetric signing key so tokens are minted offline):

1. `AppOnlyToken_WhenFeatureDisabled_Returns403` — **the most important test** per #163; default policy rejects app-only tokens.
2. `AppOnlyToken_WhenFeatureDisabled_IsRejectedOnHubs_ViaQueryToken` — both hubs stay closed to app-only when off.
3. `AppOnlyToken_WhenFeatureEnabled_WithRequiredRole_Returns200` — accepted with role when on.
4. `AppOnlyToken_WhenFeatureEnabled_WithRequiredRole_ConnectsToHub` — REST and hub surfaces both accept.
5. `AppOnlyToken_WhenFeatureEnabled_MissingRole_Returns403` — no roles claim → 403.
6. `AppOnlyToken_WhenFeatureEnabled_WrongRole_Returns403` — unrelated role → 403.
7. `DelegatedToken_WithRoleAndScope_Returns200_InBothConfigurations` — `[Theory]` over `AllowAppOnlyTokens=false|true`; delegated success unchanged.
8. `DelegatedToken_MissingScope_Returns403_InBothConfigurations` — `[Theory]` over `AllowAppOnlyTokens=false|true`; delegated missing-scope 403 unchanged.
9. `DelegatedToken_MissingRole_Returns403_InBothConfigurations` — `[Theory]` over `AllowAppOnlyTokens=false|true`; delegated missing-role 403 unchanged.
10. `TokenWithNeitherScpNorRoles_Returns403_InBothConfigurations` — `[Theory]`; deny in both configurations.
11. `AppOnlyToken_WhenAllowlistConfigured_MatchesAzp_Returns200` — v2 caller accepted.
12. `AppOnlyToken_WhenAllowlistConfigured_MatchesAppId_Returns200` — v1 caller accepted.
13. `AppOnlyToken_WhenAllowlistConfigured_UnknownAzp_Returns403` — non-listed caller rejected.
14. `AppOnlyToken_WhenAllowlistConfigured_NoAzpOrAppId_Returns403` — no claim to match → deny (fail closed).
15. `AnonymousHubNegotiate_Returns401_InBothConfigurations` — `[Theory]`; both hubs still reject anonymous negotiate.

**New — appended to `EntraAuthOptionsTests`** (pure-options misconfiguration contract):

- `AllowAppOnlyTokens_DefaultsToFalse`
- `AllowAppOnlyTokens_WhenTrue_WithoutAllowlist_IsAccepted`
- `AllowAppOnlyTokens_WithValidAllowlist_IsAccepted`
- `AllowAppOnlyTokens_WithPlaceholderInAllowlist_ThrowsAtStartup`
- `AllowAppOnlyTokens_WithNonGuidInAllowlist_ThrowsAtStartup`
- `AllowAppOnlyTokens_WithPlaceholderAppRole_FallsBackToDefault` — proves the placeholder-cleaning rule composes with the opt-in validation.
- `AllowAppOnlyTokens_WithExplicitlyEmptyAppRole_ThrowsAtStartup` — direct-construction defence-in-depth.
- `AllowAppOnlyTokens_MisconfigurationFailsStartupEvenInDevelopment` — opt-in misconfig fails Development too.

**Unchanged and still green:**

- `EndpointAuthorizationCoverageTests` (all four tests) — the deny-by-default fallback policy still has ≥3 requirements; the compiled endpoint graph still shows no unannotated `/api` or `/hubs` route; the anonymous surface still shrinks to bootstrap + `POST /api/chat` only.
- `EntraAuthenticationTests` — all delegated success/failure and hub-query-token cases unchanged.

**Local results** (`dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj`):

```
Passed!  - Failed:     0, Passed:  3424, Skipped:     9, Total:  3433, Duration: 1 m 27 s
```

**Whole-solution format**: `dotnet format RetailPulse.slnx --verify-no-changes` — clean.

The Auth Provider Matrix job in `.github/workflows/ci.yml` runs the same test project via `scripts/Test-BackendAuthMatrix.ps1` and inherits these new tests automatically; existing matrix rows are unchanged.

## Files changed

- `src/RetailPulse.Api/Security/EntraAuthOptions.cs` — `AllowAppOnlyTokens`, `AllowedAppClientIds`, `ValidateAppOnlyOptIn()`, config binding.
- `src/RetailPulse.Api/Security/AuthenticationSetup.cs` — `IsAuthorizedPrincipal` dual-mode assertion, `HasAllowedAppClientId` helper, xmldoc updates.
- `tests/RetailPulse.Tests/Security/AppOnlyTokenAuthenticationTests.cs` — new; 15 end-to-end HTTP tests.
- `tests/RetailPulse.Tests/Security/EntraAuthOptionsTests.cs` — appended 8 misconfiguration/contract tests.
- `docs/security.md` — new subsection under Authentication → Production with keys, defaults, startup validation, and the allow-list decision.
- `docs/authentication-matrix.md` — new subsection under "Runtime authorization matrix (Entra mode)" with the app-only rows.

## Not changed on purpose

- Shipped Bicep (`infra/modules/container-apps.bicep`) — the default remains disabled; production stays Entra-only as it does today.
- `AuthenticationMode` / provider-neutral selection — no new mode; this is a narrow extension inside the existing Entra path.
- Anonymous/GitHub modes — untouched.
- No `scripts/`, `docs/testing/`, `README.md`, or `.github/workflows/` changes (per the parallel session on #57).

## Risks

- If a deployment later enables `AllowAppOnlyTokens=true` without an allow-list, every service principal in the tenant admin-consented to `RetailPulse.User` will gain API access. Mitigation: the docs explicitly recommend the allow-list; the app-role assignment is already tenant-admin-gated; the allow-list is opt-in but the recommended path.
- App-only tokens do not carry a `scp`, so tools that assume every authenticated principal has an `scp` claim would need to check for the app-only case. Existing code paths already read `roles` for authorization; a targeted grep found no code that depends on `scp` being present. If a future endpoint needs to distinguish, the `IsAuthorizedPrincipal` helper documents the branching contract.
