### PR TITLE
fix(#168): probe the route APIM actually exposes so /health can report Healthy

### DIFF
--- a/infra/modules/apim-openai-api.bicep
+++ b/infra/modules/apim-openai-api.bicep
@@ -110,6 +110,26 @@ resource apiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-01-pre
   }
 }
 
+// The `listModels` readiness probe overrides the API-scope policy so the
+// AI-Gateway token policies — which are defined only for inference payloads —
+// never run against a token-free GET. See apim-openai-models-policy.xml.
+resource listModelsOperation 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' existing = {
+  parent: api
+  name: 'listModels'
+}
+
+resource listModelsPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2024-06-01-preview' = {
+  parent: listModelsOperation
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: replace(loadTextContent('apim-openai-models-policy.xml'), '{backend-id}', backend.name)
+  }
+  dependsOn: [
+    apiPolicy
+  ]
+}
+
 resource appInsightsLogger 'Microsoft.ApiManagement/service/loggers@2024-06-01-preview' existing = {
   parent: apim
   name: 'appinsights-logger'

--- a/infra/modules/apim-openai-models-policy.xml
+++ b/infra/modules/apim-openai-models-policy.xml
@@ -1,0 +1,31 @@
+<!--
+  Operation-scope policy for the `listModels` readiness probe.
+
+  This deliberately does NOT include <base /> in <inbound>. The API-scope policy
+  applies `azure-openai-token-limit` and `azure-openai-emit-token-metric`, both of
+  which are defined only for Azure OpenAI inference payloads - they parse a chat
+  request body to estimate and meter prompt tokens. A token-free GET has no such
+  body, so inheriting them would meter a non-inference call and risk a policy fault
+  on the one route that has to stay dependable when things are going wrong.
+
+  Everything the request genuinely needs is therefore re-declared explicitly:
+  the same backend, and the same managed-identity authentication to Azure AI
+  Foundry. The AI Gateway invariant is untouched - this operation is served by
+  APIM, routed to the APIM backend, and requires the API's subscription key. It
+  creates no path from the API to Azure OpenAI that bypasses the gateway.
+-->
+<policies>
+    <inbound>
+        <set-backend-service backend-id="{backend-id}" />
+        <authentication-managed-identity resource="https://cognitiveservices.azure.com" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/infra/modules/apim-openai-spec.json
+++ b/infra/modules/apim-openai-spec.json
@@ -15,6 +15,36 @@
     }
   ],
   "paths": {
+    "/models": {
+      "get": {
+        "operationId": "listModels",
+        "summary": "List Model Deployments",
+        "description": "Lists the model deployments available on the upstream Azure AI Foundry account. Exposed as a cheap, token-free readiness probe for the inference path — a 200 proves gateway routing, the APIM subscription key, APIM's managed-identity authentication to Azure AI Foundry, and upstream availability, without consuming any model tokens.",
+        "tags": [
+          "Operations"
+        ],
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "2025-03-01-preview"
+            },
+            "description": "The Azure OpenAI API version to use."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "401": {
+            "description": "Missing or invalid APIM subscription key"
+          }
+        }
+      }
+    },
     "/deployments/{deployment-id}/chat/completions": {
       "post": {
         "operationId": "createChatCompletion",

--- a/src/RetailPulse.Api/Health/AzureOpenAiHealthCheck.cs
+++ b/src/RetailPulse.Api/Health/AzureOpenAiHealthCheck.cs
@@ -4,11 +4,17 @@ using RetailPulse.Api.OpenAI;
 namespace RetailPulse.Api.Health;
 
 /// <summary>
-/// Health check that validates Azure OpenAI client connectivity by listing models.
-/// Uses the configured OpenAI endpoint to verify the service is reachable.
+/// Health check that validates Azure OpenAI inference connectivity by listing model
+/// deployments. Probes the same route shape the Azure OpenAI SDK uses, so a pass proves
+/// the whole configured inference path — DNS, TLS, the APIM subscription key, APIM's
+/// managed-identity authentication to Azure AI Foundry, and the upstream account —
+/// rather than merely that some host answered.
 /// </summary>
 public class AzureOpenAiHealthCheck : IHealthCheck
 {
+    /// <summary>Fallback api-version when <c>OpenAI:ApiVersion</c> is not configured.</summary>
+    internal const string FallbackApiVersion = "2025-03-01-preview";
+
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IConfiguration _configuration;
     private readonly ILogger<AzureOpenAiHealthCheck> _logger;
@@ -23,6 +29,41 @@ public class AzureOpenAiHealthCheck : IHealthCheck
         _logger = logger;
     }
 
+    /// <summary>
+    /// Builds the model-listing probe URL for a configured OpenAI endpoint.
+    ///
+    /// <para>
+    /// <c>OpenAI:Endpoint</c> is the inference base — for a gateway deployment
+    /// <c>https://{apim}.azure-api.net/inference</c>, for a direct account
+    /// <c>https://{account}.cognitiveservices.azure.com</c>. In both cases the Azure
+    /// OpenAI SDK appends its own <c>/openai/...</c> segment (see
+    /// <see cref="OpenAiConnectionSettings"/>, which rejects an endpoint that already
+    /// ends in <c>/openai</c> precisely because the SDK would double it). This probe
+    /// composes the URL the same way so it exercises the real registered route.
+    /// </para>
+    ///
+    /// <para>
+    /// Probing <c>{endpoint}/models</c> — without the <c>/openai</c> segment — is what
+    /// this check used to do, and it matched no APIM API at all: the inference API is
+    /// registered at path <c>{inference}/openai</c>, so every gateway deployment
+    /// reported a permanent <c>404</c> Degraded regardless of actual health.
+    /// </para>
+    /// </summary>
+    internal static string BuildModelsProbeUrl(string endpoint, string apiVersion)
+    {
+        string trimmed = endpoint.TrimEnd('/');
+
+        // Defensive: OpenAiConnectionSettings rejects an endpoint ending in "/openai"
+        // outside Development, but a Development override must not produce a doubled
+        // "/openai/openai" segment here either.
+        if (!trimmed.EndsWith("/openai", StringComparison.OrdinalIgnoreCase))
+        {
+            trimmed += "/openai";
+        }
+
+        return $"{trimmed}/models?api-version={Uri.EscapeDataString(apiVersion)}";
+    }
+
     public async Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context, CancellationToken cancellationToken = default)
     {
@@ -34,11 +75,16 @@ public class AzureOpenAiHealthCheck : IHealthCheck
                 return HealthCheckResult.Degraded("OpenAI endpoint is not configured.");
             }
 
+            string apiVersion = _configuration["OpenAI:ApiVersion"] is { Length: > 0 } configured
+                ? configured
+                : FallbackApiVersion;
+
             HttpClient client = _httpClientFactory.CreateClient();
             bool useManagedIdentity = _configuration.GetValue("OpenAI:UseManagedIdentity", false);
             string? apiKey = OpenAiConnectionSettings.ResolveConfiguredApiKey(_configuration);
 
-            using var request = new HttpRequestMessage(HttpMethod.Get, $"{endpoint}/models");
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get, BuildModelsProbeUrl(endpoint, apiVersion));
             if (!useManagedIdentity && !string.IsNullOrWhiteSpace(apiKey))
             {
                 request.Headers.Add(OpenAiConnectionSettings.ApimSubscriptionKeyHeaderName, apiKey);
@@ -56,6 +102,17 @@ public class AzureOpenAiHealthCheck : IHealthCheck
             {
                 return HealthCheckResult.Degraded(
                     $"Azure OpenAI returned {(int)response.StatusCode} — credentials may be invalid.");
+            }
+
+            // 404 means the host answered but no route matched. That is a configuration
+            // fault worth naming explicitly, because it is indistinguishable from a
+            // healthy gateway unless the operator knows which URL was probed.
+            if (response.StatusCode is System.Net.HttpStatusCode.NotFound)
+            {
+                _logger.LogWarning(
+                    "Azure OpenAI health check returned 404 — no route matched the model-listing probe. Check that OpenAI:Endpoint is the inference base (no trailing '/openai') and that the gateway exposes the model-listing operation.");
+                return HealthCheckResult.Degraded(
+                    "Azure OpenAI returned HTTP 404 — the model-listing route was not found. Check OpenAI:Endpoint and the gateway's exposed operations.");
             }
 
             _logger.LogWarning("Azure OpenAI health check returned {StatusCode}", response.StatusCode);

--- a/tests/RetailPulse.Tests/Observability/HealthCheckTests.cs
+++ b/tests/RetailPulse.Tests/Observability/HealthCheckTests.cs
@@ -158,6 +158,74 @@ public class HealthCheckTests
         request.Headers.Contains("api-key").Should().BeFalse();
     }
 
+    [Fact]
+    public async Task AzureOpenAiHealthCheck_ProbesGatewayModelsRoute_IncludingOpenAiSegmentAndApiVersion()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        DelegatingHandler handler = CreateCapturingHandler(HttpStatusCode.OK, request => capturedRequest = request);
+        Mock<IHttpClientFactory> factory = CreateRawFactory(handler);
+        IConfiguration config = CreateConfig(
+            endpoint: "https://test.azure-api.net/inference",
+            apiKey: null,
+            apimSubscriptionKey: "apim-sub-key",
+            useManagedIdentity: false,
+            apiVersion: "2025-03-01-preview");
+        var logger = new Mock<ILogger<AzureOpenAiHealthCheck>>();
+
+        var check = new AzureOpenAiHealthCheck(factory.Object, config, logger.Object);
+        await check.CheckHealthAsync(new HealthCheckContext());
+
+        HttpRequestMessage request = capturedRequest ?? throw new InvalidOperationException("Expected the health check to issue a request.");
+
+        // The APIM inference API is registered at path "{inference}/openai", so a probe
+        // of "{endpoint}/models" matches no API and 404s on every gateway deployment.
+        request.RequestUri!.AbsoluteUri.Should()
+            .Be("https://test.azure-api.net/inference/openai/models?api-version=2025-03-01-preview");
+    }
+
+    [Theory]
+    // Gateway base — the SDK's own "/openai" segment must be appended.
+    [InlineData("https://test.azure-api.net/inference", "https://test.azure-api.net/inference/openai/models?api-version=v1")]
+    // Trailing slash must not produce a doubled separator.
+    [InlineData("https://test.azure-api.net/inference/", "https://test.azure-api.net/inference/openai/models?api-version=v1")]
+    // Direct Azure OpenAI account (Development / AllowDirectEndpoint).
+    [InlineData("https://test.cognitiveservices.azure.com", "https://test.cognitiveservices.azure.com/openai/models?api-version=v1")]
+    // Defensive: an endpoint that already carries "/openai" must not be doubled.
+    [InlineData("https://test.azure-api.net/inference/openai", "https://test.azure-api.net/inference/openai/models?api-version=v1")]
+    public void BuildModelsProbeUrl_ComposesTheSdkRouteShape(string endpoint, string expected) =>
+        AzureOpenAiHealthCheck.BuildModelsProbeUrl(endpoint, "v1").Should().Be(expected);
+
+    [Fact]
+    public async Task AzureOpenAiHealthCheck_ReturnsDegradedNamingTheRoute_WhenProbeReturns404()
+    {
+        DelegatingHandler handler = CreateMockHandler(HttpStatusCode.NotFound);
+        Mock<IHttpClientFactory> factory = CreateRawFactory(handler);
+        IConfiguration config = CreateConfig("https://test.azure-api.net/inference", "key");
+        var logger = new Mock<ILogger<AzureOpenAiHealthCheck>>();
+
+        var check = new AzureOpenAiHealthCheck(factory.Object, config, logger.Object);
+        HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Description.Should().Contain("404").And.Contain("model-listing route");
+    }
+
+    [Fact]
+    public async Task AzureOpenAiHealthCheck_FallsBackToADefaultApiVersion_WhenNotConfigured()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        DelegatingHandler handler = CreateCapturingHandler(HttpStatusCode.OK, request => capturedRequest = request);
+        Mock<IHttpClientFactory> factory = CreateRawFactory(handler);
+        IConfiguration config = CreateConfig("https://test.azure-api.net/inference", "key");
+        var logger = new Mock<ILogger<AzureOpenAiHealthCheck>>();
+
+        var check = new AzureOpenAiHealthCheck(factory.Object, config, logger.Object);
+        await check.CheckHealthAsync(new HealthCheckContext());
+
+        HttpRequestMessage request = capturedRequest ?? throw new InvalidOperationException("Expected the health check to issue a request.");
+        request.RequestUri!.Query.Should().StartWith("?api-version=").And.NotBe("?api-version=");
+    }
+
     #endregion
 
     #region Helpers
@@ -211,13 +279,15 @@ public class HealthCheckTests
         string? endpoint,
         string? apiKey,
         string? apimSubscriptionKey = null,
-        bool? useManagedIdentity = null)
+        bool? useManagedIdentity = null,
+        string? apiVersion = null)
     {
         var configData = new Dictionary<string, string?>();
         if (endpoint != null) configData["OpenAI:Endpoint"] = endpoint;
         if (apiKey != null) configData["OpenAI:ApiKey"] = apiKey;
         if (apimSubscriptionKey != null) configData["OpenAI:ApimSubscriptionKey"] = apimSubscriptionKey;
         if (useManagedIdentity.HasValue) configData["OpenAI:UseManagedIdentity"] = useManagedIdentity.Value.ToString();
+        if (apiVersion != null) configData["OpenAI:ApiVersion"] = apiVersion;
 
         return new ConfigurationBuilder()
             .AddInMemoryCollection(configData)


### PR DESCRIPTION
Closes #168. Found while verifying the deployed stack for the #59 G4 sweep.

## The bug

The deployed API has been reporting `Degraded` on `/health` continuously:

```
Azure OpenAI health check returned NotFound
Health check azure-openai with status Degraded ... 'Azure OpenAI returned HTTP 404.'
```

`AzureOpenAiHealthCheck` probed `{OpenAI:Endpoint}/models`. `OpenAI:Endpoint` is deliberately the inference **base** with no trailing `/openai` — the SDK appends its own `/openai/deployments/...`, and `OpenAiConnectionSettings` rejects a pre-suffixed endpoint to prevent the doubled-segment regression from incident #55.

But the APIM inference API is registered at path `inference/openai`. So `.../inference/models` matched **no API at all** → 404. The probe could never succeed on an APIM-routed deployment, i.e. every non-Development deployment under G1.

Net effect: `/health` could not distinguish a healthy stack from a broken one. A real Azure OpenAI outage would have looked identical to the steady state.

## The fix

| Area | Change |
|---|---|
| `AzureOpenAiHealthCheck` | `BuildModelsProbeUrl` composes `{endpoint}/openai/models?api-version=...` the same way the SDK composes calls — idempotent if already suffixed, tolerates a trailing slash |
| `AzureOpenAiHealthCheck` | api-version from `OpenAI:ApiVersion` with a fallback, so an unset value can't emit an empty query param |
| `AzureOpenAiHealthCheck` | 404 gets a distinct description naming the route, so this is self-diagnosing next time |
| `apim-openai-spec.json` | New `GET /models` (`listModels`) — a token-free readiness route |
| `apim-openai-models-policy.xml` | Operation-scope policy: re-declares backend + managed identity, deliberately **omits** `<base />` so the chat-only `azure-openai-token-limit` / `azure-openai-emit-token-metric` policies don't meter a body-less GET |

A 200 from the new route now proves gateway routing, the APIM subscription key, APIM→Foundry managed identity, and upstream availability — a genuine readiness signal rather than a formality.

## G1 is unaffected

The new operation is served by APIM, routed to the APIM backend, and requires the API's subscription key. No direct API→AOAI path is introduced.

## Verification

- Backend suite: **3431 passed, 0 failed**, 9 skipped
- `dotnet format --verify-no-changes` → clean
- `az bicep build --file infra/main.bicep` → compiles
- New tests pin the composed URL for gateway base, trailing slash, direct account, and already-suffixed endpoints, plus the 404 description and api-version fallback

Live `/health` will be re-verified against the deployed stack after provisioning this change.