### PR TITLE
fix(#170): carry charts and routing through the response cache

### DIFF
--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -201,8 +201,14 @@ public static class ChatEndpoints
                             cached.Response,
                             sessionId,
                             [new AgentSpan("cache.hit", "cache", $"Served from cache (agent: {cached.AgentId})", 0, DateTimeOffset.UtcNow, sessionId)],
+                            // Replay the charts and routing captured with this entry so a
+                            // cached answer is indistinguishable from a fresh one apart from
+                            // cost and latency (issue #170). Copy the list so a caller cannot
+                            // mutate the cached instance through the returned response.
+                            cached.Charts is { Count: > 0 } cachedCharts ? [.. cachedCharts] : null,
+                            0,
                             null,
-                            0));
+                            cached.Routing));
                     }
                 }
 
@@ -905,7 +911,16 @@ public static class ChatEndpoints
                 {
                     string cacheKey = CacheHelpers.BuildCacheKey("pre-route", request.Message);
                     await responseCache.SetAsync(cacheKey,
-                        new CachedResponse(response.Reply, specialist.Key, DateTime.UtcNow, cacheKey),
+                        new CachedResponse(
+                            response.Reply,
+                            specialist.Key,
+                            DateTime.UtcNow,
+                            cacheKey,
+                            // Charts and routing travel with the reply so a hit replays the
+                            // whole answer (issue #170). Copy the list — the cache must not
+                            // alias a collection the pipeline may still mutate.
+                            response.Charts is { Count: > 0 } c ? [.. c] : null,
+                            response.Routing),
                         TimeSpan.FromMinutes(5), ct);
                 }
 

--- a/src/RetailPulse.Contracts/Caching/IResponseCache.cs
+++ b/src/RetailPulse.Contracts/Caching/IResponseCache.cs
@@ -30,8 +30,23 @@ public interface IResponseCache
 
 /// <summary>
 /// A cached agent response with metadata for staleness tracking.
+///
+/// <para>
+/// <paramref name="Charts"/> and <paramref name="Routing"/> are carried so a cache hit
+/// can replay the FULL response, not just its prose. Storing the reply alone made a
+/// repeated chart question silently lose its visualization inside the TTL (issue #170)
+/// — the same user-visible failure as #50/#55, reached through repetition rather than
+/// routing. Both fields are optional and trailing, so existing positional construction
+/// is unaffected and a non-chart response simply leaves them null.
+/// </para>
 /// </summary>
-public record CachedResponse(string Response, string AgentId, DateTime CachedAt, string QueryHash);
+public record CachedResponse(
+    string Response,
+    string AgentId,
+    DateTime CachedAt,
+    string QueryHash,
+    List<ChartSpec>? Charts = null,
+    RoutingInfo? Routing = null);
 
 /// <summary>
 /// Snapshot of cache health metrics.

--- a/tests/RetailPulse.Tests/Integration/ChatPipelineIntegrationTests.cs
+++ b/tests/RetailPulse.Tests/Integration/ChatPipelineIntegrationTests.cs
@@ -99,6 +99,98 @@ public class ChatPipelineIntegrationTests
     }
 
     [Fact]
+    public async Task CacheHit_ReplaysChartsAndRouting_SoARepeatedChartQuestionKeepsItsChart()
+    {
+        // Issue #170: the cache used to store only the reply string, so the second
+        // identical chart question inside the TTL came back as prose with no chart,
+        // no routing, and no tool spans — the #50/#55 "chart vanished" failure
+        // reached through repetition instead of routing.
+        var harness = new PipelineHarness();
+        harness.WhenRouterClassifies(AgentIntent.General, confidence: 0.9);
+        harness.WhenAgentReplies("LIVE AGENT RESPONSE — should not appear");
+
+        const string query = "Show a horizontal bar chart ranking all brands by depletion growth rate";
+        string cacheKey = CacheHelpers.BuildCacheKey("pre-route", query);
+
+        var chart = new ChartSpec
+        {
+            Type = "horizontalBar",
+            Title = "Depletion growth by brand",
+            Data =
+            [
+                new ChartSeries
+                {
+                    Legend = "YoY growth",
+                    Values =
+                    [
+                        new ChartDataPoint { X = "BrandA", Y = 12 },
+                        new ChartDataPoint { X = "BrandB", Y = 8 },
+                        new ChartDataPoint { X = "BrandC", Y = 5 },
+                        new ChartDataPoint { X = "BrandD", Y = 3 },
+                        new ChartDataPoint { X = "BrandE", Y = 1 },
+                        new ChartDataPoint { X = "BrandF", Y = -2 },
+                    ],
+                },
+            ],
+        };
+        var routing = new RoutingInfo("demand", "Demand Forecasting", AgentIntent.DemandForecasting, 0.92, 1234);
+
+        await harness.Cache.SetAsync(cacheKey,
+            new CachedResponse("Cached ranking prose.", "demand", DateTime.UtcNow, cacheKey, [chart], routing),
+            TimeSpan.FromMinutes(5));
+
+        ChatResponse response = await harness.RunPipelineAsync(
+            new ChatRequest(query, SessionId: "cache-hit-chart"));
+
+        harness.AgentWasInvoked.Should().BeFalse("the cache hit must still short-circuit execution");
+        response.Reply.Should().Be("Cached ranking prose.");
+
+        response.Charts.Should().NotBeNull("a cached chart answer must replay its chart");
+        response.Charts.Should().ContainSingle();
+        response.Charts[0].Type.Should().Be("horizontalBar");
+        response.Charts[0].Data.Sum(s => s.Values.Count).Should().BeGreaterThanOrEqualTo(6, "the G3 mark floor must survive a cache hit");
+
+        response.Routing.Should().NotBeNull("routing metadata must survive a cache hit");
+        response.Routing.Intent.Should().Be(AgentIntent.DemandForecasting);
+    }
+
+    [Fact]
+    public async Task CacheRoundTrip_PreservesCharts_SoBackToBackIdenticalRequestsMatch()
+    {
+        // The write-back path and the read path must agree: whatever a fresh run
+        // returns, the cached replay of that same question must return too.
+        var harness = new PipelineHarness();
+        harness.WhenRouterClassifies(AgentIntent.DemandForecasting, confidence: 0.9);
+
+        var chart = new ChartSpec
+        {
+            Type = "groupedBar",
+            Title = "Two-brand comparison",
+            Data =
+            [
+                new ChartSeries { Legend = "BrandA", Values = [new ChartDataPoint { X = "Northeast", Y = 10 }, new ChartDataPoint { X = "Midwest", Y = 12 }] },
+                new ChartSeries { Legend = "BrandB", Values = [new ChartDataPoint { X = "Northeast", Y = 8 }, new ChartDataPoint { X = "Midwest", Y = 9 }] },
+            ],
+        };
+        harness.WhenAgentRepliesWithCharts("Here is the comparison.", [chart]);
+
+        const string query = "Compare two brands across all regions";
+
+        ChatResponse first = await harness.RunPipelineAsync(new ChatRequest(query, SessionId: "s1"));
+        first.Charts.Should().NotBeNull();
+        first.Charts.Should().ContainSingle();
+
+        ChatResponse second = await harness.RunPipelineAsync(new ChatRequest(query, SessionId: "s2"));
+
+        second.Spans.Should().Contain(s => s.Type == "cache", "the second identical request must be served from cache");
+        second.Charts.Should().NotBeNull("the cached replay must carry the same chart");
+        second.Charts.Should().ContainSingle();
+        second.Charts[0].Type.Should().Be(first.Charts[0].Type);
+        second.Charts[0].Data.Sum(s => s.Values.Count)
+            .Should().Be(first.Charts[0].Data.Sum(s => s.Values.Count));
+    }
+
+    [Fact]
     public async Task CacheMiss_FallsThroughToFullPipeline()
     {
         var harness = new PipelineHarness();
@@ -267,6 +359,7 @@ public class ChatPipelineIntegrationTests
         private readonly List<ISpecialistAgent> _specialists = [];
         private readonly Mock<IAgentRouter> _routerMock = new();
         private string _cannedReply = "default reply";
+        private List<ChartSpec>? _cannedCharts;
         private readonly Dictionary<string, Func<ChatRequest, CancellationToken, Task<ChatResponse>>> _agentHandlers = [];
 
         public PipelineHarness()
@@ -297,7 +390,7 @@ public class ChatPipelineIntegrationTests
                             new AgentSpan($"agent.{key}.thought", "thought", "Thinking", 5, DateTimeOffset.UtcNow, req.SessionId),
                             new AgentSpan($"agent.{key}.response", "response", "Done", 12, DateTimeOffset.UtcNow, req.SessionId)
                         ],
-                        Charts: null,
+                        Charts: _cannedCharts is { Count: > 0 } cc ? [.. cc] : null,
                         TotalDurationMs: 17));
                 });
 
@@ -326,6 +419,12 @@ public class ChatPipelineIntegrationTests
         }
 
         public void WhenAgentReplies(string reply) => _cannedReply = reply;
+
+        public void WhenAgentRepliesWithCharts(string reply, List<ChartSpec> charts)
+        {
+            _cannedReply = reply;
+            _cannedCharts = charts;
+        }
 
         public void ResetCallTracking()
         {
@@ -365,7 +464,10 @@ public class ChatPipelineIntegrationTests
                         cached.Response,
                         sessionId,
                         [new AgentSpan("cache.hit", "cache", $"Served from cache (agent: {cached.AgentId})", 0, DateTimeOffset.UtcNow, sessionId)],
-                        null, 0);
+                        cached.Charts is { Count: > 0 } cachedCharts ? [.. cachedCharts] : null,
+                        0,
+                        null,
+                        cached.Routing);
                 }
             }
 
@@ -402,7 +504,13 @@ public class ChatPipelineIntegrationTests
             {
                 string cacheKey = CacheHelpers.BuildCacheKey("pre-route", request.Message);
                 await Cache.SetAsync(cacheKey,
-                    new CachedResponse(response.Reply, specialist.Key, DateTime.UtcNow, cacheKey),
+                    new CachedResponse(
+                        response.Reply,
+                        specialist.Key,
+                        DateTime.UtcNow,
+                        cacheKey,
+                        response.Charts is { Count: > 0 } c ? [.. c] : null,
+                        response.Routing),
                     TimeSpan.FromMinutes(5), ct);
             }
 


### PR DESCRIPTION
Closes #170. Found during the first live G4 acceptance sweep for #59.

## The bug

Ask a chart question twice inside the 5-minute cache TTL. First answer: chart. Second answer: prose only — **no chart, no routing, no tool spans**.

11 of 26 curated prompts failed the live sweep purely because an earlier identical request had warmed the cache. The same prompts pass cold. Deterministic, not flaky.

```
[ 8/26] FAIL  qsr  Compare Coastline Tacos vs Apex Grill depletions across all regions
          -> no routing metadata; no tool_call span; expected chart 'groupedBar', saw '[]'
```

`CachedResponse` stored only the reply string, so the hit path could only rebuild:

```csharp
new ChatResponse(cached.Response, sessionId, [cache.hit span],
                 null,   // Charts — always null
                 0)      // Routing — left null
```

This is the #50/#55 "chart vanished" failure mode reached through **repetition** rather than routing.

## The fix

| Area | Change |
|---|---|
| `CachedResponse` | Optional trailing `Charts` + `Routing`; existing positional construction unaffected |
| Write-back | Stores charts and routing with the reply; copies the list so the cache never aliases a collection the pipeline may still mutate |
| Hit path | Replays both, copying again on the way out so callers can't mutate the cached instance |
| Integration harness | Mirrored the endpoint's cache read/write, so it was updated in step — otherwise it would keep asserting the old lossy shape |

Replaying a chart is exactly as valid as replaying the prose it accompanies — both come from the same tool payload inside the same TTL. Caching the prose while discarding the chart was the inconsistency.

## Tests

- `CacheHit_ReplaysChartsAndRouting_SoARepeatedChartQuestionKeepsItsChart` — pins chart type, the **G3 six-mark floor**, and routing survival across a hit
- `CacheRoundTrip_PreservesCharts_SoBackToBackIdenticalRequestsMatch` — drives a real write-back and proves back-to-back identical requests return matching charts

## Verification

- Backend suite: **3433 passed, 0 failed**, 9 skipped (run twice — stable)
- `dotnet format --verify-no-changes` → clean

Live re-verification against the deployed stack follows once this is deployed; the sweep should then be repeatable back-to-back with identical results.
