### PR TITLE
fix(#174): remove the clock race from the session-cleanup retention test

### DIFF
--- a/tests/RetailPulse.Tests/Persistence/SessionCleanupBackgroundServiceTests.cs
+++ b/tests/RetailPulse.Tests/Persistence/SessionCleanupBackgroundServiceTests.cs
@@ -21,9 +21,14 @@ public sealed class SessionCleanupBackgroundServiceTests
     public async Task PurgesExpiredSessions_OnClockTick_AndLogsRowCounts()
     {
         var store = new Mock<ISessionStore>(MockBehavior.Strict);
-        DateTimeOffset? seenCutoff = null;
+        // Record EVERY cutoff, not just the first. The service sweeps once
+        // immediately on start and again on each timer tick, so capturing only the
+        // first observation raced the clock: whichever of the two sweeps happened to
+        // land first decided the assertion. Recording all of them lets the test pin
+        // each sweep to its own point on the injected clock.
+        var seenCutoffs = new System.Collections.Concurrent.ConcurrentQueue<DateTimeOffset>();
         store.Setup(s => s.PurgeExpiredAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
-            .Callback<DateTimeOffset, CancellationToken>((cutoff, _) => seenCutoff ??= cutoff)
+            .Callback<DateTimeOffset, CancellationToken>((cutoff, _) => seenCutoffs.Enqueue(cutoff))
             .ReturnsAsync(new CleanupResult(SessionsDeleted: 3, TurnsDeleted: 12));
 
         IOptions<SessionPersistenceOptions> options = Options.Create(new SessionPersistenceOptions
@@ -42,17 +47,28 @@ public sealed class SessionCleanupBackgroundServiceTests
         using var cts = new CancellationTokenSource();
         Task loop = svc.StartAsync(cts.Token);
 
-        // One tick of the CleanupInterval → PeriodicTimer fires → PurgeExpiredAsync runs.
+        // The service sweeps immediately on start, before waiting on the timer. Let
+        // that first sweep settle BEFORE advancing the clock, so the tick-driven
+        // sweep is unambiguously the second observation.
+        bool startupSwept = await WaitUntilAsync(() => seenCutoffs.Count >= 1, TimeSpan.FromSeconds(5));
+        startupSwept.Should().BeTrue("the service must sweep once on start, before the first interval elapses");
+
+        seenCutoffs.TryPeek(out DateTimeOffset startupCutoff).Should().BeTrue();
+        startupCutoff.Should().Be(now - options.Value.RetentionTtl,
+            "the startup sweep's cutoff must be (injected-now - RetentionTtl)");
+
+        // One tick of the CleanupInterval → PeriodicTimer fires → a second sweep runs.
         // Poll rather than sleep so the test doesn't race the timer's own scheduling.
         clock.Advance(options.Value.CleanupInterval);
-        bool purged = await WaitUntilAsync(() => seenCutoff.HasValue, TimeSpan.FromSeconds(5));
-        purged.Should().BeTrue("the first tick after CleanupInterval must trigger a purge sweep");
+        bool purged = await WaitUntilAsync(() => seenCutoffs.Count >= 2, TimeSpan.FromSeconds(5));
+        purged.Should().BeTrue("the first tick after CleanupInterval must trigger another purge sweep");
 
-        // The sweep reads GetUtcNow() at tick time, which is now start + CleanupInterval.
+        // The tick sweep reads GetUtcNow() at tick time, which is now + CleanupInterval.
         // The cutoff must therefore reflect the injected clock at THAT moment, not the
         // wall clock — the whole point of the TimeProvider abstraction.
         DateTimeOffset expectedCutoff = now + options.Value.CleanupInterval - options.Value.RetentionTtl;
-        seenCutoff.Should().Be(expectedCutoff,
+        DateTimeOffset[] cutoffs = [.. seenCutoffs];
+        cutoffs[1].Should().Be(expectedCutoff,
             "the cutoff must be exactly (injected-now - RetentionTtl) so the injected clock — not the wall clock — drives retention");
 
         bool logged = await WaitUntilAsync(() => logger.InformationCount >= 2, TimeSpan.FromSeconds(5));


### PR DESCRIPTION
Closes #174. Surfaced by blocking an unrelated docs/script PR (#173).

## Root cause

`SessionCleanupBackgroundService.ExecuteAsync` is a `do { sweep } while (await timer.WaitForNextTickAsync(...))`, so it sweeps **immediately on start** and **again on each tick**:

| Sweep | Cutoff |
|---|---|
| startup | `now - RetentionTtl` -> `12:00` |
| first tick | `now + CleanupInterval - RetentionTtl` -> `12:15` |

The test captured only the first observation (`seenCutoff ??= cutoff`) and advanced the clock immediately after `StartAsync`. Which sweep it saw depended on whether the startup sweep finished before the advance landed - a pure race. The assertion only described the tick sweep, so the startup sweep winning produced a false failure.

Same class as #152/#154/#156/#158; missed in that sweep.

## Fix

Record every cutoff rather than just the first, and pin both sweeps:

1. Wait for the startup sweep, assert cutoff is `now - RetentionTtl`
2. **Then** advance the clock, wait for the second sweep, assert cutoff is `now + CleanupInterval - RetentionTtl`

Removes the ordering ambiguity and strengthens the test - the immediate startup sweep was previously unasserted behaviour the race was quietly relying on.

**No production code changed** - the service was behaving correctly.

## Verification

Test class run **8 consecutive times, all green**.