### PR TITLE
fix(#172): draw curated charts from tool data instead of trusting the model

### DIFF
--- a/scripts/Invoke-SyntheticChatMonitor.ps1
+++ b/scripts/Invoke-SyntheticChatMonitor.ps1
@@ -116,7 +116,11 @@ param(
     [string]$TenantId,
     [string]$ClientId,
     [object[]]$Prompts,
-    [int]$TimeoutSec = 60,
+    # The API's own single-shot ceiling for /api/chat is 90s (ChatTimeoutOptions).
+    # A 60s client timeout sat below that, so a legitimately slow-but-successful
+    # turn was reported as a transport failure rather than being allowed to
+    # complete. Give the server room to hit its own ceiling first, plus margin.
+    [int]$TimeoutSec = 120,
     [switch]$SelfTest
 )
 
@@ -272,12 +276,15 @@ function Test-ChatResponseContract {
         return @{ Ok = $false; Detail = 'response body was null / could not be parsed as JSON'; CorrelationId = '' }
     }
     $text = $null
-    if ($Body.PSObject.Properties['text']) { $text = $Body.text }
+    # ChatResponse.Reply — serialised as `reply`. An earlier revision read `text`,
+    # which no version of the API has ever emitted; because the self-test builds its
+    # own payloads it stayed self-consistently wrong until the first live run.
+    if ($Body.PSObject.Properties['reply']) { $text = $Body.reply }
     if ([string]::IsNullOrWhiteSpace($text)) {
-        return @{ Ok = $false; Detail = 'response body has no non-empty `text` assistant payload'; CorrelationId = '' }
+        return @{ Ok = $false; Detail = 'response body has no non-empty `reply` assistant payload'; CorrelationId = '' }
     }
     $charts = $null
-    if ($Body.PSObject.Properties['charts']) { $charts = @($Body.charts) }
+    if ($Body.PSObject.Properties['charts']) { $charts = @($Body.charts | Where-Object { $null -ne $_ }) }
     if (-not $charts -or $charts.Count -eq 0) {
         return @{ Ok = $false; Detail = 'response body has no `charts[]` entries'; CorrelationId = '' }
     }
@@ -291,16 +298,17 @@ function Test-ChatResponseContract {
     }
     $marks = 0
     if ($expected.PSObject.Properties['data'] -and $expected.data) {
-        # Chart data is a set of series each with data points. Count the sum
-        # of data-point counts across series ("marks" in the acceptance
-        # contract) with a graceful fallback for either a flat shape or a
-        # per-series shape.
+        # ChartSpec.Data is a list of ChartSeries, each with a `values` list of
+        # {x,y} datapoints — `charts[].data[].values[]`. "Marks" is the total
+        # datapoint count across series. An earlier revision walked
+        # `data[].data[]`, which does not exist on the wire, so every series
+        # silently counted as a single mark.
         $data = $expected.data
         if ($data -is [System.Collections.IEnumerable] -and -not ($data -is [string])) {
             foreach ($series in $data) {
                 if ($null -eq $series) { continue }
-                if ($series.PSObject.Properties['data'] -and $series.data -is [System.Collections.IEnumerable]) {
-                    $marks += @($series.data).Count
+                if ($series.PSObject.Properties['values'] -and $series.values -is [System.Collections.IEnumerable]) {
+                    $marks += @($series.values | Where-Object { $null -ne $_ }).Count
                 }
                 else {
                     $marks += 1
@@ -328,6 +336,16 @@ function Test-ChatResponseContract {
 }
 
 # ── live-run driver ────────────────────────────────────────────────────────
+# Redact an identifier down to its last four characters for log output. Tenant
+# and client ids are non-secret configuration, but there is no reason to print
+# them in full.
+function Get-IdTail {
+    param([AllowNull()][string]$Value)
+    if ([string]::IsNullOrEmpty($Value)) { return '' }
+    if ($Value.Length -gt 4) { return $Value.Substring($Value.Length - 4) }
+    return $Value
+}
+
 function Invoke-Live {
     param(
         [Parameter(Mandatory)][hashtable]$Config,
@@ -335,11 +353,14 @@ function Invoke-Live {
         [Parameter(Mandatory)][int]$TimeoutSec
     )
 
+    # PowerShell has no `if` expression, so an inline `(if (...) {...} else {...})`
+    # inside a -f argument is a parse-time-valid but run-time fatal construct: it
+    # only fails when the live path actually executes. Use a helper instead.
     Write-Host "Optional authenticated synthetic monitor (issue #57)"
     Write-Host ("  apiOrigin   = {0}" -f $Config.ApiOrigin)
     Write-Host ("  apiResource = {0}" -f $Config.ApiResource)
-    Write-Host ("  tenantId    = ****{0}" -f (if ($Config.TenantId.Length -gt 4) { $Config.TenantId.Substring($Config.TenantId.Length - 4) } else { $Config.TenantId }))
-    Write-Host ("  clientId    = ****{0}" -f (if ($Config.ClientId.Length -gt 4) { $Config.ClientId.Substring($Config.ClientId.Length - 4) } else { $Config.ClientId }))
+    Write-Host ("  tenantId    = ****{0}" -f (Get-IdTail $Config.TenantId))
+    Write-Host ("  clientId    = ****{0}" -f (Get-IdTail $Config.ClientId))
     Write-Host ("  prompts     = {0}" -f $Prompts.Count)
     Write-Host ""
 
@@ -349,7 +370,7 @@ function Invoke-Live {
         exit 0
     }
 
-    Write-Host "Acquiring API access token via federation (`az account get-access-token`) ..."
+    Write-Host "Acquiring API access token via federation ('az account get-access-token') ..."
     $tok = Get-ApiAccessToken -Resource $Config.ApiResource -TenantId $Config.TenantId
     if (-not $tok.Ok) {
         Write-Skip $tok.Reason
@@ -370,7 +391,7 @@ function Invoke-Live {
         $promptText = [string]$p.Prompt
         $expectedType = [string]$p.ExpectedChartType
         $minMarks = [int]$p.MinMarks
-        $bodyJson = @{ prompt = $promptText } | ConvertTo-Json -Depth 4 -Compress
+        $bodyJson = @{ message = $promptText } | ConvertTo-Json -Depth 4 -Compress
         $status = 0
         $parsed = $null
         $detail = ''
@@ -450,14 +471,14 @@ function Invoke-SelfTest {
 
     # (b) Response validator — PASS path on a well-formed payload.
     $goodBody = [pscustomobject]@{
-        text     = 'Here is the horizontal bar chart ranking depletion growth.'
+        reply    = 'Here is the horizontal bar chart ranking depletion growth.'
         traceId  = '00-abcdef1234567890abcdef1234567890-0011223344556677-01'
         sessionId = 'session-000-selftest'
         charts   = @(
             [pscustomobject]@{
                 type = 'horizontalBar'
                 data = @(
-                    [pscustomobject]@{ name = 'series-a'; data = @(
+                    [pscustomobject]@{ legend = 'series-a'; values = @(
                             [pscustomobject]@{ x = 'BrandA'; y = 12 },
                             [pscustomobject]@{ x = 'BrandB'; y = 8 },
                             [pscustomobject]@{ x = 'BrandC'; y = 5 },
@@ -477,28 +498,44 @@ function Invoke-SelfTest {
 
     # (b) Response validator — FAIL paths on malformed payloads. Each of
     # these should produce Ok=$false with a clear reason, NOT throw and NOT
-    # falsely pass. Missing text / missing charts / wrong type / too few
+    # falsely pass. Missing reply / missing charts / wrong type / too few
     # marks / missing correlation id / null body.
     $null1 = Test-ChatResponseContract -Body $null -ExpectedChartType 'horizontalBar' -MinMarks 6
     _Expect 'validator FAILs a null body' (-not $null1.Ok)
     $noText = [pscustomobject]@{ charts = @([pscustomobject]@{ type = 'horizontalBar'; data = @() }) }
     $r = Test-ChatResponseContract -Body $noText -ExpectedChartType 'horizontalBar' -MinMarks 6
-    _Expect 'validator FAILs a response with no `text` payload' (-not $r.Ok)
-    $noCharts = [pscustomobject]@{ text = 'no charts here'; traceId = 't' }
+    _Expect 'validator FAILs a response with no `reply` payload' (-not $r.Ok)
+    # A body carrying the OLD `text` field must still fail — the API never emits it,
+    # so accepting it would re-open exactly the drift this guard exists to catch.
+    $legacyText = [pscustomobject]@{
+        text = 'legacy field'; traceId = 't'
+        charts = @([pscustomobject]@{ type = 'horizontalBar'; data = @([pscustomobject]@{ legend = 's'; values = 1..8 }) })
+    }
+    $r = Test-ChatResponseContract -Body $legacyText -ExpectedChartType 'horizontalBar' -MinMarks 6
+    _Expect 'validator FAILs a body using the legacy `text` field instead of `reply`' (-not $r.Ok)
+    $noCharts = [pscustomobject]@{ reply = 'no charts here'; traceId = 't' }
     $r = Test-ChatResponseContract -Body $noCharts -ExpectedChartType 'horizontalBar' -MinMarks 6
     _Expect 'validator FAILs a response with no `charts[]`' (-not $r.Ok)
-    $wrongType = [pscustomobject]@{ text = 'wrong type'; traceId = 't'; charts = @([pscustomobject]@{ type = 'pie'; data = @() }) }
+    $wrongType = [pscustomobject]@{ reply = 'wrong type'; traceId = 't'; charts = @([pscustomobject]@{ type = 'pie'; data = @() }) }
     $r = Test-ChatResponseContract -Body $wrongType -ExpectedChartType 'horizontalBar' -MinMarks 6
     _Expect 'validator FAILs when chart type does not match' (-not $r.Ok)
     $tooFewMarks = [pscustomobject]@{
-        text = 'too few marks'; traceId = 't'
-        charts = @([pscustomobject]@{ type = 'horizontalBar'; data = @([pscustomobject]@{ name = 's'; data = @(1, 2, 3) }) })
+        reply = 'too few marks'; traceId = 't'
+        charts = @([pscustomobject]@{ type = 'horizontalBar'; data = @([pscustomobject]@{ legend = 's'; values = @(1, 2, 3) }) })
     }
     $r = Test-ChatResponseContract -Body $tooFewMarks -ExpectedChartType 'horizontalBar' -MinMarks 6
     _Expect 'validator FAILs when marks < required' (-not $r.Ok)
+    # Marks must be counted over data[].values[], not per-series. A single series
+    # carrying 8 datapoints satisfies MinMarks 6; counting series would yield 1.
+    $oneSeriesManyMarks = [pscustomobject]@{
+        reply = 'one series, eight marks'; traceId = 't'
+        charts = @([pscustomobject]@{ type = 'horizontalBar'; data = @([pscustomobject]@{ legend = 's'; values = 1..8 }) })
+    }
+    $r = Test-ChatResponseContract -Body $oneSeriesManyMarks -ExpectedChartType 'horizontalBar' -MinMarks 6
+    _Expect 'validator counts marks across data[].values[], not per series' $r.Ok
     $noCorr = [pscustomobject]@{
-        text = 'no correlation'
-        charts = @([pscustomobject]@{ type = 'horizontalBar'; data = @([pscustomobject]@{ name = 's'; data = 1..8 }) })
+        reply = 'no correlation'
+        charts = @([pscustomobject]@{ type = 'horizontalBar'; data = @([pscustomobject]@{ legend = 's'; values = 1..8 }) })
     }
     $r = Test-ChatResponseContract -Body $noCorr -ExpectedChartType 'horizontalBar' -MinMarks 6
     _Expect 'validator FAILs when no correlation id is present' (-not $r.Ok)
@@ -574,6 +611,49 @@ function Invoke-SelfTest {
     $secretParamPattern = '\[string\]\s*\$' + $CS + '\b'
     $hasSecretParam = ($codeOnly -match $secretParamPattern)
     _Expect 'federation-only guard: no [string]$ClientSecret parameter is declared' (-not $hasSecretParam)
+
+    # (d) Live-contract drift guard: the request/response field names this script
+    # uses MUST match the real DTOs. This is the guard that was missing when the
+    # monitor shipped posting `prompt` and reading `text` — the self-test built its
+    # own payloads in the same wrong shape, so it stayed self-consistently wrong and
+    # a live run would have failed 400 on every prompt (issue #176). Read the
+    # contracts from source, exactly as the manifest check above does, so the guard
+    # stays offline and signin-free.
+    $chatModelsPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\src\RetailPulse.Contracts\ChatModels.cs'))
+    $chartSpecPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\src\RetailPulse.Contracts\ChartSpec.cs'))
+    _Expect 'ChatModels.cs is discoverable relative to scripts/' (Test-Path $chatModelsPath)
+    _Expect 'ChartSpec.cs is discoverable relative to scripts/' (Test-Path $chartSpecPath)
+
+    if ((Test-Path $chatModelsPath) -and (Test-Path $chartSpecPath)) {
+        $chatModelsSrc = Get-Content -LiteralPath $chatModelsPath -Raw
+        $chartSpecSrc = Get-Content -LiteralPath $chartSpecPath -Raw
+        $scriptSrc = Get-Content -LiteralPath $PSCommandPath -Raw
+
+        # ChatRequest's first positional member is the prompt text the API reads.
+        # Scope the request-body guards to the line that actually builds the JSON
+        # body — the curated smoke set legitimately uses a `Prompt` hashtable key,
+        # and a naive search would match that instead.
+        $bodyLines = @($scriptSrc -split "`n" | Where-Object { $_ -match 'ConvertTo-Json' -and $_ -match '@\{' })
+        _Expect 'a request-body construction line is present' ($bodyLines.Count -ge 1)
+        _Expect 'ChatRequest declares `Message` (so the live body must post `message`)' `
+            ($chatModelsSrc -match 'record\s+ChatRequest\s*\(\s*\r?\n?\s*string\s+Message\b')
+        _Expect 'live request body posts `message =`' `
+            (@($bodyLines | Where-Object { $_ -match '@\{\s*message\s*=' }).Count -ge 1)
+        _Expect 'live request body does NOT post the non-existent `prompt` field' `
+            (@($bodyLines | Where-Object { $_ -match '@\{\s*prompt\s*=' }).Count -eq 0)
+
+        # ChatResponse's first positional member is the assistant text.
+        _Expect 'ChatResponse declares `Reply` (so the validator must read `reply`)' `
+            ($chatModelsSrc -match 'record\s+ChatResponse\s*\(\s*\r?\n?\s*string\s+Reply\b')
+        _Expect 'validator reads Body.reply' ($scriptSrc -match "Properties\['reply'\]")
+        _Expect 'validator does NOT read the non-existent Body.text' (-not ($scriptSrc -match "Properties\['text'\]"))
+
+        # ChartSpec.Data is List<ChartSeries>; ChartSeries.Values is the datapoint list.
+        _Expect 'ChartSpec declares `Data` as the series list' ($chartSpecSrc -match 'List<ChartSeries>\s+Data\b')
+        _Expect 'ChartSeries declares `Values` as the datapoint list' ($chartSpecSrc -match 'List<ChartDataPoint>\s+Values\b')
+        _Expect 'mark counting walks series.values' ($scriptSrc -match "Properties\['values'\]")
+        _Expect 'mark counting does NOT walk the non-existent series.data' (-not ($scriptSrc -match "\`$series\.PSObject\.Properties\['data'\]"))
+    }
 
     if ($script:_selfFailed -gt 0) {
         Write-Host ("SELFTEST FAIL ({0} case(s))" -f $script:_selfFailed) -ForegroundColor Red

--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs
@@ -169,42 +169,85 @@ public partial class AgentExecutionPipeline
             }
         }
 
-        // Already fulfilled by the model / inline recovery.
-        if (charts.Count > 0)
-        {
-            // If a roster-complete portfolio ranking chart is present, scrub any
-            // fallback/truncation vocabulary the model may have narrated into the
-            // prose (issue #74) — the chart is authoritative and the prose must
-            // not undermine it.
-            string sanitizedReply = (roster is { Count: > 0 } && charts.Any(c =>
-                    string.Equals(c?.Type, "horizontalBar", StringComparison.OrdinalIgnoreCase)
-                    && DeterministicChartBuilder.CoversRoster(c, roster)))
-                ? StripFallbackClaims(reply)
-                : reply;
-            return new ChartFulfillmentResult(charts, sanitizedReply);
-        }
-
-        // Deterministic, no-LLM reconstruction from this turn's tool results. For a
-        // horizontal-bar ranking ask we raise the minimum-marks floor to the P0
-        // contract (>= 6 finite marks, at least one non-zero) so an underpopulated
-        // or all-zero result FAILS CLOSED to the chart-unavailable diagnostic below
-        // rather than reaching the frontend as an empty shell.
-        int fallbackMinMarks = isPortfolioRanking
+        // ── Deterministic-first chart construction (issue #172) ──────────────
+        // The tool payload — not the model's improvisation — is the source of
+        // truth for an explicit chart request. Build from it whenever we can and
+        // prefer that chart over whatever the model emitted.
+        //
+        // This generalises the portfolio-ranking coverage contract above to every
+        // chart intent, and that precedent is the evidence for it: the ranking
+        // prompt was the ONLY curated chart that rendered correctly on every live
+        // run precisely because its chart was rebuilt from tool data, while the
+        // eight prompts left to model discretion drifted between runs — wrong
+        // type, too few marks, or the chart JSON narrated into the prose.
+        //
+        // The model still writes the words; the code draws the chart.
+        int requiredMarks = isPortfolioRanking
             ? Math.Max(6, ChartSpecValidator.MinimumMarksForType(intent.ChartType))
             : ChartSpecValidator.MinimumMarksForType(intent.ChartType);
 
-        if (DeterministicChartBuilder.TryBuild(response, intent.ChartType, fallbackMinMarks, out ChartSpec? built) && built is not null)
+        if (DeterministicChartBuilder.TryBuild(response, intent.ChartType, requiredMarks, out ChartSpec? deterministic)
+            && deterministic is not null)
         {
             _logger.LogInformation(
-                "Chart-fulfillment: reconstructed a {ChartType} chart deterministically from tool results "
-                + "for an explicit chart request that returned prose-only.",
-                built.Type);
-            charts.Add(built);
-            return new ChartFulfillmentResult(charts, reply);
+                "Chart-fulfillment: built a {ChartType} chart deterministically from tool results "
+                + "for an explicit chart request (deterministic-first, issue #172).",
+                deterministic.Type);
+
+            // Drop model charts of the same type — the deterministic chart is
+            // authoritative for the requested visualization. Any unrelated extra
+            // chart the model produced is left alone.
+            charts.RemoveAll(c => c is null
+                || string.Equals(c.Type, deterministic.Type, StringComparison.OrdinalIgnoreCase));
+            charts.Insert(0, deterministic);
+            return new ChartFulfillmentResult(charts, StripFallbackClaims(reply));
         }
 
-        // No renderable chart and no data to build one — surface a precise, structured
-        // diagnostic instead of a silent prose-only reply.
+        // Already fulfilled by the model / inline recovery.
+        if (charts.Count > 0)
+        {
+            // No deterministic reconstruction was possible, so the model-emitted
+            // chart is the fallback — but it is held to the same renderability and
+            // mark floor rather than trusted on sight. An under-populated chart
+            // (e.g. a "compare all spirits brands" bar carrying one mark) is worse
+            // than no chart: it renders, so it looks like success while silently
+            // misrepresenting the data.
+            ChartSpec? candidate = charts.FirstOrDefault(c => c is not null
+                && (string.IsNullOrWhiteSpace(intent.ChartType)
+                    || string.Equals(c.Type, intent.ChartType, StringComparison.OrdinalIgnoreCase)));
+
+            if (candidate is not null
+                && ChartSpecValidator.TryGetRenderable(candidate, minSeries: 1, minMarks: requiredMarks, out ChartSpec? cleanedModelChart)
+                && cleanedModelChart is not null)
+            {
+                // If a roster-complete portfolio ranking chart is present, scrub any
+                // fallback/truncation vocabulary the model may have narrated into the
+                // prose (issue #74) — the chart is authoritative and the prose must
+                // not undermine it.
+                string sanitizedReply = (roster is { Count: > 0 } && charts.Any(c =>
+                        string.Equals(c?.Type, "horizontalBar", StringComparison.OrdinalIgnoreCase)
+                        && DeterministicChartBuilder.CoversRoster(c, roster)))
+                    ? StripFallbackClaims(reply)
+                    : reply;
+
+                int replaceAt = charts.IndexOf(candidate);
+                charts[replaceAt] = cleanedModelChart;
+                return new ChartFulfillmentResult(charts, sanitizedReply);
+            }
+
+            _logger.LogWarning(
+                "Chart-fulfillment: dropping a model-emitted chart that does not meet the "
+                + "{MinMarks}-mark floor for '{ChartType}' and could not be rebuilt from tool "
+                + "results — failing closed rather than rendering an under-populated chart.",
+                requiredMarks, intent.ChartType ?? "chart");
+            charts.Clear();
+        }
+
+        // No renderable chart and no data to build one — the deterministic-first
+        // attempt above already tried to reconstruct from this turn's tool results
+        // with the same mark floor, so reaching here means the tool payload simply
+        // does not contain a chartable shape for what was asked. Surface a precise,
+        // structured diagnostic instead of a silent prose-only reply.
         _logger.LogWarning(
             "Chart-fulfillment: explicit {ChartType} chart request could not be satisfied — "
             + "no renderable chart and no chartable tool data present; emitting chart-unavailable diagnostic.",

--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
@@ -152,7 +152,7 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         using IDisposable toolTimingScope = ToolInvocationTimings.Begin();
         using IDisposable budgetScope = RequestToolContext.Begin(
             sessionId,
-            isChartIntent: Charts.ChartRequestDetector.Detect(request.Message).IsExplicitChartRequest);
+            isChartIntent: Charts.ChartRequestDetector.Detect(request.UserIntentMessage).IsExplicitChartRequest);
         using Activity? thoughtActivity = AgentTelemetry.StartAgentThought(context.AgentName, request.Message);
 
         // Emit progress: thinking phase
@@ -247,7 +247,7 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         // Chart-fulfillment invariant: an explicit chart request must yield a renderable
         // chart (reconstructed deterministically from tool results if the model emitted
         // none) or a structured chart-unavailable diagnostic — never silent prose-only.
-        ChartFulfillmentResult fulfillment = EnforceChartFulfillment(context.Request.Message, response, charts, reply);
+        ChartFulfillmentResult fulfillment = EnforceChartFulfillment(context.Request.UserIntentMessage, response, charts, reply);
         charts = fulfillment.Charts;
         reply = fulfillment.Reply;
 
@@ -445,7 +445,7 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         using IDisposable toolTimingScope = ToolInvocationTimings.Begin();
         using IDisposable budgetScope = RequestToolContext.Begin(
             sessionId,
-            isChartIntent: Charts.ChartRequestDetector.Detect(request.Message).IsExplicitChartRequest);
+            isChartIntent: Charts.ChartRequestDetector.Detect(request.UserIntentMessage).IsExplicitChartRequest);
         using Activity? thoughtActivity = AgentTelemetry.StartAgentThought(context.AgentName, request.Message);
 
         // Emit progress: thinking phase
@@ -536,7 +536,7 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         // Chart-fulfillment invariant (streaming): reconstruct deterministically or append
         // a structured chart-unavailable diagnostic before streaming, so the streamed reply
         // matches the final response and never silently omits an explicitly requested chart.
-        ChartFulfillmentResult fulfillment = EnforceChartFulfillment(context.Request.Message, response, charts, reply);
+        ChartFulfillmentResult fulfillment = EnforceChartFulfillment(context.Request.UserIntentMessage, response, charts, reply);
         charts = fulfillment.Charts;
         reply = fulfillment.Reply;
 

--- a/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
+++ b/src/RetailPulse.Api/Agents/Planning/PlanExecutor.cs
@@ -436,7 +436,11 @@ public sealed class PlanExecutor
             Message: stepMessage,
             SessionId: execution.SessionId,
             User: message.User,
-            History: stepHistory);
+            History: stepHistory,
+            // Chart intent must come from what the USER asked for, not from the step
+            // action woven into the message above — otherwise a step phrased as
+            // "…as a bar chart" overrides the user's "create a table …" (issue #172).
+            OriginalMessage: message.Request);
 
         using var stepCts = CancellationTokenSource.CreateLinkedTokenSource(workflowCt);
         if (_options.StepTimeout > TimeSpan.Zero)

--- a/src/RetailPulse.Api/Charts/DeterministicChartBuilder.cs
+++ b/src/RetailPulse.Api/Charts/DeterministicChartBuilder.cs
@@ -189,10 +189,15 @@ internal static class DeterministicChartBuilder
                     ?? TryBuildDemandBar(payloads, requestedType),
                 "line" => TryBuildDemandLine(payloads)
                     ?? TryBuildDemandBar(payloads, "line"),
-                "pie" or "donut" => TryBuildShareOrMixPie(payloads, requestedType ?? "pie")
-                    ?? TryBuildDemandBar(payloads, requestedType),
-                "table" => TryBuildDepletionStatsTable(payloads)
-                    ?? TryBuildDemandBar(payloads, "bar"),
+                // Pie/donut and table are their own structural families (share/mix
+                // proportions; a row grid). Falling through to a bar here produced a
+                // chart in a DIFFERENT family from the one the user asked for — the
+                // pipeline's own Group D guard would then have to drop it, so the
+                // fallback could only ever waste work or, when type enforcement was
+                // bypassed, leak a bar under a "create a table…" request. Fail closed
+                // instead, exactly as the horizontalBar ranking above does.
+                "pie" or "donut" => TryBuildShareOrMixPie(payloads, requestedType ?? "pie"),
+                "table" => TryBuildDepletionStatsTable(payloads),
                 _ => TryBuildDemandBar(payloads, requestedType) ?? TryBuildGauge(payloads),
             };
     }

--- a/src/RetailPulse.Contracts/ChatModels.cs
+++ b/src/RetailPulse.Contracts/ChatModels.cs
@@ -14,8 +14,28 @@ public record ChatRequest(
     string? SessionId = null,
     UserContext? User = null,
     List<ChatHistoryMessage>? History = null,
-    string? ForceExecutionPath = null
-);
+    string? ForceExecutionPath = null,
+    /// <summary>
+    /// The user's original, unmodified request, when <see cref="Message"/> is a derived
+    /// or scoped rewrite of it — as the plan path does, weaving a step action into the
+    /// message it hands each specialist.
+    ///
+    /// Chart intent MUST be detected from this rather than from the rewritten message:
+    /// a step action such as "chart the regional rollup as a bar" would otherwise win
+    /// over the user's actual "create a table …" ask, because the detector matches the
+    /// first chart-type phrase it sees. Null on the single-shot path, where
+    /// <see cref="Message"/> already is the original.
+    /// </summary>
+    string? OriginalMessage = null
+)
+{
+    /// <summary>
+    /// The text that represents what the USER asked for — <see cref="OriginalMessage"/>
+    /// when a scoped rewrite is in play, otherwise <see cref="Message"/>.
+    /// </summary>
+    public string UserIntentMessage =>
+        string.IsNullOrWhiteSpace(OriginalMessage) ? Message : OriginalMessage;
+}
 
 /// <summary>
 /// Routing metadata included in the chat response for telemetry display.

--- a/tests/RetailPulse.Tests/Agents/ChartFulfillmentTests.cs
+++ b/tests/RetailPulse.Tests/Agents/ChartFulfillmentTests.cs
@@ -226,25 +226,125 @@ public sealed class ChartFulfillmentTests
     }
 
     [Fact]
-    public void EnforceChartFulfillment_AlreadyHasChart_LeavesItUnchanged()
+    public void EnforceChartFulfillment_ModelChartMeetingTheMarkFloor_IsKept_WhenNothingCanBeRebuilt()
     {
+        // With no tool payloads there is nothing to rebuild from, so a model-emitted
+        // chart is the fallback — and it is kept, provided it clears the mark floor
+        // for its type.
         AgentExecutionPipeline pipeline = CreatePipeline();
-        MeaiChatResponse response = ResponseWithToolResults(
-            CompactedDemand("Summit Vodka", "Northeast", 910.0));
+        MeaiChatResponse response = ResponseWithToolResults();
 
         var existing = new ChartSpec
         {
             Type = "bar",
             Title = "Existing",
-            Data = [new ChartSeries { Legend = "S", Values = [new ChartDataPoint { X = "A", Y = 1 }] }]
+            Data =
+            [
+                new ChartSeries
+                {
+                    Legend = "S",
+                    Values =
+                    [
+                        new ChartDataPoint { X = "A", Y = 1 },
+                        new ChartDataPoint { X = "B", Y = 2 },
+                        new ChartDataPoint { X = "C", Y = 3 },
+                    ],
+                },
+            ],
         };
         var charts = new List<ChartSpec> { existing };
 
         AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
             "Show me a bar chart of depletion velocity in the Northeast", response, charts, "Done.");
 
-        result.Charts.Should().ContainSingle().Which.Should().BeSameAs(existing);
+        result.Charts.Should().ContainSingle();
+        result.Charts[0].Type.Should().Be("bar");
+        result.Charts[0].Data.Sum(s => s.Values.Count).Should().Be(3);
         result.Reply.Should().Be("Done.");
+    }
+
+    [Fact]
+    public void EnforceChartFulfillment_PrefersTheDeterministicChart_OverAnUnderPopulatedModelChart()
+    {
+        // Issue #172: the tool payload is the source of truth. A model chart carrying
+        // a single mark must not win over a chart the code can build from the data.
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults(
+            CompactedDemand("Sierra Gold Tequila", "Northeast", 1893.2),
+            CompactedDemand("Ridgeline Bourbon", "Northeast", 2109.5),
+            CompactedDemand("Summit Vodka", "Northeast", 2296.3));
+
+        var thin = new ChartSpec
+        {
+            Type = "bar",
+            Title = "Model chart with one brand",
+            Data = [new ChartSeries { Legend = "S", Values = [new ChartDataPoint { X = "Summit Vodka", Y = 2296.3 }] }]
+        };
+        var charts = new List<ChartSpec> { thin };
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            "Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast",
+            response, charts, "Here you go.");
+
+        result.Charts.Should().ContainSingle("the deterministic chart replaces the model's");
+        result.Charts[0].Should().NotBeSameAs(thin);
+        result.Charts[0].Data.Sum(s => s.Values.Count)
+            .Should().BeGreaterThanOrEqualTo(3, "all three seeded Northeast spirits brands must appear");
+    }
+
+    [Fact]
+    public void EnforceChartFulfillment_UnderPopulatedModelChart_IsDroppedRatherThanRendered()
+    {
+        // An under-populated chart is worse than no chart: it renders, so it looks
+        // like success while misrepresenting the data. With nothing to rebuild from,
+        // fail closed to the diagnostic.
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults();
+
+        var thin = new ChartSpec
+        {
+            Type = "bar",
+            Title = "One mark",
+            Data = [new ChartSeries { Legend = "S", Values = [new ChartDataPoint { X = "A", Y = 1 }] }]
+        };
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            "Show me a bar chart of depletion velocity in the Northeast",
+            response, [thin], "Done.");
+
+        result.Charts.Should().BeEmpty();
+        result.Reply.Should().Contain("Chart unavailable");
+    }
+
+    [Fact]
+    public void EnforceChartFulfillment_UsesTheUsersOriginalRequest_NotAScopedStepRewrite()
+    {
+        // Issue #172: on the plan path the specialist receives a rewritten message —
+        // "<step action> — original user request: <what the user typed>". If chart
+        // intent were read from that rewrite, a step action mentioning a bar would
+        // override the user's actual table request, and a bar would be emitted under
+        // a "create a table …" ask. UserIntentMessage is what must drive detection.
+        var scoped = new ChatRequest(
+            Message: "Chart the regional rollup as a bar chart — original user request: "
+                + "Create a table showing depletion stats for all home improvement brands by region",
+            OriginalMessage: "Create a table showing depletion stats for all home improvement brands by region");
+
+        scoped.UserIntentMessage.Should().Be(
+            "Create a table showing depletion stats for all home improvement brands by region");
+
+        ChartIntent fromRewrite = ChartRequestDetector.Detect(scoped.Message);
+        ChartIntent fromUser = ChartRequestDetector.Detect(scoped.UserIntentMessage);
+
+        fromRewrite.ChartType.Should().Be("bar", "the step action's own wording wins on the rewritten message");
+        fromUser.ChartType.Should().Be("table", "the user's actual request is a table");
+    }
+
+    [Fact]
+    public void ChatRequest_UserIntentMessage_FallsBackToMessage_OnTheSingleShotPath()
+    {
+        // No rewrite in play — Message already is what the user asked for.
+        var direct = new ChatRequest("Create a pie chart showing market share breakdown");
+        direct.UserIntentMessage.Should().Be("Create a pie chart showing market share breakdown");
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #172.

## The problem in one line

Eight of the nine curated chart prompts let **the model** author its own `ChartSpec`, so the same prompt rendered correctly one run and drifted the next.

The ninth — the portfolio ranking — passed on **every** run. It is the only one whose chart was already rebuilt from the tool payload rather than taken from the model.

That contrast is the whole argument. **The model writes the words; the code draws the chart.**

## Changes

### 1. Deterministic-first fulfillment

For an explicit chart request, `EnforceChartFulfillment` now builds from this turn's tool results **first** and prefers that chart, dropping model charts of the same type.

The model chart survives only as a fallback when nothing can be rebuilt — and even then it must clear the renderability and minimum-mark floor for its type. An under-populated chart is worse than none: it renders, so it *looks* like success while misrepresenting the data. Failing closed to the existing chart-unavailable diagnostic is the honest outcome.

Also removes a now-unreachable duplicate rebuild that ran after the model-chart branch with identical arguments.

### 2. No cross-family substitution

`SelectBuilder` fell back to a **bar** when a pie/donut or table couldn't be built. Those are separate structural families (proportions; a row grid), so the fallback could only produce the wrong family — which the pipeline's own Group D guard then has to drop, and which leaked a bar under `Create a table showing…` when type enforcement was bypassed. Both now fail closed, exactly as `horizontalBar` already did.

### 3. Chart intent follows the user, not the plan step

On the plan path each specialist gets a rewritten message:

```
<step action> — original user request: <what the user typed>
```

Chart intent was read from that rewrite, so a step action phrased "…as a bar chart" **won over** the user's actual "create a table …" — the detector matches the first chart-type phrase it sees.

`ChatRequest` gains an optional trailing `OriginalMessage` plus a `UserIntentMessage` accessor that prefers it. `PlanExecutor` sets it on every scoped step; the pipeline detects intent and enforces fulfillment from it. Null on the single-shot path, where `Message` already is the original — nothing changes there.

## Tests

| Test | Pins |
|---|---|
| `PrefersTheDeterministicChart_OverAnUnderPopulatedModelChart` | tool data beats a 1-mark model chart; all three seeded Northeast spirits brands appear |
| `ModelChartMeetingTheMarkFloor_IsKept_WhenNothingCanBeRebuilt` | the fallback still works |
| `UnderPopulatedModelChart_IsDroppedRatherThanRendered` | fail closed, not a misleading chart |
| `UsesTheUsersOriginalRequest_NotAScopedStepRewrite` | rewrite yields `bar`, user's text yields `table` |
| `UserIntentMessage_FallsBackToMessage_OnTheSingleShotPath` | no behaviour change off the plan path |

## Verification

- **3437 passed, 0 failed**, 9 skipped
- `dotnet format --verify-no-changes` → clean

Live re-measurement of the G4 sweep follows deployment.
