### PR TITLE
fix(#172): never let the deterministic rebuild cost chart completeness

### DIFF
--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs
@@ -189,17 +189,33 @@ public partial class AgentExecutionPipeline
         if (DeterministicChartBuilder.TryBuild(response, intent.ChartType, requiredMarks, out ChartSpec? deterministic)
             && deterministic is not null)
         {
-            _logger.LogInformation(
-                "Chart-fulfillment: built a {ChartType} chart deterministically from tool results "
-                + "for an explicit chart request (deterministic-first, issue #172).",
-                deterministic.Type);
+            // Prefer the deterministic chart, but never at the cost of completeness.
+            // When the model also produced a valid chart of the requested type that
+            // covers MORE of the data, keeping the thinner rebuild would be a
+            // regression — the tool payload is authoritative about what is true, not
+            // about what is complete (a turn may have queried only some regions).
+            // Deterministic wins ties, so behaviour stays stable run to run.
+            ChartSpec? modelRival = charts.FirstOrDefault(c => c is not null
+                && string.Equals(c.Type, deterministic.Type, StringComparison.OrdinalIgnoreCase));
 
-            // Drop model charts of the same type — the deterministic chart is
-            // authoritative for the requested visualization. Any unrelated extra
-            // chart the model produced is left alone.
+            ChartSpec? richerModelChart = null;
+            if (modelRival is not null
+                && ChartSpecValidator.TryGetRenderable(modelRival, minSeries: 1, minMarks: requiredMarks, out ChartSpec? cleanedRival)
+                && cleanedRival is not null
+                && CountMarks(cleanedRival) > CountMarks(deterministic))
+            {
+                richerModelChart = cleanedRival;
+            }
+
+            ChartSpec chosen = richerModelChart ?? deterministic;
+            _logger.LogInformation(
+                "Chart-fulfillment: emitting a {ChartType} chart with {Marks} marks from the "
+                + "{Source} source for an explicit chart request (deterministic-first, issue #172).",
+                chosen.Type, CountMarks(chosen), richerModelChart is null ? "deterministic" : "model (richer)");
+
             charts.RemoveAll(c => c is null
                 || string.Equals(c.Type, deterministic.Type, StringComparison.OrdinalIgnoreCase));
-            charts.Insert(0, deterministic);
+            charts.Insert(0, chosen);
             return new ChartFulfillmentResult(charts, StripFallbackClaims(reply));
         }
 
@@ -259,6 +275,21 @@ public partial class AgentExecutionPipeline
             : $"{reply}\n\n{diagnostic}";
 
         return new ChartFulfillmentResult(charts, updatedReply);
+    }
+
+    /// <summary>Total finite datapoints across every series in a chart.</summary>
+    private static int CountMarks(ChartSpec? chart)
+    {
+        if (chart is null) return 0;
+        int n = 0;
+        foreach (ChartSeries s in chart.Data)
+        {
+            foreach (ChartDataPoint p in s.Values)
+            {
+                if (p is not null && double.IsFinite(p.Y)) n++;
+            }
+        }
+        return n;
     }
 
     private static IReadOnlyList<string> ComputeMissingBrands(

--- a/tests/RetailPulse.Tests/Agents/ChartFulfillmentTests.cs
+++ b/tests/RetailPulse.Tests/Agents/ChartFulfillmentTests.cs
@@ -347,6 +347,45 @@ public sealed class ChartFulfillmentTests
         direct.UserIntentMessage.Should().Be("Create a pie chart showing market share breakdown");
     }
 
+    [Fact]
+    public void EnforceChartFulfillment_KeepsTheRicherModelChart_WhenTheRebuildCoversLessData()
+    {
+        // Deterministic-first must not cost completeness. A turn may have queried only
+        // some regions, so the rebuild can be thinner than a valid model chart. The
+        // tool payload is authoritative about what is TRUE, not about what is COMPLETE.
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults(
+            CompactedDemand("FreshMart", "Northeast", 900.0),
+            CompactedDemand("Harvest Table", "Northeast", 800.0));
+
+        var richer = new ChartSpec
+        {
+            Type = "bar",
+            Title = "Model chart covering more regions",
+            Data =
+            [
+                new ChartSeries
+                {
+                    Legend = "FreshMart",
+                    Values =
+                    [
+                        new ChartDataPoint { X = "Northeast", Y = 900 },
+                        new ChartDataPoint { X = "Midwest", Y = 850 },
+                        new ChartDataPoint { X = "Southeast", Y = 810 },
+                        new ChartDataPoint { X = "West Coast", Y = 790 },
+                    ],
+                },
+            ],
+        };
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            "Show me a bar chart of depletion velocity in the Northeast", response, [richer], "Done.");
+
+        result.Charts.Should().ContainSingle();
+        result.Charts[0].Data.Sum(s => s.Values.Count)
+            .Should().Be(4, "the richer valid model chart is kept over a thinner rebuild");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static AgentExecutionPipeline CreatePipeline()


### PR DESCRIPTION
Follow-up to #178. Refs #172.

## What the live sweep showed

Deterministic-first replaced **every** model chart of the requested type. That fixed the table prompt, but regressed the grouped-bar comparison:

\\\
[22/26] FAIL  charts  Show a grouped bar chart comparing FreshMart and Har...
          -> chart 'groupedBar' had 10 marks, needs >= 12
\\\

The rebuild covered five regions (10 marks); the model's valid chart covered more. A previously passing prompt started failing.

## The correction

The tool payload is authoritative about what is **true**, not about what is **complete** — a turn may have queried only some regions.

So the deterministic chart is preferred only when it is **at least as complete** as a valid model chart of the same type. Otherwise the richer model chart is kept, after being held to the same renderability and mark floor. **Deterministic wins ties**, so behaviour stays stable run to run.

This keeps the #178 guarantee (an under-populated or wrong-family model chart can never win) while removing the completeness regression it introduced.

## Test

\KeepsTheRicherModelChart_WhenTheRebuildCoversLessData\ — a one-region rebuild loses to a valid four-region model chart.

## Verification

- **3438 passed, 0 failed**
- \dotnet format --verify-no-changes\ → clean