### PR TITLE
fix(#59): roll market share up nationally instead of filtering on a region that does not exist

### DIFF
--- a/src/RetailPulse.Api/Tools/MarketShareTool.cs
+++ b/src/RetailPulse.Api/Tools/MarketShareTool.cs
@@ -14,11 +14,11 @@ public class MarketShareTool
         _logger = logger;
     }
 
-    [Description("Get market share trends over time. Returns quarterly share data with period-over-period changes and identifies significant share losses.")]
+    [Description("Get market share trends over time. Returns quarterly share data with period-over-period changes and identifies significant share losses. Pass region='National' for a nationwide rollup (the unweighted mean of each brand's regional shares); pass a specific region for that region's rows.")]
     public async Task<string> GetMarketShare(
         [Description("Brand name to filter. Omit for all brands.")] string? brand = null,
         [Description("Category to filter. Omit for all categories.")] string? category = null,
-        [Description("Region to filter. Omit for all regions.")] string? region = null,
+        [Description("Region to filter, or 'National' for a nationwide rollup. Omit for all regions.")] string? region = null,
         [Description("Period to filter (e.g. '2026-Q1'). Omit for all periods.")] string? period = null,
         CancellationToken cancellationToken = default)
     {

--- a/src/RetailPulse.McpServer/Data/RetailPulseDb.cs
+++ b/src/RetailPulse.McpServer/Data/RetailPulseDb.cs
@@ -2709,8 +2709,29 @@ public class RetailPulseDb
         };
     }
 
+    /// <summary>
+    /// Region tokens that mean "the whole country", not a literal region row. Depletion
+    /// stats, variant mix and historical demand already normalise these to a national
+    /// rollup; market share did not, so <c>Region LIKE '%National%'</c> matched nothing
+    /// and any "market share breakdown … nationally" ask returned zero rows — the pie
+    /// chart then failed closed with a chart-unavailable diagnostic (issue #59 / G2).
+    /// </summary>
+    private static bool IsNationalRegionToken(string region) =>
+        region.Trim() is var r && (
+            r.Equals("National", StringComparison.OrdinalIgnoreCase)
+            || r.Equals("Nationwide", StringComparison.OrdinalIgnoreCase)
+            || r.Equals("Aggregate", StringComparison.OrdinalIgnoreCase)
+            || r.Equals("US", StringComparison.OrdinalIgnoreCase)
+            || r.Equals("USA", StringComparison.OrdinalIgnoreCase)
+            || r.Equals("United States", StringComparison.OrdinalIgnoreCase));
+
     public object GetMarketShare(string? brand = null, string? category = null, string? region = null, string? period = null)
     {
+        // An explicit national ask is a ROLLUP, not a region filter. A blank region is
+        // left alone — it already means "every region's rows", which existing callers
+        // depend on.
+        bool nationalRollup = !string.IsNullOrWhiteSpace(region) && IsNationalRegionToken(region);
+
         using SqliteConnection conn = OpenConnection();
         conn.Open();
         using SqliteCommand cmd = conn.CreateCommand();
@@ -2726,7 +2747,7 @@ public class RetailPulseDb
             filters.Add("Category LIKE @category");
             cmd.Parameters.AddWithValue("@category", $"%{category}%");
         }
-        if (!string.IsNullOrWhiteSpace(region))
+        if (!nationalRollup && !string.IsNullOrWhiteSpace(region))
         {
             filters.Add("Region LIKE @region");
             cmd.Parameters.AddWithValue("@region", $"%{region}%");
@@ -2738,6 +2759,65 @@ public class RetailPulseDb
         }
 
         string where = filters.Count > 0 ? $"WHERE {string.Join(" AND ", filters)}" : "";
+
+        if (nationalRollup)
+        {
+            // Average each brand's regional share for the period. The table carries no
+            // volume weights, so an unweighted mean across the regions that reported is
+            // the honest rollup — and it is stated as such in the payload rather than
+            // being passed off as a measured national figure.
+            cmd.CommandText = $"""
+                SELECT Brand,
+                       Category,
+                       Period,
+                       AVG(SharePercent)          AS SharePercent,
+                       AVG(PreviousSharePercent)  AS PreviousSharePercent,
+                       AVG(ShareChangePoints)     AS ShareChangePoints,
+                       COUNT(DISTINCT Region)     AS RegionsCounted
+                FROM MarketShare
+                {where}
+                GROUP BY Brand, Category, Period
+                ORDER BY Period DESC, SharePercent DESC
+                LIMIT 300
+                """;
+
+            using SqliteDataReader nationalReader = cmd.ExecuteReader();
+            var nationalRecords = new List<object>();
+            int nationalLosses = 0;
+            while (nationalReader.Read())
+            {
+                double? changePoints = nationalReader.IsDBNull(5) ? null : nationalReader.GetDouble(5);
+                if (changePoints is < -2.0) nationalLosses++;
+
+                nationalRecords.Add(new
+                {
+                    brand = nationalReader.GetString(0),
+                    category = nationalReader.GetString(1),
+                    region = "National",
+                    period = nationalReader.GetString(2),
+                    share_percent = Math.Round(nationalReader.GetDouble(3), 2),
+                    previous_share_percent = nationalReader.IsDBNull(4) ? (double?)null : Math.Round(nationalReader.GetDouble(4), 2),
+                    share_change_points = changePoints is null ? (double?)null : Math.Round(changePoints.Value, 2),
+                    regions_counted = nationalReader.GetInt32(6),
+                    source = "national rollup (unweighted mean of regional shares)"
+                });
+            }
+
+            return new
+            {
+                filters = new { brand = brand ?? "all", category = category ?? "all", region = "National", period = period ?? "all" },
+                total_records = nationalRecords.Count,
+                significant_share_losses = nationalLosses,
+                aggregation = new
+                {
+                    scope = "national",
+                    method = "unweighted mean of regional SharePercent, grouped by brand, category and period",
+                    note = "The source table stores share by region with no volume weights, so a national figure is the average of the regions that reported."
+                },
+                share_data = nationalRecords
+            };
+        }
+
         cmd.CommandText = $"""
             SELECT Brand, Category, Region, Period, SharePercent, PreviousSharePercent, ShareChangePoints, Source
             FROM MarketShare

--- a/src/RetailPulse.McpServer/Tools/CompetitiveTools.cs
+++ b/src/RetailPulse.McpServer/Tools/CompetitiveTools.cs
@@ -17,12 +17,12 @@ public static class CompetitiveTools
         [Description("Comma-separated competitor names (e.g. 'Jack Daniel\\'s,Patrón'). Omit for all.")] string? competitors = null) => data.GetCompetitorPricing(brand, category, region, competitors);
 
     [McpServerTool(Name = "GetMarketShare")]
-    [Description("Get market share trends over time. Returns quarterly share data with period-over-period changes. Identifies significant share losses (>2 points). Filterable by brand, category, region, and time period.")]
+    [Description("Get market share trends over time. Returns quarterly share data with period-over-period changes. Identifies significant share losses (>2 points). Filterable by brand, category, region, and time period. Pass region='National' for a nationwide rollup (the unweighted mean of each brand's regional shares); pass a specific region for that region's rows.")]
     public static object GetMarketShare(
         RetailPulseDb data,
         [Description("Brand name to filter. Omit for all brands.")] string? brand = null,
         [Description("Category to filter. Omit for all categories.")] string? category = null,
-        [Description("Region to filter. Omit for all regions.")] string? region = null,
+        [Description("Region to filter, or 'National' for a nationwide rollup. Omit for all regions.")] string? region = null,
         [Description("Period to filter (e.g. '2026-Q1', '2025-Q4'). Omit for all periods.")] string? period = null) => data.GetMarketShare(brand, category, region, period);
 
     [McpServerTool(Name = "DetectThreats")]

--- a/tests/RetailPulse.Tests/Data/MarketShareNationalRollupTests.cs
+++ b/tests/RetailPulse.Tests/Data/MarketShareNationalRollupTests.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using FluentAssertions;
+using RetailPulse.Contracts;
+using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
+
+namespace RetailPulse.Tests.Data;
+
+/// <summary>
+/// Regression cover for the national market-share rollup.
+///
+/// <para>
+/// Depletion stats, variant mix and historical demand all normalise a "National"
+/// region to a country-wide rollup. Market share did not: it applied
+/// <c>Region LIKE '%National%'</c> to a table that only stores real regions, so the
+/// query matched nothing. A prompt like "market share breakdown for our grocery
+/// brands nationally" therefore returned zero rows, and the pie chart correctly —
+/// but unhelpfully — failed closed with a chart-unavailable diagnostic. That was the
+/// last deterministic failure in the G4 acceptance sweep (issue #59, gate G2).
+/// </para>
+/// </summary>
+public sealed class MarketShareNationalRollupTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly RetailPulseDb _db;
+
+    public MarketShareNationalRollupTests()
+    {
+        string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+        string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
+
+        _dbPath = SqliteTestCleanup.NewDbPath("retailpulse_marketshare_national");
+        var tenantProvider = new FileTenantProvider(tenantConfigPath);
+        _db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
+    }
+
+    private static JsonElement Query(RetailPulseDb db, string? region, string? category = null)
+    {
+        object result = db.GetMarketShare(category: category, region: region);
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(result));
+        return doc.RootElement.Clone();
+    }
+
+    [Theory]
+    [InlineData("National")]
+    [InlineData("national")]
+    [InlineData("Nationwide")]
+    [InlineData("US")]
+    [InlineData("USA")]
+    [InlineData("United States")]
+    [InlineData("Aggregate")]
+    public void NationalRegionTokens_ReturnARollup_NotAnEmptyResult(string token)
+    {
+        JsonElement payload = Query(_db, token);
+
+        payload.GetProperty("total_records").GetInt32()
+            .Should().BeGreaterThan(0, "a national ask must roll the regions up, not filter on a region that does not exist");
+
+        JsonElement rows = payload.GetProperty("share_data");
+        rows.GetArrayLength().Should().BeGreaterThan(0);
+
+        foreach (JsonElement row in rows.EnumerateArray())
+        {
+            row.GetProperty("region").GetString().Should().Be("National");
+            double share = row.GetProperty("share_percent").GetDouble();
+            double.IsFinite(share).Should().BeTrue();
+            share.Should().BeInRange(0, 100);
+        }
+    }
+
+    [Fact]
+    public void NationalRollup_IsTheMeanOfTheRegionalShares()
+    {
+        JsonElement national = Query(_db, "National");
+        JsonElement allRegions = Query(_db, region: null);
+
+        JsonElement sample = national.GetProperty("share_data").EnumerateArray().First();
+        string brand = sample.GetProperty("brand").GetString()!;
+        string category = sample.GetProperty("category").GetString()!;
+        string period = sample.GetProperty("period").GetString()!;
+
+        double[] regional = [.. allRegions.GetProperty("share_data").EnumerateArray()
+            .Where(r => r.GetProperty("brand").GetString() == brand
+                     && r.GetProperty("category").GetString() == category
+                     && r.GetProperty("period").GetString() == period)
+            .Select(r => r.GetProperty("share_percent").GetDouble())];
+
+        regional.Should().NotBeEmpty("the sampled brand/period must exist in the regional rows");
+        sample.GetProperty("share_percent").GetDouble()
+            .Should().BeApproximately(regional.Average(), 0.01,
+                "the national figure is the unweighted mean of the regions that reported");
+    }
+
+    [Fact]
+    public void NationalRollup_DeclaresHowItWasComputed()
+    {
+        // The table has no volume weights, so the mean is an approximation. It must be
+        // labelled as one rather than presented as a measured national figure.
+        JsonElement payload = Query(_db, "National");
+        JsonElement aggregation = payload.GetProperty("aggregation");
+
+        aggregation.GetProperty("scope").GetString().Should().Be("national");
+        aggregation.GetProperty("method").GetString().Should().Contain("unweighted mean");
+    }
+
+    [Fact]
+    public void NationalRollup_CollapsesEachBrandToASingleSliceForTheLatestPeriod()
+    {
+        // A pie needs one slice per brand. The rollup groups by brand/category/period and
+        // orders newest first, so the first row per brand is that brand's latest national
+        // share — which is what the deterministic pie builder reads.
+        JsonElement payload = Query(_db, "National", category: "Grocery");
+        List<JsonElement> rows = [.. payload.GetProperty("share_data").EnumerateArray()];
+
+        rows.Should().NotBeEmpty();
+
+        string newestPeriod = rows[0].GetProperty("period").GetString()!;
+        string[] brandsInNewestPeriod = [.. rows
+            .Where(r => r.GetProperty("period").GetString() == newestPeriod)
+            .Select(r => r.GetProperty("brand").GetString()!)];
+
+        brandsInNewestPeriod.Should().OnlyHaveUniqueItems(
+            "each brand contributes exactly one national slice per period");
+        brandsInNewestPeriod.Length.Should().BeGreaterThanOrEqualTo(2,
+            "a pie breakdown needs at least two slices");
+    }
+
+    [Fact]
+    public void ASpecificRegion_StillReturnsThatRegionsRows_Unchanged()
+    {
+        JsonElement payload = Query(_db, "Northeast");
+
+        payload.GetProperty("total_records").GetInt32().Should().BeGreaterThan(0);
+        foreach (JsonElement row in payload.GetProperty("share_data").EnumerateArray())
+        {
+            row.GetProperty("region").GetString().Should().Be("Northeast");
+        }
+    }
+
+    [Fact]
+    public void AnOmittedRegion_StillReturnsPerRegionRows_Unchanged()
+    {
+        // Callers that pass no region rely on getting every region's rows. Only an
+        // EXPLICIT national token switches to the rollup.
+        JsonElement payload = Query(_db, region: null);
+
+        string[] regions = [.. payload.GetProperty("share_data").EnumerateArray()
+            .Select(r => r.GetProperty("region").GetString()!)
+            .Distinct()];
+
+        regions.Should().NotContain("National");
+        regions.Length.Should().BeGreaterThan(1, "omitting the region must not collapse the regions");
+    }
+}


### PR DESCRIPTION
Refs #59 (gate **G2/G4**). The last deterministic failure in the acceptance sweep.

## Not a chart bug

`Create a pie chart showing market share breakdown for our grocery brands nationally` failed on **every** sweep. The pipeline was behaving correctly — it failed closed with a chart-unavailable diagnostic — because the tool genuinely returned nothing:

```
GET /api/competitive/market-share?region=National   -> total_records = 0
GET /api/competitive/market-share?region=Northeast  -> total_records = 300
GET /api/competitive/market-share                   -> total_records = 300
```

`GetMarketShare` applied `Region LIKE '%National%'` to a table that only stores real regions, so it matched nothing.

Depletion stats, variant mix and historical demand **all** normalise "National" to a country-wide rollup (`Program.cs` lines 158/169/189, `RetailPulseDb` lines 709/896). Market share was the one path that never did.

This is also why pie charts "used to work" — a *regional* market-share ask still works today; only the national one silently returned an empty set.

## The fix

An explicit national token (`National`, `Nationwide`, `US`, `USA`, `United States`, `Aggregate`) now produces a rollup: each brand's regional shares averaged, grouped by brand/category/period, newest first — exactly the one-slice-per-brand shape the deterministic pie builder reads from `share_data[].share_percent`.

The table carries **no volume weights**, so an unweighted mean of the regions that reported is the honest aggregate. It's labelled as such rather than passed off as a measured national figure:

```json
"aggregation": {
  "scope": "national",
  "method": "unweighted mean of regional SharePercent, grouped by brand, category and period",
  "note": "The source table stores share by region with no volume weights, so a national figure is the average of the regions that reported."
}
```

Each row also reports `regions_counted`.

### Deliberately narrow

Only an **explicit** national token changes behaviour:

- blank region → still every region's rows (existing callers depend on this)
- specific region → untouched

Both tool descriptions now advertise `region='National'`, so the model has a reason to pass it.

## Tests

| Test | Pins |
|---|---|
| `NationalRegionTokens_ReturnARollup_NotAnEmptyResult` | all 7 tokens, region stamped `National`, shares in 0–100 |
| `NationalRollup_IsTheMeanOfTheRegionalShares` | the arithmetic is actually the mean |
| `NationalRollup_DeclaresHowItWasComputed` | the approximation is labelled |
| `NationalRollup_CollapsesEachBrandToASingleSliceForTheLatestPeriod` | one slice per brand, ≥2 slices |
| `ASpecificRegion_StillReturnsThatRegionsRows_Unchanged` | no regression |
| `AnOmittedRegion_StillReturnsPerRegionRows_Unchanged` | no regression |

## Verification

- **3450 passed, 0 failed**, 9 skipped
- `dotnet format --verify-no-changes` → clean

Requires redeploying the **MCP server** as well as the API. Live sweep re-measurement follows.
