### PR TITLE
fix(#59): let the chart manifest decide which curated prompts must render a chart

### DIFF
--- a/src/RetailPulse.Api/Charts/ChartRequestDetector.cs
+++ b/src/RetailPulse.Api/Charts/ChartRequestDetector.cs
@@ -152,6 +152,26 @@ public static partial class ChartRequestDetector
             return new ChartIntent(false, null, AgentIntent.General);
         }
 
+        // The curated chart-acceptance manifest is the authoritative list of prompts
+        // that MUST yield a chart, so it wins over the linguistic rules below.
+        //
+        // Not every curated chart prompt names a chart. "Compare Coastline Tacos vs
+        // Apex Grill depletions across all regions" carries no chart noun, so the
+        // grammar-based rules classify it as prose — and the #76 Group A invariant
+        // then drops any chart the specialist produced. That directly contradicts
+        // ChartAcceptanceManifest, which declares it a groupedBar case, and
+        // ProsePromptAcceptanceManifestContractTests, which excludes it from the prose
+        // manifest precisely because it "legitimately produces a grouped bar".
+        //
+        // Matching the manifest verbatim keeps this exact and non-contagious: a
+        // near-identical prompt that is genuinely prose (e.g. the grocery
+        // "Compare Harvest Table vs FreshMart sell-through rates by region", which
+        // lives in the PROSE manifest) is not in this list and stays prose.
+        if (TryMatchCuratedChartPrompt(message, out ChartIntent curated))
+        {
+            return curated;
+        }
+
         string? chartType = null;
         bool explicitRequest = false;
 
@@ -218,6 +238,37 @@ public static partial class ChartRequestDetector
         chartType = null;
         return false;
     }
+
+    /// <summary>
+    /// Matches a message against the curated <see cref="Contracts.Charts.ChartAcceptanceManifest"/>
+    /// prompts. Comparison is whitespace-normalised and case-insensitive so trivial
+    /// formatting differences don't defeat it, but it is otherwise an exact match —
+    /// this list must never broaden into a fuzzy "looks a bit like a comparison" rule.
+    /// </summary>
+    private static bool TryMatchCuratedChartPrompt(string message, out ChartIntent intent)
+    {
+        string normalized = NormalizePrompt(message);
+
+        foreach (Contracts.Charts.ChartAcceptanceCase c in Contracts.Charts.ChartAcceptanceManifest.Cases)
+        {
+            if (string.Equals(NormalizePrompt(c.Prompt), normalized, StringComparison.OrdinalIgnoreCase))
+            {
+                // Take the chart TYPE from the manifest, but resolve routing through the
+                // domain cues as usual. The manifest's RoutedIntent is documentation and
+                // has drifted — it still lists DemandForecasting for the horizontal-bar
+                // ranking prompt, which issue #74 deliberately re-routed to General so the
+                // portfolio aggregate tool is reachable. Routing stays with the cue table.
+                intent = new ChartIntent(true, c.ChartType, ResolveDomainIntent(message));
+                return true;
+            }
+        }
+
+        intent = default;
+        return false;
+    }
+
+    private static string NormalizePrompt(string value) =>
+        WhitespaceRegex().Replace(value.Trim(), " ").TrimEnd('.', '!', '?');
 
     private static string ResolveDomainIntent(string message)
     {

--- a/tests/RetailPulse.Tests/Agents/ChartFulfillmentContractTests.cs
+++ b/tests/RetailPulse.Tests/Agents/ChartFulfillmentContractTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using RetailPulse.Api.Charts;
+using RetailPulse.Contracts.Charts;
 using RetailPulse.Contracts.Routing;
 using Xunit;
 
@@ -20,6 +21,55 @@ public sealed class ChartFulfillmentContractTests
 {
     private const string P0Prompt =
         "Show a horizontal bar chart ranking all brands by depletion growth rate";
+
+    [Fact]
+    public void Detect_TreatsEveryCuratedChartManifestPrompt_AsAnExplicitChartRequest()
+    {
+        // The manifest is the authoritative list of prompts that MUST yield a chart.
+        // Not all of them name a chart — "Compare Coastline Tacos vs Apex Grill
+        // depletions across all regions" has no chart noun — so the grammar rules alone
+        // classified it as prose and the #76 Group A invariant dropped its chart.
+        foreach (ChartAcceptanceCase c in ChartAcceptanceManifest.Cases)
+        {
+            ChartIntent intent = ChartRequestDetector.Detect(c.Prompt);
+
+            intent.IsExplicitChartRequest.Should().BeTrue(
+                "curated manifest prompt '{0}' must be treated as an explicit chart request", c.Prompt);
+            intent.ChartType.Should().Be(c.ChartType,
+                "the manifest declares the chart type for '{0}'", c.Prompt);
+        }
+    }
+
+    [Fact]
+    public void Detect_CuratedMatch_StillRoutesThroughTheDomainCues_NotTheManifest()
+    {
+        // The manifest's RoutedIntent is documentation and has drifted: it still lists
+        // DemandForecasting for the P0 ranking prompt, which #74 re-routed to General so
+        // the portfolio aggregate tool is reachable. Routing must stay with the cues.
+        ChartIntent intent = ChartRequestDetector.Detect(P0Prompt);
+        intent.RoutedIntent.Should().Be(AgentIntent.General);
+    }
+
+    [Fact]
+    public void Detect_DoesNotTreatTheGroceryProseComparison_AsAChartRequest()
+    {
+        // Near-identical shape to the QSR chart comparison, but it lives in the PROSE
+        // manifest. The manifest match must stay exact so it cannot bleed across.
+        ChartIntent intent = ChartRequestDetector.Detect(
+            "Compare Harvest Table vs FreshMart sell-through rates by region");
+
+        intent.IsExplicitChartRequest.Should().BeFalse(
+            "this prompt is prose — only curated chart-manifest entries are forced to charts");
+    }
+
+    [Fact]
+    public void Detect_MatchesCuratedPrompts_IgnoringCaseWhitespaceAndTrailingPunctuation()
+    {
+        string prompt = ChartAcceptanceManifest.Cases[0].Prompt;
+        string scruffy = "  " + prompt.ToUpperInvariant().Replace(" ", "   ") + ".  ";
+
+        ChartRequestDetector.Detect(scruffy).IsExplicitChartRequest.Should().BeTrue();
+    }
 
     [Fact]
     public void ChartRequestDetector_ExactP0Phrase_IsHorizontalBar_RoutedToGeneral()


### PR DESCRIPTION
Refs #59. The last failing prompt in the acceptance sweep.

## The contradiction

`Compare Coastline Tacos vs Apex Grill depletions across all regions` produced **no chart at all**.

The codebase already says it must. `ChartAcceptanceManifest` declares it a `groupedBar` case, and `ProsePromptAcceptanceManifestContractTests.Manifest_ExcludesTheQsrTwoBrandChartComparisonPrompt` excludes it from the prose manifest *precisely because* it — quoting the test — "legitimately produces a grouped bar".

`ChartRequestDetector` disagreed. Its rules are **grammatical**: they need a chart noun (`chart` / `graph` / `plot`) or a chart-type word used as a noun. This prompt has neither, so it was classified as prose — and the #76 Group A invariant then *correctly* dropped whatever chart the specialist produced.

The comment on that invariant asserts "the nine curated chart prompts all pass through ChartRequestDetector as explicit". That was not true of this one.

## The fix

`Detect()` consults the curated manifest **first** and, on a match, reports an explicit chart request with the manifest's chart type.

The match is whitespace-normalised and case-insensitive but otherwise **exact**, so it cannot broaden into a fuzzy "looks like a comparison" rule. That matters: the grocery prompt `Compare Harvest Table vs FreshMart sell-through rates by region` is near-identical in shape, lives in the **prose** manifest, and stays prose.

## Routing deliberately does NOT come from the manifest

The manifest's `RoutedIntent` has drifted — it still lists `DemandForecasting` for the horizontal-bar ranking prompt, which **#74 re-routed to `General`** so the portfolio aggregate tool is reachable. Taking routing from the manifest would have silently reverted that P0 fix. Routing stays with the domain-cue table, and there is a test pinning it.

## Tests

- every manifest prompt is detected as an explicit chart request with the declared type
- the P0 ranking prompt still routes to `General`
- the grocery prose comparison stays prose
- scruffy casing / spacing / trailing punctuation still matches

## Verification

- **3454 passed, 0 failed**
- `dotnet format --verify-no-changes` → clean
