### PR TITLE
fix(#59): enforce the manifest mark floor on curated chart prompts

### DIFF
--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs
@@ -186,6 +186,13 @@ public partial class AgentExecutionPipeline
             ? Math.Max(6, ChartSpecValidator.MinimumMarksForType(intent.ChartType))
             : ChartSpecValidator.MinimumMarksForType(intent.ChartType);
 
+        // A curated prompt carries its own acceptance floor from the chart manifest.
+        // Enforcing it here means the live pipeline holds a chart to the SAME contract
+        // the acceptance tests assert, rather than the looser "is it renderable at all"
+        // per-type minimum — e.g. the two-brand region comparison needs 4 marks, where
+        // the generic groupedBar floor is only 2.
+        requiredMarks = Math.Max(requiredMarks, intent.MinMarks);
+
         if (DeterministicChartBuilder.TryBuild(response, intent.ChartType, requiredMarks, out ChartSpec? deterministic)
             && deterministic is not null)
         {

--- a/src/RetailPulse.Api/Charts/ChartRequestDetector.cs
+++ b/src/RetailPulse.Api/Charts/ChartRequestDetector.cs
@@ -25,10 +25,18 @@ namespace RetailPulse.Api.Charts;
 /// an explicit chart request must reach a data+chart specialist, not the multi-agent
 /// council (which produces prose/votes, no chart).
 /// </param>
+/// <param name="MinMarks">
+/// The minimum finite datapoints this chart must carry, when the prompt is a curated
+/// entry in <see cref="Contracts.Charts.ChartAcceptanceManifest"/>. Zero for an ad-hoc
+/// request, where only the generic per-type floor applies. Carrying the manifest's own
+/// figure means the live pipeline enforces the SAME contract the acceptance tests
+/// assert, instead of the looser "is it renderable at all" minimum.
+/// </param>
 public readonly record struct ChartIntent(
     bool IsExplicitChartRequest,
     string? ChartType,
-    string RoutedIntent);
+    string RoutedIntent,
+    int MinMarks = 0);
 
 /// <summary>
 /// Deterministic, generic detector for explicit chart requests. Shared by the router
@@ -258,7 +266,7 @@ public static partial class ChartRequestDetector
                 // has drifted — it still lists DemandForecasting for the horizontal-bar
                 // ranking prompt, which issue #74 deliberately re-routed to General so the
                 // portfolio aggregate tool is reachable. Routing stays with the cue table.
-                intent = new ChartIntent(true, c.ChartType, ResolveDomainIntent(message));
+                intent = new ChartIntent(true, c.ChartType, ResolveDomainIntent(message), c.MinMarks);
                 return true;
             }
         }

--- a/tests/RetailPulse.Tests/Agents/ChartFulfillmentContractTests.cs
+++ b/tests/RetailPulse.Tests/Agents/ChartFulfillmentContractTests.cs
@@ -37,6 +37,8 @@ public sealed class ChartFulfillmentContractTests
                 "curated manifest prompt '{0}' must be treated as an explicit chart request", c.Prompt);
             intent.ChartType.Should().Be(c.ChartType,
                 "the manifest declares the chart type for '{0}'", c.Prompt);
+            intent.MinMarks.Should().Be(c.MinMarks,
+                "the manifest's acceptance floor must reach the live pipeline for '{0}'", c.Prompt);
         }
     }
 


### PR DESCRIPTION
Refs #59.

## The gap

The two-brand region comparison rendered a `groupedBar` with **2 marks**. That clears the generic per-type minimum (`groupedBar` = 2) but not the acceptance contract, which requires **4** — two brands across at least two regions.

The live pipeline was holding curated charts to "is it renderable at all", while the acceptance suite asserted something stricter. Same prompt, two different bars.

```
[8] qsr :: Compare Coastline Tacos vs Apex Grill depletions across all regions
     -> chart 'groupedBar' had 2 marks, needs >= 4
     cacheHit=False tools=8 charts=[groupedBar]
```

## The fix

`ChartIntent` now carries the manifest's `MinMarks` on a curated match, and chart fulfillment raises its floor to it. A chart under that floor is rebuilt from tool data or failed closed — exactly as an under-populated chart already was.

The live path and the acceptance suite now enforce the **same number**.

`MinMarks` is zero for ad-hoc requests, where only the per-type floor applies, so nothing changes off the curated set.

## Verification

- **3454 passed, 0 failed**
- `dotnet format --verify-no-changes` → clean
- Contract test extended: every manifest prompt's `MinMarks` must reach the live pipeline
