### PR TITLE
fix(#59): scrub chart scaffolding the inline extractor cannot bind

### DIFF
--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartExtraction.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartExtraction.cs
@@ -32,6 +32,67 @@ public partial class AgentExecutionPipeline
     [GeneratedRegex(@"(\r?\n){3,}")]
     private static partial Regex ExcessiveBlankLinesPattern();
 
+    // A fenced ```json block, captured with its body so the body can be inspected.
+    [GeneratedRegex(@"```json\s*(?<body>\{.*?\})\s*```", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex FencedJsonBlockPattern();
+
+    /// <summary>
+    /// Keys that mark a fenced JSON block as chart scaffolding rather than content the
+    /// user asked for. <c>chart</c> is deliberately included: a model that writes
+    /// <c>{"chart":"groupedBar","title":"…"}</c> is announcing a chart, not answering a
+    /// question — and because that shape has no <c>type</c> key it never binds to a
+    /// <see cref="ChartSpec"/>, so <see cref="ExtractInlineCharts"/> leaves it in the
+    /// prose. The user then sees raw JSON in the chat bubble, which the G2 acceptance
+    /// contract forbids.
+    /// </summary>
+    private static readonly string[] _chartScaffoldingKeys =
+        ["\"chart\"", "\"type\"", "\"xaxistitle\"", "\"yaxistitle\"", "\"series\"", "\"datapoints\"", "\"legend\""];
+
+    /// <summary>
+    /// Removes fenced JSON blocks that are chart scaffolding but did NOT resolve to a
+    /// renderable chart. Runs after <see cref="ExtractInlineCharts"/>, which already
+    /// strips the blocks it could bind — this catches the near-misses it cannot.
+    ///
+    /// <para>
+    /// Deliberately narrow: only fenced <c>```json</c> blocks whose body parses as a
+    /// JSON object AND carries a chart-scaffolding key are removed. Arbitrary JSON the
+    /// user legitimately asked for is left alone.
+    /// </para>
+    /// </summary>
+    internal static string StripResidualChartJson(string reply)
+    {
+        if (string.IsNullOrWhiteSpace(reply) || !reply.Contains("```", StringComparison.Ordinal))
+        {
+            return reply;
+        }
+
+        string cleaned = FencedJsonBlockPattern().Replace(reply, match =>
+        {
+            string body = match.Groups["body"].Value;
+
+            try
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(body);
+                if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object)
+                {
+                    return match.Value;
+                }
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                return match.Value;
+            }
+
+            string lowered = body.ToLowerInvariant();
+            bool looksLikeChart = Array.Exists(_chartScaffoldingKeys, k => lowered.Contains(k, StringComparison.Ordinal));
+            return looksLikeChart ? string.Empty : match.Value;
+        });
+
+        cleaned = EmptyCodeFencePattern().Replace(cleaned, string.Empty);
+        cleaned = ExcessiveBlankLinesPattern().Replace(cleaned, "\n\n");
+        return cleaned.Trim();
+    }
+
     internal readonly record struct InlineChartExtraction(string Reply, List<ChartSpec> Charts);
 
     /// <summary>

--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.cs
@@ -244,6 +244,10 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         reply = inlineCharts.Reply;
         charts = MergeInlineCharts(charts, inlineCharts.Charts);
 
+        // Near-miss chart scaffolding the extractor could not bind (e.g. {"chart":"groupedBar"})
+        // must not reach the chat bubble as raw JSON - G2 forbids leaked chart JSON.
+        reply = StripResidualChartJson(reply);
+
         // Chart-fulfillment invariant: an explicit chart request must yield a renderable
         // chart (reconstructed deterministically from tool results if the model emitted
         // none) or a structured chart-unavailable diagnostic — never silent prose-only.
@@ -532,6 +536,10 @@ public partial class AgentExecutionPipeline : IAgentExecutionPipeline
         InlineChartExtraction inlineCharts = ExtractInlineCharts(reply);
         reply = inlineCharts.Reply;
         charts = MergeInlineCharts(charts, inlineCharts.Charts);
+
+        // Near-miss chart scaffolding the extractor could not bind (e.g. {"chart":"groupedBar"})
+        // must not reach the chat bubble as raw JSON - G2 forbids leaked chart JSON.
+        reply = StripResidualChartJson(reply);
 
         // Chart-fulfillment invariant (streaming): reconstruct deterministically or append
         // a structured chart-unavailable diagnostic before streaming, so the streamed reply

--- a/tests/RetailPulse.Tests/Agents/ResidualChartJsonScrubTests.cs
+++ b/tests/RetailPulse.Tests/Agents/ResidualChartJsonScrubTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using RetailPulse.Api.Agents;
+using Xunit;
+
+namespace RetailPulse.Tests.Agents;
+
+/// <summary>
+/// The G2 acceptance contract forbids chart JSON reaching the chat bubble.
+/// <see cref="AgentExecutionPipeline.ExtractInlineCharts"/> strips the blocks it can
+/// bind to a ChartSpec, but a near-miss shape slips through — observed live on
+/// "Compare Foundry Home vs Urban Living performance in the West Coast":
+///
+/// <code>
+/// ```json
+/// {"chart":"groupedBar","title":"West Coast Demand Comparison: Foundry Home vs Urban Living"}
+/// ```
+/// </code>
+///
+/// The key is <c>chart</c>, not <c>type</c>, so it never binds and was left in the prose.
+/// </summary>
+public sealed class ResidualChartJsonScrubTests
+{
+    [Fact]
+    public void StripsTheObservedLiveLeak()
+    {
+        const string reply = """
+            Foundry Home leads Urban Living on the West Coast.
+
+            ```json
+            {"chart":"groupedBar","title":"West Coast Demand Comparison: Foundry Home vs Urban Living"}
+            ```
+
+            Let me know if you want a regional split.
+            """;
+
+        string cleaned = AgentExecutionPipeline.StripResidualChartJson(reply);
+
+        cleaned.Should().NotContain("```");
+        cleaned.Should().NotContain("groupedBar");
+        cleaned.Should().Contain("Foundry Home leads Urban Living");
+        cleaned.Should().Contain("regional split");
+    }
+
+    [Theory]
+    [InlineData(/*lang=json,strict*/ """{"type":"bar","title":"x"}""")]
+    [InlineData(/*lang=json,strict*/ """{"chart":"pie"}""")]
+    [InlineData(/*lang=json,strict*/ """{"xAxisTitle":"Region","yAxisTitle":"Volume"}""")]
+    [InlineData(/*lang=json,strict*/ """{"series":[{"name":"A"}]}""")]
+    [InlineData(/*lang=json,strict*/ """{"legend":"Brand"}""")]
+    public void StripsAnyFencedBlockCarryingChartScaffolding(string body)
+    {
+        string reply = "Prose before.\n\n```json\n" + body + "\n```\n\nProse after.";
+
+        string cleaned = AgentExecutionPipeline.StripResidualChartJson(reply);
+
+        cleaned.Should().NotContain("```");
+        cleaned.Should().Contain("Prose before.");
+        cleaned.Should().Contain("Prose after.");
+    }
+
+    [Fact]
+    public void LeavesLegitimateJsonAlone()
+    {
+        // Not chart scaffolding — the user may genuinely have asked for this.
+        const string reply = """
+            Here is the payload you asked for.
+
+            ```json
+            {"brand":"FreshMart","region":"Northeast","units":1200}
+            ```
+            """;
+
+        string cleaned = AgentExecutionPipeline.StripResidualChartJson(reply);
+
+        cleaned.Should().Contain("```json");
+        cleaned.Should().Contain("FreshMart");
+    }
+
+    [Fact]
+    public void LeavesMalformedJsonAlone()
+    {
+        // Unparseable content is not silently hidden — same principle the inline
+        // extractor already follows.
+        const string reply = "Text.\n\n```json\n{\"chart\": broken\n```";
+
+        string cleaned = AgentExecutionPipeline.StripResidualChartJson(reply);
+
+        cleaned.Should().Contain("broken");
+    }
+
+    [Fact]
+    public void IsANoOpWhenThereAreNoFences()
+    {
+        const string reply = "Just prose, no code fences at all.";
+        AgentExecutionPipeline.StripResidualChartJson(reply).Should().Be(reply);
+    }
+}


### PR DESCRIPTION
Refs #59.

## Observed live

On `Compare Foundry Home vs Urban Living performance in the West Coast` — a **prose** prompt — the reply carried a raw fenced block straight into the chat bubble:

````
```json
{"chart":"groupedBar","title":"West Coast Demand Comparison: Foundry Home vs Urban Living"}
```
````

The G2 acceptance contract forbids leaked chart JSON.

## Why the existing extractor missed it

`ExtractInlineCharts` strips fenced JSON it can bind to a `ChartSpec`. This shape keys the type as **`chart`**, not `type`, so it never binds — and the extractor deliberately leaves anything it cannot bind in place, so nothing legitimate is silently hidden. Correct principle, wrong outcome here.

## The fix

`StripResidualChartJson` runs immediately after inline extraction on **both** pipeline paths. It removes fenced `json` blocks that parse as an object **and** carry a chart-scaffolding key (`chart`, `type`, `xAxisTitle`, `yAxisTitle`, `series`, `dataPoints`, `legend`).

A model writing `{"chart":"groupedBar"}` is announcing a chart, not answering a question.

Deliberately narrow, mirroring the extractor's own principle:

- only fenced ` ```json ` blocks are considered
- malformed bodies are left in place
- a block with no chart scaffolding is untouched (`{"brand":"FreshMart","units":1200}` survives)

## Tests

- the exact observed live leak is removed, surrounding prose preserved
- five scaffolding shapes stripped (`type`, `chart`, axis titles, `series`, `legend`)
- legitimate JSON left alone
- malformed JSON left alone
- no-op when there are no fences

## Verification

- **3463 passed, 0 failed**
- `dotnet format --verify-no-changes` → clean
