### PR TITLE
fix(#59): treat the curated mark contract as a target, not a cliff

### DIFF
--- a/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs
+++ b/src/RetailPulse.Api/Agents/AgentExecutionPipeline.ChartFulfillment.cs
@@ -182,21 +182,44 @@ public partial class AgentExecutionPipeline
         // type, too few marks, or the chart JSON narrated into the prose.
         //
         // The model still writes the words; the code draws the chart.
-        int requiredMarks = isPortfolioRanking
+        //
+        // A curated prompt carries its own acceptance floor from the chart manifest.
+        // Aim for it — the live pipeline should hold a chart to the SAME contract the
+        // acceptance tests assert, rather than the looser "is it renderable at all"
+        // per-type minimum (the two-brand region comparison wants 4 marks where the
+        // generic groupedBar floor is only 2).
+        //
+        // But treat it as a TARGET, not a cliff. The manifest describes a complete
+        // turn — two brands across all six regions is twelve marks — and a turn where
+        // the model scoped its tool calls more narrowly yields fewer. Dropping the
+        // chart entirely in that case is the worst outcome: real data exists, it
+        // renders correctly, and the user is shown nothing. So we try the manifest
+        // floor first and fall back to the per-type floor, never below it.
+        int typeFloor = isPortfolioRanking
             ? Math.Max(6, ChartSpecValidator.MinimumMarksForType(intent.ChartType))
             : ChartSpecValidator.MinimumMarksForType(intent.ChartType);
+        int targetMarks = Math.Max(typeFloor, intent.MinMarks);
 
-        // A curated prompt carries its own acceptance floor from the chart manifest.
-        // Enforcing it here means the live pipeline holds a chart to the SAME contract
-        // the acceptance tests assert, rather than the looser "is it renderable at all"
-        // per-type minimum — e.g. the two-brand region comparison needs 4 marks, where
-        // the generic groupedBar floor is only 2.
-        requiredMarks = Math.Max(requiredMarks, intent.MinMarks);
-
-        if (DeterministicChartBuilder.TryBuild(response, intent.ChartType, requiredMarks, out ChartSpec? deterministic)
-            && deterministic is not null)
+        int requiredMarks = targetMarks;
+        if (!DeterministicChartBuilder.TryBuild(response, intent.ChartType, targetMarks, out ChartSpec? deterministic)
+            || deterministic is null)
         {
-            // Prefer the deterministic chart, but never at the cost of completeness.
+            requiredMarks = typeFloor;
+            if (targetMarks > typeFloor
+                && DeterministicChartBuilder.TryBuild(response, intent.ChartType, typeFloor, out ChartSpec? relaxed)
+                && relaxed is not null)
+            {
+                _logger.LogInformation(
+                    "Chart-fulfillment: tool data supports {Marks} marks, below the curated "
+                    + "{Target}-mark contract for '{ChartType}'. Emitting the chart the data does "
+                    + "support rather than nothing.",
+                    CountMarks(relaxed), targetMarks, intent.ChartType ?? "chart");
+                deterministic = relaxed;
+            }
+        }
+
+        if (deterministic is not null)
+        {
             // When the model also produced a valid chart of the requested type that
             // covers MORE of the data, keeping the thinner rebuild would be a
             // regression — the tool payload is authoritative about what is true, not


### PR DESCRIPTION
Refs #59.

## What went wrong

Enforcing the manifest's `MinMarks` as a **hard floor** (from the previous PR) made the grouped-bar comparison worse, not better:

```
[22] Show a grouped bar chart comparing FreshMart and Harvest Table across all regions
     -> expected chart 'groupedBar', saw '[]'
     tools=2 charts=[] marks=0 secs=27.5
```

The manifest's twelve marks describe a **complete** turn — two brands across all six regions. When the model scoped its tool calls more narrowly the data supported ten, the rebuild was rejected, and the user was shown **no chart at all**.

Real data existed and would have rendered correctly. That's the worst of the three outcomes: a chart built from ten real marks is honest and useful; nothing is not.

## The fix

Try the curated target first, fall back to the per-type floor, never below it.

- a complete turn still produces the full twelve-mark chart (strict attempt runs first)
- a partial turn produces the chart the data supports, and logs that it did
- a genuinely under-populated result — below the per-type floor — still fails closed to the chart-unavailable diagnostic, exactly as before

## Verification

- **3463 passed, 0 failed**
- `dotnet format --verify-no-changes` → clean
