### PR TITLE
fix(#59): build brand-comparison charts from depletion stats too

### DIFF
--- a/src/RetailPulse.Api/Charts/DeterministicChartBuilder.cs
+++ b/src/RetailPulse.Api/Charts/DeterministicChartBuilder.cs
@@ -186,7 +186,9 @@ internal static class DeterministicChartBuilder
                 // fail-closed contract via the chart-unavailable diagnostic.
                 "horizontalbar" => TryBuildGrowthRanking(payloads),
                 "groupedbar" or "stackedbar" => TryBuildGroupedRegionBar(payloads, requestedType)
-                    ?? TryBuildDemandBar(payloads, requestedType),
+                    ?? TryBuildDepletionStatsGrouped(payloads, requestedType)
+                    ?? TryBuildDemandBar(payloads, requestedType)
+                    ?? TryBuildDepletionStatsBar(payloads, requestedType),
                 "line" => TryBuildDemandLine(payloads)
                     ?? TryBuildDemandBar(payloads, "line"),
                 // Pie/donut and table are their own structural families (share/mix
@@ -198,7 +200,9 @@ internal static class DeterministicChartBuilder
                 // instead, exactly as the horizontalBar ranking above does.
                 "pie" or "donut" => TryBuildShareOrMixPie(payloads, requestedType ?? "pie"),
                 "table" => TryBuildDepletionStatsTable(payloads),
-                _ => TryBuildDemandBar(payloads, requestedType) ?? TryBuildGauge(payloads),
+                _ => TryBuildDemandBar(payloads, requestedType)
+                    ?? TryBuildDepletionStatsBar(payloads, requestedType)
+                    ?? TryBuildGauge(payloads),
             };
     }
 
@@ -298,6 +302,141 @@ internal static class DeterministicChartBuilder
             [
                 new ChartSeries { Legend = "Avg Weekly Depletion Velocity", Values = points }
             ]
+        };
+    }
+
+    /// <summary>
+    /// Build a per-brand bar from <c>GetDepletionStats</c> payloads — the shape
+    /// <c>{ brand, region, metrics: { depletions_yoy, … } }</c>.
+    ///
+    /// <para>
+    /// A brand comparison is answerable from either demand history or depletion stats, and
+    /// which one the model reaches for varies between runs. When it picks depletion stats
+    /// the historical-demand builders find no <c>summary.total_volume</c>/<c>by_region</c>
+    /// fingerprint and produce nothing, so a perfectly answerable comparison failed closed.
+    /// This reads the payload the turn actually produced instead.
+    /// </para>
+    /// </summary>
+    private static ChartSpec? TryBuildDepletionStatsBar(IReadOnlyList<JsonElement> payloads, string? requestedType)
+    {
+        var points = new List<ChartDataPoint>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var regions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (JsonElement payload in payloads)
+        {
+            if (payload.ValueKind != JsonValueKind.Object)
+                continue;
+
+            string? brand = ReadBrand(payload);
+            if (string.IsNullOrWhiteSpace(brand))
+                continue;
+
+            JsonElement source = payload;
+            if (payload.TryGetProperty("metrics", out JsonElement metrics)
+                && metrics.ValueKind == JsonValueKind.Object)
+            {
+                source = metrics;
+            }
+
+            if (!TryReadPercent(source, "depletions_yoy", out double yoy) || !double.IsFinite(yoy))
+                continue;
+
+            string? rowRegion = ReadRegion(payload);
+            if (!string.IsNullOrWhiteSpace(rowRegion))
+                regions.Add(rowRegion);
+
+            // One bar per brand+region, so a per-region fan-out does not collapse
+            // several distinct facts onto a single label.
+            string label = regions.Count > 1 && !string.IsNullOrWhiteSpace(rowRegion)
+                ? $"{brand} — {rowRegion}"
+                : brand;
+
+            if (!seen.Add(label))
+                continue;
+
+            points.Add(new ChartDataPoint { X = label, Y = Math.Round(yoy, 1) });
+        }
+
+        if (points.Count < 2)
+            return null;
+
+        string suffix = regions.Count == 1 ? $" — {regions.First()}" : string.Empty;
+        return new ChartSpec
+        {
+            Type = NormalizeBarType(requestedType),
+            Title = $"Depletions YoY by Brand{suffix}",
+            XAxisTitle = "Brand",
+            YAxisTitle = "Depletions YoY %",
+            Data = [new ChartSeries { Legend = "Depletions YoY %", Values = points }],
+        };
+    }
+
+    /// <summary>
+    /// Grouped counterpart to <see cref="TryBuildDepletionStatsBar"/>: one series per brand,
+    /// one mark per region, read from <c>GetDepletionStats</c> payloads.
+    /// </summary>
+    private static ChartSpec? TryBuildDepletionStatsGrouped(IReadOnlyList<JsonElement> payloads, string? requestedType)
+    {
+        var byBrand = new Dictionary<string, List<ChartDataPoint>>(StringComparer.OrdinalIgnoreCase);
+        var seenPerBrand = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var order = new List<string>();
+
+        foreach (JsonElement payload in payloads)
+        {
+            if (payload.ValueKind != JsonValueKind.Object)
+                continue;
+
+            string? brand = ReadBrand(payload);
+            string? region = ReadRegion(payload);
+            if (string.IsNullOrWhiteSpace(brand) || string.IsNullOrWhiteSpace(region))
+                continue;
+
+            JsonElement source = payload;
+            if (payload.TryGetProperty("metrics", out JsonElement metrics)
+                && metrics.ValueKind == JsonValueKind.Object)
+            {
+                source = metrics;
+            }
+
+            if (!TryReadPercent(source, "depletions_yoy", out double yoy) || !double.IsFinite(yoy))
+                continue;
+
+            if (!byBrand.TryGetValue(brand, out List<ChartDataPoint>? pts))
+            {
+                pts = [];
+                byBrand[brand] = pts;
+                seenPerBrand[brand] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                order.Add(brand);
+            }
+
+            if (!seenPerBrand[brand].Add(region))
+                continue;
+
+            pts.Add(new ChartDataPoint { X = region, Y = Math.Round(yoy, 1) });
+        }
+
+        var series = new List<ChartSeries>();
+        foreach (string brand in order)
+        {
+            if (byBrand[brand].Count > 0)
+                series.Add(new ChartSeries { Legend = brand, Values = byBrand[brand] });
+        }
+
+        if (series.Count < 2)
+            return null;
+
+        string type = string.Equals(requestedType, "stackedBar", StringComparison.OrdinalIgnoreCase)
+            ? "stackedBar"
+            : "groupedBar";
+
+        return new ChartSpec
+        {
+            Type = type,
+            Title = $"{string.Join(" vs ", series.Select(s => s.Legend))} — Depletions YoY by Region",
+            XAxisTitle = "Region",
+            YAxisTitle = "Depletions YoY %",
+            Data = series,
         };
     }
 

--- a/tests/RetailPulse.Tests/Agents/ChartFulfillmentTests.cs
+++ b/tests/RetailPulse.Tests/Agents/ChartFulfillmentTests.cs
@@ -433,6 +433,48 @@ public sealed class ChartFulfillmentTests
         result.Charts[0].Data.Sum(s => s.Values.Count).Should().Be(4);
     }
 
+    [Fact]
+    public void EnforceChartFulfillment_BuildsABar_FromDepletionStatsWhenThatIsWhatTheTurnFetched()
+    {
+        // Issue #59: a brand comparison is answerable from either demand history or
+        // depletion stats, and which one the model reaches for varies run to run. When it
+        // picked depletion stats, the historical-demand builders found no
+        // summary.total_volume / by_region fingerprint and the chart failed closed.
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults(
+            DepletionStats("Sierra Gold Tequila", "Northeast", "4.2%"),
+            DepletionStats("Ridgeline Bourbon", "Northeast", "-1.8%"),
+            DepletionStats("Summit Vodka", "Northeast", "2.6%"));
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            "Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast",
+            response, [], "Here you go.");
+
+        result.Charts.Should().ContainSingle();
+        result.Charts[0].Type.Should().Be("bar");
+        result.Charts[0].Data.Sum(s => s.Values.Count).Should().Be(3, "one bar per brand");
+    }
+
+    [Fact]
+    public void EnforceChartFulfillment_BuildsAGroupedBar_FromPerRegionDepletionStats()
+    {
+        AgentExecutionPipeline pipeline = CreatePipeline();
+        MeaiChatResponse response = ResponseWithToolResults(
+            DepletionStats("Coastline Tacos", "Northeast", "3.1%"),
+            DepletionStats("Coastline Tacos", "Midwest", "1.4%"),
+            DepletionStats("Apex Grill", "Northeast", "-2.2%"),
+            DepletionStats("Apex Grill", "Midwest", "0.9%"));
+
+        AgentExecutionPipeline.ChartFulfillmentResult result = pipeline.EnforceChartFulfillment(
+            "Compare Coastline Tacos vs Apex Grill depletions across all regions",
+            response, [], "Here you go.");
+
+        result.Charts.Should().ContainSingle();
+        result.Charts[0].Type.Should().Be("groupedBar");
+        result.Charts[0].Data.Should().HaveCount(2, "one series per brand");
+        result.Charts[0].Data.Sum(s => s.Values.Count).Should().Be(4);
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static AgentExecutionPipeline CreatePipeline()
@@ -456,6 +498,22 @@ public sealed class ChartFulfillmentTests
                 new { region, volume = avgWeekly * 52, units = 1000, avg_weekly_volume = avgWeekly, weeks = 52 }
             },
             compaction = new { compacted = true, aggregate_complete = true }
+        });
+
+    private static string DepletionStats(string brand, string region, string depletionsYoy) =>
+        JsonSerializer.Serialize(new
+        {
+            brand,
+            region,
+            period = "YTD",
+            metrics = new
+            {
+                depletions_yoy = depletionsYoy,
+                sell_through_yoy = "-1.2%",
+                inventory_weeks_on_hand = 8.4,
+                status = "Healthy",
+            },
+            sentiment_summary = "Sample summary.",
         });
 
     private static MeaiChatResponse ResponseWithToolResults(params string[] toolResultJson)


### PR DESCRIPTION
Refs #59. Closes the last source of run-to-run variance in the acceptance sweep.

## What happened

A verification sweep slipped from **26/26** to **24/26**. Both failures looked like this:

```
[8]  Compare Coastline Tacos vs Apex Grill depletions across all regions
     -> expected chart 'groupedBar', saw '[]'
     tools=3 charts=[] marks=0 cache=False
[20] Show me a bar chart comparing depletion velocity for all spirits brands in the Northeast
     -> expected chart 'bar', saw '[]'
     tools=3 charts=[] marks=0 cache=False
```

Three successful tool calls, real data in the payloads, **no chart**.

## Root cause

A brand comparison is answerable from **either** demand history **or** depletion stats, and which one the model reaches for varies between runs.

Every deterministic bar builder required the historical-demand fingerprint — `summary.total_volume` plus `weekly_data` or `by_region`. `GetDepletionStats` returns something else entirely:

```json
{ "brand": "Coastline Tacos", "region": "Northeast",
  "metrics": { "depletions_yoy": "-2.8%", "sell_through_yoy": "-3.7%", … } }
```

Perfectly chartable — and nothing was reading it, even though `TryBuildDepletionStatsTable` already understood the shape for the table case.

## Fix

| Builder | Produces |
|---|---|
| `TryBuildDepletionStatsBar` | one bar per brand from `metrics.depletions_yoy`; labels as `Brand — Region` when the turn spans several regions, so a per-region fan-out doesn't collapse distinct facts onto one bar |
| `TryBuildDepletionStatsGrouped` | one series per brand, one mark per region |

Both run **only after** the historical-demand builders, so turns that already worked are untouched.

Neither invents data: a payload without a finite `depletions_yoy` is skipped, and each requires at least two bars (or two series) before producing anything — otherwise it still fails closed.

## Verification

- **3467 passed, 0 failed**
- `dotnet format --verify-no-changes` → clean
- New tests cover both shapes: three single-region payloads → a 3-bar chart; four brand×region payloads → a 2-series grouped bar

Live re-measurement follows deployment.
