### PR TITLE
fix(security): close public unauthenticated exposure of MCP server and Teams bot

### DIFF
--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -47,7 +47,12 @@ param entraAppRole string = 'RetailPulse.User'
 @description('ACR login server for the private registry that hosts the service images. When set, containers pull via system-assigned identity so `azd provision` re-asserts the registry auth binding declaratively.')
 param containerRegistryLoginServer string = ''
 
+@description('Shared secret the API presents to the MCP server as X-Api-Key. Stored as an ACA secret on both apps. Defaults to a value generated per deployment.')
+@secure()
+param mcpApiKey string = newGuid()
+
 var apimSubscriptionKeySecretName = 'apim-sub-key'
+var mcpApiKeySecretName = 'mcp-api-key'
 
 // The `registries` block binds a container app's image-pull auth to its own
 // system-assigned identity, with no admin credentials. It is only emitted when
@@ -86,8 +91,18 @@ resource mcpServer 'Microsoft.App/containerApps@2024-03-01' = {
     configuration: {
       activeRevisionsMode: 'Single'
       registries: mcpUsesPrivateRegistry ? privateRegistryBlock : []
+      secrets: [
+        {
+          name: mcpApiKeySecretName
+          value: mcpApiKey
+        }
+      ]
+      // The MCP server is a server-to-server dependency of the API, never a
+      // browser-facing surface. `external: false` keeps it addressable only from
+      // inside the Container Apps environment, so the tool transport and the REST
+      // data endpoints are unreachable from the public internet.
       ingress: {
-        external: true
+        external: false
         targetPort: 8080
         transport: 'auto'
         allowInsecure: false
@@ -102,10 +117,21 @@ resource mcpServer 'Microsoft.App/containerApps@2024-03-01' = {
             cpu: json('0.5')
             memory: '1Gi'
           }
+          // Production (not Development) so the API-key gate is enforced and the
+          // OpenAPI document is not published. Running this app as Development is
+          // what previously disabled the gate entirely.
           env: [
             {
               name: 'ASPNETCORE_ENVIRONMENT'
-              value: 'Development'
+              value: 'Production'
+            }
+            {
+              name: 'ApiKey__Enabled'
+              value: 'true'
+            }
+            {
+              name: 'ApiKey__Value'
+              secretRef: mcpApiKeySecretName
             }
           ]
         }
@@ -147,6 +173,10 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
         {
           name: apimSubscriptionKeySecretName
           value: apimSubscriptionKey
+        }
+        {
+          name: mcpApiKeySecretName
+          value: mcpApiKey
         }
       ]
       ingress: {
@@ -197,6 +227,10 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'McpServer__BaseUrl'
               value: effectiveMcpBaseUrl
+            }
+            {
+              name: 'McpServer__ApiKey'
+              secretRef: mcpApiKeySecretName
             }
             {
               name: 'Security__RequireAuth'
@@ -298,10 +332,15 @@ resource teamsBot 'Microsoft.App/containerApps@2024-03-01' = {
             cpu: json('0.5')
             memory: '1Gi'
           }
+          // Production (not Development) so the M365 Agents SDK maps the messaging
+          // endpoints with requireAuth: true and inbound Activities are validated
+          // against the Bot Framework channel. Running this app as Development is
+          // what previously disabled inbound channel authentication on a publicly
+          // exposed endpoint.
           env: [
             {
               name: 'ASPNETCORE_ENVIRONMENT'
-              value: 'Development'
+              value: 'Production'
             }
             {
               name: 'TeamsBot__ApiBaseUrl'

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -1,11 +1,9 @@
 using System.Text.Json;
-using System.Threading.RateLimiting;
 using Asp.Versioning;
 using Microsoft.Agents.AI.Workflows.Checkpointing;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -219,93 +217,8 @@ if (entraAuthOptions is not null)
 }
 
 // ── Rate Limiting ───────────────────────────────────────────────────────
-builder.Services.AddRateLimiter(options =>
-{
-    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
-
-    options.AddFixedWindowLimiter("strict", opt =>
-    {
-        opt.PermitLimit = 10;
-        opt.Window = TimeSpan.FromMinutes(1);
-        opt.QueueLimit = 0;
-    });
-
-    options.AddFixedWindowLimiter("upload", opt =>
-    {
-        opt.PermitLimit = 5;
-        opt.Window = TimeSpan.FromMinutes(1);
-        opt.QueueLimit = 0;
-    });
-
-    options.AddFixedWindowLimiter("moderate", opt =>
-    {
-        opt.PermitLimit = 30;
-        opt.Window = TimeSpan.FromMinutes(1);
-        opt.QueueLimit = 0;
-    });
-
-    options.AddFixedWindowLimiter("relaxed", opt =>
-    {
-        opt.PermitLimit = 100;
-        opt.Window = TimeSpan.FromMinutes(1);
-        opt.QueueLimit = 0;
-    });
-
-    // Rate limiter for the unauthenticated Anonymous bootstrap endpoint. Always registered so the
-    // limiter graph is stable and testable; only used when Authentication:Mode=Anonymous maps the
-    // bootstrap route.
-    //
-    // IMPORTANT (ACA ingress reality): when hosted behind Azure Container Apps, every request
-    // arrives from the ingress/proxy, so HttpContext.Connection.RemoteIpAddress is the proxy's IP,
-    // NOT the client's — a per-IP partition would therefore collapse to a single global bucket
-    // anyway. We do NOT trust X-Forwarded-For to recover the client IP: ACA does not give us a
-    // cryptographically verifiable client-IP header, and an attacker can forge XFF to shard around a
-    // per-IP limit. So bootstrap is intentionally a single GLOBAL, conservative fixed window — it
-    // caps total anonymous session minting per minute for the whole replica and cannot be bypassed
-    // by header spoofing. Fine-grained abuse control is enforced AFTER bootstrap by the per-subject
-    // (immutable, server-minted sub) limits in AnonymousGuardMiddleware, which is the primary
-    // control. Note: this window is replica-local; hosted Anonymous runs at maxReplicas=1.
-    //
-    // Config key: Anonymous:Bootstrap:GlobalPerMinute (conservative default 5). The legacy
-    // Anonymous:Bootstrap:PerIpPerMinute key is still honoured as a fallback for backward
-    // compatibility — it was never actually per-IP behind ACA, hence the rename.
-    options.AddPolicy("anonymous-bootstrap", _ =>
-        RateLimitPartition.GetFixedWindowLimiter(
-            partitionKey: "anonymous-bootstrap-global",
-            factory: _ => new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = builder.Configuration.GetValue("Anonymous:Bootstrap:GlobalPerMinute",
-                    builder.Configuration.GetValue("Anonymous:Bootstrap:PerIpPerMinute", 5)),
-                Window = TimeSpan.FromMinutes(1),
-                QueueLimit = 0,
-            }));
-
-    // Rate limiters for the GitHub confidential OAuth BFF endpoints. Always registered so the limiter
-    // graph is stable and testable; only used when Authentication:Mode=GitHub maps the endpoints.
-    // Behind ACA the client IP is the proxy's and X-Forwarded-For is forgeable, so these are single
-    // GLOBAL per-replica fixed windows (not per-IP) that cap login-flow abuse (state minting and code
-    // redemption) without being bypassable by header spoofing. Replica-local; hosted GitHub runs at
-    // maxReplicas=1. Config keys: GitHub:RateLimits:StartPerMinute / ExchangePerMinute.
-    options.AddPolicy("github-start", _ =>
-        RateLimitPartition.GetFixedWindowLimiter(
-            partitionKey: "github-start-global",
-            factory: _ => new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = builder.Configuration.GetValue("GitHub:RateLimits:StartPerMinute", 10),
-                Window = TimeSpan.FromMinutes(1),
-                QueueLimit = 0,
-            }));
-
-    options.AddPolicy("github-exchange", _ =>
-        RateLimitPartition.GetFixedWindowLimiter(
-            partitionKey: "github-exchange-global",
-            factory: _ => new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = builder.Configuration.GetValue("GitHub:RateLimits:ExchangePerMinute", 20),
-                Window = TimeSpan.FromMinutes(1),
-                QueueLimit = 0,
-            }));
-});
+// Policies live in RateLimitingSetup so tests can exercise the real limits.
+builder.Services.AddRetailPulseRateLimiting(builder.Configuration);
 
 // ── API Versioning ──────────────────────────────────────────────────────
 builder.Services.AddApiVersioning(options =>
@@ -458,8 +371,30 @@ string mcpBaseUrl = builder.Configuration["McpServer:BaseUrl"]
     ?? (builder.Environment.IsDevelopment() ? "http://localhost:5200" : null)
     ?? throw new InvalidOperationException(
         "Configuration value 'McpServer:BaseUrl' is required outside of Development.");
+
+// Shared secret presented to the MCP server's API-key gate. The MCP server runs
+// with ApiKey:Enabled=true outside Development, so a deployed API that does not
+// send this header is refused. Required outside Development — failing closed here
+// surfaces a misconfiguration at startup rather than as 401s at request time.
+string? mcpApiKey = builder.Configuration["McpServer:ApiKey"];
+if (!builder.Environment.IsDevelopment() && string.IsNullOrWhiteSpace(mcpApiKey))
+{
+    throw new InvalidOperationException(
+        "Configuration value 'McpServer:ApiKey' is required outside of Development. "
+        + "The MCP server enforces its API-key gate in every non-Development environment.");
+}
+
+string mcpApiKeyHeader = builder.Configuration["McpServer:ApiKeyHeader"] ?? "X-Api-Key";
+
 builder.Services.AddTransient<McpResponseCachingHandler>();
-builder.Services.AddHttpClient("McpServer", client => client.BaseAddress = new Uri(mcpBaseUrl)).AddHttpMessageHandler<McpResponseCachingHandler>()
+builder.Services.AddHttpClient("McpServer", client =>
+    {
+        client.BaseAddress = new Uri(mcpBaseUrl);
+        if (!string.IsNullOrWhiteSpace(mcpApiKey))
+        {
+            client.DefaultRequestHeaders.Add(mcpApiKeyHeader, mcpApiKey);
+        }
+    }).AddHttpMessageHandler<McpResponseCachingHandler>()
   .AddMcpResilienceHandler();
 
 // Register tools

--- a/src/RetailPulse.Api/Security/RateLimitingSetup.cs
+++ b/src/RetailPulse.Api/Security/RateLimitingSetup.cs
@@ -1,0 +1,146 @@
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace RetailPulse.Api.Security;
+
+/// <summary>
+/// Centralised rate-limiter wiring for the API.
+///
+/// This lives in its own extension method rather than inline in <c>Program.cs</c> so the
+/// limits are reachable from tests. <c>Program.cs</c> uses top-level statements and boots
+/// the full application graph (Azure OpenAI, tenant config, durable stores), which a unit
+/// test cannot stand up. When the limits were configured inline, the only thing a test
+/// could do was restate the expected numbers in its own fixture — which passes even when
+/// the production limits are wrong. Registering through this seam lets
+/// <c>RateLimitingConfigTests</c> exercise the REAL policies behaviourally.
+///
+/// Do not inline these values back into <c>Program.cs</c>.
+/// </summary>
+public static class RateLimitingSetup
+{
+    /// <summary>Permit limit for AI-intensive routes (chat, streaming chat, council, escalate).</summary>
+    public const int StrictPermitLimit = 10;
+
+    /// <summary>Permit limit for the file/large-body upload route.</summary>
+    public const int UploadPermitLimit = 5;
+
+    /// <summary>Permit limit for state-changing endpoints.</summary>
+    public const int ModeratePermitLimit = 30;
+
+    /// <summary>Permit limit for read-only reporting endpoints.</summary>
+    public const int RelaxedPermitLimit = 100;
+
+    /// <summary>Conservative default for the global anonymous bootstrap window.</summary>
+    public const int AnonymousBootstrapDefaultPermitLimit = 5;
+
+    /// <summary>Default permit limit for the GitHub BFF login-start window.</summary>
+    public const int GitHubStartDefaultPermitLimit = 10;
+
+    /// <summary>Default permit limit for the GitHub BFF code-exchange window.</summary>
+    public const int GitHubExchangeDefaultPermitLimit = 20;
+
+    /// <summary>The window shared by every policy.</summary>
+    public static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
+
+    /// <summary>The four always-on core policies, in ascending order of permitted volume.</summary>
+    public static readonly IReadOnlyDictionary<string, int> CorePolicies =
+        new Dictionary<string, int>
+        {
+            ["upload"] = UploadPermitLimit,
+            ["strict"] = StrictPermitLimit,
+            ["moderate"] = ModeratePermitLimit,
+            ["relaxed"] = RelaxedPermitLimit,
+        };
+
+    /// <summary>
+    /// Registers every Retail Pulse rate-limiting policy. Behaviour is identical to the
+    /// previous inline configuration in <c>Program.cs</c>.
+    /// </summary>
+    public static IServiceCollection AddRetailPulseRateLimiting(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+            foreach ((string policyName, int permitLimit) in CorePolicies)
+            {
+                options.AddFixedWindowLimiter(policyName, opt =>
+                {
+                    opt.PermitLimit = permitLimit;
+                    opt.Window = Window;
+                    opt.QueueLimit = 0;
+                });
+            }
+
+            // Rate limiter for the unauthenticated Anonymous bootstrap endpoint. Always registered so
+            // the limiter graph is stable and testable; only used when Authentication:Mode=Anonymous
+            // maps the bootstrap route.
+            //
+            // IMPORTANT (ACA ingress reality): when hosted behind Azure Container Apps, every request
+            // arrives from the ingress/proxy, so HttpContext.Connection.RemoteIpAddress is the proxy's
+            // IP, NOT the client's — a per-IP partition would therefore collapse to a single global
+            // bucket anyway. We do NOT trust X-Forwarded-For to recover the client IP: ACA does not
+            // give us a cryptographically verifiable client-IP header, and an attacker can forge XFF
+            // to shard around a per-IP limit. So bootstrap is intentionally a single GLOBAL,
+            // conservative fixed window — it caps total anonymous session minting per minute for the
+            // whole replica and cannot be bypassed by header spoofing. Fine-grained abuse control is
+            // enforced AFTER bootstrap by the per-subject (immutable, server-minted sub) limits in
+            // AnonymousGuardMiddleware, which is the primary control. Note: this window is
+            // replica-local; hosted Anonymous runs at maxReplicas=1.
+            //
+            // Config key: Anonymous:Bootstrap:GlobalPerMinute (conservative default 5). The legacy
+            // Anonymous:Bootstrap:PerIpPerMinute key is still honoured as a fallback for backward
+            // compatibility — it was never actually per-IP behind ACA, hence the rename.
+            options.AddPolicy("anonymous-bootstrap", _ =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: "anonymous-bootstrap-global",
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = configuration.GetValue("Anonymous:Bootstrap:GlobalPerMinute",
+                            configuration.GetValue("Anonymous:Bootstrap:PerIpPerMinute",
+                                AnonymousBootstrapDefaultPermitLimit)),
+                        Window = Window,
+                        QueueLimit = 0,
+                    }));
+
+            // Rate limiters for the GitHub confidential OAuth BFF endpoints. Always registered so the
+            // limiter graph is stable and testable; only used when Authentication:Mode=GitHub maps the
+            // endpoints. Behind ACA the client IP is the proxy's and X-Forwarded-For is forgeable, so
+            // these are single GLOBAL per-replica fixed windows (not per-IP) that cap login-flow abuse
+            // (state minting and code redemption) without being bypassable by header spoofing.
+            // Replica-local; hosted GitHub runs at maxReplicas=1.
+            // Config keys: GitHub:RateLimits:StartPerMinute / ExchangePerMinute.
+            options.AddPolicy("github-start", _ =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: "github-start-global",
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = configuration.GetValue("GitHub:RateLimits:StartPerMinute",
+                            GitHubStartDefaultPermitLimit),
+                        Window = Window,
+                        QueueLimit = 0,
+                    }));
+
+            options.AddPolicy("github-exchange", _ =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: "github-exchange-global",
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = configuration.GetValue("GitHub:RateLimits:ExchangePerMinute",
+                            GitHubExchangeDefaultPermitLimit),
+                        Window = Window,
+                        QueueLimit = 0,
+                    }));
+        });
+
+        return services;
+    }
+}

--- a/tests/RetailPulse.Tests/Security/ContainerAppDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Security/ContainerAppDeploymentContractTests.cs
@@ -1,0 +1,184 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Deployment-contract coverage over <c>infra/modules/container-apps.bicep</c>.
+///
+/// <para>
+/// Both of the authentication gates in this solution that are keyed to the hosting
+/// environment — the MCP server's API-key gate
+/// (<c>apiKeyRequired = !IsDevelopment() || ApiKey:Enabled</c>) and the Teams bot's
+/// <c>MapAgentApplicationEndpoints(requireAuth: !IsDevelopment())</c> — silently turn
+/// themselves OFF when the app runs as <c>Development</c>. Both apps were deployed with
+/// <c>ASPNETCORE_ENVIRONMENT=Development</c> behind a public ingress, which left the whole
+/// MCP REST and tool surface reachable from the internet with no credential.
+/// </para>
+///
+/// <para>
+/// No unit test could see that, because the defect lived entirely in the deployment
+/// manifest. These tests read the real Bicep and assert the invariant directly.
+/// </para>
+/// </summary>
+public sealed partial class ContainerAppDeploymentContractTests
+{
+    [GeneratedRegex(@"^resource\s+(?<symbol>\w+)\s+'Microsoft\.App/containerApps@[^']+'\s*=\s*\{", RegexOptions.Multiline)]
+    private static partial Regex ContainerAppDeclaration();
+
+    [GeneratedRegex(@"external:\s*true")]
+    private static partial Regex ExternalIngress();
+
+    [GeneratedRegex(@"name:\s*'ASPNETCORE_ENVIRONMENT'\s*value:\s*'(?<value>[^']+)'", RegexOptions.Singleline)]
+    private static partial Regex AspNetCoreEnvironmentAssignment();
+
+    private static string BicepPath()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "RetailPulse.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        if (directory is null)
+        {
+            throw new InvalidOperationException(
+                "Could not locate the repository root (no RetailPulse.slnx found above the test output directory).");
+        }
+
+        string path = Path.Combine(directory.FullName, "infra", "modules", "container-apps.bicep");
+        File.Exists(path).Should().BeTrue($"expected the container apps Bicep module at {path}");
+
+        return path;
+    }
+
+    private static string BicepText() => File.ReadAllText(BicepPath());
+
+    /// <summary>
+    /// Splits the Bicep into one block per <c>resource ... 'Microsoft.App/containerApps@...'</c>
+    /// declaration so ingress and env can be correlated per app.
+    /// </summary>
+    private static IReadOnlyList<(string Name, string Body)> ContainerAppBlocks()
+    {
+        string text = BicepText();
+        MatchCollection starts = ContainerAppDeclaration().Matches(text);
+
+        starts.Should().NotBeEmpty("the module must declare at least one container app");
+
+        var blocks = new List<(string, string)>(starts.Count);
+
+        for (int i = 0; i < starts.Count; i++)
+        {
+            int start = starts[i].Index;
+            int end = i + 1 < starts.Count ? starts[i + 1].Index : text.Length;
+            blocks.Add((starts[i].Groups["symbol"].Value, text[start..end]));
+        }
+
+        return blocks;
+    }
+
+    private static (string Name, string Body) BlockFor(string containerAppName) =>
+        ContainerAppBlocks().Single(b => b.Body.Contains(containerAppName, StringComparison.Ordinal));
+
+    private static string? AspNetCoreEnvironment(string body)
+    {
+        Match match = AspNetCoreEnvironmentAssignment().Match(body);
+        return match.Success ? match.Groups["value"].Value : null;
+    }
+
+    [Fact]
+    [Trait("OWASP", "A05-SecurityMisconfiguration")]
+    public void NoContainerApp_IsDeployedAsDevelopment()
+    {
+        foreach ((string name, string body) in ContainerAppBlocks())
+        {
+            AspNetCoreEnvironment(body).Should().NotBe(
+                "Development",
+                $"container app '{name}' must not run as Development — environment-gated auth "
+                + "(the MCP API-key gate and the Teams bot channel auth) disables itself there");
+        }
+    }
+
+    [Fact]
+    [Trait("OWASP", "A01-BrokenAccessControl")]
+    public void NoPubliclyExposedContainerApp_IsDeployedAsDevelopment()
+    {
+        foreach ((string name, string body) in ContainerAppBlocks())
+        {
+            if (!ExternalIngress().IsMatch(body))
+            {
+                continue;
+            }
+
+            AspNetCoreEnvironment(body).Should().NotBe(
+                "Development",
+                $"container app '{name}' has a public ingress, so running it as Development "
+                + "would expose an unauthenticated surface to the internet");
+        }
+    }
+
+    [Fact]
+    [Trait("OWASP", "A01-BrokenAccessControl")]
+    public void McpServer_IsNotPubliclyExposed()
+    {
+        (_, string body) = BlockFor("ca-retailpulse-mcp");
+
+        ExternalIngress().IsMatch(body).Should().BeFalse(
+            "the MCP server is a server-to-server dependency of the API and must not be "
+            + "reachable from the public internet");
+    }
+
+    [Fact]
+    [Trait("OWASP", "A01-BrokenAccessControl")]
+    public void McpServer_EnforcesItsApiKeyGate()
+    {
+        (_, string body) = BlockFor("ca-retailpulse-mcp");
+
+        body.Should().MatchRegex(
+            @"name:\s*'ApiKey__Enabled'\s*value:\s*'true'",
+            "the MCP server must have its API-key gate explicitly enabled");
+
+        body.Should().MatchRegex(
+            @"name:\s*'ApiKey__Value'\s*secretRef:",
+            "the MCP API key must be supplied from an ACA secret, never a plain env value");
+    }
+
+    [Fact]
+    [Trait("OWASP", "A01-BrokenAccessControl")]
+    public void Api_PresentsTheMcpApiKey()
+    {
+        (_, string body) = BlockFor("ca-retailpulse-api");
+
+        body.Should().MatchRegex(
+            @"name:\s*'McpServer__ApiKey'\s*secretRef:",
+            "the API must present the MCP API key, or every MCP call fails once the gate is on");
+    }
+
+    [Fact]
+    [Trait("OWASP", "A02-CryptographicFailures")]
+    public void SharedSecrets_AreDeclaredAsSecureParameters_NotLiterals()
+    {
+        string text = BicepText();
+
+        text.Should().MatchRegex(
+            @"@secure\(\)\s*param\s+mcpApiKey\s+string",
+            "the MCP shared secret must be a @secure() parameter");
+
+        text.Should().MatchRegex(
+            @"@secure\(\)\s*param\s+apimSubscriptionKey\s+string",
+            "the APIM subscription key must be a @secure() parameter");
+    }
+
+    [Fact]
+    [Trait("OWASP", "A05-SecurityMisconfiguration")]
+    public void EveryContainerApp_RejectsInsecureTransport()
+    {
+        foreach ((string name, string body) in ContainerAppBlocks())
+        {
+            body.Should().MatchRegex(
+                @"allowInsecure:\s*false",
+                $"container app '{name}' must not accept plaintext HTTP on its ingress");
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs
+++ b/tests/RetailPulse.Tests/Security/EndpointAuthorizationCoverageTests.cs
@@ -136,6 +136,8 @@ public sealed class EndpointAuthorizationCoverageTests
     }
 
     [Fact]
+
+    [Trait("OWASP", "A01-BrokenAccessControl")]
     public async Task EveryApiAndHubRoute_CarriesAuthorizationMetadata()
     {
         await using WebApplication app = BuildRealEndpointGraph();
@@ -156,6 +158,8 @@ public sealed class EndpointAuthorizationCoverageTests
     }
 
     [Fact]
+
+    [Trait("OWASP", "A01-BrokenAccessControl")]
     public async Task NoApiOrHubRoute_IsAnonymous_OutsideTheAllowlist()
     {
         await using WebApplication app = BuildRealEndpointGraph();
@@ -169,6 +173,8 @@ public sealed class EndpointAuthorizationCoverageTests
     }
 
     [Fact]
+
+    [Trait("OWASP", "A01-BrokenAccessControl")]
     public async Task FallbackPolicy_IsDenyByDefault_RequiringAuthRoleAndScope()
     {
         await using WebApplication app = BuildRealEndpointGraph();
@@ -183,6 +189,8 @@ public sealed class EndpointAuthorizationCoverageTests
     }
 
     [Fact]
+
+    [Trait("OWASP", "A01-BrokenAccessControl")]
     public async Task Detector_FlagsAnUnannotatedApiEndpoint_RegressionFixture()
     {
         // Proves the coverage check has teeth: an /api endpoint WITHOUT RequireAuthorization
@@ -202,6 +210,8 @@ public sealed class EndpointAuthorizationCoverageTests
     }
 
     [Fact]
+
+    [Trait("OWASP", "A01-BrokenAccessControl")]
     public async Task AnonymousCapabilityGraph_AllowsOnlyBootstrapAndChat()
     {
         await using WebApplication app = BuildRealEndpointGraph();

--- a/tests/RetailPulse.Tests/Security/OwaspTests.cs
+++ b/tests/RetailPulse.Tests/Security/OwaspTests.cs
@@ -11,51 +11,32 @@ namespace RetailPulse.Tests.Security;
 
 /// <summary>
 /// OWASP Top 10 security tests for RetailPulse API.
+///
+/// <para>
+/// This file holds the categories whose assertions do not belong to a more specific
+/// suite. Where a dedicated suite already exercises the real system, the tests live
+/// there and carry the matching <c>[Trait("OWASP", ...)]</c> tag so that
+/// <c>dotnet test --filter "OWASP=A01-BrokenAccessControl"</c> runs the genuine
+/// coverage rather than a duplicate:
+/// </para>
+/// <list type="bullet">
+///   <item><b>A01</b> — <see cref="EndpointAuthorizationCoverageTests"/> walks the real
+///     <c>EndpointDataSource</c>, plus <see cref="ContainerAppDeploymentContractTests"/>
+///     for the deployment surface.</item>
+///   <item><b>A02</b> — <c>GitHubSessionTokenTests</c>, <c>DurableAuditLogTests</c>.</item>
+///   <item><b>A05</b> — <see cref="ContainerAppDeploymentContractTests"/>.</item>
+///   <item><b>A07</b> — <see cref="RateLimitingConfigTests"/> drives real traffic through
+///     the production limiter registration.</item>
+/// </list>
+///
+/// <para>
+/// Tests here must exercise production code. Assertions over locally declared literals
+/// pass regardless of how the application behaves and are worse than no test, because
+/// they advertise coverage that does not exist.
+/// </para>
 /// </summary>
 public class OwaspTests
 {
-    // ═══════════════════════════════════════════════════════════════════════
-    // A01:2021 — Broken Access Control
-    // ═══════════════════════════════════════════════════════════════════════
-
-    [Fact]
-    [Trait("OWASP", "A01-BrokenAccessControl")]
-    public void A01_AdminEndpoints_AreRegisteredWithAuthorizationRequirement()
-    {
-        // Verify that sensitive endpoints are documented as requiring auth
-        string[] authorizedEndpoints =
-        [
-            "/api/chat",
-            "/api/chat/stream",
-            "/api/alerts/active",
-            "/api/approvals/pending",
-            "/api/knowledge/upload",
-            "/api/observability/costs",
-            "/api/council/convene",
-            "/api/scorecard",
-            "/api/escalate"
-        ];
-
-        authorizedEndpoints.Should().NotBeEmpty();
-        authorizedEndpoints.Should().AllSatisfy(e => e.Should().StartWith("/api"));
-    }
-
-    [Fact]
-    [Trait("OWASP", "A01-BrokenAccessControl")]
-    public void A01_ChatEndpoints_RequireAuthorization()
-    {
-        // /api/chat and /api/chat/stream are the production chat endpoints
-        // (versioned /api/v1/* stub routes were removed in favor of the single
-        // unversioned route documented in the OpenAPI spec).
-        string[] chatEndpoints =
-        [
-            "/api/chat",
-            "/api/chat/stream"
-        ];
-
-        chatEndpoints.Should().AllSatisfy(e => e.Should().StartWith("/api/"));
-    }
-
     // ═══════════════════════════════════════════════════════════════════════
     // A03:2021 — Injection
     // ═══════════════════════════════════════════════════════════════════════
@@ -161,25 +142,10 @@ public class OwaspTests
     // ═══════════════════════════════════════════════════════════════════════
     // A07:2021 — Identification and Authentication Failures
     // ═══════════════════════════════════════════════════════════════════════
-
-    [Fact]
-    [Trait("OWASP", "A07-AuthFailures")]
-    public void A07_RateLimiting_IsConfigured()
-    {
-        // Verify that the rate limiting policy names used in the app are correct
-        string[] expectedPolicies = ["strict", "moderate", "relaxed", "upload"];
-        expectedPolicies.Should().Contain("strict",
-            "chat endpoints should use the strict rate limiter");
-    }
-
-    [Fact]
-    [Trait("OWASP", "A07-AuthFailures")]
-    public void A07_ChatEndpoints_UseStrictRateLimiting()
-    {
-        // Documented requirement: /api/chat and /api/chat/stream use "strict" policy
-        // (10 requests/min per window)
-        int strictPolicyPermitLimit = 10;
-        strictPolicyPermitLimit.Should().BeLessThanOrEqualTo(20,
-            "chat endpoints should have aggressive rate limiting to prevent abuse");
-    }
+    //
+    // Rate limiting is the A07 control in this codebase and is covered
+    // behaviourally by RateLimitingConfigTests, which drives real traffic through
+    // the production limiter registration and asserts the 429 boundary. The two
+    // tests previously here asserted over local literals (one of them reduced to
+    // `10 <= 20`) and passed even when the chat limit was raised to 999,999/min.
 }

--- a/tests/RetailPulse.Tests/Security/RateLimitingConfigTests.cs
+++ b/tests/RetailPulse.Tests/Security/RateLimitingConfigTests.cs
@@ -1,128 +1,259 @@
+using System.Net;
 using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RetailPulse.Api.Security;
 
 namespace RetailPulse.Tests.Security;
 
 /// <summary>
-/// Tests that verify rate-limiting policy configuration values match Sprint 1 spec.
-/// These are configuration-level tests validating the four rate-limit policies
-/// defined in Program.cs.
+/// Behavioural coverage for the REAL rate-limiting policies registered by
+/// <see cref="RateLimitingSetup.AddRetailPulseRateLimiting"/>.
+///
+/// <para>
+/// These tests drive traffic through a live <see cref="TestServer"/> that has the production
+/// limiter registration applied, rather than restating the expected numbers in a local
+/// fixture. The previous version of this file asserted a private dictionary against itself,
+/// so raising the chat limit from 10/min to 999,999/min — removing DoS and cost protection
+/// from the most expensive endpoints in the product — left every test green. A limit
+/// regression must fail here.
+/// </para>
 /// </summary>
-public class RateLimitingConfigTests
+public sealed class RateLimitingConfigTests
 {
-    private static readonly Dictionary<string, (int PermitLimit, int WindowMinutes)> ExpectedPolicies = new()
+    private static async Task<IHost> StartServerAsync(
+        string policyName,
+        Dictionary<string, string?>? configuration = null)
     {
-        ["strict"] = (10, 1),
-        ["upload"] = (5, 1),
-        ["moderate"] = (30, 1),
-        ["relaxed"] = (100, 1)
-    };
+        return await new HostBuilder()
+            .ConfigureWebHost(webBuilder => webBuilder
+                .UseTestServer()
+                .ConfigureAppConfiguration(cfg =>
+                    cfg.AddInMemoryCollection(configuration ?? []))
+                .ConfigureServices((context, services) =>
+                {
+                    services.AddRouting();
+                    services.AddRetailPulseRateLimiting(context.Configuration);
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseRateLimiter();
+                    app.UseEndpoints(endpoints =>
+                        endpoints.MapGet("/probe", () => Results.Ok("ok"))
+                            .RequireRateLimiting(policyName));
+                }))
+            .StartAsync();
+    }
 
-    [Theory]
-    [InlineData("strict", 10)]
-    [InlineData("upload", 5)]
-    [InlineData("moderate", 30)]
-    [InlineData("relaxed", 100)]
-    public async Task RateLimitPolicy_HasExpectedPermitLimit(string policyName, int expectedLimit)
+    /// <summary>Sends <paramref name="count"/> sequential requests and returns the status codes in order.</summary>
+    private static async Task<List<HttpStatusCode>> ProbeAsync(IHost host, int count)
     {
-        ExpectedPolicies.Should().ContainKey(policyName);
-        ExpectedPolicies[policyName].PermitLimit.Should().Be(expectedLimit);
-        await Task.CompletedTask;
+        HttpClient client = host.GetTestClient();
+        var codes = new List<HttpStatusCode>(count);
+
+        for (int i = 0; i < count; i++)
+        {
+            HttpResponseMessage response = await client.GetAsync("/probe");
+            codes.Add(response.StatusCode);
+        }
+
+        return codes;
+    }
+
+    /// <summary>Sends sequential requests, rotating the forgeable X-Forwarded-For header.</summary>
+    private static async Task<List<HttpStatusCode>> ProbeRotatingForwardedForAsync(IHost host, int count)
+    {
+        HttpClient client = host.GetTestClient();
+        var codes = new List<HttpStatusCode>(count);
+
+        for (int i = 0; i < count; i++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/probe");
+            request.Headers.Add("X-Forwarded-For", $"203.0.113.{i}");
+            HttpResponseMessage response = await client.SendAsync(request);
+            codes.Add(response.StatusCode);
+        }
+
+        return codes;
     }
 
     [Theory]
-    [InlineData("strict")]
-    [InlineData("upload")]
-    [InlineData("moderate")]
-    [InlineData("relaxed")]
-    public async Task RateLimitPolicy_UsesOneMinuteWindow(string policyName)
+    [Trait("OWASP", "A07-AuthFailures")]
+    [InlineData("strict", RateLimitingSetup.StrictPermitLimit)]
+    [InlineData("upload", RateLimitingSetup.UploadPermitLimit)]
+    [InlineData("moderate", RateLimitingSetup.ModeratePermitLimit)]
+    [InlineData("relaxed", RateLimitingSetup.RelaxedPermitLimit)]
+    public async Task CorePolicy_AllowsExactlyItsPermitLimit_ThenRejects(string policyName, int permitLimit)
     {
-        ExpectedPolicies[policyName].WindowMinutes.Should().Be(1);
-        await Task.CompletedTask;
+        using IHost host = await StartServerAsync(policyName);
+
+        List<HttpStatusCode> codes = await ProbeAsync(host, permitLimit + 1);
+
+        codes.Take(permitLimit).Should().AllBeEquivalentTo(
+            HttpStatusCode.OK,
+            $"the '{policyName}' policy must admit exactly {permitLimit} requests per window");
+
+        codes[permitLimit].Should().Be(
+            HttpStatusCode.TooManyRequests,
+            $"request {permitLimit + 1} must be rejected by the '{policyName}' policy");
     }
 
     [Fact]
-    public async Task RateLimitPolicies_ExactlyFourDefined()
+    [Trait("OWASP", "A07-AuthFailures")]
+    public async Task StrictPolicy_ThrottlesWellBeforeTwentyRequests_GuardingAiSpend()
     {
-        ExpectedPolicies.Should().HaveCount(4);
-        await Task.CompletedTask;
+        // Independent of the exact constant: the AI-intensive tier must never admit a large
+        // burst, because every admitted request is a paid model call.
+        using IHost host = await StartServerAsync("strict");
+
+        List<HttpStatusCode> codes = await ProbeAsync(host, 20);
+
+        codes.Should().Contain(
+            HttpStatusCode.TooManyRequests,
+            "the strict tier must throttle well before 20 requests in a single window");
     }
 
     [Fact]
-    public async Task StrictPolicy_IsLowerThanModerateAndRelaxed()
+    [Trait("OWASP", "A07-AuthFailures")]
+    public async Task RejectionStatusCode_Is429_NotASilentPass()
     {
-        int strictLimit = ExpectedPolicies["strict"].PermitLimit;
+        using IHost host = await StartServerAsync("upload");
 
-        strictLimit.Should().BeLessThanOrEqualTo(ExpectedPolicies["moderate"].PermitLimit);
-        strictLimit.Should().BeLessThanOrEqualTo(ExpectedPolicies["relaxed"].PermitLimit);
-        await Task.CompletedTask;
+        List<HttpStatusCode> codes = await ProbeAsync(host, RateLimitingSetup.UploadPermitLimit + 1);
+
+        codes[RateLimitingSetup.UploadPermitLimit].Should().Be(
+            HttpStatusCode.TooManyRequests,
+            "an over-limit request must be rejected with 429, never silently admitted");
     }
 
     [Fact]
-    public async Task UploadPolicy_IsMostRestrictive()
+    [Trait("OWASP", "A07-AuthFailures")]
+    public void CoreTiers_AreOrderedFromMostToLeastRestrictive()
     {
-        int uploadLimit = ExpectedPolicies["upload"].PermitLimit;
+        RateLimitingSetup.UploadPermitLimit.Should().BeLessThan(RateLimitingSetup.StrictPermitLimit);
+        RateLimitingSetup.StrictPermitLimit.Should().BeLessThan(RateLimitingSetup.ModeratePermitLimit);
+        RateLimitingSetup.ModeratePermitLimit.Should().BeLessThan(RateLimitingSetup.RelaxedPermitLimit);
 
-        uploadLimit.Should().BeLessThanOrEqualTo(ExpectedPolicies["strict"].PermitLimit);
-        uploadLimit.Should().BeLessThanOrEqualTo(ExpectedPolicies["moderate"].PermitLimit);
-        uploadLimit.Should().BeLessThanOrEqualTo(ExpectedPolicies["relaxed"].PermitLimit);
-        await Task.CompletedTask;
+        RateLimitingSetup.CorePolicies.Should().HaveCount(4);
+        RateLimitingSetup.CorePolicies.Values.Should().AllSatisfy(limit => limit.Should().BePositive());
     }
 
     [Fact]
-    public async Task RelaxedPolicy_IsHighestPermitLimit()
+    [Trait("OWASP", "A07-AuthFailures")]
+    public void EveryPolicy_UsesAOneMinuteWindow()
     {
-        int relaxedLimit = ExpectedPolicies["relaxed"].PermitLimit;
-
-        relaxedLimit.Should().BeGreaterThanOrEqualTo(ExpectedPolicies["strict"].PermitLimit);
-        relaxedLimit.Should().BeGreaterThanOrEqualTo(ExpectedPolicies["upload"].PermitLimit);
-        relaxedLimit.Should().BeGreaterThanOrEqualTo(ExpectedPolicies["moderate"].PermitLimit);
-        await Task.CompletedTask;
+        RateLimitingSetup.Window.Should().Be(TimeSpan.FromMinutes(1));
     }
+
+    // ── Anonymous bootstrap (mode-conditional, global per replica) ─────────────
+
+    [Fact]
+    [Trait("OWASP", "A07-AuthFailures")]
+    public async Task AnonymousBootstrap_CapsSessionMintingAtConservativeDefault()
+    {
+        using IHost host = await StartServerAsync("anonymous-bootstrap");
+
+        List<HttpStatusCode> codes = await ProbeAsync(
+            host, RateLimitingSetup.AnonymousBootstrapDefaultPermitLimit + 1);
+
+        codes[RateLimitingSetup.AnonymousBootstrapDefaultPermitLimit]
+            .Should().Be(HttpStatusCode.TooManyRequests,
+                "anonymous session minting must be capped at the conservative default");
+    }
+
+    [Fact]
+    [Trait("OWASP", "A07-AuthFailures")]
+    public void AnonymousBootstrap_IsAtLeastAsRestrictiveAsTheStrictestCoreTier()
+    {
+        RateLimitingSetup.AnonymousBootstrapDefaultPermitLimit
+            .Should().BeLessThanOrEqualTo(RateLimitingSetup.StrictPermitLimit,
+                "bootstrapping a credential must be at least as restricted as the strictest core policy");
+    }
+
+    [Fact]
+    [Trait("OWASP", "A07-AuthFailures")]
+    public async Task AnonymousBootstrap_HonoursLegacyPerIpKeyAsFallback()
+    {
+        using IHost host = await StartServerAsync(
+            "anonymous-bootstrap",
+            new Dictionary<string, string?> { ["Anonymous:Bootstrap:PerIpPerMinute"] = "2" });
+
+        List<HttpStatusCode> codes = await ProbeAsync(host, 3);
+
+        codes[2].Should().Be(HttpStatusCode.TooManyRequests,
+            "the legacy PerIpPerMinute key must still be honoured as a backward-compatible fallback");
+    }
+
+    [Fact]
+    [Trait("OWASP", "A07-AuthFailures")]
+    public async Task AnonymousBootstrap_PrefersGlobalKeyOverLegacyKey()
+    {
+        using IHost host = await StartServerAsync(
+            "anonymous-bootstrap",
+            new Dictionary<string, string?>
+            {
+                ["Anonymous:Bootstrap:GlobalPerMinute"] = "1",
+                ["Anonymous:Bootstrap:PerIpPerMinute"] = "50",
+            });
+
+        List<HttpStatusCode> codes = await ProbeAsync(host, 2);
+
+        codes[0].Should().Be(HttpStatusCode.OK);
+        codes[1].Should().Be(HttpStatusCode.TooManyRequests,
+            "the current GlobalPerMinute key must win over the legacy fallback");
+    }
+
+    [Fact]
+    [Trait("OWASP", "A07-AuthFailures")]
+    public async Task AnonymousBootstrap_IsGlobal_NotPartitionedByForgeableClientHeaders()
+    {
+        // Behind Azure Container Apps, X-Forwarded-For is attacker-controlled. If the bootstrap
+        // limiter were partitioned on it, an attacker could shard around the cap and farm
+        // anonymous session tokens without limit.
+        using IHost host = await StartServerAsync(
+            "anonymous-bootstrap",
+            new Dictionary<string, string?> { ["Anonymous:Bootstrap:GlobalPerMinute"] = "2" });
+
+        List<HttpStatusCode> codes = await ProbeRotatingForwardedForAsync(host, 3);
+
+        codes[2].Should().Be(HttpStatusCode.TooManyRequests,
+            "rotating X-Forwarded-For must NOT grant additional bootstrap capacity");
+    }
+
+    // ── GitHub BFF login-flow limiters ────────────────────────────────────────
 
     [Theory]
-    [InlineData("/api/chat", "strict")]
-    [InlineData("/api/chat/stream", "strict")]
-    [InlineData("/api/knowledge/upload", "upload")]
-    [InlineData("/api/info", "relaxed")]
-    [InlineData("/api/alerts/active", "relaxed")]
-    [InlineData("/api/alerts/dismiss", "moderate")]
-    public async Task EndpointPolicyMapping_MatchesExpectedPolicy(string endpoint, string expectedPolicy)
+    [Trait("OWASP", "A07-AuthFailures")]
+    [InlineData("github-start", RateLimitingSetup.GitHubStartDefaultPermitLimit)]
+    [InlineData("github-exchange", RateLimitingSetup.GitHubExchangeDefaultPermitLimit)]
+    public async Task GitHubBffPolicy_CapsLoginFlowAbuse(string policyName, int permitLimit)
     {
-        ExpectedPolicies.Should().ContainKey(expectedPolicy,
-            $"endpoint {endpoint} should map to a valid policy");
-        await Task.CompletedTask;
-    }
+        using IHost host = await StartServerAsync(policyName);
 
-    // ── Sprint 1: mode-conditional anonymous bootstrap limiter ─────────────────
-    // The "anonymous-bootstrap" policy is NOT one of the four always-on core policies above. It is
-    // a single GLOBAL fixed-window limiter added by Program.cs ONLY when Authentication:Mode=Anonymous,
-    // so the single unauthenticated anonymous surface (the session bootstrap endpoint) cannot be used
-    // to farm session tokens. Behind Azure Container Apps the client IP is the proxy's and
-    // X-Forwarded-For is forgeable, so it is a per-replica GLOBAL window rather than per-IP. Its
-    // permit limit is driven by Anonymous:Bootstrap:GlobalPerMinute (conservative default 5); the
-    // legacy Anonymous:Bootstrap:PerIpPerMinute key is still honoured as a backward-compatible
-    // fallback. It is asserted separately here so the four-core invariant
-    // (RateLimitPolicies_ExactlyFourDefined) stays intact.
+        List<HttpStatusCode> codes = await ProbeAsync(host, permitLimit + 1);
 
-    private const string AnonymousBootstrapPolicy = "anonymous-bootstrap";
-    private const int AnonymousBootstrapDefaultPermitLimit = 5;
-    private const int AnonymousBootstrapWindowMinutes = 1;
-
-    [Fact]
-    public async Task AnonymousBootstrapPolicy_IsSeparateFromCorePolicies()
-    {
-        ExpectedPolicies.Keys.Should().NotContain(AnonymousBootstrapPolicy,
-            "the anonymous bootstrap limiter is mode-conditional and not part of the always-on core set");
-        await Task.CompletedTask;
+        codes[permitLimit].Should().Be(HttpStatusCode.TooManyRequests,
+            $"the '{policyName}' policy must cap login-flow abuse at {permitLimit} per window");
     }
 
     [Fact]
-    public async Task AnonymousBootstrapPolicy_UsesConservativeGlobalDefault()
+    [Trait("OWASP", "A07-AuthFailures")]
+    public async Task GitHubStart_IsGlobal_NotPartitionedByForgeableClientHeaders()
     {
-        AnonymousBootstrapDefaultPermitLimit.Should().BePositive();
-        AnonymousBootstrapDefaultPermitLimit.Should().BeLessThanOrEqualTo(ExpectedPolicies["strict"].PermitLimit,
-            "bootstrapping a token must be at least as restricted as the strictest core policy");
-        AnonymousBootstrapWindowMinutes.Should().Be(1);
-        await Task.CompletedTask;
+        using IHost host = await StartServerAsync(
+            "github-start",
+            new Dictionary<string, string?> { ["GitHub:RateLimits:StartPerMinute"] = "2" });
+
+        List<HttpStatusCode> codes = await ProbeRotatingForwardedForAsync(host, 3);
+
+        codes[2].Should().Be(HttpStatusCode.TooManyRequests,
+            "rotating X-Forwarded-For must NOT grant additional login-start capacity");
     }
 }


### PR DESCRIPTION
A security sweep of the whole repository found **two externally-reachable container apps deployed with `ASPNETCORE_ENVIRONMENT=Development`**. Both services gate authentication on `IsDevelopment()`, so Development silently disabled those gates in production.

## Verified against the live deployment

```
GET https://ca-retailpulse-mcp.<env>.azurecontainerapps.io/api/competitive/market-share
-> HTTP 200   (no credential sent)
```

`az containerapp list` confirmed `ca-retailpulse-mcp` and `ca-retailpulse-teamsbot` were both `External=True` with `Env=Development`. The API app was correctly `Production`.

## Finding 1 — MCP server publicly exposed, API-key gate disabled (HIGH)

```csharp
// src/RetailPulse.McpServer/Program.cs:70-71
bool apiKeyRequired = !app.Environment.IsDevelopment()
    || builder.Configuration.GetValue("ApiKey:Enabled", false);
```

With `IsDevelopment() == true` and `ApiKey:Enabled` unset, this is `false`, so `needsAuth` is `false` and the middleware passed **every** `/api` and `/mcp` request straight through. The full REST data surface and the MCP tool transport were callable from the internet, and `MapOpenApi()` published the schema.

**Fix:** ingress is now internal (`external: false`), the app runs as `Production`, and the API-key gate is enabled with the key supplied from an ACA secret. The API presents that key as `X-Api-Key` on the named `McpServer` HttpClient and **fails closed at startup** outside Development when `McpServer:ApiKey` is missing.

## Finding 2 — Teams bot channel authentication disabled (MEDIUM)

```csharp
// src/RetailPulse.TeamsBot/Program.cs:79
app.MapAgentApplicationEndpoints(requireAuth: !app.Environment.IsDevelopment());
```

Messaging endpoints were mapped with authentication off while publicly exposed, allowing forged Bot Framework Activities to drive the LLM-backed agent (prompt injection, billable model calls, forged conversation state).

**Fix:** the app now runs as `Production` so inbound Activities are validated.

## Test integrity — the reason this was invisible

The existing rate-limiting coverage was **tautological**. `RateLimitingConfigTests` asserted a private dictionary against itself; `OwaspTests.A07_ChatEndpoints_UseStrictRateLimiting` reduced to `10 <= 20`.

Proven by mutation — raising the chat limit from 10/min to **999,999/min**, gutting DoS and cost protection on the most expensive endpoints:

| | Before | After |
|---|---|---|
| Mutation caught | **0 failures** (33 passed) | **2 failures** |

- Rate-limiter config extracted to `RateLimitingSetup` so tests can reach it.
- `RateLimitingConfigTests` now drives real traffic through the production registration and asserts the 429 boundary — including that the `anonymous-bootstrap` and `github-start` windows are global and **cannot be widened by rotating a forged `X-Forwarded-For`**.
- New `ContainerAppDeploymentContractTests` reads the real Bicep and asserts no container app runs as Development, the MCP server is not publicly exposed, its key gate is on, and the API presents the key. **Restoring the original vulnerable manifest fails 3 of them.**
- Tautological A01/A07 tests removed; OWASP traits moved onto the suites that genuinely exercise the system, so `--filter "OWASP=A01-BrokenAccessControl"` now runs the real endpoint-graph walk (9 tests) instead of string-prefix assertions.

## Sweep dispositions

**Clean:** A02 (HS256 ≥256-bit, algorithm-pinned, rotation via `AdditionalValidationKeys`), A03 (fully parameterized SQL), A04, A06 (no vulnerable NuGet), A08 (no `pull_request_target`, no script injection, actions pinned), A09 (no secrets/PII in logs or span tags), A10 (fixed base addresses, no user-controlled hosts).

**Informational:** the audit hash chain is unkeyed SHA-256 — tamper-*evident*, not tamper-*proof*; an HMAC would harden it. `npm audit` shows 2 DoS-category advisories in transitive build deps (`brace-expansion`, `nanoid`).

## Verification

- Full suite: **3470 passed / 0 failed**
- `az bicep build`: clean
- 462 security tests pass

## Deployment note

These are manifest changes — they take effect on the next `azd provision`. **The live environment stays vulnerable until then.**
