### PR TITLE
style: satisfy dotnet format gate in security tests

### DIFF
--- a/tests/RetailPulse.Tests/Security/RateLimitingConfigTests.cs
+++ b/tests/RetailPulse.Tests/Security/RateLimitingConfigTests.cs
@@ -147,10 +147,8 @@ public sealed class RateLimitingConfigTests
 
     [Fact]
     [Trait("OWASP", "A07-AuthFailures")]
-    public void EveryPolicy_UsesAOneMinuteWindow()
-    {
+    public void EveryPolicy_UsesAOneMinuteWindow() =>
         RateLimitingSetup.Window.Should().Be(TimeSpan.FromMinutes(1));
-    }
 
     // ── Anonymous bootstrap (mode-conditional, global per replica) ─────────────
 


### PR DESCRIPTION
IDE0022 on \EveryPolicy_UsesAOneMinuteWindow\. The \dotnet format\ gate only runs on main-targeting PRs, so it was not exercised by #191/#192 and surfaced on the dev-to-main release PR (#193).

Verified locally with the exact CI command: \dotnet format RetailPulse.slnx --verify-no-changes --verbosity diagnostic\ exits 0. 16 rate-limiting tests still pass.