### PR TITLE
fix(deploy): pin postprovision hook to azd subscription and stabilise the MCP shared key

### DIFF
--- a/azd-hooks/postprovision.ps1
+++ b/azd-hooks/postprovision.ps1
@@ -41,13 +41,19 @@ function Get-RequiredEnv {
 function Invoke-Az {
     param([Parameter(Mandatory)][string[]] $Arguments, [Parameter(Mandatory)][string] $FailureMessage)
 
-    $result = & az @Arguments
+    # Every call is pinned to the azd environment's subscription. Without this the
+    # Azure CLI silently targets whatever `az account show` currently defaults to,
+    # which is frequently a different tenant/subscription on a developer machine.
+    # That produced an AuthorizationFailed on a resource that exists, in a
+    # subscription that has nothing to do with this deployment.
+    $result = & az @Arguments --subscription $script:subscriptionId
     if ($LASTEXITCODE -ne 0) {
         throw "$FailureMessage (az exited $LASTEXITCODE)."
     }
     return $result
 }
 
+$subscriptionId = Get-RequiredEnv 'AZURE_SUBSCRIPTION_ID'
 $resourceGroup  = Get-RequiredEnv 'AZURE_RESOURCE_GROUP'
 $registryName   = Get-RequiredEnv 'AZURE_CONTAINER_REGISTRY_NAME'
 $registryServer = Get-RequiredEnv 'AZURE_CONTAINER_REGISTRY_ENDPOINT'

--- a/azd-hooks/postprovision.sh
+++ b/azd-hooks/postprovision.sh
@@ -28,6 +28,7 @@ require_env() {
     fi
 }
 
+require_env AZURE_SUBSCRIPTION_ID
 require_env AZURE_RESOURCE_GROUP
 require_env AZURE_CONTAINER_REGISTRY_NAME
 require_env AZURE_CONTAINER_REGISTRY_ENDPOINT
@@ -42,6 +43,14 @@ resource_group="$AZURE_RESOURCE_GROUP"
 registry_name="$AZURE_CONTAINER_REGISTRY_NAME"
 registry_server="$AZURE_CONTAINER_REGISTRY_ENDPOINT"
 registry_id="$AZURE_CONTAINER_REGISTRY_RESOURCE_ID"
+subscription_id="$AZURE_SUBSCRIPTION_ID"
+
+# Pin every Azure CLI call in this hook to the azd environment's subscription.
+# Without this the CLI silently targets whatever `az account show` currently
+# defaults to, which is frequently a different tenant/subscription on a
+# developer machine — producing an AuthorizationFailed on a resource that
+# exists, in a subscription that has nothing to do with this deployment.
+az() { command az "$@" --subscription "$subscription_id"; }
 
 echo "Configuring ACR pull via system-assigned identity on registry '$registry_name'..."
 

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -47,9 +47,9 @@ param entraAppRole string = 'RetailPulse.User'
 @description('ACR login server for the private registry that hosts the service images. When set, containers pull via system-assigned identity so `azd provision` re-asserts the registry auth binding declaratively.')
 param containerRegistryLoginServer string = ''
 
-@description('Shared secret the API presents to the MCP server as X-Api-Key. Stored as an ACA secret on both apps. Defaults to a value generated per deployment.')
+@description('Shared secret the API presents to the MCP server as X-Api-Key. Stored as an ACA secret on both apps. Defaults to a value derived deterministically from the resource group so repeat provisions are idempotent — supply an explicit value to rotate it.')
 @secure()
-param mcpApiKey string = newGuid()
+param mcpApiKey string = '${uniqueString(resourceGroup().id, 'mcp-api-key')}${uniqueString(subscription().subscriptionId, 'retail-pulse-mcp')}'
 
 var apimSubscriptionKeySecretName = 'apim-sub-key'
 var mcpApiKeySecretName = 'mcp-api-key'

--- a/tests/RetailPulse.Tests/Security/ContainerAppDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Security/ContainerAppDeploymentContractTests.cs
@@ -171,6 +171,26 @@ public sealed partial class ContainerAppDeploymentContractTests
     }
 
     [Fact]
+    [Trait("OWASP", "A02-CryptographicFailures")]
+    public void McpApiKeyDefault_IsDeterministic_SoProvisionIsIdempotent()
+    {
+        string text = BicepText();
+
+        // newGuid() would mint a fresh key on every provision. The API and the MCP
+        // server read it from separate Container Apps secrets, and a secret-value
+        // change does not necessarily roll both revisions together — so a rotating
+        // default can leave the API presenting a stale key and every MCP call
+        // failing 401 until both apps happen to restart.
+        text.Should().NotMatchRegex(
+            @"param\s+mcpApiKey\s+string\s*=\s*newGuid\(\)",
+            "the MCP shared secret must not be regenerated on every provision");
+
+        text.Should().MatchRegex(
+            @"param\s+mcpApiKey\s+string\s*=\s*'\$\{uniqueString\(",
+            "the MCP shared secret default must be derived deterministically");
+    }
+
+    [Fact]
     [Trait("OWASP", "A05-SecurityMisconfiguration")]
     public void EveryContainerApp_RejectsInsecureTransport()
     {


### PR DESCRIPTION
Two defects surfaced while deploying the MCP/Teams bot security fix to Azure.

## 1. Postprovision hook targeted the wrong subscription

Neither hook pinned \--subscription\, so the Azure CLI used whatever \z account show\ defaulted to. On a machine whose default was a different tenant, provisioning aborted **after** the resources had already been updated:

\\\
ERROR: (AuthorizationFailed) The client ... does not have authorization to perform action
'Microsoft.App/containerApps/read' over scope
'/subscriptions/0832b3b6-.../ca-retailpulse-api'
\\\

That subscription has nothing to do with this deployment. Both the pwsh and sh hooks now pin every \z\ call to \AZURE_SUBSCRIPTION_ID\ from the azd environment.

## 2. MCP shared key was regenerated on every provision

\mcpApiKey\ defaulted to \
ewGuid()\, minting a new secret each provision. The API and MCP server read it from **separate** Container Apps secrets, and a secret-value change does not necessarily roll both revisions together — so a rotating default can leave the API presenting a stale key and every MCP call failing \401\ until both apps happen to restart.

The default is now derived deterministically from the resource group and subscription, so repeat provisions are idempotent. An explicit value can still be supplied to rotate deliberately.

A new contract test pins this so \
ewGuid()\ cannot be reintroduced.

## Verification

- \zd provision\ now completes end-to-end **including** the postprovision hook
- API to MCP calls return \200\ over the internal ingress with the key gate enforced
- \z bicep build\ clean, \dotnet format --verify-no-changes\ exits 0
- 8 deployment-contract tests pass