### PR TITLE
feat(plans): enable plan-first orchestration in production

### DIFF
--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -264,6 +264,25 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE'
               value: 'true'
             }
+            // Plan-first orchestration (issue #93). Enabling this registers
+            // IPlanStore, which in turn maps /api/plans/* and wires the
+            // PlanOrchestrator. With it off the "Plan" execution-path option is
+            // an inert control and the Plans panel gets a 404 from a route that
+            // was never mapped.
+            //
+            // DURABILITY: the plan store shares the ephemeral per-replica temp
+            // directory described below, so plans survive within a warm replica
+            // but reset on revision change, replica replacement, or scale-to-
+            // zero. That is acceptable for this demo — plan history is a live
+            // view of the current session, not a system of record.
+            //
+            // The human-in-the-loop review gate (PlanReview, issue #94) is a
+            // SEPARATE opt-in and stays off: with it enabled every plan pauses
+            // for approval. Plans here generate and execute straight through.
+            {
+              name: 'PlanPersistence__Enabled'
+              value: 'true'
+            }
             {
               name: 'ASPNETCORE_ENVIRONMENT'
               value: 'Production'

--- a/src/RetailPulse.Web/src/__tests__/planSurfaceAvailability.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/planSurfaceAvailability.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { initialPlanState, planReducer } from '../state/planReducer';
+import { fetchPlans, PlanSurfaceUnavailableError } from '../services/planApi';
+
+/**
+ * `/api/plans/*` is mapped only when `PlanPersistence:Enabled` is true. With it
+ * off the routes do not exist and the API answers 404 — a deliberate
+ * configuration, not a failure. The deployed app surfaced that to the user as
+ * "Failed to list plans: 404 Unknown error" in the Plans panel.
+ *
+ * These pin the degradation contract: 404 is translated to a typed sentinel and
+ * reduced to a calm "unavailable" state, while every other non-OK status stays a
+ * real, visible error.
+ */
+describe('plan surface availability', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function respond(status: number, body: unknown = {}) {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: '',
+      headers: { get: () => 'application/json' },
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    });
+  }
+
+  it('translates a 404 into PlanSurfaceUnavailableError', async () => {
+    respond(404);
+    await expect(fetchPlans()).rejects.toBeInstanceOf(PlanSurfaceUnavailableError);
+  });
+
+  it('leaves other failures as ordinary errors', async () => {
+    respond(500, { error: 'boom' });
+    const err = await fetchPlans().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(PlanSurfaceUnavailableError);
+    expect((err as Error).message).toContain('500');
+  });
+
+  it('returns plans normally on success', async () => {
+    respond(200, [{ planId: 'p1' }]);
+    await expect(fetchPlans()).resolves.toHaveLength(1);
+  });
+
+  it('reduces HISTORY_UNAVAILABLE to a non-error empty state', () => {
+    const errored = planReducer(initialPlanState, {
+      type: 'HISTORY_ERROR',
+      error: 'Failed to list plans: 404 Unknown error',
+    });
+    expect(errored.historyError).toBeDefined();
+
+    const next = planReducer(errored, { type: 'HISTORY_UNAVAILABLE' });
+
+    expect(next.historyUnavailable).toBe(true);
+    expect(next.historyError).toBeUndefined();
+    expect(next.historyLoading).toBe(false);
+    expect(next.history).toEqual([]);
+  });
+
+  it('clears the unavailable flag once a load succeeds', () => {
+    const unavailable = planReducer(initialPlanState, { type: 'HISTORY_UNAVAILABLE' });
+    expect(unavailable.historyUnavailable).toBe(true);
+
+    const loaded = planReducer(unavailable, { type: 'HISTORY_LOADED', plans: [] });
+    expect(loaded.historyUnavailable).toBe(false);
+  });
+});

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -838,6 +838,7 @@ export function Dashboard() {
                   plans={planController.state.history}
                   loading={planController.state.historyLoading}
                   error={planController.state.historyError}
+                  unavailable={planController.state.historyUnavailable}
                   activePlanId={planController.active?.planId ?? null}
                   onRefresh={() => { void planController.reloadHistory(); }}
                   onOpen={id => { void planController.openHistoryPlan(id); }}

--- a/src/RetailPulse.Web/src/components/plan/PlanHistoryPanel.tsx
+++ b/src/RetailPulse.Web/src/components/plan/PlanHistoryPanel.tsx
@@ -7,6 +7,12 @@ export interface PlanHistoryPanelProps {
   plans: PlanSummary[];
   loading?: boolean;
   error?: string;
+  /**
+   * True when the deployment exposes no plan surface at all
+   * (`PlanPersistence:Enabled=false`, so `/api/plans/` is unmapped). Renders an
+   * explanatory note instead of an alert — this is configuration, not failure.
+   */
+  unavailable?: boolean;
   activePlanId?: string | null;
   onRefresh: () => void;
   onOpen: (planId: string) => void;
@@ -114,6 +120,7 @@ export function PlanHistoryPanel({
   plans,
   loading,
   error,
+  unavailable,
   activePlanId,
   onRefresh,
   onOpen,
@@ -129,15 +136,19 @@ export function PlanHistoryPanel({
           appearance="subtle"
           icon={loading ? <Spinner size="tiny" /> : <ArrowClockwise20Regular />}
           onClick={onRefresh}
-          disabled={loading}
+          disabled={loading || unavailable}
           aria-label="Refresh plan history"
           data-testid="plan-history-refresh"
         >
           Refresh
         </Button>
       </div>
-      {error && <Text className={styles.error} role="alert">{error}</Text>}
-      {!loading && plans.length === 0 ? (
+      {error && !unavailable && <Text className={styles.error} role="alert">{error}</Text>}
+      {unavailable ? (
+        <div className={styles.empty} data-testid="plan-history-unavailable">
+          Plan history isn&apos;t enabled in this environment.
+        </div>
+      ) : !loading && plans.length === 0 ? (
         <div className={styles.empty} data-testid="plan-history-empty">
           No plans yet. Ask a multi-domain question to generate one.
         </div>

--- a/src/RetailPulse.Web/src/services/planApi.ts
+++ b/src/RetailPulse.Web/src/services/planApi.ts
@@ -41,8 +41,24 @@ function throwFor(action: string, res: Response, detail: string): never {
   throw new Error(`Failed to ${action}: ${res.status} ${detail}`.trim());
 }
 
+/**
+ * Raised when the plan surface is not present in this deployment.
+ *
+ * `/api/plans/*` is mapped only when `PlanPersistence:Enabled` is true — with it
+ * off, `IPlanStore` is never registered and the routes do not exist, so the API
+ * answers 404. That is a deliberate configuration, not a failure, and it must
+ * not surface to the user as a raw "404 Unknown error".
+ */
+export class PlanSurfaceUnavailableError extends Error {
+  readonly name = 'PlanSurfaceUnavailableError';
+  constructor() {
+    super('Plan history is not available in this deployment.');
+  }
+}
+
 export async function fetchPlans(signal?: AbortSignal): Promise<PlanSummary[]> {
   const res = await fetch(resolveApiUrl('/api/plans/'), { signal });
+  if (res.status === 404) throw new PlanSurfaceUnavailableError();
   if (!res.ok) throwFor('list plans', res, await parseErrorBody(res));
   const data: unknown = await res.json();
   return Array.isArray(data) ? (data as PlanSummary[]) : [];

--- a/src/RetailPulse.Web/src/state/planReducer.ts
+++ b/src/RetailPulse.Web/src/state/planReducer.ts
@@ -87,6 +87,12 @@ export interface PlanAppState {
   history: PlanSummary[];
   historyLoading: boolean;
   historyError?: string;
+  /**
+   * True when the API reported no plan surface at all (404 from `/api/plans/`),
+   * i.e. this deployment runs with `PlanPersistence:Enabled=false`. Distinct
+   * from `historyError`, which means a real failure the user should see.
+   */
+  historyUnavailable?: boolean;
 }
 
 export const initialPlanState: PlanAppState = {
@@ -178,6 +184,7 @@ export type PlanAction =
   | { type: 'HISTORY_LOADING' }
   | { type: 'HISTORY_LOADED'; plans: PlanSummary[] }
   | { type: 'HISTORY_ERROR'; error: string }
+  | { type: 'HISTORY_UNAVAILABLE' }
   | { type: 'HISTORY_PLAN_REMOVED'; planId: string };
 
 // ── Reducer ─────────────────────────────────────────────────────────────────
@@ -613,10 +620,27 @@ export function planReducer(state: PlanAppState, action: PlanAction): PlanAppSta
       return { ...state, historyLoading: true, historyError: undefined };
 
     case 'HISTORY_LOADED':
-      return { ...state, historyLoading: false, history: action.plans, historyError: undefined };
+      return {
+        ...state,
+        historyLoading: false,
+        history: action.plans,
+        historyError: undefined,
+        historyUnavailable: false,
+      };
 
     case 'HISTORY_ERROR':
       return { ...state, historyLoading: false, historyError: action.error };
+
+    case 'HISTORY_UNAVAILABLE':
+      // Not an error: the deployment simply has no plan surface. Clear any prior
+      // error so the panel renders the calm explanatory state instead.
+      return {
+        ...state,
+        historyLoading: false,
+        history: [],
+        historyError: undefined,
+        historyUnavailable: true,
+      };
 
     case 'HISTORY_PLAN_REMOVED':
       return {

--- a/src/RetailPulse.Web/src/state/usePlanController.ts
+++ b/src/RetailPulse.Web/src/state/usePlanController.ts
@@ -23,6 +23,7 @@ import {
   fetchPlans,
   parseClarificationPrompt,
   parseReviewProposal,
+  PlanSurfaceUnavailableError,
 } from '../services/planApi';
 import {
   reconcilePlan,
@@ -576,6 +577,13 @@ export function usePlanController(options: UsePlanControllerOptions): PlanContro
       const plans = await fetchPlans();
       dispatch({ type: 'HISTORY_LOADED', plans });
     } catch (err) {
+      // A 404 means this deployment has no plan surface at all
+      // (PlanPersistence:Enabled=false). That is configuration, not failure —
+      // render the explanatory empty state rather than a raw error.
+      if (err instanceof PlanSurfaceUnavailableError) {
+        dispatch({ type: 'HISTORY_UNAVAILABLE' });
+        return;
+      }
       dispatch({
         type: 'HISTORY_ERROR',
         error: err instanceof Error ? err.message : 'Failed to load plan history',

--- a/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
@@ -465,8 +465,14 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
         PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System);
 
         PlanReviewCoordinationInput input = SampleInput() with { Subject = "alice" };
-        _backgroundTasks.Add(coord.CoordinateAsync(input, _backgroundCts.Token));
-        ApprovalRequest aliceRow = await WaitForPending(gate, input.Subject);
+        Task<PlanReviewOutcome> coordination = coord.CoordinateAsync(input, _backgroundCts.Token);
+        _backgroundTasks.Add(coordination);
+
+        // Pass the background task in so a wait timeout can report WHY the row never
+        // arrived. This test has been intermittently flaky under full parallel load and
+        // a bare "timed out" told us nothing; if the coordinator faulted, the exception
+        // is now surfaced instead of being swallowed by the fixture's Dispose.
+        ApprovalRequest aliceRow = await WaitForPending(gate, input.Subject, coordination);
 
         // Guard the arrange step explicitly: prove alice's row really is present before
         // concluding anything from bob's empty result. Without this, a scheduling timeout
@@ -582,15 +588,34 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
     /// </summary>
     private static readonly TimeSpan PendingRowTimeout = TimeSpan.FromSeconds(30);
 
-    private static async Task<ApprovalRequest> WaitForPending(SqliteApprovalGate gate, string subject)
+    private static async Task<ApprovalRequest> WaitForPending(
+        SqliteApprovalGate gate,
+        string subject,
+        Task? producer = null)
     {
-        ApprovalRequest? row = await PollForPendingAsync(
-            gate, subject, static _ => true);
+        ApprovalRequest? row = await PollForPendingAsync(gate, subject, static _ => true);
 
         return row ?? throw new InvalidOperationException(
             $"Timed out after {PendingRowTimeout.TotalSeconds:N0}s waiting for a pending approval row "
-            + $"for subject '{subject}'. This is an arrange-step failure, not an assertion failure.");
+            + $"for subject '{subject}'. This is an arrange-step failure, not an assertion failure."
+            + DescribeProducer(producer));
     }
+
+    /// <summary>
+    /// Renders the state of the background task that was supposed to write the row. A
+    /// faulted producer is the difference between "the thread pool was slow" and "the
+    /// coordinator threw", which a bare timeout message cannot distinguish.
+    /// </summary>
+    private static string DescribeProducer(Task? producer) =>
+        producer is null
+            ? string.Empty
+            : producer.IsFaulted
+                ? $" The coordinator task FAULTED: {producer.Exception?.GetBaseException()}"
+                : producer.IsCanceled
+                    ? " The coordinator task was CANCELLED before it wrote a row."
+                    : producer.IsCompletedSuccessfully
+                        ? " The coordinator task completed without ever writing a pending row."
+                        : $" The coordinator task is still {producer.Status} — it never reached the write.";
 
     private static async Task<ApprovalRequest> WaitForPendingRound(
         SqliteApprovalGate gate, string subject, int expectedRound)

--- a/tests/RetailPulse.Tests/Security/ContainerAppDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Security/ContainerAppDeploymentContractTests.cs
@@ -201,4 +201,22 @@ public sealed partial class ContainerAppDeploymentContractTests
                 $"container app '{name}' must not accept plaintext HTTP on its ingress");
         }
     }
+
+    /// <summary>
+    /// Plan-first orchestration is gated on <c>PlanPersistence:Enabled</c>. That single
+    /// flag registers <c>IPlanStore</c>, which is what maps <c>/api/plans/*</c> AND wires
+    /// the <c>PlanOrchestrator</c>. Deployed with it off, the SPA's "Plan" execution-path
+    /// option was an inert control and the Plans panel showed a raw 404 from a route that
+    /// was never mapped. Pin it so the deployed surface and the UI stay in agreement.
+    /// </summary>
+    [Fact]
+    public void Api_EnablesPlanPersistence_SoThePlanSurfaceExists()
+    {
+        (_, string body) = BlockFor("ca-retailpulse-api");
+
+        body.Should().MatchRegex(
+            @"name:\s*'PlanPersistence__Enabled'\s*value:\s*'true'",
+            "the API must enable plan persistence, or /api/plans/* is unmapped and the "
+            + "Plan execution path silently falls back to the single-specialist route");
+    }
 }


### PR DESCRIPTION
The deployed Plans panel showed **"Failed to list plans: 404 Unknown error"**.

## Root cause

`PlanPersistence:Enabled` is `false` in `appsettings.json`, with **no** override in `appsettings.Production.json` and **no** env var on the container. I verified all three.

That one flag cascades:

1. `IPlanStore` is never registered
2. → `MapPlanEndpoints()` is never called
3. → `/api/plans/*` genuinely does not exist → **404 was correct backend behaviour**

## The second, quieter problem

The same flag gates the orchestrator. So the **"Plan" option in the Auto/Fast/Plan selector was a dead control** — `PlanOrchestrator` was not registered, `[FromServices]` resolved null, and `/api/chat` silently dropped through to the single-specialist path.

The UI was offering a capability the deployment did not have.

## Fix

The API container now sets `PlanPersistence__Enabled=true`, so both the Plans panel and the Plan execution path work.

**Durability is bounded and deliberate.** The plan store shares the ephemeral per-replica temp directory, so plans survive within a warm replica and reset on revision change, replica replacement, or scale-to-zero. That's acceptable here — plan history is a live view of the current session, not a system of record.

**`PlanReview` (issue #94, the human approval gate) stays off.** It's a separate opt-in; with it enabled *every* plan pauses for reviewer approval. Plans here generate and execute straight through.

## Graceful degradation

So no deployment can leak a raw 404 again:

- `fetchPlans` translates 404 into a typed `PlanSurfaceUnavailableError`
- the reducer reduces it to a non-error `historyUnavailable` state
- the panel renders *"Plan history isn't enabled in this environment."* instead of an alert

Any other non-OK status is still a real, visible error — verified by test.

## Flaky test made self-diagnosing

The cross-subject plan review test recurred during this work. My earlier deadline fix reduced but **did not eliminate** it, and I could not reproduce it across **12 consecutive full-suite runs**.

Rather than guess at a second fix, the wait now accepts the coordinator task and reports its state on timeout — faulted (with the base exception), cancelled, completed-without-writing, or still running. The next occurrence will say *why* instead of just "timed out".

## Verification

- **3475 backend tests pass**
- **786 frontend tests pass** (5 new)
- `az bicep build` clean
- `dotnet format --verify-no-changes` exits **0**
- `tsc --noEmit` clean, `npm run build` clean
