### PR TITLE
feat(demo): enable the full capability surface in production

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -268,3 +268,26 @@ output VITE_ENTRA_API_SCOPE string = entraApiScope
 output VITE_ENTRA_AUDIENCE string = empty(entraAudience) && !empty(entraClientId)
   ? 'api://${entraClientId}'
   : entraAudience
+
+// - VITE_FEATURE_*: build-time capability switches read by the Vite frontend
+//   (src/RetailPulse.Web/src/config/featureFlags.ts). Every one of these except
+//   observability defaults to FALSE in the SPA, so without these outputs the
+//   deployed app hides its own feature surface — campaign planner, competitive
+//   dashboard, knowledge base, health council, guardrails/security, adaptive
+//   cards, store ops, financials and portfolio were all invisible in the live
+//   demo even though the API mapped their endpoints.
+//
+//   This deployment is a full-capability demo environment, so every flag is on.
+//   They are emitted as infra outputs (rather than hardcoded in the SPA) so a
+//   differently-scoped deployment can still narrow the surface by overriding
+//   them, and so what the frontend renders stays traceable to the environment.
+output VITE_FEATURE_CAMPAIGN_PLANNER string = 'true'
+output VITE_FEATURE_COMPETITIVE string = 'true'
+output VITE_FEATURE_KNOWLEDGE_BASE string = 'true'
+output VITE_FEATURE_HEALTH_COUNCIL string = 'true'
+output VITE_FEATURE_SECURITY string = 'true'
+output VITE_FEATURE_CARDS string = 'true'
+output VITE_FEATURE_STORES string = 'true'
+output VITE_FEATURE_FINANCIALS string = 'true'
+output VITE_FEATURE_PORTFOLIO string = 'true'
+output VITE_FEATURE_OBSERVABILITY string = 'true'

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -283,6 +283,30 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'PlanPersistence__Enabled'
               value: 'true'
             }
+            // Human-in-the-loop plan review (issue #94). With this on, a plan-first
+            // request pauses and surfaces an approval card the reviewer can approve,
+            // edit, or reject with feedback (bounded replan rounds) before any step
+            // executes. This is the headline demo of the approval gate, so it is on
+            // here — note it makes every plan-path turn interactive by design.
+            //
+            // Timeouts are bounded (30m review / 15m clarification) and the replan
+            // cap is finite, so the coordinator cannot hang waiting on a human.
+            {
+              name: 'PlanReview__Enabled'
+              value: 'true'
+            }
+            // Durable server-side conversation history (issue #90). Enabled for the
+            // full-capability demo so /api/sessions/* is mapped and chats survive a
+            // reload. Anonymous callers still never persist, and PII redaction on
+            // write stays on — those are hard gates, not config.
+            //
+            // Same ephemeral-storage caveat as the plan store: session rows live in
+            // the per-replica temp directory and reset on revision change, replica
+            // replacement, or scale-to-zero.
+            {
+              name: 'SessionPersistence__Enabled'
+              value: 'true'
+            }
             {
               name: 'ASPNETCORE_ENVIRONMENT'
               value: 'Production'

--- a/tests/RetailPulse.Tests/Security/ContainerAppDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Security/ContainerAppDeploymentContractTests.cs
@@ -219,4 +219,24 @@ public sealed partial class ContainerAppDeploymentContractTests
             "the API must enable plan persistence, or /api/plans/* is unmapped and the "
             + "Plan execution path silently falls back to the single-specialist route");
     }
+
+    /// <summary>
+    /// This environment is a full-capability demo. The human-in-the-loop plan review gate
+    /// and durable session history are both opt-in and both default OFF, so they must be
+    /// asserted explicitly or a future re-provision could quietly drop the demo back to a
+    /// reduced surface.
+    /// </summary>
+    [Fact]
+    public void Api_EnablesTheHumanApprovalGateAndSessionHistory()
+    {
+        (_, string body) = BlockFor("ca-retailpulse-api");
+
+        body.Should().MatchRegex(
+            @"name:\s*'PlanReview__Enabled'\s*value:\s*'true'",
+            "the plan review approval gate must be on for the full demo");
+
+        body.Should().MatchRegex(
+            @"name:\s*'SessionPersistence__Enabled'\s*value:\s*'true'",
+            "durable session history must be on for the full demo");
+    }
 }


### PR DESCRIPTION
This environment is a demo, but most of it was invisible or inert.

## Frontend — 9 of 10 features were hidden

Nine of the ten \VITE_FEATURE_*\ flags default to \alse\ in \eatureFlags.ts\, and \main.bicep\ emitted **none** of them — so the Vite build embedded the defaults. Campaign planner, competitive dashboard, knowledge base, health council, guardrails/security, adaptive cards, store ops, financials and portfolio were all hidden in the deployed app **even though the API mapped their endpoints**.

All ten are now emitted as infra outputs set to \	rue\. They stay outputs rather than SPA hardcodes so a differently-scoped deployment can still narrow the surface, and so what the frontend renders remains traceable to the environment.

## Human-in-the-loop approvals

\PlanReview\ (issue #94) has **no appsettings section at all** and defaults to \Enabled=false\, so plan-first requests generated and executed straight through with no reviewer pause.

\PlanReview__Enabled=true\ wires the coordinator into \PlanOrchestrator\: a plan-path turn now surfaces an approval card the reviewer can **approve, edit, or reject with feedback** across bounded replan rounds before any step runs.

Timeouts remain bounded (30m review, 15m clarification) and the replan cap is finite, so the coordinator cannot hang on human input. Note this makes every plan-path turn interactive by design.

## Durable session history

\SessionPersistence\ (issue #90) was likewise off, so \/api/sessions/*\ was unmapped. Enabled so chats survive a reload.

The hard privacy gates are unchanged and are **not** config: anonymous callers still never persist, reads/deletes stay subject-scoped, and PII redaction on write stays on.

## Durability caveat

Both stores inherit the documented ephemeral-storage caveat: rows live in the per-replica temp directory and reset on revision change, replica replacement, or scale-to-zero. Acceptable for a demo where this is a live view of the current session, not a system of record.

## Regression guard

Deployment-contract coverage for both new API flags, so a future re-provision cannot quietly drop the demo back to a reduced surface.

## Verification

- **3476 backend tests pass**
- \z bicep build\ clean
- \dotnet format --verify-no-changes\ exits 0