### PR TITLE
fix(plans): drive canonical step rows on approved-plan resume

### DIFF
--- a/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
+++ b/src/RetailPulse.Api/Approval/PlanReviewCompletionService.cs
@@ -428,22 +428,35 @@ public sealed class PlanReviewCompletionService
             })],
         };
 
+        // Reuse the CANONICAL step ids the plan was created with
+        // (`{planId}-s{index}`) rather than minting a round-scoped
+        // `{planId}-r{round}-s{index}` set.
+        //
+        // The round-scoped scheme assumed the resume path would persist a
+        // parallel set of step rows, but it never did — the writes were built
+        // and dropped. The executor therefore issued UpdateStepAsync against
+        // ids with no matching row (a silent no-op, since the UPDATE matches on
+        // StepId AND PlanId), the original rows stayed Pending, and the
+        // terminal-status sweep in SqlitePlanStore swept them to Skipped. Net
+        // effect: an approved plan that really ran — real tool calls, real
+        // tokens, real answer — reported 0/N progress with every step "skipped".
+        //
+        // Reusing the canonical ids makes the executor drive the rows that
+        // actually exist: Pending -> Running -> Completed. The sweep then finds
+        // nothing Pending/Running at terminal time and leaves them alone.
+        //
+        // Per-round step history is not lost by this: only the final approved
+        // round ever executes. Earlier rejected rounds never advance a step
+        // beyond Pending, so there is no per-round result to preserve.
+        //
+        // Limitation: if a reviewer EDITS the plan to have more steps than the
+        // original, ids past the original count have no row and those updates
+        // still no-op. That was already true before this change.
         var stepIds = new List<string>(effectivePlan.Steps.Count);
-        var stepWrites = new List<PlanStepWrite>(effectivePlan.Steps.Count);
         int offset = resumeCompletedSteps?.Count ?? 0;
         for (int i = 0; i < effectivePlan.Steps.Count; i++)
         {
-            string stepId = $"{plan.PlanId}-r{state.RoundNumber}-s{offset + i}";
-            stepIds.Add(stepId);
-            stepWrites.Add(new PlanStepWrite
-            {
-                StepId = stepId,
-                StepIndex = offset + i,
-                SpecialistKey = effectivePlan.Steps[i].SpecialistKey,
-                Intent = effectivePlan.Steps[i].Intent,
-                Action = effectivePlan.Steps[i].Action,
-                Status = PlanStepStatus.Pending,
-            });
+            stepIds.Add($"{plan.PlanId}-s{offset + i}");
         }
 
         // Persist the resolved (edited/approved) plan onto the same row.

--- a/src/RetailPulse.Api/Persistence/SqlitePlanStore.cs
+++ b/src/RetailPulse.Api/Persistence/SqlitePlanStore.cs
@@ -210,15 +210,19 @@ public sealed class SqlitePlanStore : IPlanStore
         // Terminal-transition orphan sweep (issue #149). Once a plan reaches
         // any terminal state, no step row for that plan may remain Pending or
         // Running — the persisted history must honestly reflect "the plan is
-        // over; this step was never executed". The initial `{planId}-s{i}` rows
-        // that PlanOrchestrator.SuspendForReviewAsync writes at review-open
-        // time are the canonical case: reviewer-approved execution writes a
-        // parallel `{planId}-r{round}-s{i}` set and the initial rows would
-        // otherwise linger as Pending forever, over-counting anything that
-        // reads plan state directly (audit, /api/plans/{id}/reconcile,
-        // reporting, and the #91 / #141 recovery surfaces). Doing the sweep
-        // inside the same transaction guarantees atomicity — a status write
-        // that succeeds cannot leave stale Pending step rows behind.
+        // over; this step was never executed". This catches genuinely abandoned
+        // steps: a plan that failed or was cancelled part-way, or a review that
+        // timed out before any step ran. Doing the sweep inside the same
+        // transaction guarantees atomicity — a status write that succeeds
+        // cannot leave stale Pending step rows behind.
+        //
+        // NOTE: this sweep used to also fire on the ordinary approve-and-run
+        // path. The resume wrote its updates against round-scoped step ids
+        // (`{planId}-r{round}-s{i}`) that were never persisted, so the canonical
+        // `{planId}-s{i}` rows stayed Pending and got swept to Skipped even
+        // though the plan really executed. PlanReviewCompletionService now
+        // drives the canonical ids, so an approved run leaves its rows
+        // Completed and this sweep correctly finds nothing to do.
         if (isTerminal)
         {
             await using SqliteCommand sweep = conn.CreateCommand();

--- a/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanStateIntegrityTests.cs
@@ -106,14 +106,13 @@ public sealed class PlanStateIntegrityTests : IDisposable
         PlanReviewCompletionResult clarResume = await completion.ResolveAsync(suspend.PlanId, "user-1");
         clarResume.Kind.Should().Be(PlanReviewCompletionKind.Executed);
 
-        // Plan-review + clarification double-suspends materialize step rows
-        // under the review-round naming scheme `{planId}-r{round}-s{index}`
-        // (see PlanReviewCompletionService.ExecuteApprovedPlanAsync). The
-        // executor's SuspendForClarificationAsync then writes the paused row
-        // under that same id with Status = Pending. On answer resume it MUST
-        // transition to Completed so plan-detail reads don't advertise an
-        // answered clarification as still pending.
-        string pausedStepId = $"{suspend.PlanId}-r0-s1";
+        // Plan-review + clarification resumes drive the CANONICAL step rows
+        // `{planId}-s{index}` (see PlanReviewCompletionService.ExecuteApprovedPlanAsync).
+        // The executor's SuspendForClarificationAsync writes the paused row under
+        // that same id with Status = Pending. On answer resume it MUST transition
+        // to Completed so plan-detail reads don't advertise an answered
+        // clarification as still pending.
+        string pausedStepId = $"{suspend.PlanId}-s1";
         PlanStepUpdate? pausedUpdate = plans.GetLastStepUpdate("user-1", suspend.PlanId, pausedStepId);
         pausedUpdate.Should().NotBeNull(
             "the paused clarification step's row must exist under the initial-plan step id.");
@@ -339,17 +338,18 @@ public sealed class PlanStateIntegrityTests : IDisposable
     // ── Finding 4 (issue #149): terminal plan state leaves no orphan Pending step rows ─
 
     /// <summary>
-    /// Reproduces issue #149: <see cref="PlanOrchestrator.SuspendForReviewAsync"/>
+    /// Issue #149 plus the resume-id defect. <see cref="PlanOrchestrator.SuspendForReviewAsync"/>
     /// writes initial step rows under <c>{planId}-s{i}</c> as
-    /// <see cref="PlanStepStatus.Pending"/>. When the reviewer approves and
-    /// execution succeeds via <see cref="PlanReviewCompletionService.ExecuteApprovedPlanAsync"/>,
-    /// execution writes a parallel <c>{planId}-r{round}-s{i}</c> set — the
-    /// original rows would otherwise linger as Pending forever. The contract
-    /// this test pins: after ANY terminal plan status is written, no step row
-    /// for that plan may remain Pending or Running. Enforced inside
-    /// <see cref="IPlanStore.UpdatePlanStatusAsync"/> so every caller (executor
-    /// finally block, completion-service finalisers, restart recovery)
-    /// inherits the invariant without having to remember to sweep.
+    /// <see cref="PlanStepStatus.Pending"/>. When the reviewer approves,
+    /// <see cref="PlanReviewCompletionService.ExecuteApprovedPlanAsync"/> drives
+    /// those same canonical rows to Completed.
+    /// <para>
+    /// Two contracts are pinned here: after ANY terminal plan status no step row
+    /// may remain Pending or Running (enforced by the sweep inside
+    /// <see cref="IPlanStore.UpdatePlanStatusAsync"/> so every caller inherits
+    /// it), and an approved run that succeeded must report its steps as
+    /// Completed rather than Skipped.
+    /// </para>
     /// </summary>
     [Fact]
     public async Task Review_approved_completed_plan_leaves_no_orphan_pending_step_rows()
@@ -396,14 +396,23 @@ public sealed class PlanStateIntegrityTests : IDisposable
         after.Steps.Should().NotContain(s => s.Status == PlanStepStatus.Running,
             "no step row may remain Running after the plan reaches a terminal state (issue #149).");
 
-        // The initial `{planId}-s{i}` rows specifically must be Skipped (not
-        // still-Pending, not still-Running) — this is the exact orphan class
-        // the issue calls out.
+        // The initial `{planId}-s{i}` rows ARE the rows execution drives, so an
+        // approved-and-successful run leaves them Completed.
+        //
+        // This assertion previously expected Skipped. That encoded a defect:
+        // the resume path minted round-scoped ids (`{planId}-r{round}-s{i}`) for
+        // a parallel row set it never actually persisted, so every executor
+        // update no-opped, the canonical rows stayed Pending, and the terminal
+        // sweep marked them Skipped. A plan that genuinely ran — real tool
+        // calls, real tokens, real answer — therefore reported 0/N progress with
+        // every step "skipped". The resume now drives the canonical rows, so
+        // they legitimately reach Completed and the sweep finds nothing to do.
         IEnumerable<PlanStepRecordDto> initialRows = after.Steps
             .Where(s => s.StepId == $"{suspend.PlanId}-s0" || s.StepId == $"{suspend.PlanId}-s1");
-        initialRows.Should().OnlyContain(s => s.Status == PlanStepStatus.Skipped,
-            "the pre-execution planner-proposal rows must be transitioned to Skipped when execution " +
-            "supersedes them with round-scoped rows.");
+        initialRows.Should().HaveCount(2);
+        initialRows.Should().OnlyContain(s => s.Status == PlanStepStatus.Completed,
+            "approved execution drives the canonical step rows to Completed — reporting them as " +
+            "Skipped would misrepresent a plan that actually ran.");
 
         await sp.DisposeAsync();
     }


### PR DESCRIPTION
Found while testing the approval gate end to end against the deployed demo.

Approving a plan produced a **real, grounded answer** (38,130 input / 2,609 output tokens, genuine tool calls) — but the plan reported **0/3 progress** with every step persisted as \skipped\.

## Root cause

\PlanOrchestrator.SuspendForReviewAsync\ writes the plan's step rows under the canonical ids \{planId}-s{i}\.

On approval, \PlanReviewCompletionService.ExecuteApprovedPlanAsync\ minted a **different**, round-scoped id set (\{planId}-r{round}-s{i}\), built \PlanStepWrite\ rows for them — and **never persisted those rows**.

The executor therefore issued \UpdateStepAsync\ against ids with no matching row. \SqlitePlanStore\ matches on \StepId AND PlanId\, so every update silently affected **zero rows**. The canonical rows stayed \Pending\, and the terminal-status sweep (issue #149) then correctly did its job and swept them to \Skipped\.

So a plan that genuinely executed reported as if nothing had run. **The sweep was not at fault** — it was sweeping rows that execution should have been driving.

## Fix

The resume reuses the canonical \{planId}-s{offset+i}\ ids, so the executor drives rows that actually exist: \Pending → Running → Completed\. The terminal sweep then finds nothing \Pending\/\Running\ and leaves them alone. The dead \PlanStepWrite\ list is removed.

Per-round history is not lost: only the final approved round ever executes, and rejected rounds never advance a step past \Pending\.

**Known limitation, unchanged:** if a reviewer edits a plan to have *more* steps than the original, ids past the original count still have no row and those updates no-op.

## Test changes

Two tests encoded the defect rather than the intent:

- \Review_approved_completed_plan_leaves_no_orphan_pending_step_rows\ asserted the canonical rows must end **Skipped**. They must now end **Completed**, because they are the rows execution drives. Its real invariant — no \Pending\/\Running\ row survives a terminal transition — is unchanged and still asserted.
- The clarification test hardcoded \-r0-s1\; now \-s1\.

Both comments were rewritten to explain why the expectation changed. Also corrects the stale comment in \SqlitePlanStore\ describing the parallel-row design that was never implemented.

## Verification

- **3476 backend tests pass**
- \dotnet format --verify-no-changes\ exits 0