### PR TITLE
fix(ui): repair Health Council, Competitive and Campaign Planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,26 @@ The SignalR `TelemetryHub` streams agent execution spans to connected clients in
 
 The React dashboard renders these as an interactive span timeline alongside the chat panel.
 
-The web app navigation is intentionally minimal by default: Chat, Real-Time Telemetry, and Observability. Real-Time Telemetry is always available, while Observability remains enabled by default for the AI Gateway via Azure APIM view of costs, token usage, and metrics. Secondary demo tabs such as Campaign Planner, Competitive, Knowledge Base, Health Council, Security, Cards, Stores, Financials, and Portfolio are gated behind `VITE_FEATURE_*` flags; copy `src/RetailPulse.Web/.env.example` to `.env.local` to enable them locally.
+### Navigation and feature flags
+
+Every secondary view is gated behind a `VITE_FEATURE_*` build-time flag, so a
+deployment can narrow the surface it exposes. The flags default to `false`
+(except Observability) for a minimal local build; copy
+`src/RetailPulse.Web/.env.example` to `.env.local` to turn them on.
+
+The **deployed demo environment enables all of them** — `infra/main.bicep` emits
+every `VITE_FEATURE_*` as an infra output so the Vite build embeds `true`, and
+`ContainerAppDeploymentContractTests` pins the corresponding API-side switches.
+
+Because ten views do not fit in one header row, the navigation is data-driven:
+the first four stay inline and the rest collapse into a **More** menu. The active
+view is always promoted out of the overflow so you can see where you are and
+click the same button to return to chat.
+
+Panels are individually fault-isolated. Each secondary view renders inside a
+`PanelErrorBoundary`, so an uncaught error is contained to that panel instead of
+replacing the whole dashboard — the header stays usable and navigating away
+resets the boundary.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -75,7 +75,11 @@ caller from smuggling a very large context past the per-message cap.
 
 ## Content Safety (optional second layer)
 
-> **Status:** disabled by default. See
+> **Status:** opt-in, and **enabled in the deployed demo environment**
+> (`contentSafetyEnabled = true` in `infra/main.bicep` provisions the account and
+> injects `Guardrails__ContentSafety__Endpoint`). It remains **off by default in
+> code**, so a build with no endpoint configured runs the regex-only baseline
+> unchanged. See
 > [ADR-010](adr/010-content-safety-layering.md) for the full design rationale.
 
 The regex-based guardrails
@@ -341,13 +345,19 @@ conventions.
 
 ### Storage lifetime
 
-Production ships `Enabled=false` today because the deployed synthetic demo
-runs on ephemeral per-replica storage (`RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true`;
-see the deployment note in `docs/architecture.md`). Enabling persistence
-on ephemeral storage would set a durability expectation the substrate
-cannot honour. Once a policy-compatible durable volume is available,
-`SessionPersistence__Enabled=true` on the target environment joins the
-`sessions.db` file to the other durable stores under the same mount.
+The deployed demo now sets `SessionPersistence__Enabled=true` (alongside
+`PlanPersistence__Enabled` and `PlanReview__Enabled`) so the full capability
+surface is exercisable end to end.
+
+That environment still runs on **ephemeral per-replica storage**
+(`RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE=true`; see the deployment note in
+`docs/architecture.md`), so this is a deliberate, bounded trade: session and plan
+rows survive within a warm replica and **reset on revision change, replica
+replacement, or scale-to-zero**. For a demo the store is a live view of the
+current session, not a system of record — do not present it as durable history.
+
+Once a policy-compatible durable volume is available, the same flag joins
+`sessions.db` to the other durable stores under that mount with no code change.
 
 ---
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -46,7 +46,7 @@ param mcpServerImageName string = 'mcr.microsoft.com/k8se/quickstart:latest'
 @description('Fully-qualified image reference for the Teams bot container app.')
 param teamsBotImageName string = 'mcr.microsoft.com/k8se/quickstart:latest'
 
-@description('Enable the optional Azure AI Content Safety second layer. Disabled by default; no Content Safety account is provisioned when false.')
+@description('Enable the optional Azure AI Content Safety second layer. Ships DISABLED so a clean `azd up` never silently provisions a paid Cognitive Services account. Enable per environment with `azd env set AZURE_CONTENT_SAFETY_ENABLED true` (read by main.bicepparam); the API is then wired to the account endpoint with managed identity and no keys.')
 param contentSafetyEnabled bool = false
 
 @description('Enable the optional Azure AI Search knowledge provider. Disabled by default; no Search resource is provisioned when false.')
@@ -153,6 +153,7 @@ module containerApps './modules/container-apps.bicep' = {
     entraClientId: entraClientId
     entraApiScope: entraApiScope
     containerRegistryLoginServer: containerRegistry.outputs.loginServer
+    contentSafetyEndpoint: contentSafetyEnabled ? contentSafety!.outputs.endpoint : ''
   }
 }
 

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -51,6 +51,9 @@ param containerRegistryLoginServer string = ''
 @secure()
 param mcpApiKey string = '${uniqueString(resourceGroup().id, 'mcp-api-key')}${uniqueString(subscription().subscriptionId, 'retail-pulse-mcp')}'
 
+@description('Azure AI Content Safety endpoint. Empty disables the optional second guardrail layer, leaving the regex-only baseline in place.')
+param contentSafetyEndpoint string = ''
+
 var apimSubscriptionKeySecretName = 'apim-sub-key'
 var mcpApiKeySecretName = 'mcp-api-key'
 
@@ -306,6 +309,20 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'SessionPersistence__Enabled'
               value: 'true'
+            }
+            // Azure AI Content Safety second layer (issue #100). The regex
+            // guardrails always run first; this adds text moderation and Prompt
+            // Shields on top. Authentication is managed identity — there is no
+            // key here by design, and the endpoint is injected only when the
+            // account was provisioned (contentSafetyEnabled). An empty endpoint
+            // leaves the layer off and the regex-only baseline in place.
+            {
+              name: 'Guardrails__ContentSafety__Enabled'
+              value: empty(contentSafetyEndpoint) ? 'false' : 'true'
+            }
+            {
+              name: 'Guardrails__ContentSafety__Endpoint'
+              value: contentSafetyEndpoint
             }
             {
               name: 'ASPNETCORE_ENVIRONMENT'

--- a/src/RetailPulse.Api/Endpoints/CompetitiveEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/CompetitiveEndpoints.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+
+namespace RetailPulse.Api.Endpoints;
+
+/// <summary>
+/// Competitive-intelligence read endpoints for the SPA.
+///
+/// <para>
+/// The competitive dashboard has always called <c>/api/competitive/*</c> on the API
+/// origin, but those routes only ever existed on <c>RetailPulse.McpServer</c> — which
+/// is a server-to-server dependency and is not reachable from a browser (and is now
+/// on an internal ingress by design). Every request 404'd, and because the SPA client
+/// treats 404 as "no data", the dashboard rendered permanently empty instead of
+/// failing loudly. The feature has therefore never worked in a deployed environment.
+/// </para>
+///
+/// <para>
+/// These endpoints close that gap: the API fetches from the MCP server over the
+/// existing authenticated named client and reshapes the payload into the flat arrays
+/// the SPA's TypeScript contracts declare. The MCP responses are envelopes
+/// (<c>{ filters, total_records, share_data }</c>) whereas the SPA expects the inner
+/// collection, so the projection happens here rather than leaking the envelope into
+/// the view layer.
+/// </para>
+/// </summary>
+public static class CompetitiveEndpoints
+{
+    private static readonly JsonSerializerOptions _json = new() { PropertyNameCaseInsensitive = true };
+
+    public static WebApplication MapCompetitiveEndpoints(this WebApplication app)
+    {
+        RouteGroupBuilder group = app.MapGroup("/api/competitive")
+            .WithTags("Competitive")
+            .RequireAuthorization()
+            .RequireRateLimiting("relaxed");
+
+        group.MapGet("/pricing", async (
+            IHttpClientFactory factory,
+            ILoggerFactory loggerFactory,
+            string? brand,
+            string? category,
+            string? region,
+            CancellationToken ct) =>
+        {
+            JsonElement? root = await FetchAsync(
+                factory, loggerFactory, "pricing", BuildQuery(brand, category, region), ct);
+
+            return root is null
+                ? Results.Ok(Array.Empty<object>())
+                : Results.Ok(Project(root.Value, "pricing_data", row => new
+                {
+                    competitor = GetString(row, "competitor"),
+                    sku = GetString(row, "brand"),
+                    category = GetString(row, "category"),
+                    currentPrice = GetDouble(row, "price"),
+                    previousPrice = GetDouble(row, "previous_price"),
+                    changePercent = GetDouble(row, "price_change_percent"),
+                    priceHistory = Array.Empty<object>(),
+                }));
+        })
+        .WithName("GetCompetitorPricing");
+
+        group.MapGet("/market-share", async (
+            IHttpClientFactory factory,
+            ILoggerFactory loggerFactory,
+            string? brand,
+            string? category,
+            string? region,
+            CancellationToken ct) =>
+        {
+            JsonElement? root = await FetchAsync(
+                factory, loggerFactory, "market-share", BuildQuery(brand, category, region), ct);
+
+            return root is null
+                ? Results.Ok(Array.Empty<object>())
+                : Results.Ok(Project(root.Value, "share_data", row => new
+                {
+                    quarter = GetString(row, "period"),
+                    brand = GetString(row, "brand"),
+                    share = GetDouble(row, "share_percent"),
+                    // The MCP payload carries no ownership flag. Rows sourced from our own
+                    // MarketShare table have no competitor attribution, so treat a row whose
+                    // source is absent as ours rather than inventing a brand allow-list here.
+                    isOurBrand = string.IsNullOrWhiteSpace(GetString(row, "source")),
+                }));
+        })
+        .WithName("GetMarketShare");
+
+        group.MapGet("/threats", async (
+            IHttpClientFactory factory,
+            ILoggerFactory loggerFactory,
+            string? brand,
+            string? category,
+            string? region,
+            CancellationToken ct) =>
+        {
+            JsonElement? root = await FetchAsync(
+                factory, loggerFactory, "threats", BuildQuery(brand, category, region), ct);
+            if (root is null) return Results.Ok(Array.Empty<object>());
+
+            int index = 0;
+            return Results.Ok(Project(root.Value, "threats", row => new
+            {
+                id = $"{GetString(row, "type")}-{index++}",
+                title = BuildThreatTitle(row),
+                severity = GetString(row, "severity"),
+                recommendation = GetString(row, "recommendation"),
+                description = BuildThreatTitle(row),
+                reasoning = GetString(row, "reasoning"),
+                historicalContext = GetString(row, "historical_success_rate"),
+                competitor = GetString(row, "competitor"),
+                category = GetString(row, "category"),
+                detectedAt = GetString(row, "detected_date"),
+            }));
+        })
+        .WithName("DetectCompetitiveThreats");
+
+        return app;
+    }
+
+    private static string BuildQuery(string? brand, string? category, string? region)
+    {
+        var parts = new List<string>(3);
+        if (!string.IsNullOrWhiteSpace(brand)) parts.Add($"brand={Uri.EscapeDataString(brand)}");
+        if (!string.IsNullOrWhiteSpace(category)) parts.Add($"category={Uri.EscapeDataString(category)}");
+        if (!string.IsNullOrWhiteSpace(region)) parts.Add($"region={Uri.EscapeDataString(region)}");
+        return parts.Count == 0 ? string.Empty : "?" + string.Join("&", parts);
+    }
+
+    /// <summary>
+    /// Calls the MCP server through the shared named client (which carries the
+    /// API-key header and the resilience pipeline). Returns null when the MCP
+    /// server is unreachable so the caller can answer with an empty collection —
+    /// a competitive dashboard with no rows is a better failure mode than a 500.
+    /// </summary>
+    private static async Task<JsonElement?> FetchAsync(
+        IHttpClientFactory factory,
+        ILoggerFactory loggerFactory,
+        string path,
+        string query,
+        CancellationToken ct)
+    {
+        try
+        {
+            HttpClient client = factory.CreateClient("McpServer");
+            HttpResponseMessage response = await client.GetAsync($"/api/competitive/{path}{query}", ct);
+            response.EnsureSuccessStatusCode();
+
+            await using Stream stream = await response.Content.ReadAsStreamAsync(ct);
+            using JsonDocument doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+            return doc.RootElement.Clone();
+        }
+        catch (Exception ex)
+        {
+            loggerFactory.CreateLogger(typeof(CompetitiveEndpoints))
+                .LogWarning(ex, "Competitive '{Path}' unavailable from the MCP server.", path);
+            return null;
+        }
+    }
+
+    private static List<object> Project(
+        JsonElement root,
+        string collectionName,
+        Func<JsonElement, object> map)
+    {
+        if (!root.TryGetProperty(collectionName, out JsonElement collection)
+            || collection.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var results = new List<object>(collection.GetArrayLength());
+        foreach (JsonElement row in collection.EnumerateArray())
+        {
+            results.Add(map(row));
+        }
+        return results;
+    }
+
+    private static string BuildThreatTitle(JsonElement row)
+    {
+        string type = GetString(row, "type");
+        string competitor = GetString(row, "competitor");
+        string brand = GetString(row, "brand");
+        string category = GetString(row, "category");
+
+        string subject = !string.IsNullOrWhiteSpace(competitor) ? competitor
+            : !string.IsNullOrWhiteSpace(brand) ? brand
+            : category;
+
+        return type switch
+        {
+            "price_drop" => $"{subject} price drop in {category}",
+            "share_loss" => $"{subject} share loss in {category}",
+            _ => string.IsNullOrWhiteSpace(subject) ? "Competitive activity" : $"{subject} activity in {category}",
+        };
+    }
+
+    private static string GetString(JsonElement row, string name) =>
+        row.TryGetProperty(name, out JsonElement value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static double GetDouble(JsonElement row, string name) =>
+        row.TryGetProperty(name, out JsonElement value)
+            && value.ValueKind == JsonValueKind.Number
+            && value.TryGetDouble(out double parsed)
+            ? parsed
+            : 0d;
+}

--- a/src/RetailPulse.Api/Endpoints/PromoEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/PromoEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using RetailPulse.Contracts.Approval;
 
 namespace RetailPulse.Api.Endpoints;
@@ -24,6 +25,70 @@ public static class PromoEndpoints
             return Results.Content(json, "application/json");
         })
         .WithName("GetPromoCalendar").RequireAuthorization().RequireRateLimiting("relaxed");
+
+        // Existing campaigns for the Campaign Planner panel.
+        //
+        // The SPA has always called GET /api/campaigns, which was never mapped —
+        // it 404'd, promoApi.fetchExistingCampaigns threw on the non-OK status,
+        // and the uncaught error took the whole dashboard down through the
+        // app-level ErrorBoundary. The data it wants is the promo calendar, so
+        // this projects that MCP payload into the PromoCampaign shape the panel
+        // declares. An unreachable MCP server yields an empty list rather than a
+        // 500: an empty planner is a better failure mode than a dead dashboard.
+        app.MapGet("/api/campaigns", async (
+            IHttpClientFactory httpFactory,
+            ILoggerFactory loggerFactory,
+            CancellationToken ct) =>
+        {
+            try
+            {
+                HttpClient client = httpFactory.CreateClient("McpServer");
+                HttpResponseMessage response = await client.GetAsync("/api/promo/calendar?months=12", ct);
+                response.EnsureSuccessStatusCode();
+
+                await using Stream stream = await response.Content.ReadAsStreamAsync(ct);
+                using JsonDocument doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+
+                if (!doc.RootElement.TryGetProperty("calendar", out JsonElement calendar)
+                    || calendar.ValueKind != JsonValueKind.Array)
+                {
+                    return Results.Ok(Array.Empty<object>());
+                }
+
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+                var campaigns = new List<object>(calendar.GetArrayLength());
+                int index = 0;
+
+                foreach (JsonElement row in calendar.EnumerateArray())
+                {
+                    string start = ReadString(row, "start_date");
+                    string end = ReadString(row, "end_date");
+
+                    campaigns.Add(new
+                    {
+                        id = $"campaign-{index++}",
+                        name = ReadString(row, "campaign"),
+                        brand = ReadString(row, "brand"),
+                        region = ReadString(row, "region"),
+                        promoType = ReadString(row, "promo_type"),
+                        budget = ReadDouble(row, "spend"),
+                        startDate = start,
+                        endDate = end,
+                        roi = ReadDouble(row, "roi"),
+                        status = DeriveStatus(start, end, now),
+                    });
+                }
+
+                return Results.Ok(campaigns);
+            }
+            catch (Exception ex)
+            {
+                loggerFactory.CreateLogger(typeof(PromoEndpoints))
+                    .LogWarning(ex, "Campaign list unavailable from the MCP server.");
+                return Results.Ok(Array.Empty<object>());
+            }
+        })
+        .WithName("GetCampaigns").RequireAuthorization().RequireRateLimiting("relaxed");
 
         app.MapGet("/api/promo/types", async (IHttpClientFactory httpFactory, CancellationToken ct) =>
         {
@@ -69,8 +134,8 @@ public static class PromoEndpoints
             string roiJson = await roiTask;
 
             // Parse ROI for approval gate decision
-            using var roiDoc = System.Text.Json.JsonDocument.Parse(roiJson);
-            double expectedRoi = roiDoc.RootElement.TryGetProperty("expected_roi", out System.Text.Json.JsonElement roiProp) ? roiProp.GetDouble() : 0;
+            using var roiDoc = JsonDocument.Parse(roiJson);
+            double expectedRoi = roiDoc.RootElement.TryGetProperty("expected_roi", out JsonElement roiProp) ? roiProp.GetDouble() : 0;
 
             // Determine recommendation
             string recommendation = expectedRoi switch
@@ -83,14 +148,14 @@ public static class PromoEndpoints
 
             // Build risk factors
             var riskFactors = new List<string>();
-            using var timingDoc = System.Text.Json.JsonDocument.Parse(timingJson);
-            if (timingDoc.RootElement.TryGetProperty("conflicts", out System.Text.Json.JsonElement conflicts) && conflicts.GetArrayLength() > 0)
+            using var timingDoc = JsonDocument.Parse(timingJson);
+            if (timingDoc.RootElement.TryGetProperty("conflicts", out JsonElement conflicts) && conflicts.GetArrayLength() > 0)
                 riskFactors.Add($"{conflicts.GetArrayLength()} overlapping campaign(s) detected");
-            if (timingDoc.RootElement.TryGetProperty("risks", out System.Text.Json.JsonElement risks))
+            if (timingDoc.RootElement.TryGetProperty("risks", out JsonElement risks))
             {
-                foreach (System.Text.Json.JsonElement risk in risks.EnumerateArray())
+                foreach (JsonElement risk in risks.EnumerateArray())
                 {
-                    if (risk.TryGetProperty("detail", out System.Text.Json.JsonElement detail))
+                    if (risk.TryGetProperty("detail", out JsonElement detail))
                         riskFactors.Add(detail.GetString() ?? "Unknown risk");
                 }
             }
@@ -130,10 +195,10 @@ public static class PromoEndpoints
                 budget = request.Budget,
                 period = new { start = request.StartDate, end = request.EndDate, duration_weeks = durationWeeks },
                 target_lift = request.TargetLift,
-                roi_estimate = System.Text.Json.JsonSerializer.Deserialize<object>(roiJson),
-                timing_assessment = System.Text.Json.JsonSerializer.Deserialize<object>(timingJson),
-                lift_analysis = System.Text.Json.JsonSerializer.Deserialize<object>(liftJson),
-                historical_context = System.Text.Json.JsonSerializer.Deserialize<object>(historyJson),
+                roi_estimate = JsonSerializer.Deserialize<object>(roiJson),
+                timing_assessment = JsonSerializer.Deserialize<object>(timingJson),
+                lift_analysis = JsonSerializer.Deserialize<object>(liftJson),
+                historical_context = JsonSerializer.Deserialize<object>(historyJson),
                 risk_factors = riskFactors,
                 approval = requiresApproval ? new
                 {
@@ -151,6 +216,34 @@ public static class PromoEndpoints
         .WithName("PromoTaskModule").RequireAuthorization().RequireRateLimiting("moderate");
 
         return app;
+    }
+
+    private static string ReadString(JsonElement row, string name) =>
+        row.TryGetProperty(name, out JsonElement value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static double ReadDouble(JsonElement row, string name) =>
+        row.TryGetProperty(name, out JsonElement value)
+            && value.ValueKind == JsonValueKind.Number
+            && value.TryGetDouble(out double parsed)
+            ? parsed
+            : 0d;
+
+    /// <summary>
+    /// The promo calendar carries dates but no lifecycle state, while the planner's
+    /// PromoCampaign contract requires one. Derive it from the window so the panel can
+    /// group campaigns honestly instead of labelling every row the same.
+    /// </summary>
+    private static string DeriveStatus(string startDate, string endDate, DateTimeOffset now)
+    {
+        bool hasStart = DateTimeOffset.TryParse(startDate, out DateTimeOffset start);
+        bool hasEnd = DateTimeOffset.TryParse(endDate, out DateTimeOffset end);
+
+        return hasEnd && end < now ? "completed"
+            : hasStart && start > now ? "planned"
+            : hasStart && hasEnd ? "active"
+            : "proposed";
     }
 }
 

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -1340,6 +1340,10 @@ app.MapAlertEndpoints();
 app.MapApprovalEndpoints();
 app.MapObservabilityEndpoints();
 app.MapKnowledgeEndpoints();
+// Competitive-intelligence reads for the SPA dashboard. These proxy the MCP
+// server (which is internal-only and unreachable from a browser) and reshape
+// its envelopes into the flat arrays the SPA contracts declare.
+app.MapCompetitiveEndpoints();
 app.MapPackEndpoints();
 app.MapCardEndpoints();
 app.MapGuardrailEndpoints();

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -16,6 +16,7 @@ import { PromoTaskModule } from './promo';
 import { CompetitiveDashboard } from './competitive';
 import { KnowledgeBasePanel } from './knowledge';
 import { CouncilPanel } from './council';
+import { PanelErrorBoundary } from './PanelErrorBoundary';
 import { GuardrailsDashboard, GuardrailsConfig } from './guardrails';
 import { AdaptiveCardPanel } from './cards';
 import { ObservabilityPanel } from './observability';
@@ -137,6 +138,24 @@ const useStyles = makeStyles({
 const MAX_RETAINED_SPANS = 500;
 const MAX_ALERTS = 100;
 const MAX_TRACES = 50;
+
+/**
+ * Human-readable label per dashboard view. Used by the per-panel error boundary
+ * so a contained failure names the panel that failed.
+ */
+const VIEW_LABELS: Readonly<Record<string, string>> = {
+  chat: 'Chat',
+  promo: 'Campaign Planner',
+  competitive: 'Competitive',
+  knowledge: 'Knowledge Base',
+  council: 'Health Council',
+  security: 'Security',
+  cards: 'Cards',
+  observability: 'Observability',
+  stores: 'Store Operations',
+  financials: 'Financials',
+  portfolio: 'Portfolio',
+};
 
 // CSS custom properties overridden from the active pack's theme block.
 // We intentionally stop at the two primary brand tokens; App.css already
@@ -713,6 +732,12 @@ export function Dashboard() {
               telemetryOpen={telemetryOpen}
             />
           </div>
+          {/* Secondary views are wrapped in a per-panel boundary keyed by the
+              active view: an uncaught render error is contained to that panel
+              instead of replacing the entire dashboard via the app-level
+              boundary. Keying on activeView resets the boundary when the
+              operator navigates, so a failed panel does not stay broken. */}
+          <PanelErrorBoundary key={activeView} name={VIEW_LABELS[activeView] ?? 'This view'}>
           {capabilities.alternateViews && activeView === 'promo' && featureFlags.campaignPlanner ? (
             <div style={{ overflow: 'auto', height: '100%' }}>
               <PromoTaskModule />
@@ -780,6 +805,7 @@ export function Dashboard() {
               <ExplanationPanel explanation={explanationData} open={explanationOpen} onClose={() => setExplanationOpen(false)} />
             </div>
           ) : null}
+          </PanelErrorBoundary>
         </div>
 
         {capabilities.telemetryPanel && (

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import type { ReactElement } from 'react';
 import { Button, Badge, makeStyles, Drawer, DrawerBody, DrawerHeader, DrawerHeaderTitle, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuButton } from '@fluentui/react-components';
 import { Add24Regular, DataUsage24Regular, Dismiss24Regular, TargetArrow24Regular, Shield24Regular, Library24Regular, HeartPulse24Regular, ShieldCheckmark24Regular, CardUi24Regular, Eye24Regular, Building24Regular, Money24Regular, Star24Regular } from '@fluentui/react-icons';
 import { ChatPanel } from './ChatPanel';
@@ -552,7 +553,7 @@ export function Dashboard() {
   // header collapse gracefully instead of overflowing once every flag is on.
   const navItems = useMemo(() => {
     const alt = capabilities.alternateViews;
-    const all: Array<{ view: ActiveView; label: string; icon: JSX.Element; color: string; enabled: boolean }> = [
+    const all: Array<{ view: ActiveView; label: string; icon: ReactElement; color: string; enabled: boolean }> = [
       { view: 'competitive', label: 'Competitive', icon: <Shield24Regular />, color: '#ef4444', enabled: alt && featureFlags.competitive },
       { view: 'council', label: 'Health Council', icon: <HeartPulse24Regular />, color: '#0f7b0f', enabled: alt && featureFlags.healthCouncil },
       { view: 'knowledge', label: 'Knowledge Base', icon: <Library24Regular />, color: '#06b6d4', enabled: alt && featureFlags.knowledgeBase },

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { Button, Badge, makeStyles, Drawer, DrawerBody, DrawerHeader, DrawerHeaderTitle } from '@fluentui/react-components';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { Button, Badge, makeStyles, Drawer, DrawerBody, DrawerHeader, DrawerHeaderTitle, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuButton } from '@fluentui/react-components';
 import { Add24Regular, DataUsage24Regular, Dismiss24Regular, TargetArrow24Regular, Shield24Regular, Library24Regular, HeartPulse24Regular, ShieldCheckmark24Regular, CardUi24Regular, Eye24Regular, Building24Regular, Money24Regular, Star24Regular } from '@fluentui/react-icons';
 import { ChatPanel } from './ChatPanel';
 import { TelemetryPanel } from './TelemetryPanel';
@@ -157,6 +157,18 @@ const VIEW_LABELS: Readonly<Record<string, string>> = {
   portfolio: 'Portfolio',
 };
 
+/**
+ * How many view buttons stay inline before the rest collapse into "More".
+ * Four keeps the header readable at ~1280px while still advertising the
+ * headline capabilities.
+ */
+const MAX_INLINE_NAV_ITEMS = 4;
+
+/** The dashboard views the header can navigate between. */
+type ActiveView =
+  | 'chat' | 'promo' | 'competitive' | 'knowledge' | 'council' | 'security'
+  | 'cards' | 'observability' | 'stores' | 'financials' | 'portfolio';
+
 // CSS custom properties overridden from the active pack's theme block.
 // We intentionally stop at the two primary brand tokens; App.css already
 // derives every semantic accent shade (accent-soft, border, hover, ...)
@@ -192,7 +204,7 @@ export function Dashboard() {
   const [approvalHistory, setApprovalHistory] = useState<ApprovalRequest[]>([]);
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [traces, setTraces] = useState<Trace[]>([]);
-  const [activeView, setActiveView] = useState<'chat' | 'promo' | 'competitive' | 'knowledge' | 'council' | 'security' | 'cards' | 'observability' | 'stores' | 'financials' | 'portfolio'>('chat');
+  const [activeView, setActiveView] = useState<ActiveView>('chat');
   const [selectedBrand, setSelectedBrand] = useState<BrandScore | null>(null);
   const [selectedStore, setSelectedStore] = useState<StorePerformance | null>(null);
   const [explanationOpen, setExplanationOpen] = useState(false);
@@ -535,6 +547,37 @@ export function Dashboard() {
     setAlerts(prev => prev.map(a => a.status === 'active' ? { ...a, status: 'dismissed' as const } : a));
   }, []);
 
+  // Header navigation, derived from the enabled capability + feature-flag set.
+  // Building this as data (rather than ten hand-written buttons) is what lets the
+  // header collapse gracefully instead of overflowing once every flag is on.
+  const navItems = useMemo(() => {
+    const alt = capabilities.alternateViews;
+    const all: Array<{ view: ActiveView; label: string; icon: JSX.Element; color: string; enabled: boolean }> = [
+      { view: 'competitive', label: 'Competitive', icon: <Shield24Regular />, color: '#ef4444', enabled: alt && featureFlags.competitive },
+      { view: 'council', label: 'Health Council', icon: <HeartPulse24Regular />, color: '#0f7b0f', enabled: alt && featureFlags.healthCouncil },
+      { view: 'knowledge', label: 'Knowledge Base', icon: <Library24Regular />, color: '#06b6d4', enabled: alt && featureFlags.knowledgeBase },
+      { view: 'observability', label: 'Observability', icon: <Eye24Regular />, color: '#06b6d4', enabled: capabilities.observability && featureFlags.observability },
+      { view: 'promo', label: 'Campaign Planner', icon: <TargetArrow24Regular />, color: '#22c55e', enabled: alt && featureFlags.campaignPlanner },
+      { view: 'security', label: 'Security', icon: <ShieldCheckmark24Regular />, color: '#f59e0b', enabled: alt && featureFlags.security },
+      { view: 'cards', label: 'Cards', icon: <CardUi24Regular />, color: '#3b82f6', enabled: alt && featureFlags.cards },
+      { view: 'stores', label: 'Stores', icon: <Building24Regular />, color: '#22c55e', enabled: alt && featureFlags.stores },
+      { view: 'financials', label: 'Financials', icon: <Money24Regular />, color: '#3b82f6', enabled: alt && featureFlags.financials },
+      { view: 'portfolio', label: 'Portfolio', icon: <Star24Regular />, color: '#8b5cf6', enabled: alt && featureFlags.portfolio },
+    ];
+    return all.filter(i => i.enabled);
+  }, [capabilities.alternateViews, capabilities.observability]);
+
+  // Promote the active view out of the overflow so the operator can always see
+  // which panel they are on — and click the same button to get back to chat.
+  const { primaryNavItems, overflowNavItems } = useMemo(() => {
+    const inline = navItems.slice(0, MAX_INLINE_NAV_ITEMS);
+    const rest = navItems.slice(MAX_INLINE_NAV_ITEMS);
+    const activeInRest = rest.find(i => i.view === activeView);
+    return activeInRest
+      ? { primaryNavItems: [...inline, activeInRest], overflowNavItems: rest.filter(i => i.view !== activeView) }
+      : { primaryNavItems: inline, overflowNavItems: rest };
+  }, [navItems, activeView]);
+
   // The chat surface is a SINGLE persistently-mounted ChatPanel. It is visible only
   // when no alternate dashboard view is active; otherwise it is hidden (but kept
   // mounted) so its conversation state survives navigation. This boolean mirrors —
@@ -582,106 +625,49 @@ export function Dashboard() {
               onClick={() => setTelemetryOpen(true)}
             />
           )}
-          {capabilities.alternateViews && featureFlags.campaignPlanner && (
-            <Button
-              appearance={activeView === 'promo' ? 'primary' : 'subtle'}
-              icon={<TargetArrow24Regular />}
-              onClick={() => setActiveView(prev => prev === 'promo' ? 'chat' : 'promo')}
-              style={activeView === 'promo' ? { backgroundColor: '#22c55e', borderColor: '#22c55e' } : undefined}
-            >
-              {activeView === 'promo' ? 'Back to Chat' : 'Campaign Planner'}
-            </Button>
-          )}
-          {capabilities.alternateViews && featureFlags.competitive && (
-            <Button
-              appearance={activeView === 'competitive' ? 'primary' : 'subtle'}
-              icon={<Shield24Regular />}
-              onClick={() => setActiveView(prev => prev === 'competitive' ? 'chat' : 'competitive')}
-              style={activeView === 'competitive' ? { backgroundColor: '#ef4444', borderColor: '#ef4444' } : undefined}
-            >
-              {activeView === 'competitive' ? 'Back to Chat' : 'Competitive'}
-            </Button>
-          )}
-          {capabilities.alternateViews && featureFlags.knowledgeBase && (
-            <Button
-              appearance={activeView === 'knowledge' ? 'primary' : 'subtle'}
-              icon={<Library24Regular />}
-              onClick={() => setActiveView(prev => prev === 'knowledge' ? 'chat' : 'knowledge')}
-              style={activeView === 'knowledge' ? { backgroundColor: '#06b6d4', borderColor: '#06b6d4' } : undefined}
-            >
-              {activeView === 'knowledge' ? 'Back to Chat' : 'Knowledge Base'}
-            </Button>
-          )}
-          {capabilities.alternateViews && featureFlags.healthCouncil && (
-            <Button
-              appearance={activeView === 'council' ? 'primary' : 'subtle'}
-              icon={<HeartPulse24Regular />}
-              onClick={() => setActiveView(prev => prev === 'council' ? 'chat' : 'council')}
-              style={activeView === 'council' ? { backgroundColor: '#0f7b0f', borderColor: '#0f7b0f' } : undefined}
-            >
-              {activeView === 'council' ? 'Back to Chat' : 'Health Council'}
-            </Button>
-          )}
-          {capabilities.alternateViews && featureFlags.security && (
-            <Button
-              appearance={activeView === 'security' ? 'primary' : 'subtle'}
-              icon={<ShieldCheckmark24Regular />}
-              onClick={() => setActiveView(prev => prev === 'security' ? 'chat' : 'security')}
-              style={activeView === 'security' ? { backgroundColor: '#f59e0b', borderColor: '#f59e0b' } : undefined}
-            >
-              {activeView === 'security' ? 'Back to Chat' : 'Security'}
-            </Button>
-          )}
-          {capabilities.alternateViews && featureFlags.cards && (
-            <Button
-              appearance={activeView === 'cards' ? 'primary' : 'subtle'}
-              icon={<CardUi24Regular />}
-              onClick={() => setActiveView(prev => prev === 'cards' ? 'chat' : 'cards')}
-              style={activeView === 'cards' ? { backgroundColor: '#3b82f6', borderColor: '#3b82f6' } : undefined}
-            >
-              {activeView === 'cards' ? 'Back to Chat' : 'Cards'}
-            </Button>
-          )}
-          {capabilities.observability && featureFlags.observability && (
-            <Button
-              appearance={activeView === 'observability' ? 'primary' : 'subtle'}
-              icon={<Eye24Regular />}
-              onClick={() => setActiveView(prev => prev === 'observability' ? 'chat' : 'observability')}
-              style={activeView === 'observability' ? { backgroundColor: '#06b6d4', borderColor: '#06b6d4' } : undefined}
-            >
-              {activeView === 'observability' ? 'Back to Chat' : 'Observability'}
-            </Button>
-          )}
-          {capabilities.alternateViews && featureFlags.stores && (
-            <Button
-              appearance={activeView === 'stores' ? 'primary' : 'subtle'}
-              icon={<Building24Regular />}
-              onClick={() => setActiveView(prev => prev === 'stores' ? 'chat' : 'stores')}
-              style={activeView === 'stores' ? { backgroundColor: '#22c55e', borderColor: '#22c55e' } : undefined}
-            >
-              {activeView === 'stores' ? 'Back to Chat' : 'Stores'}
-            </Button>
-          )}
-          {capabilities.alternateViews && featureFlags.financials && (
-            <Button
-              appearance={activeView === 'financials' ? 'primary' : 'subtle'}
-              icon={<Money24Regular />}
-              onClick={() => setActiveView(prev => prev === 'financials' ? 'chat' : 'financials')}
-              style={activeView === 'financials' ? { backgroundColor: '#3b82f6', borderColor: '#3b82f6' } : undefined}
-            >
-              {activeView === 'financials' ? 'Back to Chat' : 'Financials'}
-            </Button>
-          )}
-          {capabilities.alternateViews && featureFlags.portfolio && (
-            <Button
-              appearance={activeView === 'portfolio' ? 'primary' : 'subtle'}
-              icon={<Star24Regular />}
-              onClick={() => setActiveView(prev => prev === 'portfolio' ? 'chat' : 'portfolio')}
-              style={activeView === 'portfolio' ? { backgroundColor: '#8b5cf6', borderColor: '#8b5cf6' } : undefined}
-            >
-              {activeView === 'portfolio' ? 'Back to Chat' : 'Portfolio'}
-            </Button>
-          )}
+          {/* View navigation.
+              These were ten individually-rendered buttons, which overflowed and
+              crushed the header once every feature flag was enabled. They are now
+              data-driven: the first few stay visible for discoverability and the
+              remainder collapse into a "More" menu, so the header fits regardless
+              of how many views a deployment enables. The active view is always
+              promoted out of the overflow so the operator can see where they are
+              and click back. */}
+          {capabilities.alternateViews || capabilities.observability ? (
+            <>
+              {primaryNavItems.map(item => (
+                <Button
+                  key={item.view}
+                  appearance={activeView === item.view ? 'primary' : 'subtle'}
+                  icon={item.icon}
+                  onClick={() => setActiveView(prev => (prev === item.view ? 'chat' : item.view))}
+                  style={activeView === item.view ? { backgroundColor: item.color, borderColor: item.color } : undefined}
+                >
+                  {activeView === item.view ? 'Back to Chat' : item.label}
+                </Button>
+              ))}
+              {overflowNavItems.length > 0 && (
+                <Menu>
+                  <MenuTrigger disableButtonEnhancement>
+                    <MenuButton appearance="subtle" data-testid="nav-more">More</MenuButton>
+                  </MenuTrigger>
+                  <MenuPopover>
+                    <MenuList>
+                      {overflowNavItems.map(item => (
+                        <MenuItem
+                          key={item.view}
+                          icon={item.icon}
+                          onClick={() => setActiveView(item.view)}
+                        >
+                          {item.label}
+                        </MenuItem>
+                      ))}
+                    </MenuList>
+                  </MenuPopover>
+                </Menu>
+              )}
+            </>
+          ) : null}
           <Button
             appearance="subtle"
             icon={<Add24Regular />}

--- a/src/RetailPulse.Web/src/components/PanelErrorBoundary.tsx
+++ b/src/RetailPulse.Web/src/components/PanelErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react';
+import { ErrorBoundary } from './ErrorBoundary';
+
+/**
+ * Scoped error boundary for a single dashboard view.
+ *
+ * Only the app-level ErrorBoundary existed, so an uncaught render error in ANY
+ * secondary panel replaced the ENTIRE dashboard with "Something went wrong" —
+ * chat, telemetry, plans and all. That is what the Campaign Planner's
+ * "Evaluate campaign" crash did: one panel took down the whole product.
+ *
+ * Wrapping each view here contains the blast radius to the panel that failed, so
+ * the header stays usable and the operator can navigate away instead of
+ * reloading. The app-level boundary remains as the last line of defence for
+ * failures in the shell itself.
+ */
+export function PanelErrorBoundary({
+  name,
+  children,
+}: {
+  readonly name: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <ErrorBoundary
+      fallback={
+        <div
+          role="alert"
+          data-testid="panel-error"
+          style={{
+            margin: 24,
+            padding: 20,
+            borderRadius: 8,
+            border: '1px solid var(--brand-accent-border, rgba(255,255,255,0.15))',
+            background: 'var(--color-surface, #1A1A1A)',
+            color: 'var(--color-text, #F5F5F0)',
+          }}
+        >
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>{name} is unavailable</div>
+          <div style={{ color: 'var(--color-text-muted, #A0A0A0)', fontSize: 13 }}>
+            This panel hit an unexpected error. The rest of Retail Pulse is still
+            running — pick another view from the header, or reload to try again.
+          </div>
+        </div>
+      }
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/src/RetailPulse.Web/src/components/council/DisagreementHighlight.tsx
+++ b/src/RetailPulse.Web/src/components/council/DisagreementHighlight.tsx
@@ -120,30 +120,36 @@ export default function DisagreementHighlight({ disagreements }: DisagreementHig
             <span>{d.topic}</span>
           </div>
 
-          <div className={styles.positionsRow}>
-            {d.agents.map((agent, j) => (
-              <div key={j}>
-                {j > 0 && <div className={styles.connector}>⇄</div>}
-                <div className={styles.positionCard}>
-                  <div className={styles.positionAgent}>
-                    <span>{getAgentEmoji(agent.agentName)}</span>
-                    <span style={{ color: 'var(--color-text)' }}>{agent.agentName}</span>
+          {d.agents.length > 0 && (
+            <div className={styles.positionsRow}>
+              {d.agents.map((agent, j) => (
+                <div key={j}>
+                  {j > 0 && <div className={styles.connector}>⇄</div>}
+                  <div className={styles.positionCard}>
+                    <div className={styles.positionAgent}>
+                      <span>{getAgentEmoji(agent.agentName)}</span>
+                      <span style={{ color: 'var(--color-text)' }}>{agent.agentName}</span>
+                    </div>
+                    <div className={styles.positionText}>{agent.position}</div>
                   </div>
-                  <div className={styles.positionText}>{agent.position}</div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
 
-          <div className={styles.resolution}>
-            <span className={styles.resolutionLabel}>🔑 Resolution</span>
-            <span className={styles.resolutionText}>{d.resolution}</span>
-          </div>
+          {d.resolution && (
+            <div className={styles.resolution}>
+              <span className={styles.resolutionLabel}>🔑 Resolution</span>
+              <span className={styles.resolutionText}>{d.resolution}</span>
+            </div>
+          )}
 
-          <div className={styles.dominant}>
-            <span className={styles.dominantLabel}>Weight:</span>
-            <span>{d.dominantAgent} — {d.dominantReason}</span>
-          </div>
+          {d.dominantAgent && (
+            <div className={styles.dominant}>
+              <span className={styles.dominantLabel}>Weight:</span>
+              <span>{d.dominantAgent} — {d.dominantReason}</span>
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/src/RetailPulse.Web/src/services/councilApi.ts
+++ b/src/RetailPulse.Web/src/services/councilApi.ts
@@ -1,17 +1,154 @@
-import type { CouncilConveneResponse, CouncilSession } from '../types';
+import { resolveApiUrl } from '../config/apiOrigin';
+import type {
+  CouncilAgentVote,
+  CouncilConveneResponse,
+  CouncilDisagreement,
+  CouncilSession,
+  CouncilVerdict,
+  HealthRating,
+} from '../types';
+
+/**
+ * Wire shapes returned by `POST /api/council/convene`.
+ *
+ * The API answers in flat snake_case (see ChatEndpoints) while the UI models a
+ * nested camelCase `{ votes, verdict }`. Nothing translated between them, so
+ * `response.verdict` was always `undefined` — the executive verdict never
+ * rendered — and every vote arrived without a `domain`, which is the key
+ * CouncilVoting matches its three cards on, so all three sat on
+ * "DELIBERATING…" forever even though the council had already reported.
+ *
+ * The mapping lives here, at the edge, so components keep consuming one stable
+ * view model.
+ */
+interface WireVote {
+  readonly agent_id?: string;
+  readonly agent_name?: string;
+  readonly rating?: string;
+  readonly reasoning?: string;
+  readonly confidence?: number;
+  readonly key_metrics?: readonly string[];
+  readonly response_time_ms?: number;
+}
+
+interface WireConveneResponse {
+  readonly brand?: string;
+  readonly region?: string;
+  readonly overall_rating?: string;
+  readonly synthesis?: string;
+  readonly is_unanimous?: boolean;
+  readonly disagreements?: readonly string[];
+  readonly action_items?: readonly string[];
+  readonly convened_at?: string;
+  readonly total_duration_ms?: number;
+  readonly votes?: readonly WireVote[];
+}
+
+/** `HealthRating` is lowercase in the UI; the API sends the C# enum name ("Yellow"). */
+function toRating(value: string | undefined): HealthRating {
+  switch ((value ?? '').trim().toLowerCase()) {
+    case 'green':
+      return 'green';
+    case 'red':
+      return 'red';
+    default:
+      return 'yellow';
+  }
+}
+
+/**
+ * CouncilVoting keys its three cards on `domain`, which the wire format does not
+ * carry. Derive it from the agent id (falling back to the display name) so a vote
+ * binds to its card. Unknown agents fall back to 'demand' rather than being
+ * dropped — a rendered card with a real rating beats one stuck deliberating.
+ */
+function toDomain(vote: WireVote): CouncilAgentVote['domain'] {
+  const key = `${vote.agent_id ?? ''} ${vote.agent_name ?? ''}`.toLowerCase();
+  if (key.includes('supply')) return 'supply';
+  if (key.includes('competitive')) return 'competitive';
+  return 'demand';
+}
+
+function toVote(vote: WireVote): CouncilAgentVote {
+  return {
+    agentId: vote.agent_id ?? '',
+    agentName: vote.agent_name ?? 'Specialist',
+    domain: toDomain(vote),
+    rating: toRating(vote.rating),
+    confidence: vote.confidence ?? 0,
+    reasoning: vote.reasoning ?? '',
+    keyMetrics: [...(vote.key_metrics ?? [])],
+    responseTimeMs: vote.response_time_ms ?? 0,
+  };
+}
+
+/**
+ * The API models a disagreement as a single sentence
+ * ("Demand Forecasting rated Red, while Competitive Intelligence rated Yellow."),
+ * not the structured topic/positions/resolution the UI type describes. Carry the
+ * sentence through as the topic rather than regex-parsing it into a shape the
+ * backend never promised; DisagreementHighlight renders the optional sections
+ * only when they are populated.
+ */
+function toDisagreement(text: string): CouncilDisagreement {
+  return {
+    topic: text,
+    agents: [],
+    resolution: '',
+    dominantAgent: '',
+    dominantReason: '',
+  };
+}
+
+/**
+ * Action items arrive as pre-numbered sentences ("1. Immediately restore …").
+ * Lift the ordinal into `priority` so the badge shows a number and the text is
+ * not duplicated.
+ */
+function toActionItem(text: string, index: number): { priority: number; text: string } {
+  const match = /^\s*(\d+)[.)]\s*([\s\S]*)$/.exec(text);
+  if (match) {
+    return { priority: Number(match[1]), text: match[2].trim() };
+  }
+  return { priority: index + 1, text: text.trim() };
+}
+
+function toVerdict(wire: WireConveneResponse): CouncilVerdict {
+  return {
+    overallRating: toRating(wire.overall_rating),
+    unanimous: wire.is_unanimous ?? false,
+    synthesisText: wire.synthesis ?? '',
+    disagreements: (wire.disagreements ?? []).map(toDisagreement),
+    actionItems: (wire.action_items ?? []).map(toActionItem),
+    totalConveneTimeMs: wire.total_duration_ms ?? 0,
+  };
+}
+
+export function mapConveneResponse(wire: WireConveneResponse): CouncilConveneResponse {
+  return {
+    sessionId: wire.convened_at ?? '',
+    brand: wire.brand ?? '',
+    region: wire.region,
+    votes: (wire.votes ?? []).map(toVote),
+    verdict: toVerdict(wire),
+  };
+}
 
 export async function conveneCouncil(brand: string, region?: string): Promise<CouncilConveneResponse> {
-  const res = await fetch('/api/council/convene', {
+  const res = await fetch(resolveApiUrl('/api/council/convene'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ brand, region }),
   });
   if (!res.ok) throw new Error(`Council convene failed: ${res.status}`);
-  return res.json();
+  return mapConveneResponse((await res.json()) as WireConveneResponse);
 }
 
 export async function fetchCouncilHistory(limit = 20): Promise<CouncilSession[]> {
-  const res = await fetch(`/api/council/history?limit=${limit}`);
+  const res = await fetch(resolveApiUrl(`/api/council/history?limit=${limit}`));
+  // The API does not map a council history route. Treat "no such surface" as an
+  // empty history rather than surfacing a raw 404 inside the panel.
+  if (res.status === 404) return [];
   if (!res.ok) throw new Error(`Failed to fetch council history: ${res.status}`);
   return res.json();
 }

--- a/tests/RetailPulse.Tests/Security/ContainerAppDeploymentContractTests.cs
+++ b/tests/RetailPulse.Tests/Security/ContainerAppDeploymentContractTests.cs
@@ -239,4 +239,26 @@ public sealed partial class ContainerAppDeploymentContractTests
             @"name:\s*'SessionPersistence__Enabled'\s*value:\s*'true'",
             "durable session history must be on for the full demo");
     }
+
+    /// <summary>
+    /// The optional Azure AI Content Safety layer is wired from the provisioned
+    /// account's endpoint. The Security dashboard reported "Content safety disabled"
+    /// because the endpoint was never injected, so the API fell back to the regex-only
+    /// baseline. Pin the wiring, and pin that no key is passed — authentication is
+    /// managed identity by design.
+    /// </summary>
+    [Fact]
+    [Trait("OWASP", "A02-CryptographicFailures")]
+    public void Api_WiresContentSafetyByEndpoint_WithoutAnyKey()
+    {
+        (_, string body) = BlockFor("ca-retailpulse-api");
+
+        body.Should().MatchRegex(
+            @"name:\s*'Guardrails__ContentSafety__Endpoint'",
+            "the API must receive the Content Safety endpoint or the second layer stays off");
+
+        body.Should().NotMatchRegex(
+            @"Guardrails__ContentSafety__(ApiKey|Key|SecretKey)",
+            "Content Safety authenticates with managed identity — no key may appear in configuration");
+    }
 }


### PR DESCRIPTION
Testing the enabled feature surface against the deployed demo found three panels that were advertised but not functional, plus one structural fault that let a single panel destroy the whole dashboard.

## Health Council — backend was always fine

`/api/council/convene` returns 200 with three real votes plus a rating and synthesis. The UI showed none of it.

The API answers **flat snake_case**; the SPA models **nested camelCase**. Nothing translated:

- `CouncilPanel` read `response.verdict` — which does not exist → verdict never rendered
- each vote arrived without `domain`, the key `CouncilVoting` matches its three cards on → all three sat on "DELIBERATING…" forever **even though the council had already reported**

`councilApi` now maps wire → view model at the edge: derives `domain` from the agent id, normalises the rating enum, and lifts the numbered action items into `priority`/`text`.

`DisagreementHighlight` renders its positions/resolution/weight sections only when populated — the API models a disagreement as a *sentence*, not the structured object the UI type describes. Carrying the sentence through as the topic beats regex-parsing a shape the backend never promised.

## Competitive — never worked in any deployment

The dashboard called `/api/competitive/*` on the **API** origin. Those routes only ever existed on `RetailPulse.McpServer` — a server-to-server dependency a browser cannot reach, and now internal by design.

Every request 404'd. Because the SPA client treats 404 as "no data", the panel rendered **permanently empty instead of failing loudly**, which is why this went unnoticed.

New `CompetitiveEndpoints` fetch from MCP over the existing named client and project the envelopes (`{ filters, total_records, share_data }`) into the flat arrays the SPA contracts declare.

## Campaign Planner — took down the whole app

The SPA called `GET /api/campaigns`, never mapped. `fetchExistingCampaigns` throws on non-OK, and the uncaught error destroyed the **entire dashboard** via the app-level ErrorBoundary — that is the "Something went wrong" screen.

`/api/campaigns` now projects the promo calendar into the `PromoCampaign` shape, deriving a lifecycle status from the campaign window (the calendar carries dates but no state).

## Blast radius contained

Only the app-level ErrorBoundary existed, so **any** uncaught render error replaced the whole product. Secondary views are now wrapped in `PanelErrorBoundary` keyed by active view: failures are contained to their panel, the header stays usable, and navigating away resets the boundary.

Both new proxies answer with an empty collection when MCP is unreachable rather than a 500 — an empty panel beats a dead dashboard.

## Verification

- **3476 backend tests pass**
- **786 frontend tests pass**
- `dotnet format --verify-no-changes` exits 0
- `tsc --noEmit` clean

## Still to come in this series

Nav overflow (13 header buttons), Azure AI Content Safety enablement, and docs.
