### PR TITLE
fix(competitive): read the correct pricing collection key

### DIFF
--- a/src/RetailPulse.Api/Endpoints/CompetitiveEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/CompetitiveEndpoints.cs
@@ -47,7 +47,7 @@ public static class CompetitiveEndpoints
 
             return root is null
                 ? Results.Ok(Array.Empty<object>())
-                : Results.Ok(Project(root.Value, "pricing_data", row => new
+                : Results.Ok(Project(root.Value, "pricing", row => new
                 {
                     competitor = GetString(row, "competitor"),
                     sku = GetString(row, "brand"),


### PR DESCRIPTION
The MCP pricing envelope names its collection \pricing\, not \pricing_data\. The projection found nothing, so \/api/competitive/pricing\ answered an empty array while market-share (300 rows) and threats (35 rows) returned real data.

Caught by exercising the deployed endpoints rather than trusting the shape inferred from surrounding code.