### PR TITLE
fix(council): ground specialist votes in real tool data

### DIFF
--- a/src/RetailPulse.Api/Consensus/ConsensusOrchestrator.cs
+++ b/src/RetailPulse.Api/Consensus/ConsensusOrchestrator.cs
@@ -104,10 +104,24 @@ public class ConsensusOrchestrator : IConsensusCouncil
     }
 
     /// <summary>
-    /// Lightweight voting mode: sends a focused prompt directly to the LLM without
-    /// tool calls. Each voter gets a stripped system prompt and returns a JSON vote
-    /// based on domain knowledge. Temperature 0 for deterministic voting.
-    /// Falls back to full agent execution only if lightweight mode fails.
+    /// Collects one specialist's vote by running the REAL agent — tools included.
+    ///
+    /// <para>
+    /// This used to take a "lightweight" path: a direct toolless LLM call whose prompt
+    /// nonetheless instructed the model to "use your available tools to gather current
+    /// data". With no tools attached the model did the only honest thing available to
+    /// it — reported that it had no data, rated Yellow, and returned ~0.12 confidence.
+    /// Every council convened produced a procedurally valid verdict built on nothing.
+    /// The comment claiming it "falls back to full agent execution" described a
+    /// fallback that was never implemented.
+    /// </para>
+    ///
+    /// <para>
+    /// Routing through <see cref="ISpecialistAgent.HandleAsync"/> gives each voter its
+    /// real tool set, so the vote is grounded in the same MCP-backed data the chat path
+    /// uses. It costs a tool round-trip per specialist, which is why the timeout is the
+    /// tool-aware <see cref="_agentTimeout"/> rather than the old 10s budget.
+    /// </para>
     /// </summary>
     private async Task<AgentVote?> CollectVoteAsync(
         ISpecialistAgent agent, string brand, string? region, CancellationToken ct)
@@ -118,44 +132,26 @@ public class ConsensusOrchestrator : IConsensusCouncil
         try
         {
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            timeoutCts.CancelAfter(_lightweightVoteTimeout);
+            timeoutCts.CancelAfter(_agentTimeout);
 
-            // Lightweight path: direct LLM call with voting system prompt, no tools
-            var messages = new List<ChatMessage>
-            {
-                new(ChatRole.System, _voteDef.SystemPrompt),
-                new(ChatRole.User, $"[{agent.DisplayName}] {votePrompt}")
-            };
-
-            var options = new ChatOptions
-            {
-                Temperature = 0f,
-                ResponseFormat = ChatResponseFormat.Json
-            };
-
-            // Route through MAF: the lightweight voter is a real ChatClientAgent invocation
-            // (no tools attached; UseProvidedChatClientAsIs preserves the DI decorator stack).
-            AgentResponse response = await MafAgentInvoker.RunAsync(
-                _chatClient,
-                $"{MafVoterAgentName}.{agent.Key}",
-                messages,
-                options,
-                _loggerFactory,
+            Contracts.ChatResponse response = await agent.HandleAsync(
+                new ChatRequest(votePrompt, SessionId: $"council-{agent.Key}-{Guid.NewGuid():N}"),
                 timeoutCts.Token);
+
             agentSw.Stop();
 
-            string responseText = response.Text ?? "";
+            string responseText = response.Reply ?? "";
             return ParseVote(agent.Key, agent.DisplayName, responseText, agentSw.Elapsed);
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
             agentSw.Stop();
-            _logger.LogWarning("Agent {AgentKey} timed out after {Ms}ms during lightweight council vote",
+            _logger.LogWarning("Agent {AgentKey} timed out after {Ms}ms during council vote",
                 agent.Key, agentSw.ElapsedMilliseconds);
 
             return new AgentVote(
                 agent.Key, agent.DisplayName, HealthRating.Yellow,
-                $"Agent timed out after {_lightweightVoteTimeout.TotalSeconds}s — unable to complete assessment.",
+                $"Agent timed out after {_agentTimeout.TotalSeconds}s — unable to complete assessment.",
                 0.0, ["timeout"], agentSw.Elapsed);
         }
         catch (Exception ex)
@@ -177,7 +173,8 @@ public class ConsensusOrchestrator : IConsensusCouncil
         return $$"""
             Provide a health assessment for the brand "{{brand}}" {{regionClause}}.
 
-            Use your available tools to gather current data, then respond with a JSON vote:
+            Call your tools to gather current data first, then respond with a JSON vote
+            grounded in what they returned:
 
             {
               "rating": "Green" | "Yellow" | "Red",
@@ -191,6 +188,7 @@ public class ConsensusOrchestrator : IConsensusCouncil
             - Yellow: Some concerns or mixed signals requiring monitoring
             - Red: Critical issues requiring immediate attention
 
+            Populate key_metrics with actual figures your tools returned, not placeholders.
             Respond with ONLY the JSON object. No other text.
             """;
     }

--- a/tests/RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs
+++ b/tests/RetailPulse.Tests/Agents/MafPrimitivesCharacterizationTests.cs
@@ -200,23 +200,38 @@ public class MafPrimitivesCharacterizationTests
 
     #region Consensus Council
 
+    /// <summary>
+    /// The council's synthesis pass must flow through MAF, and each voter must be
+    /// collected by invoking the REAL specialist agent rather than a toolless direct
+    /// chat call.
+    /// <para>
+    /// This previously asserted four probe calls — three votes plus the synthesis —
+    /// because voters took a "lightweight" path that called <see cref="IChatClient"/>
+    /// directly with no tools attached. That path is why every council verdict came
+    /// back ungrounded ("no tool data available", ~0.12 confidence): the prompt asked
+    /// the model to use tools it had never been given. Voters now delegate to
+    /// <see cref="ISpecialistAgent.HandleAsync"/>, so the MAF invariant is upheld one
+    /// level down by the specialists themselves — proven for all nine LLM-backed
+    /// specialists by the inventory characterization below.
+    /// </para>
+    /// </summary>
     [Fact]
-    public async Task ConsensusOrchestrator_VoterAndSynthesizer_BothRouteThroughMaf()
+    public async Task ConsensusOrchestrator_DelegatesVotesToSpecialists_AndSynthesizesThroughMaf()
     {
 #pragma warning disable JSON002 // deliberate stub-vote payload; not produced by application code
         var probe = MafChatClientProbe.WithAssistantReply(
             "{\"rating\":\"Green\",\"reasoning\":\"stable performance across domain\",\"confidence\":0.85,\"tags\":[]}");
 #pragma warning restore JSON002
 
-        ISpecialistAgent[] specialists =
+        Mock<ISpecialistAgent>[] specialistMocks =
         [
-            AgentTestFixtures.CreateMockSpecialist("demand-forecasting", [AgentIntent.DemandForecasting]),
-            AgentTestFixtures.CreateMockSpecialist("competitive-intel",  [AgentIntent.CompetitiveMarket]),
-            AgentTestFixtures.CreateMockSpecialist("supply-chain",       [AgentIntent.SupplyShipments]),
+            CreateVotingSpecialistMock("demand-forecasting", AgentIntent.DemandForecasting),
+            CreateVotingSpecialistMock("competitive-intel", AgentIntent.CompetitiveMarket),
+            CreateVotingSpecialistMock("supply-chain", AgentIntent.SupplyShipments),
         ];
 
         var orchestrator = new ConsensusOrchestrator(
-            specialists,
+            [.. specialistMocks.Select(m => m.Object)],
             probe,
             synthesisDef: new AgentDefinition { Name = "council-synth", SystemPrompt = "Synthesize.", Temperature = 0.1 },
             voteDef: new AgentDefinition { Name = "council-vote", SystemPrompt = "Vote.", Temperature = 0.0 },
@@ -227,11 +242,43 @@ public class MafPrimitivesCharacterizationTests
 
         verdict.Should().NotBeNull();
 
-        // 3 specialists vote in parallel + 1 synthesis pass = 4 MAF-routed chat calls.
-        probe.Calls.Should().HaveCount(4,
-            "the council must issue exactly one MAF-routed vote per participant plus one MAF-routed synthesis call");
+        // Each participant must be asked for a vote through its real (tool-bearing)
+        // entry point. This is the assertion that keeps the council grounded.
+        foreach (Mock<ISpecialistAgent> specialist in specialistMocks)
+        {
+            specialist.Verify(
+                a => a.HandleAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()),
+                Times.Once,
+                "every council participant must vote via its tool-enabled HandleAsync path");
+        }
+
+        // Only the synthesis pass talks to the chat client directly, and it must be
+        // MAF-routed like every other first-party LLM call.
+        probe.Calls.Should().HaveCount(1,
+            "the orchestrator itself issues exactly one direct chat call — the synthesis pass");
         probe.Calls.Should().OnlyContain(c => c.WasCalledFromMafFrame,
-            "every voter and synthesis call must flow through the shared MafAgentInvoker path");
+            "the synthesis call must flow through the shared MafAgentInvoker path");
+    }
+
+    /// <summary>
+    /// A specialist whose HandleAsync returns a well-formed JSON vote, so the
+    /// orchestrator's parse path is exercised rather than short-circuited.
+    /// </summary>
+    private static Mock<ISpecialistAgent> CreateVotingSpecialistMock(string key, string intent)
+    {
+        var mock = new Mock<ISpecialistAgent>();
+        mock.Setup(a => a.Key).Returns(key);
+        mock.Setup(a => a.DisplayName).Returns(key);
+        mock.Setup(a => a.Model).Returns("gpt-4o");
+        mock.Setup(a => a.SupportedIntents).Returns([intent]);
+        mock.Setup(a => a.HandleAsync(It.IsAny<ChatRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Contracts.ChatResponse(
+#pragma warning disable JSON002 // deliberate stub-vote payload
+                "{\"rating\":\"Green\",\"reasoning\":\"grounded in tool data\",\"confidence\":0.9,\"key_metrics\":[\"depletions: +4%\"]}",
+#pragma warning restore JSON002
+                $"session-{key}",
+                []));
+        return mock;
     }
 
     #endregion


### PR DESCRIPTION
Every Health Council verdict came back ungrounded. All three specialists reported *"no tool data available"* with **~0.12 confidence**, so the council rated everything Yellow regardless of the brand.

## Root cause

The voting path was a "lightweight" direct chat call with **no tools attached** — while the prompt it sent instructed the model to *"use your available tools to gather current data"*. The model did the only honest thing open to it and said it had none.

The code comment claiming this *"falls back to full agent execution if lightweight mode fails"* described a fallback that was **never implemented** — there was no `HandleAsync` call anywhere in the orchestrator.

## Fix

Votes now run through `ISpecialistAgent.HandleAsync` — the same tool-enabled entry point the chat path uses — so each specialist reasons over real MCP-backed data.

- Timeout moves from the 10s lightweight budget to the existing tool-aware 30s `_agentTimeout`, since a vote now costs a tool round-trip
- The prompt no longer implies tools that were absent, and asks for actual returned figures in `key_metrics` rather than placeholders

## Test change

The MAF characterization test asserted four probe calls (three votes + synthesis) because voters bypassed the specialists. It now asserts what actually matters:

- every participant is asked for a vote through its **tool-bearing** `HandleAsync`
- the orchestrator's own single direct chat call — the synthesis pass — is MAF-routed

The MAF invariant for voters is upheld one level down by the specialists themselves, which the specialist inventory characterization already proves for all nine LLM-backed agents.

## Verification

- **3477 backend tests pass**
- `dotnet format --verify-no-changes` exits 0
