### PR TITLE
fix(promo): map the evaluation response so the planner stops crashing

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/promoEvaluationMapping.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/promoEvaluationMapping.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { mapPromoEvaluation } from '../services/promoApi';
+
+/**
+ * `POST /api/taskmodule/promo` answers in flat snake_case; the planner UI models a
+ * flattened camelCase `PromoEvaluation`. Nothing translated between them, so
+ * `evaluation.risks` was `undefined` and `[...evaluation.risks]` in
+ * PromoRecommendation threw "risks is not iterable" — which killed the Campaign
+ * Planner the moment an evaluation returned.
+ *
+ * These pin the mapping, and specifically that every array the component spreads or
+ * maps over is always an array.
+ */
+describe('promo evaluation mapping', () => {
+  const wire = {
+    recommendation: 'recommended',
+    risk_factors: [
+      '2 overlapping campaign(s) detected',
+      'Expected ROI below breakeven (1.0x)',
+    ],
+    roi_estimate: {
+      expected_roi: 2.4,
+      roi_range: { low: 1.8, high: 3.1 },
+      break_even_days: 21,
+      historical_avg_roi: 2.1,
+    },
+    timing_assessment: {
+      assessment: 'Good window',
+      conflicts: [{ campaign: 'Apex Grill BOGO Sep25' }],
+      seasonality: 'Favourable',
+      risks: [{ type: 'timing', detail: 'Overlaps a holiday freeze', severity: 'high' }],
+    },
+    lift_analysis: { reasoning: 'Lift is supported by prior comparable promos.' },
+    historical_context: { campaign_count: 7 },
+  };
+
+  it('maps the flat wire shape onto the view model', () => {
+    const e = mapPromoEvaluation(wire);
+
+    expect(e.recommendation).toBe('recommended');
+    expect(e.roi).toBe(2.4);
+    expect(e.roiLower).toBe(1.8);
+    expect(e.roiUpper).toBe(3.1);
+    expect(e.breakEvenDays).toBe(21);
+    expect(e.historicalAvgRoi).toBe(2.1);
+    expect(e.similarCampaigns).toBe(7);
+    expect(e.timingAssessment).toBe('Good window');
+    expect(e.seasonalityFit).toBe('Favourable');
+    expect(e.reasoning).toContain('Lift is supported');
+  });
+
+  it('merges structured timing risks with the flat risk_factors sentences', () => {
+    const e = mapPromoEvaluation(wire);
+
+    expect(Array.isArray(e.risks)).toBe(true);
+    expect(e.risks).toHaveLength(3);
+    expect(e.risks.map(r => r.detail)).toContain('Overlaps a holiday freeze');
+    expect(e.risks.map(r => r.detail)).toContain('2 overlapping campaign(s) detected');
+
+    // A sub-breakeven ROI is a hard problem, not an advisory note.
+    const breakeven = e.risks.find(r => /below breakeven/i.test(r.detail));
+    expect(breakeven?.severity).toBe('high');
+  });
+
+  it('flattens conflict objects into displayable strings', () => {
+    const e = mapPromoEvaluation(wire);
+    expect(e.conflicts).toEqual(['Apex Grill BOGO Sep25']);
+  });
+
+  // The regression that took the panel down: an empty or partial payload must still
+  // produce iterable arrays, never undefined.
+  it('never yields a non-iterable risks or conflicts array', () => {
+    for (const payload of [{}, { recommendation: 'recommended' }, { timing_assessment: {} }]) {
+      const e = mapPromoEvaluation(payload);
+      expect(Array.isArray(e.risks)).toBe(true);
+      expect(Array.isArray(e.conflicts)).toBe(true);
+      expect(() => [...e.risks].sort()).not.toThrow();
+    }
+  });
+
+  it('falls back to a safe recommendation level for an unknown value', () => {
+    expect(mapPromoEvaluation({ recommendation: 'nonsense' }).recommendation)
+      .toBe('proceed_with_caution');
+  });
+});

--- a/src/RetailPulse.Web/src/services/promoApi.ts
+++ b/src/RetailPulse.Web/src/services/promoApi.ts
@@ -1,17 +1,128 @@
-import type { PromoFormData, PromoEvaluation, PromoCampaign } from '../types';
+import { resolveApiUrl } from '../config/apiOrigin';
+import type { PromoFormData, PromoEvaluation, PromoCampaign, PromoRisk, PromoRecommendationLevel } from '../types';
+
+/**
+ * Wire shape returned by `POST /api/taskmodule/promo`.
+ *
+ * The endpoint orchestrates four MCP promo tools and returns their raw payloads
+ * under flat snake_case keys. The planner UI models a flattened camelCase
+ * `PromoEvaluation`, and nothing translated between them: `evaluation.risks` was
+ * always `undefined`, so `[...evaluation.risks]` in PromoRecommendation threw
+ * "risks is not iterable" and killed the panel the moment an evaluation returned.
+ *
+ * Mapping at the edge keeps the component consuming one stable view model.
+ */
+interface WirePromoEvaluation {
+  readonly recommendation?: string;
+  readonly risk_factors?: readonly string[];
+  readonly roi_estimate?: {
+    readonly expected_roi?: number;
+    readonly roi_range?: { readonly low?: number; readonly high?: number };
+    readonly break_even_days?: number;
+    readonly historical_avg_roi?: number;
+  };
+  readonly timing_assessment?: {
+    readonly assessment?: string;
+    readonly conflicts?: readonly unknown[];
+    readonly seasonality?: string;
+    readonly risks?: readonly { readonly type?: string; readonly detail?: string; readonly severity?: string }[];
+  };
+  readonly lift_analysis?: { readonly reasoning?: string };
+  readonly historical_context?: { readonly campaign_count?: number };
+}
+
+const RECOMMENDATION_LEVELS: ReadonlySet<string> = new Set([
+  'strongly_recommended',
+  'recommended',
+  'proceed_with_caution',
+  'not_recommended',
+]);
+
+function toRecommendation(value: string | undefined): PromoRecommendationLevel {
+  const normalized = (value ?? '').trim().toLowerCase();
+  return (RECOMMENDATION_LEVELS.has(normalized)
+    ? normalized
+    : 'proceed_with_caution') as PromoRecommendationLevel;
+}
+
+function toSeverity(value: string | undefined): PromoRisk['severity'] {
+  const normalized = (value ?? '').trim().toLowerCase();
+  return normalized === 'high' || normalized === 'low' ? normalized : 'medium';
+}
+
+/**
+ * Risks arrive from two places: structured entries on the timing assessment, and
+ * the endpoint's own flat `risk_factors` sentences (budget thresholds, sub-breakeven
+ * ROI, campaign overlaps). Merge both so the panel shows the complete picture, and
+ * give the flat sentences a severity rather than dropping them.
+ */
+function toRisks(wire: WirePromoEvaluation): PromoRisk[] {
+  const structured: PromoRisk[] = (wire.timing_assessment?.risks ?? []).map(r => ({
+    type: r.type ?? 'timing',
+    detail: r.detail ?? '',
+    severity: toSeverity(r.severity),
+  }));
+
+  const flat: PromoRisk[] = (wire.risk_factors ?? []).map(text => ({
+    type: 'planning',
+    detail: text,
+    // The endpoint only emits a risk factor when a threshold was crossed, so
+    // "medium" is the honest floor — these are not advisory notes.
+    severity: /below breakeven|executive approval/i.test(text) ? 'high' : 'medium',
+  }));
+
+  // De-duplicate on detail so a risk surfaced by both paths is shown once.
+  const seen = new Set<string>();
+  return [...structured, ...flat].filter(r => {
+    const key = r.detail.trim().toLowerCase();
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function toConflicts(wire: WirePromoEvaluation): string[] {
+  return (wire.timing_assessment?.conflicts ?? []).map(c => {
+    if (typeof c === 'string') return c;
+    const obj = c as Record<string, unknown>;
+    const name = obj.campaign ?? obj.name ?? obj.detail;
+    return typeof name === 'string' ? name : JSON.stringify(c);
+  });
+}
+
+export function mapPromoEvaluation(wire: WirePromoEvaluation): PromoEvaluation {
+  const roi = wire.roi_estimate ?? {};
+  return {
+    recommendation: toRecommendation(wire.recommendation),
+    roi: roi.expected_roi ?? 0,
+    roiLower: roi.roi_range?.low ?? roi.expected_roi ?? 0,
+    roiUpper: roi.roi_range?.high ?? roi.expected_roi ?? 0,
+    reasoning: wire.lift_analysis?.reasoning ?? '',
+    timingAssessment: wire.timing_assessment?.assessment ?? '',
+    conflicts: toConflicts(wire),
+    seasonalityFit: wire.timing_assessment?.seasonality ?? '',
+    risks: toRisks(wire),
+    similarCampaigns: wire.historical_context?.campaign_count ?? 0,
+    breakEvenDays: roi.break_even_days ?? 0,
+    historicalAvgRoi: roi.historical_avg_roi ?? 0,
+  };
+}
 
 export async function evaluatePromo(data: PromoFormData): Promise<PromoEvaluation> {
-  const res = await fetch('/api/taskmodule/promo', {
+  const res = await fetch(resolveApiUrl('/api/taskmodule/promo'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error(`Failed to evaluate promo: ${res.status}`);
-  return res.json();
+  return mapPromoEvaluation((await res.json()) as WirePromoEvaluation);
 }
 
 export async function fetchExistingCampaigns(): Promise<PromoCampaign[]> {
-  const res = await fetch('/api/campaigns');
+  const res = await fetch(resolveApiUrl('/api/campaigns'));
+  // The campaign surface is optional. Treat "not mapped" as "no campaigns" rather
+  // than throwing — an unhandled rejection here used to take the panel down.
+  if (res.status === 404) return [];
   if (!res.ok) throw new Error(`Failed to fetch campaigns: ${res.status}`);
   return res.json();
 }
@@ -20,7 +131,7 @@ export async function submitForApproval(
   formData: PromoFormData,
   evaluation: PromoEvaluation,
 ): Promise<void> {
-  const res = await fetch('/api/taskmodule/promo/submit', {
+  const res = await fetch(resolveApiUrl('/api/taskmodule/promo/submit'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ formData, evaluation }),


### PR DESCRIPTION
Clicking **Evaluate Campaign** threw `e.risks is not iterable` and destroyed the Campaign Planner panel.

## Root cause

`POST /api/taskmodule/promo` orchestrates four MCP promo tools and answers in flat snake_case (`roi_estimate`, `timing_assessment`, `risk_factors`, `lift_analysis`, `historical_context`). The planner UI models a flattened camelCase `PromoEvaluation`.

Nothing translated between them, so `evaluation.risks` was `undefined` and the `[...evaluation.risks]` spread in `PromoRecommendation` threw the moment a result came back.

Same class of defect as the Health Council binding.

## Fix

`promoApi` maps the wire shape at the edge. Notably, **risks are merged from both places the API reports them**:

- structured entries on `timing_assessment.risks`
- the endpoint's own flat `risk_factors` sentences (budget thresholds, sub-breakeven ROI, campaign overlaps)

De-duplicated on detail, with sub-breakeven and executive-approval factors rated **high** rather than dropped. Conflict objects are flattened to displayable strings.

`fetchExistingCampaigns` now treats 404 as an empty list instead of throwing, and every call routes through `resolveApiUrl` like the other services.

## Regression coverage

Includes the specific failure: a partial or empty payload must still yield **iterable** `risks` and `conflicts` arrays, never `undefined`.

## Verification

- **791 frontend tests pass** (5 new)
- `tsc -b` clean

## Note on containment

Thanks to the `PanelErrorBoundary` shipped in #203, this crash no longer took down the whole dashboard — it was contained to the panel, with the header still usable. That is how I was able to isolate it cleanly.
