### PR TITLE
fix(promo): map the ACTUAL evaluation wire shape, not the assumed one

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/promoEvaluationMapping.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/promoEvaluationMapping.test.ts
@@ -19,19 +19,19 @@ describe('promo evaluation mapping', () => {
       'Expected ROI below breakeven (1.0x)',
     ],
     roi_estimate: {
-      expected_roi: 2.4,
-      roi_range: { low: 1.8, high: 3.1 },
-      break_even_days: 21,
-      historical_avg_roi: 2.1,
+      roi: { expected: 2.4, lower_bound: 1.8, upper_bound: 3.1 },
+      break_even_weeks: 3,
+      inputs: { expected_lift_percent: 16.71 },
     },
     timing_assessment: {
-      assessment: 'Good window',
+      recommendation: 'Acceptable, review conflicts',
+      timing_score: 0.6,
+      seasonality_score: 0.8,
       conflicts: [{ campaign: 'Apex Grill BOGO Sep25' }],
-      seasonality: 'Favourable',
       risks: [{ type: 'timing', detail: 'Overlaps a holiday freeze', severity: 'high' }],
     },
     lift_analysis: { reasoning: 'Lift is supported by prior comparable promos.' },
-    historical_context: { campaign_count: 7 },
+    historical_context: { total_campaigns: 7, campaigns: [{ roi: 2.0 }, { roi: 3.0 }] },
   };
 
   it('maps the flat wire shape onto the view model', () => {
@@ -41,12 +41,16 @@ describe('promo evaluation mapping', () => {
     expect(e.roi).toBe(2.4);
     expect(e.roiLower).toBe(1.8);
     expect(e.roiUpper).toBe(3.1);
+    // break_even_weeks is reported in weeks; the panel labels days.
     expect(e.breakEvenDays).toBe(21);
-    expect(e.historicalAvgRoi).toBe(2.1);
     expect(e.similarCampaigns).toBe(7);
-    expect(e.timingAssessment).toBe('Good window');
-    expect(e.seasonalityFit).toBe('Favourable');
+    expect(e.timingAssessment).toBe('Acceptable, review conflicts');
+    expect(e.seasonalityFit).toContain('Strong seasonal fit');
     expect(e.reasoning).toContain('Lift is supported');
+  });
+
+  it('derives the historical average ROI from the returned campaigns', () => {
+    expect(mapPromoEvaluation(wire).historicalAvgRoi).toBe(2.5);
   });
 
   it('merges structured timing risks with the flat risk_factors sentences', () => {

--- a/src/RetailPulse.Web/src/services/promoApi.ts
+++ b/src/RetailPulse.Web/src/services/promoApi.ts
@@ -16,19 +16,32 @@ interface WirePromoEvaluation {
   readonly recommendation?: string;
   readonly risk_factors?: readonly string[];
   readonly roi_estimate?: {
-    readonly expected_roi?: number;
-    readonly roi_range?: { readonly low?: number; readonly high?: number };
+    readonly roi?: {
+      readonly expected?: number;
+      readonly lower_bound?: number;
+      readonly upper_bound?: number;
+    };
+    readonly break_even_weeks?: number;
     readonly break_even_days?: number;
-    readonly historical_avg_roi?: number;
+    readonly inputs?: { readonly expected_lift_percent?: number };
   };
   readonly timing_assessment?: {
-    readonly assessment?: string;
+    readonly recommendation?: string;
+    readonly timing_score?: number;
+    readonly seasonality_score?: number;
     readonly conflicts?: readonly unknown[];
-    readonly seasonality?: string;
     readonly risks?: readonly { readonly type?: string; readonly detail?: string; readonly severity?: string }[];
   };
-  readonly lift_analysis?: { readonly reasoning?: string };
-  readonly historical_context?: { readonly campaign_count?: number };
+  readonly lift_analysis?: {
+    readonly reasoning?: string;
+    readonly summary?: string;
+    readonly expected_lift_percent?: number;
+  };
+  readonly historical_context?: {
+    readonly total_campaigns?: number;
+    readonly avg_roi?: number;
+    readonly campaigns?: readonly { readonly roi?: number }[];
+  };
 }
 
 const RECOMMENDATION_LEVELS: ReadonlySet<string> = new Set([
@@ -90,21 +103,50 @@ function toConflicts(wire: WirePromoEvaluation): string[] {
   });
 }
 
+/** Renders the 0..1 seasonality score as a phrase the panel can display. */
+function toSeasonalityFit(score: number | undefined): string {
+  if (score === undefined) return '';
+  if (score >= 0.75) return `Strong seasonal fit (${Math.round(score * 100)}%)`;
+  if (score >= 0.5) return `Acceptable seasonal fit (${Math.round(score * 100)}%)`;
+  return `Weak seasonal fit (${Math.round(score * 100)}%)`;
+}
+
 export function mapPromoEvaluation(wire: WirePromoEvaluation): PromoEvaluation {
-  const roi = wire.roi_estimate ?? {};
+  const est = wire.roi_estimate ?? {};
+  const roi = est.roi ?? {};
+  const hist = wire.historical_context ?? {};
+
+  // The MCP payload reports break-even in weeks; the panel labels it in days.
+  const breakEvenDays = est.break_even_days
+    ?? (est.break_even_weeks !== undefined ? Math.round(est.break_even_weeks * 7) : 0);
+
+  // No aggregate average is published, so derive it from the returned campaigns
+  // rather than showing a hardcoded zero.
+  const campaignRois = (hist.campaigns ?? [])
+    .map(c => c.roi)
+    .filter((r): r is number => typeof r === 'number');
+  const historicalAvgRoi = hist.avg_roi
+    ?? (campaignRois.length > 0
+      ? campaignRois.reduce((a, b) => a + b, 0) / campaignRois.length
+      : 0);
+
   return {
     recommendation: toRecommendation(wire.recommendation),
-    roi: roi.expected_roi ?? 0,
-    roiLower: roi.roi_range?.low ?? roi.expected_roi ?? 0,
-    roiUpper: roi.roi_range?.high ?? roi.expected_roi ?? 0,
-    reasoning: wire.lift_analysis?.reasoning ?? '',
-    timingAssessment: wire.timing_assessment?.assessment ?? '',
+    roi: roi.expected ?? 0,
+    roiLower: roi.lower_bound ?? roi.expected ?? 0,
+    roiUpper: roi.upper_bound ?? roi.expected ?? 0,
+    reasoning: wire.lift_analysis?.reasoning
+      ?? wire.lift_analysis?.summary
+      ?? (wire.lift_analysis?.expected_lift_percent !== undefined
+        ? `Modelled lift of ${wire.lift_analysis.expected_lift_percent}% against the regional baseline.`
+        : ''),
+    timingAssessment: wire.timing_assessment?.recommendation ?? '',
     conflicts: toConflicts(wire),
-    seasonalityFit: wire.timing_assessment?.seasonality ?? '',
+    seasonalityFit: toSeasonalityFit(wire.timing_assessment?.seasonality_score),
     risks: toRisks(wire),
-    similarCampaigns: wire.historical_context?.campaign_count ?? 0,
-    breakEvenDays: roi.break_even_days ?? 0,
-    historicalAvgRoi: roi.historical_avg_roi ?? 0,
+    similarCampaigns: hist.total_campaigns ?? 0,
+    breakEvenDays,
+    historicalAvgRoi,
   };
 }
 


### PR DESCRIPTION
The previous mapping stopped the crash but produced an all-zero result card: 0.0x ROI, break-even 0 days, historical average 0.0x, 'Based on 0 similar campaigns'. The field paths were **inferred from surrounding code rather than observed**, and none of them existed.

Captured the real response from the deployed endpoint:

| Assumed | Actual |
|---|---|
| roi_estimate.expected_roi / roi_range | roi_estimate.roi.expected / lower_bound / upper_bound |
| roi_estimate.break_even_days | roi_estimate.break_even_weeks (weeks) |
| timing_assessment.assessment | timing_assessment.recommendation |
| timing_assessment.seasonality (phrase) | timing_assessment.seasonality_score (0..1) |
| historical_context.campaign_count | historical_context.total_campaigns |

Break-even is converted weeks to days. The seasonality score is rendered as a phrase the panel can display. No aggregate average ROI is published, so it is derived from the returned campaigns rather than showing a hardcoded zero.

Tests assert against the observed shape, including the conversion and the derived average.

**Verified:** 792 frontend tests pass; tsc -b clean.