### PR TITLE
fix(promo): surface the risk reason instead of the literal word planning

### DIFF
--- a/src/RetailPulse.Web/src/services/promoApi.ts
+++ b/src/RetailPulse.Web/src/services/promoApi.ts
@@ -76,8 +76,11 @@ function toRisks(wire: WirePromoEvaluation): PromoRisk[] {
     severity: toSeverity(r.severity),
   }));
 
+  // RiskCard shows `type` as the headline and reveals `detail` on expand, so the
+  // flat sentences must carry their text in `type` — otherwise every planning risk
+  // renders as the literal word "planning" with the real reason hidden behind a click.
   const flat: PromoRisk[] = (wire.risk_factors ?? []).map(text => ({
-    type: 'planning',
+    type: text,
     detail: text,
     // The endpoint only emits a risk factor when a threshold was crossed, so
     // "medium" is the honest floor — these are not advisory notes.


### PR DESCRIPTION
RiskCard renders risk.type as the headline and only reveals risk.detail when expanded. Mapping the flat risk_factors sentences to type='planning' meant the panel showed **planning** with the actual reason - for example *Expected ROI below breakeven (1.0x)* - hidden behind a click.

The sentence now carries into type so the reason is the headline.