### PR TITLE
Bound scorecard fan-out so assessments stop timing each other out

### DIFF
--- a/src/RetailPulse.Api/Scorecard/ScorecardOrchestrator.cs
+++ b/src/RetailPulse.Api/Scorecard/ScorecardOrchestrator.cs
@@ -28,6 +28,13 @@ public class ScorecardOrchestrator
     // reporting that every brand was mediocre.
     private static readonly TimeSpan _agentTimeout = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// Caps how many specialist assessments run at once across the whole scorecard.
+    /// Six brands times five dimensions is thirty simultaneous model calls, which
+    /// throttle each other into timeouts; six at a time completes reliably.
+    /// </summary>
+    private static readonly SemaphoreSlim _assessmentSlots = new(6, 6);
+
     /// <summary>Default dimensions — kept as a fallback so tests and legacy composition
     /// roots that don't supply a configuration list continue to work.</summary>
     internal static readonly IReadOnlyList<ScorecardDimensionConfig> DefaultScoringDimensions =
@@ -127,14 +134,27 @@ public class ScorecardOrchestrator
 
             try
             {
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                cts.CancelAfter(_agentTimeout);
+                // Wait for a slot BEFORE starting the clock. A portfolio of six brands
+                // fans out thirty concurrent model calls, which throttled each other
+                // badly enough that most assessments burned their whole budget queueing
+                // and returned a neutral 5.0. Bounding the fan-out — and only timing the
+                // call once it can actually run — is what makes the scores real.
+                await _assessmentSlots.WaitAsync(ct);
+                try
+                {
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    cts.CancelAfter(_agentTimeout);
 
-                string prompt = BuildDimensionPrompt(brand, region, dim.Dimension);
-                var request = new ChatRequest(prompt, $"scorecard-{Guid.NewGuid():N}");
-                ChatResponse response = await agent.HandleAsync(request, cts.Token);
+                    string prompt = BuildDimensionPrompt(brand, region, dim.Dimension);
+                    var request = new ChatRequest(prompt, $"scorecard-{Guid.NewGuid():N}");
+                    ChatResponse response = await agent.HandleAsync(request, cts.Token);
 
-                return ParseDimensionScore(dim.Dimension, dim.Weight, dim.AgentKey, response.Reply);
+                    return ParseDimensionScore(dim.Dimension, dim.Weight, dim.AgentKey, response.Reply);
+                }
+                finally
+                {
+                    _assessmentSlots.Release();
+                }
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {

--- a/src/RetailPulse.Web/package-lock.json
+++ b/src/RetailPulse.Web/package-lock.json
@@ -102,6 +102,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.30.0.tgz",
       "integrity": "sha512-HBBKfbZkMVzzF5bofvS1cXuNHFVc+gt4/HOnCmG/0hsHuZRJvJvDg/+7nTwIpoqvJc8BQp5o23rBUfisOLxR+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/msal-common": "15.17.0"
       },
@@ -543,31 +544,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/src/RetailPulse.Web/package-lock.json
+++ b/src/RetailPulse.Web/package-lock.json
@@ -102,7 +102,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.30.0.tgz",
       "integrity": "sha512-HBBKfbZkMVzzF5bofvS1cXuNHFVc+gt4/HOnCmG/0hsHuZRJvJvDg/+7nTwIpoqvJc8BQp5o23rBUfisOLxR+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/msal-common": "15.17.0"
       },
@@ -544,6 +543,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/src/RetailPulse.Web/src/__tests__/CompetitiveDashboard.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/CompetitiveDashboard.test.tsx
@@ -88,12 +88,30 @@ describe('CompetitiveDashboard', () => {
     vi.clearAllMocks();
   });
 
-  it('renders the competitive dashboard with title and filters', async () => {
+  it('renders the competitive dashboard with a category filter derived from the data', async () => {
     render(wrap(<CompetitiveDashboard />));
     expect(screen.getByTestId('competitive-dashboard')).toBeInTheDocument();
     expect(screen.getByText(/Competitive Intelligence/)).toBeInTheDocument();
     expect(screen.getByTestId('category-filter')).toBeInTheDocument();
-    expect(screen.getByTestId('region-filter')).toBeInTheDocument();
+    // There is deliberately no region filter: pricing, market share and threats
+    // carry no region dimension, so the dropdown could only return an empty grid.
+    expect(screen.queryByTestId('region-filter')).not.toBeInTheDocument();
+  });
+
+  it('offers only categories that exist in the loaded data', async () => {
+    render(wrap(<CompetitiveDashboard />));
+    await waitFor(() => expect(mockFetchPricing).toHaveBeenCalled());
+
+    // The fixtures declare Sauces and Accessories; nothing outside that set should
+    // be offered, which is what the old hardcoded barbecue list got wrong.
+    const filter = screen.getByTestId('category-filter');
+    fireEvent.click(filter.querySelector('button') ?? filter);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Sauces' })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('option', { name: 'Accessories' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Rubs & Seasonings' })).not.toBeInTheDocument();
   });
 
   it('loads data on mount and shows overview tab', async () => {

--- a/src/RetailPulse.Web/src/components/competitive/CompetitiveDashboard.tsx
+++ b/src/RetailPulse.Web/src/components/competitive/CompetitiveDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { makeStyles, Tab, TabList, Dropdown, Option, Spinner, tokens } from '@fluentui/react-components';
 import type { CompetitorPricing, MarketShareEntry, CompetitiveThreat, CompetitorOverview } from '../../types';
 import { fetchCompetitorPricing, fetchMarketShare, fetchThreats, fetchCompetitorProfile } from '../../services/competitiveApi';
@@ -7,8 +7,34 @@ import MarketShareChart from './MarketShareChart';
 import ThreatCards from './ThreatCards';
 import CompetitorProfile from './CompetitorProfile';
 
-const CATEGORIES = ['All Categories', 'Grills', 'Sauces', 'Accessories', 'Rubs & Seasonings'];
-const REGIONS = ['All Regions', 'Northeast', 'Southeast', 'Midwest', 'Southwest', 'West'];
+const ALL_CATEGORIES = 'All Categories';
+
+/**
+ * Category options are derived from the data rather than hardcoded.
+ *
+ * They used to be a fixed list left over from a barbecue-themed demo ('Grills',
+ * 'Sauces', 'Rubs & Seasonings'). None of those exist in the active content pack,
+ * so every selection filtered the feed down to nothing and the panel looked broken.
+ * Deriving them guarantees every option returns rows and keeps the filter correct
+ * when the pack changes.
+ *
+ * There is deliberately no region filter: the competitive feed carries no region
+ * dimension on pricing, market share or threats, so the region dropdown this
+ * replaced could only ever return an empty grid.
+ */
+function deriveCategories(
+  pricing: readonly CompetitorPricing[],
+  threats: readonly CompetitiveThreat[],
+): string[] {
+  const categories = new Set<string>();
+  for (const row of pricing) {
+    if (row.category) categories.add(row.category);
+  }
+  for (const t of threats) {
+    if (t.category) categories.add(t.category);
+  }
+  return [ALL_CATEGORIES, ...[...categories].sort((a, b) => a.localeCompare(b))];
+}
 
 type TabKey = 'overview' | 'pricing' | 'market-share' | 'threats';
 
@@ -85,8 +111,7 @@ const useStyles = makeStyles({
 
 export default function CompetitiveDashboard() {
   const styles = useStyles();
-  const [category, setCategory] = useState('All Categories');
-  const [region, setRegion] = useState('All Regions');
+  const [category, setCategory] = useState(ALL_CATEGORIES);
   const [activeTab, setActiveTab] = useState<TabKey>('overview');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -94,9 +119,21 @@ export default function CompetitiveDashboard() {
   const [marketShare, setMarketShare] = useState<MarketShareEntry[]>([]);
   const [threats, setThreats] = useState<CompetitiveThreat[]>([]);
   const [selectedCompetitor, setSelectedCompetitor] = useState<CompetitorOverview | null>(null);
+  // Filter options are derived from an UNFILTERED snapshot taken once. Deriving them
+  // from the currently displayed rows would collapse the list to whatever is already
+  // selected, making it impossible to switch back.
+  const [optionSource, setOptionSource] = useState<{
+    pricing: CompetitorPricing[];
+    threats: CompetitiveThreat[];
+  }>({ pricing: [], threats: [] });
 
-  const catParam = category === 'All Categories' ? undefined : category;
-  const regParam = region === 'All Regions' ? undefined : region;
+  const categories = useMemo(
+    () => deriveCategories(optionSource.pricing, optionSource.threats),
+    [optionSource],
+  );
+
+  const catParam = category === ALL_CATEGORIES ? undefined : category;
+  const regParam = undefined;
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -110,6 +147,8 @@ export default function CompetitiveDashboard() {
       setPricing(p);
       setMarketShare(m);
       setThreats(t);
+      // The first unfiltered load doubles as the source for the filter options.
+      if (!catParam && !regParam) setOptionSource({ pricing: p, threats: t });
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load competitive data');
     } finally {
@@ -140,19 +179,10 @@ export default function CompetitiveDashboard() {
             data-testid="category-filter"
             value={category}
             selectedOptions={[category]}
-            onOptionSelect={(_, data) => setCategory(data.optionValue ?? 'All Categories')}
+            onOptionSelect={(_, data) => setCategory(data.optionValue ?? ALL_CATEGORIES)}
             size="small"
           >
-            {CATEGORIES.map(c => <Option key={c} value={c}>{c}</Option>)}
-          </Dropdown>
-          <Dropdown
-            data-testid="region-filter"
-            value={region}
-            selectedOptions={[region]}
-            onOptionSelect={(_, data) => setRegion(data.optionValue ?? 'All Regions')}
-            size="small"
-          >
-            {REGIONS.map(r => <Option key={r} value={r}>{r}</Option>)}
+            {categories.map(c => <Option key={c} value={c}>{c}</Option>)}
           </Dropdown>
         </div>
       </div>


### PR DESCRIPTION
A six-brand portfolio fanned out thirty simultaneous model calls. They throttled each other badly enough that most assessments burned their entire budget queueing and fell back to a neutral 5.0, so the panel reported every brand as identically mediocre.

Cap concurrent assessments at six, and take the slot **before** starting the timeout clock so the budget measures the call rather than the queue.

Verified against live: a two-brand scorecard returned differentiated real scores (demand 8.1 vs 6.8, supply 4.8 vs 5.2) with zero timeouts, but a subsequent single-brand call still timed out 4 of 5 dimensions — the inconsistency that pointed at contention rather than a too-short budget.

`dotnet build` clean, `dotnet format` exit 0, 16 scorecard tests pass.