### PR TITLE
Score the portfolio in ceiling-safe batches

### DIFF
--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react';
 import { Button, Badge, makeStyles, Drawer, DrawerBody, DrawerHeader, DrawerHeaderTitle, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuButton, Spinner } from '@fluentui/react-components';
 import { Add24Regular, DataUsage24Regular, Dismiss24Regular, TargetArrow24Regular, Shield24Regular, Library24Regular, HeartPulse24Regular, ShieldCheckmark24Regular, CardUi24Regular, Eye24Regular, Building24Regular, Money24Regular, Star24Regular } from '@fluentui/react-icons';
 import { ChatPanel } from './ChatPanel';
-import { fetchFinancials, fetchScorecard, fetchStores, fetchStockoutRisks } from '../services/operationsApi';
+import { fetchFinancials, fetchScorecardBatched, fetchStores, fetchStockoutRisks } from '../services/operationsApi';
 import { TelemetryPanel } from './TelemetryPanel';
 import { AgentRoutingPanel } from './AgentRoutingPanel';
 import { MemoryPanel } from './MemoryPanel';
@@ -273,14 +273,15 @@ export function Dashboard() {
     void (async () => {
       const packBrands = activePack.pack?.tenant.brands?.map(b => b.name) ?? [];
       // Each brand fans out five specialist assessments, so the whole pack (11+
-      // brands) would be 55 agent calls and minutes of latency. Cap the panel at a
-      // portfolio-sized slice that still returns in a demo-reasonable time.
+      // brands) would be 55 agent calls. Cap the panel at a portfolio-sized slice.
       const target = (packBrands.length > 0 ? packBrands : ['Apex Grill', 'Summit Vodka', 'FreshMart']).slice(0, 6);
-      const result = await fetchScorecard(target);
-      if (cancelled) return;
-      setBrands(result.brands);
-      setBrandsDurationMs(result.durationMs);
-      setBrandsLoading(false);
+      await fetchScorecardBatched(target, (scored, elapsedMs) => {
+        if (cancelled) return;
+        // Render each batch as it lands rather than waiting for the whole portfolio.
+        setBrands(scored);
+        setBrandsDurationMs(elapsedMs);
+      });
+      if (!cancelled) setBrandsLoading(false);
     })();
     return () => { cancelled = true; };
   }, [activeView, activePack.pack, brands.length, brandsLoading]);
@@ -798,7 +799,7 @@ export function Dashboard() {
                   <Button appearance="subtle" onClick={() => setSelectedBrand(null)} style={{ marginBottom: '16px' }}>← Back to all brands</Button>
                   <BrandScoreCard brand={selectedBrand} onWhyClick={handleWhyClick} />
                 </div>
-              ) : brandsLoading ? (
+              ) : brandsLoading && brands.length === 0 ? (
                 /* Each brand fans out five specialist assessments, so this genuinely
                    takes a while. Say so, rather than showing an empty grid that reads
                    as a broken panel. */
@@ -807,15 +808,23 @@ export function Dashboard() {
                   <span>Assessing the portfolio — each brand is scored across five specialist dimensions.</span>
                 </div>
               ) : (
-                <PortfolioScorecard
-                  brands={brands}
-                  generationTimeMs={brandsDurationMs}
-                  onBrandClick={(name) => {
-                    const brand = brands.find(b => b.brandName === name);
-                    if (brand) setSelectedBrand(brand);
-                  }}
-                  onWhyClick={handleWhyClick}
-                />
+                <>
+                  {brandsLoading && (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '12px', color: 'var(--color-text-secondary)', fontSize: '13px' }}>
+                      <Spinner size="tiny" />
+                      <span>Scoring the rest of the portfolio…</span>
+                    </div>
+                  )}
+                  <PortfolioScorecard
+                    brands={brands}
+                    generationTimeMs={brandsDurationMs}
+                    onBrandClick={(name) => {
+                      const brand = brands.find(b => b.brandName === name);
+                      if (brand) setSelectedBrand(brand);
+                    }}
+                    onWhyClick={handleWhyClick}
+                  />
+                </>
               )}
               <ExplanationPanel explanation={explanationData} open={explanationOpen} onClose={() => setExplanationOpen(false)} />
             </div>

--- a/src/RetailPulse.Web/src/services/operationsApi.ts
+++ b/src/RetailPulse.Web/src/services/operationsApi.ts
@@ -259,3 +259,38 @@ export async function fetchScorecard(brands: readonly string[]): Promise<{
   const wire = (await res.json()) as WireScorecard;
   return { brands: toBrandScores(wire), durationMs: wire.totalDurationMs ?? 0 };
 }
+
+/**
+ * Number of brands scored per request.
+ *
+ * There is a hard 45s ceiling on the request path: two brands complete in ~24s
+ * with every dimension scored, while three or more fail at exactly 45.1s with
+ * "Backend call failure". Each brand costs five specialist assessments, so the
+ * only way to score a real portfolio is to send it in batches that each fit
+ * inside the ceiling.
+ */
+const SCORECARD_BATCH_SIZE = 2;
+
+/**
+ * Scores a portfolio in ceiling-safe batches, reporting each batch as it lands so
+ * the panel fills in progressively instead of showing nothing until the last
+ * brand is done.
+ */
+export async function fetchScorecardBatched(
+  brands: readonly string[],
+  onBatch: (scored: BrandScore[], elapsedMs: number) => void,
+): Promise<void> {
+  const started = Date.now();
+  const accumulated: BrandScore[] = [];
+
+  for (let i = 0; i < brands.length; i += SCORECARD_BATCH_SIZE) {
+    const batch = brands.slice(i, i + SCORECARD_BATCH_SIZE);
+    const { brands: scored } = await fetchScorecard(batch);
+    accumulated.push(...scored);
+    // Highest health first, so the ranking stays meaningful as batches arrive.
+    onBatch(
+      [...accumulated].sort((a, b) => b.healthScore - a.healthScore),
+      Date.now() - started,
+    );
+  }
+}


### PR DESCRIPTION
There is a hard **45s ceiling** on the request path. Measured against the live deployment:

| Brands | Result | Wall time |
|---|---|---|
| 2 | 200, all 10 dimensions scored, 0 timeouts | 24.4s |
| 3 | 500 \Backend call failure\ | 45.1s |
| 4 | 500 \Backend call failure\ | 45.2s |

Each brand costs five specialist assessments, so a six-brand portfolio could never return in one call.

Send the portfolio two brands at a time and render each batch as it lands, so the grid fills in progressively instead of showing nothing and then failing. Results are re-sorted by health on every batch so the ranking stays meaningful.