### PR TITLE
Confine margin driver bars to their track; stop the header crowding the nav

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/MarginDrivers.geometry.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/MarginDrivers.geometry.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { FluentProvider, webDarkTheme } from '@fluentui/react-components';
+import type { ReactElement } from 'react';
+import { MarginDrivers } from '../components/margin/MarginDrivers';
+import type { MarginDriver } from '../types';
+
+const wrap = (ui: ReactElement) => (
+  <FluentProvider theme={webDarkTheme}>{ui}</FluentProvider>
+);
+
+const DRIVERS: MarginDriver[] = [
+  { name: 'Overhead', impact: -3.4, trend: 'stable', isRisk: true },
+  { name: 'Packaging', impact: 2.9, trend: 'improving', isRisk: false },
+  { name: 'Logistics', impact: -2.1, trend: 'worsening', isRisk: true },
+];
+
+/**
+ * Bars grow outward from a centre line, so each one lives in half the track.
+ * These tests pin that geometry: sizing bars against the FULL track width made the
+ * largest driver span an entire container from the middle, overrunning the name
+ * column on the left and the impact labels on the right.
+ */
+describe('MarginDrivers bar geometry', () => {
+  function barWidths(drivers: MarginDriver[]): number[] {
+    const { container } = render(wrap(<MarginDrivers drivers={drivers} />));
+    return Array.from(container.querySelectorAll<HTMLElement>('[data-testid="margin-drivers"] div'))
+      .map(d => d.style.width)
+      .filter(w => w.endsWith('%'))
+      .map(w => Number.parseFloat(w));
+  }
+
+  it('never lets a bar exceed half the track', () => {
+    for (const width of barWidths(DRIVERS)) {
+      expect(width).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it('sizes the largest driver to exactly half the track', () => {
+    // -3.4 is the largest absolute impact, so it defines the scale.
+    expect(Math.max(...barWidths(DRIVERS))).toBeCloseTo(50, 5);
+  });
+
+  it('scales the remaining drivers proportionally against that maximum', () => {
+    const widths = barWidths(DRIVERS);
+    // 2.1 / 3.4 of the half-track.
+    expect(Math.min(...widths)).toBeCloseTo((2.1 / 3.4) * 50, 5);
+  });
+
+  it('still bounds the bars when every driver has the same impact', () => {
+    const flat: MarginDriver[] = [
+      { name: 'A', impact: 2, trend: 'stable', isRisk: false },
+      { name: 'B', impact: -2, trend: 'stable', isRisk: false },
+    ];
+    for (const width of barWidths(flat)) {
+      expect(width).toBeCloseTo(50, 5);
+    }
+  });
+});

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -77,6 +77,10 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     gap: '16px',
+    // Never let the brand block wrap or squeeze the nav. Without this the tagline
+    // broke onto three lines and the tenant pill overlapped the nav buttons.
+    flexShrink: 0,
+    minWidth: 0,
   },
   headerTagline: {
     fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
@@ -84,7 +88,8 @@ const useStyles = makeStyles({
     color: 'var(--color-text-muted)',
     letterSpacing: '0.5px',
     textTransform: 'uppercase',
-    '@media (max-width: 600px)': {
+    whiteSpace: 'nowrap',
+    '@media (max-width: 1500px)': {
       display: 'none',
     },
   },
@@ -99,7 +104,8 @@ const useStyles = makeStyles({
     color: 'var(--brand-accent-light)',
     background: 'var(--brand-accent-soft)',
     border: '1px solid var(--brand-accent-border)',
-    '@media (max-width: 600px)': {
+    whiteSpace: 'nowrap',
+    '@media (max-width: 1250px)': {
       display: 'none',
     },
   },

--- a/src/RetailPulse.Web/src/components/margin/MarginDrivers.tsx
+++ b/src/RetailPulse.Web/src/components/margin/MarginDrivers.tsx
@@ -45,6 +45,9 @@ const useStyles = makeStyles({
     position: 'relative',
     display: 'flex',
     alignItems: 'center',
+    // Belt and braces: nothing in this track may escape into the label columns.
+    overflow: 'hidden',
+    minWidth: 0,
   },
   barTrack: {
     position: 'absolute',
@@ -130,7 +133,11 @@ export function MarginDrivers({ drivers }: MarginDriversProps) {
       <div className={styles.title}>Margin Drivers</div>
       {sorted.map((d) => {
         const isPositive = d.impact >= 0;
-        const widthPct = (Math.abs(d.impact) / maxAbsImpact) * 100;
+        // Each bar grows from the centre line, so it can only ever occupy half the
+        // track. Sizing it as a percentage of the FULL container made the largest
+        // driver span an entire container width from the middle — overrunning the
+        // name column on the left and the impact labels on the right.
+        const widthPct = (Math.abs(d.impact) / maxAbsImpact) * 50;
         const barColor = isPositive ? MARGIN_COLORS.positiveImpact : MARGIN_COLORS.negativeImpact;
         const trend = TREND_MAP[d.trend];
 


### PR DESCRIPTION
Both caught by screenshotting the live Financials panel at a laptop viewport.

## Driver bars
Bars grow outward from a centre line, so each occupies half the track. They were sized as a percentage of the **full** container, so the largest driver spanned an entire container width from the middle — covering the name column on the left and running off past the impact labels on the right.

Halved the scale and clipped the track. Four tests pin the geometry: no bar may exceed half the track, the largest sits at exactly half, the rest scale proportionally, and a flat set stays bounded. The old \* 100\ fails all four.

## Header
The tagline and tenant pill only collapsed below 600px, so at 1440px the brand text wrapped onto three lines and overlapped the nav buttons. Collapse the decorative chrome before it can crowd the nav.