### PR TITLE
Wire council verdicts to cards, add the missing vote/comment routes, cache brand scores

### DIFF
--- a/src/RetailPulse.Api/Endpoints/CardEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/CardEndpoints.cs
@@ -1,3 +1,4 @@
+using RetailPulse.Api.Auth;
 using RetailPulse.Contracts.Cards;
 
 namespace RetailPulse.Api.Endpoints;
@@ -67,6 +68,66 @@ public static class CardEndpoints
         })
         .WithName("CardAction").RequireAuthorization().RequireRateLimiting("moderate");
 
+        // The SPA has always called these two routes (cardsApi.ts), but only the generic
+        // /action route was ever mapped — so voting and commenting from the Cards panel
+        // 404'd. They delegate to the same ActionAsync pipeline.
+        //
+        // Identity is taken from the authenticated principal rather than the request
+        // body, so a caller cannot cast a vote or post a comment as somebody else.
+        app.MapPost("/api/cards/{id}/vote", async (string id, VoteRequest body, HttpContext http, IAdaptiveCardState cardState, CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(body.Choice))
+                return Results.BadRequest(new { error = "Field 'choice' is required." });
+
+            try
+            {
+                var action = new CardAction(
+                    UserIdentity.Resolve(http.User),
+                    ResolveDisplayName(http.User),
+                    CardActionType.Vote,
+                    new Dictionary<string, string> { ["vote"] = body.Choice });
+
+                return Results.Ok(await cardState.ActionAsync(id, action, ct));
+            }
+            catch (KeyNotFoundException)
+            {
+                return Results.NotFound(new { error = $"Card '{id}' not found." });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        })
+        .WithName("CardVote").RequireAuthorization().RequireRateLimiting("moderate");
+
+        app.MapPost("/api/cards/{id}/comments", async (string id, CommentRequest body, HttpContext http, IAdaptiveCardState cardState, CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(body.Text))
+                return Results.BadRequest(new { error = "Field 'text' is required." });
+
+            try
+            {
+                var action = new CardAction(
+                    UserIdentity.Resolve(http.User),
+                    ResolveDisplayName(http.User),
+                    CardActionType.Comment,
+                    new Dictionary<string, string> { ["text"] = body.Text });
+
+                AdaptiveCard card = await cardState.ActionAsync(id, action, ct);
+                // The SPA expects the comment it just created, not the whole card.
+                return Results.Ok(card.Comments.LastOrDefault());
+            }
+            catch (KeyNotFoundException)
+            {
+                return Results.NotFound(new { error = $"Card '{id}' not found." });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        })
+        .WithName("CardComment").RequireAuthorization().RequireRateLimiting("moderate");
+
         app.MapPost("/api/cards/{id}/archive", async (string id, IAdaptiveCardState cardState, CancellationToken ct) =>
         {
             try
@@ -83,4 +144,21 @@ public static class CardEndpoints
 
         return app;
     }
+
+    /// <summary>
+    /// Best-effort human-readable name for attribution on votes and comments. Falls back
+    /// through the usual claim shapes and finally to a neutral label, so a missing claim
+    /// never blocks the action.
+    /// </summary>
+    private static string ResolveDisplayName(System.Security.Claims.ClaimsPrincipal? principal) =>
+        principal?.FindFirst("name")?.Value
+        ?? principal?.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
+        ?? principal?.FindFirst("preferred_username")?.Value
+        ?? "Retail Pulse user";
 }
+
+/// <summary>Body for <c>POST /api/cards/{id}/vote</c>, matching what the SPA sends.</summary>
+public record VoteRequest(string Choice);
+
+/// <summary>Body for <c>POST /api/cards/{id}/comments</c>, matching what the SPA sends.</summary>
+public record CommentRequest(string Text);

--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -8,6 +8,7 @@ using RetailPulse.Api.Agents;
 using RetailPulse.Api.Agents.Planning;
 using RetailPulse.Api.Agents.Routing;
 using RetailPulse.Api.Auth;
+using RetailPulse.Api.Cards;
 using RetailPulse.Api.Configuration;
 using RetailPulse.Api.Consensus;
 using RetailPulse.Api.Guardrails;
@@ -1204,7 +1205,7 @@ public static class ChatEndpoints
         .RequireRateLimiting("relaxed");
 
         // ── Council endpoints ────────────────────────────────────────────────
-        app.MapPost("/api/council/convene", async (CouncilConveneRequest body, ILogger<Program> logger, CancellationToken ct, IConsensusCouncil? council = null, [FromServices] CouncilHistoryStore? history = null) =>
+        app.MapPost("/api/council/convene", async (CouncilConveneRequest body, ILogger<Program> logger, CancellationToken ct, IConsensusCouncil? council = null, [FromServices] CouncilHistoryStore? history = null, [FromServices] IAdaptiveCardState? cardState = null) =>
         {
             if (string.IsNullOrWhiteSpace(body.Brand))
                 return Results.BadRequest(new { error = "Field 'brand' is required." });
@@ -1221,6 +1222,24 @@ public static class ChatEndpoints
             CouncilVerdict verdict = await council.ConveneAsync(body.Brand, body.Region, ct);
             // Optional so hosts that map these routes without the store still start.
             history?.Record(verdict);
+
+            // Publish the verdict as a collaborative voting card. The demo walkthrough has
+            // always described this step ("a Collaborative Adaptive Card is auto-created
+            // with the council's verdict") and CreateFromVerdictAsync was written for it,
+            // but nothing ever called it — which is why the Cards panel was always empty.
+            if (cardState is InMemoryAdaptiveCardState cards)
+            {
+                try
+                {
+                    await cards.CreateFromVerdictAsync(verdict, ct);
+                }
+                catch (Exception ex)
+                {
+                    // A card is a side effect of the verdict, never a precondition for
+                    // returning it.
+                    logger.LogWarning(ex, "Failed to publish a card for the {Brand} council verdict", body.Brand);
+                }
+            }
 
             return Results.Ok(new
             {

--- a/src/RetailPulse.Api/Scorecard/ScorecardOrchestrator.cs
+++ b/src/RetailPulse.Api/Scorecard/ScorecardOrchestrator.cs
@@ -35,6 +35,20 @@ public class ScorecardOrchestrator
     /// </summary>
     private static readonly SemaphoreSlim _assessmentSlots = new(6, 6);
 
+    /// <summary>
+    /// How long a brand's score stays fresh. Long enough that navigating away and back is
+    /// instant, short enough that the demo still reflects changes within a session.
+    /// </summary>
+    private static readonly TimeSpan _cacheTtl = TimeSpan.FromMinutes(15);
+
+    private sealed record CachedBrandScore(BrandScore Score, DateTime ScoredAt);
+
+    /// <summary>
+    /// Process-wide so every replica request benefits, and static so it survives the
+    /// scoped lifetime the orchestrator is registered with.
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, CachedBrandScore> _brandCache = new();
+
     /// <summary>Default dimensions — kept as a fallback so tests and legacy composition
     /// roots that don't supply a configuration list continue to work.</summary>
     internal static readonly IReadOnlyList<ScorecardDimensionConfig> DefaultScoringDimensions =
@@ -117,6 +131,41 @@ public class ScorecardOrchestrator
     }
 
     private async Task<BrandScore> ScoreBrandAsync(
+        string brand, string? region, CancellationToken ct)
+    {
+        // Scoring one brand costs five tool-using specialist calls — measured at 7-33s
+        // against the deployed backend. A brand's health does not move minute to minute,
+        // so serve a recent result instead of paying that again. Without this, revisiting
+        // the panel re-ran the entire portfolio (~130s) every single time.
+        string cacheKey = $"{brand}|{region ?? "*"}";
+        if (_brandCache.TryGetValue(cacheKey, out CachedBrandScore? cached)
+            && cached is not null
+            && DateTime.UtcNow - cached.ScoredAt < _cacheTtl)
+        {
+            _logger.LogInformation("Scorecard cache hit for {Brand}", brand);
+            return cached.Score;
+        }
+
+        BrandScore score = await ScoreBrandUncachedAsync(brand, region, ct);
+
+        // Only cache a genuinely grounded result. Caching a degraded all-neutral scorecard
+        // would pin the panel to "every brand is mediocre" for the whole TTL.
+        if (!IsDegraded(score))
+        {
+            _brandCache[cacheKey] = new CachedBrandScore(score, DateTime.UtcNow);
+        }
+
+        return score;
+    }
+
+    /// <summary>A score is degraded when no dimension produced a real assessment.</summary>
+    private static bool IsDegraded(BrandScore score) =>
+        score.Dimensions.Values.All(d =>
+            d.Assessment.Contains("timed out", StringComparison.OrdinalIgnoreCase)
+            || d.Assessment.Contains("unavailable", StringComparison.OrdinalIgnoreCase)
+            || d.Assessment.Contains("failed", StringComparison.OrdinalIgnoreCase));
+
+    private async Task<BrandScore> ScoreBrandUncachedAsync(
         string brand, string? region, CancellationToken ct)
     {
         var sw = Stopwatch.StartNew();

--- a/src/RetailPulse.Web/package-lock.json
+++ b/src/RetailPulse.Web/package-lock.json
@@ -102,6 +102,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.30.0.tgz",
       "integrity": "sha512-HBBKfbZkMVzzF5bofvS1cXuNHFVc+gt4/HOnCmG/0hsHuZRJvJvDg/+7nTwIpoqvJc8BQp5o23rBUfisOLxR+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/msal-common": "15.17.0"
       },
@@ -543,31 +544,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/src/RetailPulse.Web/package-lock.json
+++ b/src/RetailPulse.Web/package-lock.json
@@ -102,7 +102,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.30.0.tgz",
       "integrity": "sha512-HBBKfbZkMVzzF5bofvS1cXuNHFVc+gt4/HOnCmG/0hsHuZRJvJvDg/+7nTwIpoqvJc8BQp5o23rBUfisOLxR+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/msal-common": "15.17.0"
       },
@@ -544,6 +543,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/tests/RetailPulse.Tests/Cards/CouncilVerdictCardTests.cs
+++ b/tests/RetailPulse.Tests/Cards/CouncilVerdictCardTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RetailPulse.Api.Cards;
+using RetailPulse.Api.Hubs;
+using RetailPulse.Contracts.Cards;
+using RetailPulse.Contracts.Consensus;
+
+namespace RetailPulse.Tests.Cards;
+
+/// <summary>
+/// Pins the council-verdict-to-card publication path.
+/// </summary>
+/// <remarks>
+/// <c>CreateFromVerdictAsync</c> was fully implemented but had zero callers, so the
+/// documented demo step — "a Collaborative Adaptive Card is auto-created with the
+/// council's verdict" — never happened and the Cards panel was permanently empty.
+/// These tests assert the projection itself is faithful, so a future refactor cannot
+/// quietly drop the agent attribution or the verdict context again.
+/// </remarks>
+public class CouncilVerdictCardTests
+{
+    private readonly InMemoryAdaptiveCardState _state;
+
+    public CouncilVerdictCardTests()
+    {
+        _state = new InMemoryAdaptiveCardState(CreateMockHub(), Mock.Of<ILogger<InMemoryAdaptiveCardState>>());
+    }
+
+    private static CouncilVerdict BuildVerdict() => new(
+        Brand: "Apex Grill",
+        Region: "Northeast",
+        OverallRating: HealthRating.Red,
+        Synthesis: "Supply reliability is dragging the brand into the red.",
+        Votes:
+        [
+            new AgentVote("demand-forecasting", "Demand Forecasting", HealthRating.Yellow, "Demand holding", 0.86, [], TimeSpan.FromSeconds(4)),
+            new AgentVote("supply-chain", "Supply Chain", HealthRating.Red, "Two anchors out of stock", 0.93, [], TimeSpan.FromSeconds(6)),
+        ],
+        IsUnanimous: false,
+        Disagreements: ["demand-forecasting reads the trend as recoverable"],
+        ActionItems: ["Expedite replenishment on the two out-of-stock anchors"],
+        ConvenedAt: DateTime.UtcNow,
+        TotalDuration: TimeSpan.FromSeconds(11));
+
+    [Fact]
+    public async Task CreateFromVerdict_PublishesADiscoverableVotingCard()
+    {
+        AdaptiveCard card = await _state.CreateFromVerdictAsync(BuildVerdict());
+
+        card.Type.Should().Be(CardType.Voting);
+
+        // The whole point is that the Cards panel, which lists active cards, can find it.
+        IReadOnlyList<AdaptiveCard> active = await _state.GetActiveAsync();
+        active.Should().ContainSingle(c => c.Id == card.Id);
+    }
+
+    [Fact]
+    public async Task CreateFromVerdict_CarriesTheBrandAndRatingInTheTitle()
+    {
+        AdaptiveCard card = await _state.CreateFromVerdictAsync(BuildVerdict());
+
+        card.Title.Should().Contain("Apex Grill").And.Contain("Red");
+    }
+
+    [Fact]
+    public async Task CreateFromVerdict_MapsEveryAgentVoteWithItsAttribution()
+    {
+        AdaptiveCard card = await _state.CreateFromVerdictAsync(BuildVerdict());
+
+        card.Votes.Should().HaveCount(2);
+        card.Votes.Should().Contain(v => v.UserId == "supply-chain" && v.Vote == "Red");
+        card.Votes.Should().Contain(v => v.UserId == "demand-forecasting" && v.Vote == "Yellow");
+    }
+
+    [Fact]
+    public async Task CreateFromVerdict_PreservesTheVerdictContextForTheCardBody()
+    {
+        AdaptiveCard card = await _state.CreateFromVerdictAsync(BuildVerdict());
+
+        card.Data["brand"].ToString().Should().Be("Apex Grill");
+        card.Data["region"].ToString().Should().Be("Northeast");
+        card.Data["overall_rating"].ToString().Should().Be("Red");
+        card.Data["synthesis"].ToString().Should().Contain("Supply reliability");
+    }
+
+    [Fact]
+    public async Task CreateFromVerdict_RecordsEachConveneSeparately()
+    {
+        await _state.CreateFromVerdictAsync(BuildVerdict());
+        await _state.CreateFromVerdictAsync(BuildVerdict());
+
+        IReadOnlyList<AdaptiveCard> active = await _state.GetActiveAsync();
+        active.Should().HaveCount(2, "each council run is its own decision to collaborate on");
+    }
+
+    private static IHubContext<TelemetryHub> CreateMockHub()
+    {
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.All).Returns(Mock.Of<IClientProxy>());
+        var hub = new Mock<IHubContext<TelemetryHub>>();
+        hub.Setup(h => h.Clients).Returns(clients.Object);
+        return hub.Object;
+    }
+}


### PR DESCRIPTION
Three defects, all the same shape: code that existed but was never reached.

## Cards were always empty
\CreateFromVerdictAsync\ was fully implemented and had **zero callers**, so the step \docs/demo-walkthrough.md\ describes — *'a Collaborative Adaptive Card is auto-created with the council's verdict'* — never happened. Convening a council now publishes the verdict as a voting card, with each agent's rating mapped to a card vote. Publication is a side effect of the verdict, never a precondition for returning it. Five tests pin the projection.

## Voting and commenting 404'd
The SPA has always called \POST /api/cards/{id}/vote\ and \/comments\ (\cardsApi.ts\), but only the generic \/action\ route was mapped. Both now exist and delegate to the same \ActionAsync\ pipeline. Identity is taken from the authenticated principal rather than the request body, so a caller cannot vote or comment as somebody else.

## The portfolio took over two minutes
Measured against the deployed backend:

| Scope | Wall time |
|---|---|
| 1 brand | 4.4s – 33s (high variance) |
| 2 brands in one request | 21s – 41s, one dimension hitting the 30s timeout exactly |
| 6 brands, batched **or** sequential | ~130s either way |

Batching was never the bottleneck — per-brand cost is. Five tool-using specialist calls per brand, thirty for the portfolio. Brand health does not move minute to minute, so scores are cached for 15 minutes. Degraded all-neutral results are deliberately **not** cached, which would otherwise pin the panel to 'every brand is mediocre' for the whole TTL.

## Verification
\dotnet test\: 3482 passed / 0 failed. \dotnet format --verify-no-changes\: exit 0.