### PR TITLE
Send one brand per scorecard request and skip the summary the SPA discards

### DIFF
--- a/src/RetailPulse.Api/Endpoints/ScorecardEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ScorecardEndpoints.cs
@@ -14,7 +14,8 @@ public static class ScorecardEndpoints
             if (body.Brands is null || body.Brands.Length == 0)
                 return Results.BadRequest(new { error = "At least one brand is required." });
 
-            ScorecardOrchestrator.PortfolioScorecard result = await scorecard.GenerateAsync(body.Brands, body.Region, ct);
+            ScorecardOrchestrator.PortfolioScorecard result =
+                await scorecard.GenerateAsync(body.Brands, body.Region, body.IncludeSummary, ct);
             return Results.Ok(result);
         })
         .WithName("GenerateScorecard").RequireAuthorization().RequireRateLimiting("strict");
@@ -23,4 +24,9 @@ public static class ScorecardEndpoints
     }
 }
 
-record ScorecardRequest(string[] Brands, string? Region = null);
+/// <param name="IncludeSummary">
+/// Whether to spend an extra model call synthesising a portfolio-level executive
+/// summary. Defaults to true so existing callers are unaffected; the SPA passes false
+/// because it renders per-brand cards and discards the summary.
+/// </param>
+record ScorecardRequest(string[] Brands, string? Region = null, bool IncludeSummary = true);

--- a/src/RetailPulse.Api/Scorecard/ScorecardOrchestrator.cs
+++ b/src/RetailPulse.Api/Scorecard/ScorecardOrchestrator.cs
@@ -103,7 +103,7 @@ public class ScorecardOrchestrator
     /// Generate a scorecard for the specified brands. Fans out assessments in parallel.
     /// </summary>
     public async Task<PortfolioScorecard> GenerateAsync(
-        string[] brands, string? region = null, CancellationToken ct = default)
+        string[] brands, string? region = null, bool includeSummary = true, CancellationToken ct = default)
     {
         var sw = Stopwatch.StartNew();
         _logger.LogInformation("Generating scorecard for {Count} brands", brands.Length);
@@ -115,8 +115,11 @@ public class ScorecardOrchestrator
         // Sort by overall score descending
         BrandScore[] sorted = [.. brandScores.OrderByDescending(b => b.OverallScore)];
 
-        // Generate executive summary
-        string execSummary = await GenerateExecSummaryAsync(sorted, region, ct);
+        // The summary is an extra model call. Callers that render per-brand cards and
+        // discard it should not pay for it on every request.
+        string execSummary = includeSummary
+            ? await GenerateExecSummaryAsync(sorted, region, ct)
+            : string.Empty;
 
         string[] topActions = [.. sorted
             .SelectMany(b => b.ActionItems)

--- a/src/RetailPulse.Web/src/services/operationsApi.ts
+++ b/src/RetailPulse.Web/src/services/operationsApi.ts
@@ -253,7 +253,7 @@ export async function fetchScorecard(brands: readonly string[]): Promise<{
   const res = await fetch(resolveApiUrl('/api/scorecard'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ brands }),
+    body: JSON.stringify({ brands, includeSummary: false }),
   });
   // Surface the failure. Returning an empty batch silently left the panel spinning
   // with no indication that anything had gone wrong.
@@ -265,13 +265,13 @@ export async function fetchScorecard(brands: readonly string[]): Promise<{
 /**
  * Number of brands scored per request.
  *
- * There is a hard 45s ceiling on the request path: two brands complete in ~24s
- * with every dimension scored, while three or more fail at exactly 45.1s with
- * "Backend call failure". Each brand costs five specialist assessments, so the
- * only way to score a real portfolio is to send it in batches that each fit
- * inside the ceiling.
+ * There is a hard 45s ceiling on the request path and per-brand latency is highly
+ * variable (measured 4s-33s for a single brand against the deployed backend). Two
+ * brands in one request has been observed to breach the ceiling outright, so the
+ * portfolio is sent one brand at a time. The server caches each brand's score, so
+ * the cost is paid once and revisits are near-instant.
  */
-const SCORECARD_BATCH_SIZE = 2;
+const SCORECARD_BATCH_SIZE = 1;
 
 /**
  * Scores a portfolio in ceiling-safe batches, reporting each batch as it lands so


### PR DESCRIPTION
Follow-up to the caching change, from live measurement.

Two brands in a single request was observed **breaching the 45s gateway ceiling outright** (45.2s, HTTP 500) — per-brand latency varies from 4s to 33s, so a pair is not reliably safe. Send one brand at a time; the server-side cache means the cost is paid once.

\GenerateAsync\ also spent an extra model call synthesising a portfolio executive summary on **every** request. The SPA renders per-brand cards and discards it, so it was pure latency. \IncludeSummary\ defaults to \	rue\ (API contract unchanged for other callers); the SPA passes \alse\.

## Measured after caching landed
| Call | Cold | Warm |
|---|---|---|
| 2 brands | 45.2s (**500**) / 18.3s | 1.65s |
| 1 brand | 5.5s | 1.48s |