### PR TITLE
Show newly created cards without a page reload

### DIFF
--- a/src/RetailPulse.Web/src/components/cards/AdaptiveCardPanel.tsx
+++ b/src/RetailPulse.Web/src/components/cards/AdaptiveCardPanel.tsx
@@ -225,6 +225,15 @@ export default function AdaptiveCardPanel() {
         .withAutomaticReconnect()
         .build();
 
+      connection.on('card:created', (newCard: AdaptiveCard) => {
+        // The server has always broadcast card:created, but the panel only listened
+        // for updates — and both update handlers work by mapping over the existing
+        // list, so a brand new card could never appear. Convening a council published
+        // a card that stayed invisible until a full page reload.
+        setCards((prev) =>
+          prev.some((c) => c.id === newCard.id) ? prev : [newCard, ...prev],
+        );
+      });
       connection.on('card:action', applyUpdate);
       connection.on('card:lifecycle', applyUpdate);
 


### PR DESCRIPTION
Caught while verifying the council-to-card wiring live: the API reported 1 card, the panel still showed 0.

The panel subscribed to \card:action\ and \card:lifecycle\ but **not** \card:created\ — which the server has always broadcast. Both existing handlers work by mapping over the current list, so a card that was not already present could never appear. Convening a council published a verdict card that stayed invisible until a full page reload.