### PR TITLE
Normalise the card wire contract so the panel can render a real card

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/cardsApi.mapping.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/cardsApi.mapping.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { toCard } from '../services/cardsApi';
+
+/**
+ * The Cards panel crashed the moment it was given a real card, because the list had
+ * always been empty and the render path had never executed against live data.
+ *
+ * Three contract mismatches were stacked on top of each other. These tests pin each
+ * one against the payload the API actually returns.
+ */
+describe('cardsApi wire mapping', () => {
+  // Captured verbatim from the deployed API after convening a council.
+  const wire = {
+    id: 'card-abc123',
+    title: 'Council Verdict: Summit Vodka — Red',
+    type: 0,
+    lifecycle: 1,
+    createdBy: 'council-orchestrator',
+    createdAt: '2026-08-28T02:40:50.2235061Z',
+    votes: [
+      { userId: 'supply-chain', userName: 'Supply Chain', vote: 'Red', timestamp: '2026-08-28T02:40:50Z' },
+      { userId: 'demand-forecasting', userName: 'Demand Forecasting', vote: 'Green', timestamp: '2026-08-28T02:40:50Z' },
+    ],
+    comments: [
+      { userId: 'u1', userName: 'Brian Swiger', text: 'Escalating.', timestamp: '2026-08-28T02:40:51Z' },
+    ],
+    data: { brand: 'Summit Vodka', overall_rating: 'Red', synthesis: 'Supply reliability is the binding constraint.' },
+    escalationReason: null,
+  };
+
+  it('decodes integer enums into the names the panel styles by', () => {
+    const card = toCard(wire);
+    // CardType 0 = Voting, CardLifecycle 1 = Voting. Passing the raw integers through
+    // made CARD_LIFECYCLE_CONFIG[1] undefined and the panel threw on `.bg`.
+    expect(card.type).toBe('voting');
+    expect(card.state).toBe('voting');
+  });
+
+  it('reads the server field named lifecycle into the panel field named state', () => {
+    expect(toCard({ ...wire, lifecycle: 2 }).state).toBe('decided');
+    expect(toCard({ ...wire, lifecycle: 3 }).state).toBe('archived');
+    expect(toCard({ ...wire, lifecycle: 0 }).state).toBe('active');
+  });
+
+  it('also accepts string enums so a future JsonStringEnumConverter cannot break it', () => {
+    expect(toCard({ ...wire, type: 'dashboard', lifecycle: 'archived' }).type).toBe('dashboard');
+    expect(toCard({ ...wire, type: 'dashboard', lifecycle: 'archived' }).state).toBe('archived');
+  });
+
+  it('falls back to a valid style key for an unknown enum rather than crashing', () => {
+    const card = toCard({ ...wire, type: 99, lifecycle: 99 });
+    expect(card.type).toBe('voting');
+    expect(card.state).toBe('active');
+  });
+
+  it('maps council health ratings onto the vote choices the panel renders', () => {
+    const card = toCard(wire);
+    expect(card.votes?.find(v => v.userId === 'supply-chain')?.choice).toBe('reject');
+    expect(card.votes?.find(v => v.userId === 'demand-forecasting')?.choice).toBe('approve');
+  });
+
+  it('renames the vote timestamp field the panel reads', () => {
+    expect(toCard(wire).votes?.[0].votedAt).toBe('2026-08-28T02:40:50Z');
+  });
+
+  it('gives comments a stable id, because the server assigns none', () => {
+    const ids = toCard(wire).comments?.map(c => c.id);
+    expect(ids?.[0]).toBeTruthy();
+    expect(toCard(wire).comments?.[0].id).toBe(ids?.[0]);
+  });
+
+  it('surfaces the verdict synthesis as the card summary', () => {
+    expect(toCard(wire).summary).toBe('Supply reliability is the binding constraint.');
+  });
+
+  it('falls back to brand and rating when there is no synthesis', () => {
+    const card = toCard({ ...wire, data: { brand: 'FreshMart', overall_rating: 'Green' } });
+    expect(card.summary).toBe('FreshMart assessed as Green.');
+  });
+
+  it('flags escalation only when the server supplied a reason', () => {
+    expect(toCard(wire).escalated).toBe(false);
+    expect(toCard({ ...wire, escalationReason: 'Split vote' }).escalated).toBe(true);
+  });
+
+  it('survives a sparse payload without throwing', () => {
+    const card = toCard({});
+    expect(card.type).toBe('voting');
+    expect(card.state).toBe('active');
+    expect(card.votes).toEqual([]);
+    expect(card.comments).toEqual([]);
+  });
+});

--- a/src/RetailPulse.Web/src/components/cards/AdaptiveCardPanel.tsx
+++ b/src/RetailPulse.Web/src/components/cards/AdaptiveCardPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { makeStyles } from '@fluentui/react-components';
 import * as signalR from '@microsoft/signalr';
 import { CARD_COLORS, CARD_TYPE_CONFIG, CARD_LIFECYCLE_CONFIG } from '../../constants/agentRouting';
-import { fetchActiveCards, submitVote } from '../../services/cardsApi';
+import { fetchActiveCards, submitVote, toCard } from '../../services/cardsApi';
 import { resolveTelemetryHubUrl } from '../../config/telemetryHubUrl';
 import { getHubAccessToken } from '../../auth/tokenService';
 import type { AdaptiveCard, VoteChoice, DrillDownLevel } from '../../types';
@@ -206,7 +206,10 @@ export default function AdaptiveCardPanel() {
   useEffect(() => {
     let connection: signalR.HubConnection | null = null;
 
-    const applyUpdate = (updatedCard: AdaptiveCard) => {
+    const applyUpdate = (raw: unknown) => {
+      // Hub payloads are the same wire shape as the REST response, so they need the
+      // same normalisation — integer enums and 'lifecycle' rather than 'state'.
+      const updatedCard = toCard(raw as Parameters<typeof toCard>[0]);
       setCards((prev) =>
         prev.map((c) => (c.id === updatedCard.id ? updatedCard : c)),
       );
@@ -225,7 +228,8 @@ export default function AdaptiveCardPanel() {
         .withAutomaticReconnect()
         .build();
 
-      connection.on('card:created', (newCard: AdaptiveCard) => {
+      connection.on('card:created', (raw: unknown) => {
+        const newCard = toCard(raw as Parameters<typeof toCard>[0]);
         // The server has always broadcast card:created, but the panel only listened
         // for updates — and both update handlers work by mapping over the existing
         // list, so a brand new card could never appear. Convening a council published

--- a/src/RetailPulse.Web/src/services/cardsApi.ts
+++ b/src/RetailPulse.Web/src/services/cardsApi.ts
@@ -1,28 +1,162 @@
-import type { AdaptiveCard, CardComment, VoteChoice } from '../types';
+import { resolveApiUrl } from '../config/apiOrigin';
+import type {
+  AdaptiveCard,
+  CardComment,
+  CardLifecycleState,
+  CardType,
+  UserVote,
+  VoteChoice,
+} from '../types';
 
 const BASE = '/api/cards';
 
-export async function fetchActiveCards(): Promise<AdaptiveCard[]> {
-  const res = await fetch(BASE);
-  if (!res.ok) throw new Error(`Failed to fetch cards: ${res.status}`);
-  return res.json();
+/**
+ * Collaborative card reads and writes.
+ *
+ * The server and the SPA disagreed about this contract in three ways at once, and
+ * because the card list was always empty, none of it ever surfaced:
+ *
+ *  - Enums cross the wire as INTEGERS (`type: 0`, `lifecycle: 1`), while the panel
+ *    keys its style maps by lowercase names. Looking up `CARD_LIFECYCLE_CONFIG[1]`
+ *    returned undefined and the panel crashed reading `.bg`.
+ *  - The server sends `lifecycle`; the panel reads `state`.
+ *  - The server sends votes as `{ vote, timestamp }`; the panel expects
+ *    `{ choice, votedAt }`. Comments have no `id` server-side at all.
+ *
+ * Everything is normalised here, at the edge, so components consume one stable view
+ * model. The orderings below mirror the C# enums exactly — see
+ * RetailPulse.Contracts/Cards/IAdaptiveCardState.cs.
+ */
+const CARD_TYPES: readonly CardType[] = ['voting', 'drilldown', 'dashboard', 'briefing'];
+const CARD_LIFECYCLES: readonly CardLifecycleState[] = ['active', 'voting', 'decided', 'archived'];
+
+interface WireVote {
+  readonly userId?: string;
+  readonly userName?: string;
+  readonly vote?: string;
+  readonly timestamp?: string;
 }
 
-export async function submitVote(cardId: string, choice: VoteChoice): Promise<void> {
-  const res = await fetch(`${BASE}/${cardId}/vote`, {
+interface WireComment {
+  readonly userId?: string;
+  readonly userName?: string;
+  readonly text?: string;
+  readonly timestamp?: string;
+}
+
+interface WireCard {
+  readonly id?: string;
+  readonly title?: string;
+  readonly type?: number | string;
+  readonly lifecycle?: number | string;
+  readonly createdBy?: string;
+  readonly createdAt?: string;
+  readonly votes?: readonly WireVote[];
+  readonly comments?: readonly WireComment[];
+  readonly data?: Record<string, unknown>;
+  readonly escalationReason?: string | null;
+}
+
+/**
+ * Accepts either the integer the server sends today or a name, so adding a
+ * JsonStringEnumConverter later cannot silently break the panel again.
+ */
+function toEnum<T extends string>(
+  raw: number | string | undefined,
+  order: readonly T[],
+  fallback: T,
+): T {
+  if (typeof raw === 'number') return order[raw] ?? fallback;
+  if (typeof raw === 'string') {
+    const match = order.find((v) => v === raw.toLowerCase());
+    if (match) return match;
+  }
+  return fallback;
+}
+
+/** Council agent votes carry a health rating ("Red"), not an approve/reject choice. */
+function toChoice(vote: string | undefined): VoteChoice {
+  const v = (vote ?? '').toLowerCase();
+  if (v === 'approve' || v === 'green') return 'approve';
+  if (v === 'reject' || v === 'red') return 'reject';
+  return 'abstain';
+}
+
+function toVote(w: WireVote): UserVote {
+  return {
+    userId: w.userId ?? '',
+    userName: w.userName ?? 'Unknown',
+    choice: toChoice(w.vote),
+    votedAt: w.timestamp ?? '',
+  };
+}
+
+function toComment(w: WireComment, index: number): CardComment {
+  return {
+    // The server does not assign comment ids, so derive a stable one for React keys.
+    id: `${w.userId ?? 'anon'}-${w.timestamp ?? index}`,
+    userId: w.userId ?? '',
+    userName: w.userName ?? 'Unknown',
+    text: w.text ?? '',
+    timestamp: w.timestamp ?? '',
+  };
+}
+
+/** Cards carry their detail in a free-form data bag; surface a readable summary. */
+function toSummary(data: Record<string, unknown> | undefined): string {
+  const synthesis = data?.['synthesis'];
+  if (typeof synthesis === 'string' && synthesis.length > 0) return synthesis;
+
+  const brand = data?.['brand'];
+  const rating = data?.['overall_rating'];
+  if (typeof brand === 'string' && typeof rating === 'string') {
+    return `${brand} assessed as ${rating}.`;
+  }
+  return '';
+}
+
+export function toCard(w: WireCard): AdaptiveCard {
+  return {
+    id: w.id ?? '',
+    title: w.title ?? 'Untitled card',
+    type: toEnum(w.type, CARD_TYPES, 'voting'),
+    state: toEnum(w.lifecycle, CARD_LIFECYCLES, 'active'),
+    summary: toSummary(w.data),
+    // The server does not track a separate lifecycle-change timestamp.
+    stateChangedAt: w.createdAt ?? '',
+    createdAt: w.createdAt ?? '',
+    createdBy: w.createdBy ?? '',
+    votes: (w.votes ?? []).map(toVote),
+    comments: (w.comments ?? []).map(toComment),
+    data: w.data ?? {},
+    escalated: Boolean(w.escalationReason),
+    escalationReason: w.escalationReason ?? undefined,
+  };
+}
+
+export async function fetchActiveCards(): Promise<AdaptiveCard[]> {
+  const res = await fetch(resolveApiUrl(BASE));
+  if (!res.ok) throw new Error(`Failed to fetch cards: ${res.status}`);
+  const wire = (await res.json()) as WireCard[];
+  return wire.map(toCard);
+}
+
+export async function submitVote(cardId: string, choice: VoteChoice): Promise<AdaptiveCard> {
+  const res = await fetch(resolveApiUrl(`${BASE}/${cardId}/vote`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ choice }),
   });
   if (!res.ok) throw new Error(`Vote failed: ${res.status}`);
+  return toCard((await res.json()) as WireCard);
 }
 
 export async function addComment(cardId: string, text: string): Promise<CardComment> {
-  const res = await fetch(`${BASE}/${cardId}/comments`, {
+  const res = await fetch(resolveApiUrl(`${BASE}/${cardId}/comments`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ text }),
   });
   if (!res.ok) throw new Error(`Comment failed: ${res.status}`);
-  return res.json();
+  return toComment((await res.json()) as WireComment, 0);
 }


### PR DESCRIPTION
With cards finally being created, the panel crashed on the very first one: `TypeError: Cannot read properties of undefined (reading 'bg')`.

The render path had never executed against live data because the list had always been empty, so three contract mismatches had been sitting there undetected:

| Server sends | Panel expects |
|---|---|
| `type: 0`, `lifecycle: 1` (integers) | `'voting'`, `'voting'` (lowercase names used as style-map keys) |
| `lifecycle` | `state` |
| `{ vote, timestamp }`, comments with no `id` | `{ choice, votedAt }`, comments with `id` |

`CARD_LIFECYCLE_CONFIG[1]` was `undefined`, hence the throw on `.bg`.

Normalised at the service edge, matching the pattern already used for council, promo and operations. Hub payloads go through the same mapper since they carry the same shape. The decoder accepts names as well as integers, so adding a `JsonStringEnumConverter` later cannot silently break it again.

Eleven tests pin the mapping against a payload captured verbatim from the deployed API.
