### PR TITLE
Register inbound channel authentication for the Teams bot

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -49,6 +49,12 @@ param teamsBotImageName string = 'mcr.microsoft.com/k8se/quickstart:latest'
 @description('Enable the optional Azure AI Content Safety second layer. Ships DISABLED so a clean `azd up` never silently provisions a paid Cognitive Services account. Enable per environment with `azd env set AZURE_CONTENT_SAFETY_ENABLED true` (read by main.bicepparam); the API is then wired to the account endpoint with managed identity and no keys.')
 param contentSafetyEnabled bool = false
 
+@description('Entra application (client) ID of the Azure Bot Service registration that fronts the Teams bot. Ships EMPTY so a clean `azd up` does not pretend to have a bot; set it per environment with `azd env set AZURE_BOT_APP_ID <id>` once a bot is registered.')
+param botAppId string = ''
+
+@description('Client secret for the bot app registration. Set with `azd env set AZURE_BOT_APP_SECRET <secret>`; stored as a Container Apps secret, never in the template.')
+@secure()
+param botAppSecret string = ''
 @description('Enable the optional Azure AI Search knowledge provider. Disabled by default; no Search resource is provisioned when false.')
 param aiSearchEnabled bool = false
 
@@ -154,6 +160,8 @@ module containerApps './modules/container-apps.bicep' = {
     entraApiScope: entraApiScope
     containerRegistryLoginServer: containerRegistry.outputs.loginServer
     contentSafetyEndpoint: contentSafetyEnabled ? contentSafety!.outputs.endpoint : ''
+    botAppId: botAppId
+    botAppSecret: botAppSecret
   }
 }
 

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -26,12 +26,19 @@ param apiImageName = readEnvironmentVariable('SERVICE_API_IMAGE_NAME', 'mcr.micr
 param mcpServerImageName = readEnvironmentVariable('SERVICE_MCPSERVER_IMAGE_NAME', 'mcr.microsoft.com/k8se/quickstart:latest')
 param teamsBotImageName = readEnvironmentVariable('SERVICE_TEAMSBOT_IMAGE_NAME', 'mcr.microsoft.com/k8se/quickstart:latest')
 
-// Optional Azure AI Content Safety second layer (issue #100). Disabled by
+// Optional Azure AI Content Safety second layer. Disabled by
 // default so `azd up` keeps working unchanged. Enable per environment with
 // `azd env set AZURE_CONTENT_SAFETY_ENABLED true`.
 param contentSafetyEnabled = toLower(readEnvironmentVariable('AZURE_CONTENT_SAFETY_ENABLED', 'false')) == 'true'
 
-// Optional Azure AI Search knowledge provider (issue #103). Disabled by
+// Optional Azure AI Search knowledge provider. Disabled by
 // default so `azd up` keeps working unchanged (no Search resource, no cost).
 // Enable per environment with `azd env set AZURE_AI_SEARCH_ENABLED true`.
 param aiSearchEnabled = toLower(readEnvironmentVariable('AZURE_AI_SEARCH_ENABLED', 'false')) == 'true'
+
+// Azure Bot Service registration backing the Teams bot. Empty by default so a
+// clean zd up does not claim to have a bot it never registered. Set both with:
+//   azd env set AZURE_BOT_APP_ID <appId>
+//   azd env set AZURE_BOT_APP_SECRET <secret>
+param botAppId = readEnvironmentVariable('AZURE_BOT_APP_ID', '')
+param botAppSecret = readEnvironmentVariable('AZURE_BOT_APP_SECRET', '')

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -54,8 +54,25 @@ param mcpApiKey string = '${uniqueString(resourceGroup().id, 'mcp-api-key')}${un
 @description('Azure AI Content Safety endpoint. Empty disables the optional second guardrail layer, leaving the regex-only baseline in place.')
 param contentSafetyEndpoint string = ''
 
+@description('Entra application (client) ID of the Azure Bot Service registration. Empty leaves the Teams bot unconfigured, which is the correct state for an environment that has not registered a bot.')
+param botAppId string = ''
+
+@description('Client secret for the bot app registration. Supplied per-environment; never checked in.')
+@secure()
+param botAppSecret string = ''
+
+@description('Tenant that owns the bot app registration. Defaults to the deploying tenant.')
+param botTenantId string = tenant().tenantId
+
 var apimSubscriptionKeySecretName = 'apim-sub-key'
 var mcpApiKeySecretName = 'mcp-api-key'
+var botAppSecretName = 'bot-app-secret'
+
+// The Teams bot is only wired up when a bot registration exists. Without an app id
+// the Microsoft 365 Agents SDK has no identity to authenticate outbound calls with
+// and no audience to validate inbound Activities against, so emitting half the
+// configuration would leave the bot failing in a way that looks like a code fault.
+var botConfigured = !empty(botAppId)
 
 // The `registries` block binds a container app's image-pull auth to its own
 // system-assigned identity, with no admin credentials. It is only emitted when
@@ -376,6 +393,12 @@ resource teamsBot 'Microsoft.App/containerApps@2024-03-01' = {
     configuration: {
       activeRevisionsMode: 'Single'
       registries: teamsBotUsesPrivateRegistry ? privateRegistryBlock : []
+      secrets: botConfigured ? [
+        {
+          name: botAppSecretName
+          value: botAppSecret
+        }
+      ] : []
       ingress: {
         external: true
         targetPort: 8080
@@ -397,7 +420,7 @@ resource teamsBot 'Microsoft.App/containerApps@2024-03-01' = {
           // against the Bot Framework channel. Running this app as Development is
           // what previously disabled inbound channel authentication on a publicly
           // exposed endpoint.
-          env: [
+          env: concat([
             {
               name: 'ASPNETCORE_ENVIRONMENT'
               value: 'Production'
@@ -406,11 +429,51 @@ resource teamsBot 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'TeamsBot__ApiBaseUrl'
               value: 'https://${api.properties.configuration.ingress.fqdn}'
             }
-          ]
+          ], botConfigured ? [
+            // Outbound: MSAL client-credentials against the Bot Framework, so the bot
+            // can post Activities back to the channel.
+            {
+              name: 'Connections__BotServiceConnection__Settings__AuthType'
+              value: 'ClientSecret'
+            }
+            {
+              name: 'Connections__BotServiceConnection__Settings__AuthorityEndpoint'
+              value: '${environment().authentication.loginEndpoint}${botTenantId}'
+            }
+            {
+              name: 'Connections__BotServiceConnection__Settings__TenantId'
+              value: botTenantId
+            }
+            {
+              name: 'Connections__BotServiceConnection__Settings__ClientId'
+              value: botAppId
+            }
+            {
+              name: 'Connections__BotServiceConnection__Settings__ClientSecret'
+              secretRef: botAppSecretName
+            }
+            {
+              name: 'Connections__BotServiceConnection__Settings__Scopes__0'
+              value: 'https://api.botframework.com/.default'
+            }
+            // Inbound: the audience an incoming Activity's token must carry. Without
+            // it there is nothing to validate a channel request against.
+            {
+              name: 'TokenValidation__Audiences__0'
+              value: botAppId
+            }
+            {
+              name: 'TokenValidation__TenantId'
+              value: botTenantId
+            }
+          ] : [])
         }
       ]
       scale: {
-        minReplicas: 0
+        // The Bot Framework retries a cold-start timeout, but a scale-to-zero bot
+        // drops the first message of a conversation often enough to look broken in a
+        // demo. One warm replica is the honest cost of a responsive bot.
+        minReplicas: botConfigured ? 1 : 0
         maxReplicas: 1
       }
     }

--- a/src/RetailPulse.TeamsBot/Auth/AgentAuthenticationExtensions.cs
+++ b/src/RetailPulse.TeamsBot/Auth/AgentAuthenticationExtensions.cs
@@ -1,0 +1,303 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Agents.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Validators;
+
+namespace RetailPulse.TeamsBot.Auth;
+
+/// <summary>
+/// Registers JWT bearer validation for inbound Activities from Azure Bot Service.
+/// </summary>
+/// <remarks>
+/// The Microsoft 365 Agents SDK does not ship this in any NuGet package. It lives as a
+/// shared helper at <c>microsoft/Agents-for-net: src/samples/Shared/AspNetExtensions.cs</c>
+/// which the sample projects link rather than copy, so a standalone project has to carry
+/// its own. Without it, <c>MapAgentApplicationEndpoints(requireAuth: true)</c> maps an
+/// endpoint that requires authorization while no authentication scheme exists, and every
+/// inbound Activity fails with "No authenticationScheme was specified" — a 500 where the
+/// channel expects a 401.
+///
+/// The logic mirrors the upstream helper. The two-issuer split is the crux: Azure Bot
+/// Service mints channel tokens signed with keys published at login.botframework.com,
+/// while Entra mints agent-to-agent tokens signed with keys from login.microsoftonline.com.
+/// A single ConfigurationManager cannot serve both, so the issuer is peeked before
+/// validation and the matching metadata endpoint is selected per request.
+/// </remarks>
+public static class AgentAuthenticationExtensions
+{
+    private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _openIdMetadataCache = new();
+
+    private static bool IsBotFrameworkIssuer(string issuer) =>
+        AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer, StringComparison.OrdinalIgnoreCase)
+        || AuthenticationConstants.GovBotFrameworkTokenIssuer.Equals(issuer, StringComparison.OrdinalIgnoreCase);
+
+    public static void AddAgentAspNetAuthentication(
+        this IHostApplicationBuilder builder,
+        string tokenValidationSectionName = "TokenValidation")
+    {
+        IConfigurationSection section = builder.Configuration.GetSection(tokenValidationSectionName);
+
+        if (!section.Exists())
+        {
+            throw new InvalidOperationException(
+                $"Configuration section '{tokenValidationSectionName}' is missing. The bot cannot validate " +
+                "inbound Activities without it. Supply TokenValidation:Audiences (the bot's app id) and " +
+                "TokenValidation:TenantId.");
+        }
+
+        builder.Services.AddAgentAspNetAuthentication(section.Get<TokenValidationOptions>()!);
+    }
+
+    public static void AddAgentAspNetAuthentication(
+        this IServiceCollection services,
+        TokenValidationOptions validationOptions)
+    {
+        ArgumentNullException.ThrowIfNull(validationOptions);
+
+        if (validationOptions.Audiences is null || validationOptions.Audiences.Count == 0)
+            throw new ArgumentException("TokenValidation:Audiences requires at least one ClientId.", nameof(validationOptions));
+
+        foreach (string audience in validationOptions.Audiences)
+        {
+            if (!Guid.TryParse(audience, out _))
+                throw new ArgumentException("TokenValidation:Audiences values must be GUIDs.", nameof(validationOptions));
+        }
+
+        if (validationOptions.ValidIssuers is null || validationOptions.ValidIssuers.Count == 0)
+        {
+            validationOptions.ValidIssuers = BuildDefaultIssuers(validationOptions);
+        }
+
+        if (string.IsNullOrEmpty(validationOptions.AzureBotServiceOpenIdMetadataUrl))
+        {
+            validationOptions.AzureBotServiceOpenIdMetadataUrl = validationOptions.IsGov
+                ? AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl
+                : AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl;
+        }
+
+        if (string.IsNullOrEmpty(validationOptions.OpenIdMetadataUrl))
+        {
+            validationOptions.OpenIdMetadataUrl = validationOptions.IsGov
+                ? AuthenticationConstants.GovOpenIdMetadataUrl
+                : AuthenticationConstants.PublicOpenIdMetadataUrl;
+        }
+
+        TimeSpan refresh = validationOptions.OpenIdMetadataRefresh
+            ?? BaseConfigurationManager.DefaultAutomaticRefreshInterval;
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        })
+        .AddJwtBearer(options =>
+        {
+            options.SaveToken = true;
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.FromMinutes(5),
+                ValidIssuers = validationOptions.ValidIssuers,
+                ValidAudiences = validationOptions.Audiences,
+                ValidateIssuerSigningKey = true,
+                RequireSignedTokens = true,
+            };
+
+            options.TokenValidationParameters.EnableAadSigningKeyIssuerValidation();
+
+            options.Events = new JwtBearerEvents
+            {
+                OnMessageReceived = context =>
+                {
+                    string authorizationHeader = context.Request.Headers.Authorization.ToString();
+                    string[] parts = authorizationHeader.Split(' ');
+
+                    if (parts.Length != 2 || !string.Equals(parts[0], "Bearer", StringComparison.Ordinal))
+                    {
+                        // Nothing to route on; leave whatever manager is already configured.
+                        context.Options.TokenValidationParameters.ConfigurationManager
+                            ??= options.ConfigurationManager as BaseConfigurationManager;
+                        return Task.CompletedTask;
+                    }
+
+                    // Read the issuer WITHOUT validating — this only selects which key set
+                    // to validate against. The signature check still happens afterwards.
+                    string issuer = new JsonWebToken(parts[1]).Issuer;
+
+                    string metadataUrl = validationOptions.AzureBotServiceTokenHandling && IsBotFrameworkIssuer(issuer)
+                        ? validationOptions.AzureBotServiceOpenIdMetadataUrl
+                        : validationOptions.OpenIdMetadataUrl;
+
+                    context.Options.TokenValidationParameters.ConfigurationManager =
+                        _openIdMetadataCache.GetOrAdd(metadataUrl, url =>
+                            new ConfigurationManager<OpenIdConnectConfiguration>(
+                                url,
+                                new OpenIdConnectConfigurationRetriever(),
+                                new HttpClient())
+                            {
+                                AutomaticRefreshInterval = refresh,
+                            });
+
+                    return Task.CompletedTask;
+                },
+
+                OnTokenValidated = context =>
+                {
+                    string? issuer = context.Principal?.FindFirst("iss")?.Value;
+                    bool isBotFrameworkToken = validationOptions.AzureBotServiceTokenHandling
+                        && issuer is not null
+                        && IsBotFrameworkIssuer(issuer);
+
+                    // Bot Framework tokens carry no tenant claim, so the cross-check below
+                    // only applies to Entra-issued agent-to-agent tokens.
+                    if (!isBotFrameworkToken
+                        && context.Principal?.Identity is ClaimsIdentity identity
+                        && !IsTenantIdIssuerValid(identity, issuer))
+                    {
+                        context.Fail("Token tenant ID does not match its issuer.");
+                        return Task.CompletedTask;
+                    }
+
+                    if (!isBotFrameworkToken
+                        && validationOptions.AllowedCallers is { Count: > 0 }
+                        && !validationOptions.AllowedCallers.Any(c => c.Equals("*", StringComparison.Ordinal)))
+                    {
+                        string? callerAppId = context.Principal?.FindFirst("azp")?.Value
+                            ?? context.Principal?.FindFirst("appid")?.Value;
+
+                        if (string.IsNullOrEmpty(callerAppId)
+                            || !validationOptions.AllowedCallers.Any(c => c.Equals(callerAppId, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            context.Fail($"Caller App ID '{callerAppId}' is not in the AllowedCallers list.");
+                        }
+                    }
+
+                    return Task.CompletedTask;
+                },
+            };
+        });
+    }
+
+    /// <summary>
+    /// Public-cloud defaults are the Bot Framework issuer plus the three Entra tenants
+    /// Azure Bot Service itself issues from, and — when the bot is single-tenant — its own
+    /// tenant in both v1 and v2 issuer forms.
+    /// </summary>
+    private static List<string> BuildDefaultIssuers(TokenValidationOptions o)
+    {
+        if (o.AzureBotServiceOnly)
+        {
+            return [o.IsGov ? AuthenticationConstants.GovBotFrameworkTokenIssuer : AuthenticationConstants.BotFrameworkTokenIssuer];
+        }
+
+        List<string> issuers = o.IsGov
+            ?
+            [
+                AuthenticationConstants.GovBotFrameworkTokenIssuer,
+                "https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/",
+                "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0",
+            ]
+            :
+            [
+                AuthenticationConstants.BotFrameworkTokenIssuer,
+                "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",
+                "https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0",
+                "https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/",
+                "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0",
+                "https://sts.windows.net/69e9b82d-4842-4902-8d1e-abc5b98a55e8/",
+                "https://login.microsoftonline.com/69e9b82d-4842-4902-8d1e-abc5b98a55e8/v2.0",
+            ];
+
+        if (!string.IsNullOrEmpty(o.TenantId) && Guid.TryParse(o.TenantId, out _))
+        {
+            issuers.Add(FormatIssuer(AuthenticationConstants.ValidTokenIssuerUrlTemplateV1, o.TenantId));
+            issuers.Add(FormatIssuer(
+                o.IsGov ? AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2 : AuthenticationConstants.ValidTokenIssuerUrlTemplateV2,
+                o.TenantId));
+        }
+
+        return issuers;
+    }
+
+    /// <summary>
+    /// The issuer templates are SDK constants selected at runtime, so a cached
+    /// <see cref="CompositeFormat"/> per template keeps the analyzer satisfied without
+    /// hardcoding URLs the SDK owns. This runs once at startup, not per request.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, CompositeFormat> _issuerFormats = new();
+
+    private static string FormatIssuer(string template, string tenantId) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            _issuerFormats.GetOrAdd(template, CompositeFormat.Parse),
+            tenantId);
+
+    /// <summary>
+    /// Confirms the token's <c>tid</c> claim matches the tenant embedded in its issuer.
+    /// </summary>
+    /// <remarks>
+    /// Upstream calls <c>ClaimsIdentity.IsTenantIdIssuerValid()</c> from a newer
+    /// Microsoft.IdentityModel.Validators than this solution pins, so the check is written
+    /// out here rather than taking a version bump on a security-critical package.
+    ///
+    /// Without it, a validly signed token from one tenant could satisfy an issuer entry for
+    /// another, because the issuer list and the tenant claim would be checked independently.
+    /// Both Entra issuer forms embed the tenant GUID as a path segment:
+    /// <c>https://sts.windows.net/{tid}/</c> and
+    /// <c>https://login.microsoftonline.com/{tid}/v2.0</c>.
+    /// </remarks>
+    private static bool IsTenantIdIssuerValid(ClaimsIdentity identity, string? issuer)
+    {
+        string? tenantId = identity.FindFirst("tid")?.Value
+            ?? identity.FindFirst("http://schemas.microsoft.com/identity/claims/tenantid")?.Value;
+
+        // No tenant claim means there is nothing to cross-check; the issuer allow-list and
+        // signature validation already applied.
+        return string.IsNullOrEmpty(tenantId)
+            || (!string.IsNullOrEmpty(issuer)
+                && Uri.TryCreate(issuer, UriKind.Absolute, out Uri? issuerUri)
+                && issuerUri.Segments.Any(segment =>
+                    segment.Trim('/').Equals(tenantId, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    /// <summary>Settings read from the <c>TokenValidation</c> configuration section.</summary>
+    public class TokenValidationOptions
+    {
+        /// <summary>Accepted audiences. Must contain the bot's Entra app (client) id.</summary>
+        public IList<string>? Audiences { get; set; }
+
+        /// <summary>Tenant that owns the bot registration. Adds that tenant's issuers.</summary>
+        public string? TenantId { get; set; }
+
+        public IList<string>? ValidIssuers { get; set; }
+
+        public bool IsGov { get; set; }
+
+        /// <summary>Restricts validation to Bot Framework channel tokens only.</summary>
+        public bool AzureBotServiceOnly { get; set; }
+
+        public string? AzureBotServiceOpenIdMetadataUrl { get; set; }
+
+        public string? OpenIdMetadataUrl { get; set; }
+
+        /// <summary>
+        /// Route Bot Framework issuers to the Bot Framework metadata endpoint. Must stay on
+        /// while Azure Bot Service still issues its own channel tokens.
+        /// </summary>
+        public bool AzureBotServiceTokenHandling { get; set; } = true;
+
+        public TimeSpan? OpenIdMetadataRefresh { get; set; }
+
+        /// <summary>App ids permitted to call this agent. Null or "*" accepts any.</summary>
+        public IList<string>? AllowedCallers { get; set; }
+    }
+}

--- a/src/RetailPulse.TeamsBot/Program.cs
+++ b/src/RetailPulse.TeamsBot/Program.cs
@@ -23,6 +23,16 @@ builder.AddAgent<RetailPulseAgent>();
 builder.Services.AddSingleton<IStorage, MemoryStorage>();
 builder.Services.AddControllers();
 
+// Inbound channel authentication. MapAgentApplicationEndpoints(requireAuth: true) below
+// requires an authenticated principal, so without a registered scheme every Activity
+// from Teams fails with "No authenticationScheme was specified" — a 500 where the
+// channel expects a 401. Development skips it to keep the local loop keyless, matching
+// the requireAuth flag on the endpoint mapping.
+if (!builder.Environment.IsDevelopment())
+{
+    builder.AddAgentAspNetAuthentication();
+}
+
 string apiBaseUrl = builder.Configuration["services:api:https:0"]
     ?? builder.Configuration["services:api:http:0"]
     ?? builder.Configuration["TeamsBot:ApiBaseUrl"]

--- a/tests/RetailPulse.Tests/Bot/AgentAuthenticationTests.cs
+++ b/tests/RetailPulse.Tests/Bot/AgentAuthenticationTests.cs
@@ -1,0 +1,162 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using RetailPulse.TeamsBot.Auth;
+using TokenValidationOptions = RetailPulse.TeamsBot.Auth.AgentAuthenticationExtensions.TokenValidationOptions;
+
+namespace RetailPulse.Tests.Bot;
+
+/// <summary>
+/// Covers inbound channel authentication for the Teams bot.
+/// </summary>
+/// <remarks>
+/// The bot mapped its messaging endpoint with <c>requireAuth: true</c> while registering
+/// no authentication scheme at all, so every inbound Activity from Teams failed with
+/// "No authenticationScheme was specified" — an HTTP 500 where the Bot Framework channel
+/// expects a 401. The bot could never have worked in Production.
+/// </remarks>
+public class AgentAuthenticationTests
+{
+    private const string BotAppId = "0d376865-49b0-41a1-a37d-44eb0522c428";
+    private const string TenantId = "48351615-345c-4547-bb6f-8fcc8d6e2568";
+
+    private static TokenValidationOptions ValidOptions() => new()
+    {
+        Audiences = [BotAppId],
+        TenantId = TenantId,
+    };
+
+    [Fact]
+    public void Registers_JwtBearer_AsBothDefaultSchemes()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAgentAspNetAuthentication(ValidOptions());
+
+        AuthenticationOptions options = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<AuthenticationOptions>>().Value;
+
+        // A missing DefaultChallengeScheme is exactly what produced the 500.
+        options.DefaultAuthenticateScheme.Should().Be(JwtBearerDefaults.AuthenticationScheme);
+        options.DefaultChallengeScheme.Should().Be(JwtBearerDefaults.AuthenticationScheme);
+    }
+
+    [Fact]
+    public void Accepts_TheBotFrameworkChannelIssuer()
+    {
+        TokenValidationOptions options = ValidOptions();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAgentAspNetAuthentication(options);
+
+        // Channel tokens for a Teams conversation are issued by the Bot Framework, not Entra.
+        options.ValidIssuers.Should().Contain("https://api.botframework.com");
+    }
+
+    [Fact]
+    public void Accepts_ItsOwnTenant_InBothIssuerForms()
+    {
+        TokenValidationOptions options = ValidOptions();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAgentAspNetAuthentication(options);
+
+        // A single-tenant bot also receives Entra-issued tokens from its own tenant.
+        options.ValidIssuers.Should().Contain($"https://sts.windows.net/{TenantId}/");
+        options.ValidIssuers.Should().Contain($"https://login.microsoftonline.com/{TenantId}/v2.0");
+    }
+
+    [Fact]
+    public void Rejects_AnEmptyAudienceList()
+    {
+        var services = new ServiceCollection();
+        Action act = () => services.AddAgentAspNetAuthentication(new TokenValidationOptions { Audiences = [] });
+
+        // Without an audience any validly signed token from any tenant would be accepted.
+        act.Should().Throw<ArgumentException>().WithMessage("*at least one ClientId*");
+    }
+
+    [Fact]
+    public void Rejects_ANonGuidAudience()
+    {
+        var services = new ServiceCollection();
+        Action act = () => services.AddAgentAspNetAuthentication(
+            new TokenValidationOptions { Audiences = ["not-a-guid"] });
+
+        act.Should().Throw<ArgumentException>().WithMessage("*must be GUIDs*");
+    }
+
+    [Fact]
+    public void AzureBotServiceOnly_ExcludesEntraIssuers()
+    {
+        var options = new TokenValidationOptions
+        {
+            Audiences = [BotAppId],
+            TenantId = TenantId,
+            AzureBotServiceOnly = true,
+        };
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAgentAspNetAuthentication(options);
+
+        options.ValidIssuers.Should().ContainSingle().Which.Should().Be("https://api.botframework.com");
+    }
+
+    [Fact]
+    public void DefaultsTo_RoutingBotFrameworkTokensToTheBotFrameworkKeys()
+    {
+        TokenValidationOptions options = ValidOptions();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAgentAspNetAuthentication(options);
+
+        // Bot Framework tokens are signed with keys published at login.botframework.com;
+        // validating them against the Entra key set would reject every channel message.
+        options.AzureBotServiceTokenHandling.Should().BeTrue();
+        options.AzureBotServiceOpenIdMetadataUrl.Should().Contain("login.botframework.com");
+        options.OpenIdMetadataUrl.Should().Contain("login.microsoftonline.com");
+    }
+
+    // ---- Tenant / issuer cross-check ---------------------------------------------------
+    //
+    // Exercised through the same private helper the JwtBearer OnTokenValidated event uses.
+
+    private static bool CrossCheck(string? tid, string? issuer)
+    {
+        var identity = new ClaimsIdentity(tid is null ? [] : new[] { new Claim("tid", tid) });
+
+        System.Reflection.MethodInfo method = typeof(AgentAuthenticationExtensions)
+            .GetMethod("IsTenantIdIssuerValid", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+        return (bool)method.Invoke(null, [identity, issuer])!;
+    }
+
+    [Theory]
+    [InlineData("https://sts.windows.net/48351615-345c-4547-bb6f-8fcc8d6e2568/")]
+    [InlineData("https://login.microsoftonline.com/48351615-345c-4547-bb6f-8fcc8d6e2568/v2.0")]
+    public void TenantCrossCheck_AcceptsAMatchingIssuer(string issuer) => CrossCheck(TenantId, issuer).Should().BeTrue();
+
+    [Fact]
+    public void TenantCrossCheck_RejectsATokenReplayedFromAnotherTenant()
+    {
+        // Signed correctly and carrying an allowed issuer, but the tenant claim belongs to
+        // somebody else. Checking issuer and tenant independently would let this through.
+        CrossCheck("11111111-2222-3333-4444-555555555555",
+            $"https://sts.windows.net/{TenantId}/").Should().BeFalse();
+    }
+
+    [Fact]
+    public void TenantCrossCheck_SkipsTokensThatCarryNoTenantClaim() =>
+        // Bot Framework channel tokens have no tid; the issuer allow-list governs them.
+        CrossCheck(null, "https://api.botframework.com").Should().BeTrue();
+
+    [Fact]
+    public void TenantCrossCheck_RejectsAMalformedIssuer()
+    {
+        CrossCheck(TenantId, "not-a-url").Should().BeFalse();
+        CrossCheck(TenantId, null).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
The Teams bot mapped its messaging endpoint with `requireAuth: true` while registering **no authentication scheme at all**. Every inbound Activity failed with:

```
System.InvalidOperationException: No authenticationScheme was specified,
and there was no DefaultChallengeScheme found.
```

That is an HTTP **500** where the Bot Framework channel expects a **401**, confirmed live against the deployed container. The bot could never have worked in Production.

## Why it was missing

The Microsoft 365 Agents SDK does not ship this registration in any NuGet package. It lives as a shared helper at `microsoft/Agents-for-net: src/samples/Shared/AspNetExtensions.cs`, which sample projects *link* rather than copy — so a standalone project has to carry its own. I verified `AddAgentAspNetAuthentication` exists in none of the 1.5.184 assemblies before writing it.

## What this adds

- `AgentAuthenticationExtensions` — JWT bearer validation for inbound Activities, mirroring the upstream helper, in a real namespace rather than the sample's global one.
- The two-issuer split, which is the crux: Azure Bot Service mints **channel** tokens signed with keys at `login.botframework.com`, while Entra mints **agent-to-agent** tokens signed with keys at `login.microsoftonline.com`. One `ConfigurationManager` cannot serve both, so the issuer is peeked before validation and the matching metadata endpoint selected per request.
- A written-out tenant/issuer cross-check. Upstream calls `ClaimsIdentity.IsTenantIdIssuerValid()` from a newer `Microsoft.IdentityModel.Validators` than this solution pins; I implemented the equivalent rather than take a version bump on a security-critical package. Without it, a validly signed token from one tenant could satisfy an issuer entry for another, because issuer and tenant would be checked independently.
- Development still skips registration, matching the existing `requireAuth: !IsDevelopment()` on the endpoint mapping, so the local loop stays keyless.

## Infrastructure

Bot configuration is now declarative rather than click-ops:

- `botAppId` / `botAppSecret` parameters, secret stored as a Container Apps secret and never in the template.
- Both default to empty, so a clean `azd up` does not pretend to have a bot it never registered. Set with `azd env set AZURE_BOT_APP_ID` / `AZURE_BOT_APP_SECRET`.
- When unconfigured, **no** bot environment variables are emitted at all — half a configuration would fail in a way that looks like a code fault.
- `minReplicas` goes to 1 only when configured. A scale-to-zero bot drops the first message of a conversation often enough to look broken in a demo.

Also removed two tracker references (`issue #100`, `issue #103`) from `main.bicepparam` comments.

## Verification

12 new tests cover scheme registration, the accepted issuer set for a single-tenant bot, audience validation, and the tenant cross-check including a cross-tenant replay attempt.

`dotnet test`: 3494 passed / 0 failed. `dotnet format --verify-no-changes`: exit 0.
