### PR TITLE
Authenticate the Teams bot to the Retail Pulse API

### DIFF
--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -280,6 +280,18 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'MicrosoftEntra__AppRole'
               value: entraAppRole
             }
+            // The Teams bot is a service caller with no user token to exchange, so it
+            // presents an app-only token bearing the app role. Accepted only when a bot is
+            // configured, and only from that bot's client id — the allow-list is what keeps
+            // this from widening the API to any app-only token in the tenant.
+            {
+              name: 'MicrosoftEntra__AllowAppOnlyTokens'
+              value: botConfigured ? 'true' : 'false'
+            }
+            {
+              name: 'MicrosoftEntra__AllowedAppClientIds__0'
+              value: botAppId
+            }
             {
               name: 'RETAIL_PULSE_ALLOW_EPHEMERAL_STORAGE'
               value: 'true'
@@ -465,6 +477,24 @@ resource teamsBot 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'TokenValidation__TenantId'
               value: botTenantId
+            }
+            // The Teams SSO handler validates the *user* token carried inside an
+            // Activity, which is a separate concern from the channel token above. It
+            // fails closed outside Development, so without these the bot authenticates
+            // the channel correctly and then throws on the first turn.
+            {
+              name: 'MicrosoftEntra__TenantId'
+              value: botTenantId
+            }
+            {
+              name: 'MicrosoftEntra__ClientId'
+              value: botAppId
+            }
+            // Scope the bot requests for the API. ".default" asks for every application
+            // permission already consented, which is the RetailPulse.User app role.
+            {
+              name: 'TeamsBot__ApiScope'
+              value: empty(entraClientId) ? '' : 'api://${entraClientId}/.default'
             }
           ] : [])
         }

--- a/src/RetailPulse.TeamsBot/Auth/ApiTokenHandler.cs
+++ b/src/RetailPulse.TeamsBot/Auth/ApiTokenHandler.cs
@@ -1,0 +1,78 @@
+using Microsoft.Identity.Client;
+
+namespace RetailPulse.TeamsBot.Auth;
+
+/// <summary>
+/// Attaches an app-only access token to every outbound call to the Retail Pulse API.
+/// </summary>
+/// <remarks>
+/// The bot called the API with a bare <see cref="HttpClient"/> and no credential at all,
+/// so every turn ended in <c>401 Unauthorized</c> and the user saw a generic error card.
+/// The API's authorization policy is deny-by-default and requires either a delegated
+/// scope or an app-only token bearing the <c>RetailPulse.User</c> app role.
+///
+/// The bot uses the client-credentials flow with its own registration rather than
+/// on-behalf-of. There is no user token to exchange on a proactive or channel-initiated
+/// turn, and the API already supports app-only callers behind an explicit opt-in plus a
+/// client-id allow-list — so the bot is authorised as a named service principal rather
+/// than impersonating whoever happens to be typing. User attribution still travels in the
+/// request body, where the API treats it as data rather than as an authorization signal.
+///
+/// MSAL caches tokens in memory and refreshes them before expiry, so this acquires once
+/// per token lifetime rather than per request.
+/// </remarks>
+public sealed class ApiTokenHandler : DelegatingHandler
+{
+    private readonly IConfidentialClientApplication _app;
+    private readonly string[] _scopes;
+    private readonly ILogger<ApiTokenHandler> _logger;
+
+    public ApiTokenHandler(IConfiguration configuration, ILogger<ApiTokenHandler> logger)
+    {
+        _logger = logger;
+
+        string tenantId = Require(configuration, "MicrosoftEntra:TenantId");
+        string clientId = Require(configuration, "MicrosoftEntra:ClientId");
+        string clientSecret = Require(configuration, "Connections:BotServiceConnection:Settings:ClientSecret");
+
+        // ".default" requests every application permission already consented for this
+        // client, which is exactly the app role granted on the API registration.
+        string apiScope = configuration["TeamsBot:ApiScope"]
+            ?? throw new InvalidOperationException(
+                "TeamsBot:ApiScope is required so the bot can request a token for the Retail Pulse API.");
+
+        _scopes = [apiScope];
+
+        _app = ConfidentialClientApplicationBuilder.Create(clientId)
+            .WithClientSecret(clientSecret)
+            .WithAuthority($"https://login.microsoftonline.com/{tenantId}")
+            .Build();
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            AuthenticationResult result = await _app
+                .AcquireTokenForClient(_scopes)
+                .ExecuteAsync(cancellationToken);
+
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(
+                "Bearer", result.AccessToken);
+        }
+        catch (MsalException ex)
+        {
+            // Let the request proceed unauthenticated so the API's own 401 surfaces in the
+            // logs alongside this, rather than masking a config problem as a transport fault.
+            _logger.LogError(ex, "Could not acquire an API access token for scope {Scope}", _scopes[0]);
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+
+    private static string Require(IConfiguration configuration, string key) =>
+        configuration[key] ?? throw new InvalidOperationException(
+            $"'{key}' is required for the Teams bot to authenticate to the Retail Pulse API.");
+}

--- a/src/RetailPulse.TeamsBot/Program.cs
+++ b/src/RetailPulse.TeamsBot/Program.cs
@@ -42,11 +42,20 @@ string apiBaseUrl = builder.Configuration["services:api:https:0"]
         "Configure 'TeamsBot:ApiBaseUrl' or run under Aspire.");
 
 // HttpClient for calling RetailPulse API via Aspire service discovery or explicit deployment URL
-builder.Services.AddHttpClient("RetailPulseApi", client =>
+IHttpClientBuilder apiClientBuilder = builder.Services.AddHttpClient("RetailPulseApi", client =>
 {
     client.BaseAddress = new Uri(apiBaseUrl);
     client.DefaultRequestHeaders.Add("Accept", "application/json");
 });
+
+// The API is deny-by-default, so an unauthenticated call returns 401 and the user sees a
+// generic error card. Attach an app-only token whenever the bot is configured to have one.
+// Development keeps the bare client so the local loop still works against a dev-auth API.
+if (!string.IsNullOrEmpty(builder.Configuration["TeamsBot:ApiScope"]))
+{
+    builder.Services.AddTransient<ApiTokenHandler>();
+    apiClientBuilder.AddHttpMessageHandler<ApiTokenHandler>();
+}
 
 // SignalR client for telemetry hub via Aspire service discovery
 builder.Services.AddSingleton(sp =>


### PR DESCRIPTION
The bot called the API with a bare `HttpClient` and **no credential**, so every turn ended in `401 Unauthorized` and the user got a generic error card. Confirmed against the live deployment through a real Direct Line conversation:

```
POST https://ca-retailpulse-api.../api/chat
Received HTTP response headers after 101ms - 401
System.Net.Http.HttpRequestException: Response status code does not indicate success: 401 (Unauthorized).
```

## Approach

The API's authorization policy is deny-by-default and **already** supported app-only callers behind an explicit opt-in plus a client-id allow-list. Nothing about that policy is loosened here — the bot simply starts satisfying it.

**Client credentials rather than on-behalf-of**, deliberately: there is no user token to exchange on a channel-initiated or proactive turn, and this authorises the bot as a *named service principal* rather than impersonating whoever happens to be typing. User attribution still travels in the request body, where the API treats it as data rather than as an authorization signal.

MSAL caches in memory and refreshes ahead of expiry, so this acquires once per token lifetime, not per request.

## Security posture

- `AllowAppOnlyTokens` turns on **only** when a bot is configured.
- `AllowedAppClientIds` is pinned to the bot's client id — this allow-list is what stops the change widening the API to any app-only token in the tenant.
- The `RetailPulse.User` app role is still required; the role assignment was granted to the bot's service principal.
- Token acquisition failures log and let the request proceed, so the API's own 401 surfaces alongside rather than masking a config problem as a transport fault.

## Also fixed

`MicrosoftEntra__TenantId` / `ClientId` were missing, so the Teams SSO handler threw `MicrosoftEntra:TenantId is required in non-development environments` on the first turn — the bot authenticated the channel correctly and then failed anyway.

## Verification

`dotnet test`: 3494 passed / 0 failed. `dotnet format --verify-no-changes`: exit 0. Bicep compiles.
