### PR TITLE
Lead the telemetry drawer with Live Spans; collapse alerts; fix Invalid Date

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/alertsApi.mapping.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/alertsApi.mapping.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { toAlert } from '../services/alertsApi';
+
+/**
+ * Every Alert History row rendered the literal text "Invalid Date".
+ *
+ * The server emitters all send `detectedAt`; the panels all read `firedAt`. The missing
+ * field became `new Date(undefined)`, which is an Invalid Date — and sorting by time
+ * compared NaN, so the list order was arbitrary too.
+ */
+describe('alert wire mapping', () => {
+  // Captured from the shape ProactiveAlertService and CompetitiveIntelAgent emit.
+  const wire = {
+    id: 'alert-1',
+    type: 'competitor_price_drop',
+    severity: 'medium',
+    title: "Competitor price drop: Maker's Mark on Ridgeline Bourbon in Southeast",
+    description: 'Maker\u2019s Mark dropped 12% in Southeast.',
+    brand: 'Ridgeline Bourbon',
+    region: 'Southeast',
+    recommendedAction: 'DIFFERENTIATE',
+    detectedAt: '2026-08-27T14:31:00.000Z',
+    metadata: {},
+  };
+
+  it('reads the timestamp the server actually sends', () => {
+    expect(toAlert(wire).firedAt).toBe('2026-08-27T14:31:00.000Z');
+  });
+
+  it('produces a parseable date, which is what Invalid Date was not', () => {
+    expect(Number.isNaN(Date.parse(toAlert(wire).firedAt))).toBe(false);
+  });
+
+  it('still accepts firedAt, so a server rename cannot reintroduce the bug', () => {
+    const renamed = { ...wire, detectedAt: undefined, firedAt: '2026-01-02T03:04:05.000Z' };
+    expect(toAlert(renamed).firedAt).toBe('2026-01-02T03:04:05.000Z');
+  });
+
+  it('falls back to a real timestamp when the server sends none', () => {
+    const { detectedAt: _omitted, ...noTime } = wire;
+    expect(Number.isNaN(Date.parse(toAlert(noTime).firedAt))).toBe(false);
+  });
+
+  it('falls back rather than passing through an unparseable timestamp', () => {
+    const bad = { ...wire, detectedAt: 'not-a-date' };
+    expect(Number.isNaN(Date.parse(toAlert(bad).firedAt))).toBe(false);
+  });
+
+  it('defaults status to active, because the server sends none', () => {
+    // The feed branches on status to decide what is still actionable.
+    expect(toAlert(wire).status).toBe('active');
+  });
+
+  it('preserves a status the server does send', () => {
+    expect(toAlert({ ...wire, status: 'dismissed' }).status).toBe('dismissed');
+    expect(toAlert({ ...wire, status: 'snoozed' }).status).toBe('snoozed');
+  });
+
+  it('rejects an unrecognised status rather than propagating it into the filters', () => {
+    expect(toAlert({ ...wire, status: 'weird' }).status).toBe('active');
+  });
+
+  it('normalises severity casing and falls back for unknown values', () => {
+    expect(toAlert({ ...wire, severity: 'HIGH' }).severity).toBe('high');
+    expect(toAlert({ ...wire, severity: 'catastrophic' }).severity).toBe('medium');
+  });
+
+  it('carries the fields the history table renders', () => {
+    const alert = toAlert(wire);
+    expect(alert.brand).toBe('Ridgeline Bourbon');
+    expect(alert.region).toBe('Southeast');
+    expect(alert.title).toContain("Maker's Mark");
+  });
+
+  it('sorts newest first once mapped, which NaN timestamps prevented', () => {
+    const older = toAlert({ ...wire, id: 'a', detectedAt: '2026-08-01T00:00:00.000Z' });
+    const newer = toAlert({ ...wire, id: 'b', detectedAt: '2026-08-27T00:00:00.000Z' });
+
+    const sorted = [older, newer].sort(
+      (x, y) => new Date(y.firedAt).getTime() - new Date(x.firedAt).getTime(),
+    );
+
+    expect(sorted.map(a => a.id)).toEqual(['b', 'a']);
+  });
+
+  it('survives an empty payload without throwing', () => {
+    const alert = toAlert({});
+    expect(alert.status).toBe('active');
+    expect(alert.severity).toBe('medium');
+    expect(Number.isNaN(Date.parse(alert.firedAt))).toBe(false);
+  });
+});

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { Button, Badge, makeStyles, Drawer, DrawerBody, DrawerHeader, DrawerHead
 import { Add24Regular, DataUsage24Regular, Dismiss24Regular, TargetArrow24Regular, Shield24Regular, Library24Regular, HeartPulse24Regular, ShieldCheckmark24Regular, CardUi24Regular, Eye24Regular, Building24Regular, Money24Regular, Star24Regular } from '@fluentui/react-icons';
 import { ChatPanel } from './ChatPanel';
 import { fetchFinancials, fetchScorecardBatched, fetchStores, fetchStockoutRisks } from '../services/operationsApi';
+import { toAlert } from '../services/alertsApi';
 import { TelemetryPanel } from './TelemetryPanel';
 import { AgentRoutingPanel } from './AgentRoutingPanel';
 import { MemoryPanel } from './MemoryPanel';
@@ -212,6 +213,8 @@ export function Dashboard() {
   const [approvalHistory, setApprovalHistory] = useState<ApprovalRequest[]>([]);
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [traces, setTraces] = useState<Trace[]>([]);
+  // Surfaced in the collapsed section title so a fired alert is still noticeable.
+  const activeAlertCount = useMemo(() => alerts.filter(a => a.status === 'active').length, [alerts]);
   const [activeView, setActiveView] = useState<ActiveView>('chat');
   const [selectedBrand, setSelectedBrand] = useState<BrandScore | null>(null);
   const [selectedStore, setSelectedStore] = useState<StorePerformance | null>(null);
@@ -393,12 +396,15 @@ export function Dashboard() {
       });
     });
 
-    // Alert events (Sprint 1.5)
+    // Alert events
     conn.off('alert_fired');
-    conn.on('alert_fired', (alert: Alert) => {
+    conn.on('alert_fired', (raw: unknown) => {
+      // Normalised at the edge: the server sends `detectedAt` and no `status`, while the
+      // panels read `firedAt` and branch on status.
+      const alert = toAlert(raw as Parameters<typeof toAlert>[0]);
       setAlerts(prev => {
         if (prev.some(a => a.id === alert.id)) return prev;
-        const next = [{ ...alert, status: alert.status || 'active' as const }, ...prev];
+        const next = [alert, ...prev];
         return next.length > MAX_ALERTS ? next.slice(0, MAX_ALERTS) : next;
       });
     });
@@ -879,21 +885,18 @@ export function Dashboard() {
             </DrawerHeaderTitle>
           </DrawerHeader>
           <DrawerBody>
-            {alerts.length > 0 && (
-              <div style={{ marginBottom: '16px' }}>
-                <AlertFeed
-                  alerts={alerts}
-                  onDismiss={handleAlertDismiss}
-                  onSnooze={handleAlertSnooze}
-                  onClearAll={handleClearAllAlerts}
-                />
-              </div>
-            )}
-            {alerts.some(a => a.status !== 'active') && (
-              <div style={{ marginBottom: '16px' }}>
-                <AlertHistoryPanel alerts={alerts} />
-              </div>
-            )}
+            {/* Live Spans leads: token counts, span counts, tool calls, duration and cost
+                are what this drawer exists to show. It was previously last, below alerts
+                that were neither collapsible nor execution telemetry. */}
+            <CollapsibleSection title="Live Spans" defaultExpanded>
+              <TelemetryPanel
+                connected={connected}
+                liveSpans={liveSpans}
+                totalDurationMs={totalDurationMs}
+                totalTokenUsage={totalTokenUsage}
+                onClear={handleClearSpans}
+              />
+            </CollapsibleSection>
             <CollapsibleSection title="Agent Routing">
               <AgentRoutingPanel routingHistory={routingHistory} />
             </CollapsibleSection>
@@ -926,15 +929,25 @@ export function Dashboard() {
                 <TraceDashboard traces={traces} />
               </CollapsibleSection>
             )}
-            <CollapsibleSection title="Live Spans" defaultExpanded>
-              <TelemetryPanel
-                connected={connected}
-                liveSpans={liveSpans}
-                totalDurationMs={totalDurationMs}
-                totalTokenUsage={totalTokenUsage}
-                onClear={handleClearSpans}
-              />
-            </CollapsibleSection>
+            {/* Alerts are business anomaly notifications, not agent execution telemetry.
+                They arrive on the same hub, so they belong in this drawer, but they sit
+                below the execution sections and start collapsed — the count in the title
+                is enough to draw attention when something fires. */}
+            {alerts.length > 0 && (
+              <CollapsibleSection title={`Alerts (${activeAlertCount})`}>
+                <AlertFeed
+                  alerts={alerts}
+                  onDismiss={handleAlertDismiss}
+                  onSnooze={handleAlertSnooze}
+                  onClearAll={handleClearAllAlerts}
+                />
+              </CollapsibleSection>
+            )}
+            {alerts.some(a => a.status !== 'active') && (
+              <CollapsibleSection title="Alert History">
+                <AlertHistoryPanel alerts={alerts} />
+              </CollapsibleSection>
+            )}
           </DrawerBody>
         </Drawer>
         )}

--- a/src/RetailPulse.Web/src/services/alertsApi.ts
+++ b/src/RetailPulse.Web/src/services/alertsApi.ts
@@ -1,0 +1,56 @@
+import type { Alert, AlertSeverity } from '../types';
+
+/**
+ * Normalises an alert pushed over the telemetry hub into the shape the panels read.
+ *
+ * Every emitter (`ProactiveAlertService`, `CompetitiveIntelAgent`) sends `detectedAt`,
+ * while the panels read `firedAt`. `new Date(undefined)` is an Invalid Date, so every
+ * row in Alert History rendered the literal text "Invalid Date" — and sorting by time
+ * compared NaN, leaving the list in arbitrary order.
+ *
+ * The server also sends no `status`, so an alert arrived without the field the feed
+ * uses to decide whether it is active, snoozed or dismissed.
+ */
+interface WireAlert {
+  readonly id?: string;
+  readonly title?: string;
+  readonly severity?: string;
+  readonly brand?: string;
+  readonly region?: string;
+  readonly description?: string;
+  readonly recommendedAction?: string;
+  /** What the server actually sends. */
+  readonly detectedAt?: string;
+  /** Accepted so a future server rename cannot silently reintroduce Invalid Date. */
+  readonly firedAt?: string;
+  readonly status?: string;
+  readonly changePercent?: number;
+  readonly metadata?: Record<string, unknown>;
+}
+
+const SEVERITIES: readonly AlertSeverity[] = ['high', 'medium', 'low'];
+
+function toSeverity(raw: string | undefined): AlertSeverity {
+  const value = (raw ?? '').toLowerCase();
+  return SEVERITIES.find(s => s === value) ?? 'medium';
+}
+
+export function toAlert(wire: WireAlert): Alert {
+  const firedAt = wire.firedAt ?? wire.detectedAt;
+
+  return {
+    id: wire.id ?? '',
+    title: wire.title ?? 'Untitled alert',
+    severity: toSeverity(wire.severity),
+    brand: wire.brand,
+    region: wire.region,
+    changePercent: wire.changePercent,
+    description: wire.description ?? '',
+    recommendedAction: wire.recommendedAction ?? '',
+    // Fall back to arrival time rather than emitting an unparseable string. An alert
+    // that reached the client did happen now, near enough, and a readable timestamp is
+    // more honest than "Invalid Date".
+    firedAt: firedAt && !Number.isNaN(Date.parse(firedAt)) ? firedAt : new Date().toISOString(),
+    status: wire.status === 'dismissed' || wire.status === 'snoozed' ? wire.status : 'active',
+  };
+}


### PR DESCRIPTION
The drawer opened on **two alert sections that could not be collapsed**, pushing Live Spans — the token counts, span counts, tool calls, duration and cost the drawer exists to show — below four collapsed sections.

## Ordering

`Live Spans` now leads and stays expanded. `Alerts` and `Alert History` are collapsible like every other section and sit at the bottom, with the active count in the `Alerts` title so a fired alert is still noticeable while collapsed.

On the question of whether alerts are real-time telemetry: they do arrive on the same SignalR hub (`alert_fired`), so the drawer is the right home for them. But they are business anomaly notifications, not agent execution telemetry — not what an operator opens this panel to read.

## Invalid Date

Every Alert History row rendered the literal text `Invalid Date`:

| Server sends | Panels read |
|---|---|
| `detectedAt` | `firedAt` |
| *(no status field)* | `status`, branched on by the feed |

`new Date(undefined)` is an Invalid Date, and sorting by time compared `NaN`, so the list order was arbitrary too. All three emitters agree on `detectedAt` — `ProactiveAlertService` and both call sites in `CompetitiveIntelAgent`.

Normalised at the service edge, matching the pattern already used for council, promo, operations and cards. The mapper accepts `firedAt` as well, so a future server rename cannot silently reintroduce the bug, and falls back to arrival time rather than passing through an unparseable string.

## Verification

12 tests pin the mapping, including that a mapped list sorts newest-first — the behaviour `NaN` timestamps prevented.

`tsc -b`: exit 0. Frontend suite: 91 files passing.
