### PR TITLE
Load alerts from the server instead of only from live hub events

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/alertsApi.mapping.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/alertsApi.mapping.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { toAlert } from '../services/alertsApi';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { toAlert, fetchAlerts } from '../services/alertsApi';
 
 /**
  * Every Alert History row rendered the literal text "Invalid Date".
@@ -88,5 +88,70 @@ describe('alert wire mapping', () => {
     expect(alert.status).toBe('active');
     expect(alert.severity).toBe('medium');
     expect(Number.isNaN(Date.parse(alert.firedAt))).toBe(false);
+  });
+});
+
+describe('alert seeding from the server', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns an empty list rather than rejecting when the request fails', async () => {
+    // Seeding is best-effort: a failed snapshot must not break the drawer or suppress
+    // the live hub events, which are the primary source. An unhandled rejection here
+    // took the whole panel down.
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to parse URL'));
+
+    await expect(fetchAlerts()).resolves.toEqual([]);
+  });
+
+  it('returns an empty list on a non-OK response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 503 } as Response);
+
+    await expect(fetchAlerts()).resolves.toEqual([]);
+  });
+
+  it('marks active and historical alerts from the endpoint that answered', async () => {
+    // The server's Alert record has no status field at all.
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(
+        String(url).includes('/active')
+          ? [{ id: 'live', title: 'Live', detectedAt: '2026-08-27T10:00:00.000Z' }]
+          : [{ id: 'old', title: 'Old', detectedAt: '2026-08-01T10:00:00.000Z' }],
+      ),
+    } as Response));
+
+    const alerts = await fetchAlerts();
+    expect(alerts.find(a => a.id === 'live')?.status).toBe('active');
+    expect(alerts.find(a => a.id === 'old')?.status).toBe('dismissed');
+  });
+
+  it('keeps the active reading when an alert appears in both responses', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve([{ id: 'dup', title: 'Dup', detectedAt: '2026-08-27T10:00:00.000Z' }]),
+    } as Response));
+
+    const alerts = await fetchAlerts();
+    expect(alerts).toHaveLength(1);
+    // Otherwise request ordering could demote a live alert into history.
+    expect(alerts[0].status).toBe('active');
+  });
+
+  it('returns newest first', async () => {
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(
+        String(url).includes('/active')
+          ? [{ id: 'newer', detectedAt: '2026-08-27T10:00:00.000Z' }]
+          : [{ id: 'older', detectedAt: '2026-08-01T10:00:00.000Z' }],
+      ),
+    } as Response));
+
+    expect((await fetchAlerts()).map(a => a.id)).toEqual(['newer', 'older']);
   });
 });

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -4,7 +4,7 @@ import { Button, Badge, makeStyles, Drawer, DrawerBody, DrawerHeader, DrawerHead
 import { Add24Regular, DataUsage24Regular, Dismiss24Regular, TargetArrow24Regular, Shield24Regular, Library24Regular, HeartPulse24Regular, ShieldCheckmark24Regular, CardUi24Regular, Eye24Regular, Building24Regular, Money24Regular, Star24Regular } from '@fluentui/react-icons';
 import { ChatPanel } from './ChatPanel';
 import { fetchFinancials, fetchScorecardBatched, fetchStores, fetchStockoutRisks } from '../services/operationsApi';
-import { toAlert } from '../services/alertsApi';
+import { toAlert, fetchAlerts } from '../services/alertsApi';
 import { TelemetryPanel } from './TelemetryPanel';
 import { AgentRoutingPanel } from './AgentRoutingPanel';
 import { MemoryPanel } from './MemoryPanel';
@@ -215,6 +215,25 @@ export function Dashboard() {
   const [traces, setTraces] = useState<Trace[]>([]);
   // Surfaced in the collapsed section title so a fired alert is still noticeable.
   const activeAlertCount = useMemo(() => alerts.filter(a => a.status === 'active').length, [alerts]);
+
+  // Seed from the server. Alerts previously existed only in this tab's memory, so a
+  // refresh discarded every one of them and Alert History could only ever show what
+  // fired while the tab happened to be open. Live hub events merge on top of this.
+  useEffect(() => {
+    if (!capabilities.alternateViews) return;
+    let cancelled = false;
+    void (async () => {
+      const loaded = await fetchAlerts();
+      if (cancelled || loaded.length === 0) return;
+      setAlerts(prev => {
+        const byId = new Map(loaded.map(a => [a.id, a]));
+        // Anything already held from a live event is more current than the snapshot.
+        for (const alert of prev) byId.set(alert.id, alert);
+        return [...byId.values()].slice(0, MAX_ALERTS);
+      });
+    })();
+    return () => { cancelled = true; };
+  }, []);
   const [activeView, setActiveView] = useState<ActiveView>('chat');
   const [selectedBrand, setSelectedBrand] = useState<BrandScore | null>(null);
   const [selectedStore, setSelectedStore] = useState<StorePerformance | null>(null);

--- a/src/RetailPulse.Web/src/services/alertsApi.ts
+++ b/src/RetailPulse.Web/src/services/alertsApi.ts
@@ -1,3 +1,4 @@
+import { resolveApiUrl } from '../config/apiOrigin';
 import type { Alert, AlertSeverity } from '../types';
 
 /**
@@ -53,4 +54,38 @@ export function toAlert(wire: WireAlert): Alert {
     firedAt: firedAt && !Number.isNaN(Date.parse(firedAt)) ? firedAt : new Date().toISOString(),
     status: wire.status === 'dismissed' || wire.status === 'snoozed' ? wire.status : 'active',
   };
+}
+
+/**
+ * Loads the alerts the server already knows about.
+ *
+ * The SPA only ever populated alerts from the live hub event, so refreshing the page
+ * discarded every alert even though the server still held it, and Alert History could
+ * only show what happened to fire while that browser tab was open.
+ *
+ * The server's Alert record carries no status field — active and historical are decided
+ * by which endpoint answers — so the status is set from the source here.
+ */
+async function getAlerts(path: string, status: Alert['status']): Promise<Alert[]> {
+  const res = await fetch(resolveApiUrl(path));
+  if (!res.ok) return [];
+  const wire = (await res.json()) as WireAlert[];
+  return wire.map(w => ({ ...toAlert(w), status }));
+}
+
+export async function fetchAlerts(historyLimit = 50): Promise<Alert[]> {
+  const [active, history] = await Promise.all([
+    getAlerts('/api/alerts/active', 'active'),
+    getAlerts(`/api/alerts/history?limit=${historyLimit}`, 'dismissed'),
+  ]);
+
+  // An alert can appear in both responses; the active reading wins so a live alert is
+  // never demoted into history by the order the two requests happen to resolve in.
+  const byId = new Map<string, Alert>();
+  for (const alert of history) byId.set(alert.id, alert);
+  for (const alert of active) byId.set(alert.id, alert);
+
+  return [...byId.values()].sort(
+    (a, b) => new Date(b.firedAt).getTime() - new Date(a.firedAt).getTime(),
+  );
 }

--- a/src/RetailPulse.Web/src/services/alertsApi.ts
+++ b/src/RetailPulse.Web/src/services/alertsApi.ts
@@ -67,10 +67,16 @@ export function toAlert(wire: WireAlert): Alert {
  * by which endpoint answers — so the status is set from the source here.
  */
 async function getAlerts(path: string, status: Alert['status']): Promise<Alert[]> {
-  const res = await fetch(resolveApiUrl(path));
-  if (!res.ok) return [];
-  const wire = (await res.json()) as WireAlert[];
-  return wire.map(w => ({ ...toAlert(w), status }));
+  try {
+    const res = await fetch(resolveApiUrl(path));
+    if (!res.ok) return [];
+    const wire = (await res.json()) as WireAlert[];
+    return wire.map(w => ({ ...toAlert(w), status }));
+  } catch {
+    // Seeding is best-effort. A failed snapshot must not break the drawer or suppress
+    // the live hub events, which are the primary source.
+    return [];
+  }
 }
 
 export async function fetchAlerts(historyLimit = 50): Promise<Alert[]> {
@@ -78,7 +84,6 @@ export async function fetchAlerts(historyLimit = 50): Promise<Alert[]> {
     getAlerts('/api/alerts/active', 'active'),
     getAlerts(`/api/alerts/history?limit=${historyLimit}`, 'dismissed'),
   ]);
-
   // An alert can appear in both responses; the active reading wins so a live alert is
   // never demoted into history by the order the two requests happen to resolve in.
   const byId = new Map<string, Alert>();


### PR DESCRIPTION
Found while verifying the drawer reordering: I could not get an alert to appear, and the reason turned out to be broader than a missing test fixture.

The SPA **never called** \/api/alerts/active\ or \/api/alerts/history\ — a repo-wide search for \pi/alerts\ in the frontend returns nothing. Alerts existed solely in the tab's memory, populated by the SignalR \lert_fired\ event. So:

- A page refresh discarded every alert, while the server still held them.
- Alert History could only ever show what happened to fire while that tab was open.
- Opening the app after an alert fired showed nothing at all.

Both endpoints are now seeded on mount, with live events merging on top — anything already held from a live event wins over the snapshot, so a live alert is never demoted into history by request ordering.

The server's \Alert\ record carries **no status field**; active and historical are distinguished by which endpoint answers. Status is therefore set from the source rather than inferred from the payload.

Frontend suite: 91 files, 820 tests passing.