### PR TITLE
Keep the API and MCP server warm so prod stops looking broken

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -55,6 +55,9 @@ param botAppId string = ''
 @description('Client secret for the bot app registration. Set with `azd env set AZURE_BOT_APP_SECRET <secret>`; stored as a Container Apps secret, never in the template.')
 @secure()
 param botAppSecret string = ''
+
+@description('Keep one replica of the API and MCP server always running. Scale-to-zero makes the first request after an idle period look like an outage. Set false with `azd env set AZURE_ALWAYS_WARM false` for a cost-optimised, non-customer-facing environment.')
+param alwaysWarm bool = true
 @description('Enable the optional Azure AI Search knowledge provider. Disabled by default; no Search resource is provisioned when false.')
 param aiSearchEnabled bool = false
 
@@ -162,6 +165,7 @@ module containerApps './modules/container-apps.bicep' = {
     contentSafetyEndpoint: contentSafetyEnabled ? contentSafety!.outputs.endpoint : ''
     botAppId: botAppId
     botAppSecret: botAppSecret
+    alwaysWarm: alwaysWarm
   }
 }
 

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -42,3 +42,7 @@ param aiSearchEnabled = toLower(readEnvironmentVariable('AZURE_AI_SEARCH_ENABLED
 //   azd env set AZURE_BOT_APP_SECRET <secret>
 param botAppId = readEnvironmentVariable('AZURE_BOT_APP_ID', '')
 param botAppSecret = readEnvironmentVariable('AZURE_BOT_APP_SECRET', '')
+
+// Keep the API and MCP server warm. Defaults true so the demo never greets a
+// visitor with a cold start. Set false to save money on a non-demo environment.
+param alwaysWarm = toLower(readEnvironmentVariable('AZURE_ALWAYS_WARM', 'true')) == 'true'

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -64,6 +64,9 @@ param botAppSecret string = ''
 @description('Tenant that owns the bot app registration. Defaults to the deploying tenant.')
 param botTenantId string = tenant().tenantId
 
+@description('Keep one replica of the API and MCP server always running. Scale-to-zero saves money while idle, but the first request after an idle period pays a cold start during which SignalR cannot connect and chat appears to hang — indistinguishable from an outage to anyone looking at the screen. Set false for a cost-optimised environment that is not customer-facing.')
+param alwaysWarm bool = true
+
 var apimSubscriptionKeySecretName = 'apim-sub-key'
 var mcpApiKeySecretName = 'mcp-api-key'
 var botAppSecretName = 'bot-app-secret'
@@ -157,7 +160,10 @@ resource mcpServer 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        minReplicas: 0
+        // A cold start blocks SignalR and stalls the first chat, which reads as an
+        // outage rather than a scale event. The MCP server matters as much as the API:
+        // a warm API still stalls on its first tool call if MCP is cold.
+        minReplicas: alwaysWarm ? 1 : 0
         maxReplicas: 1
       }
     }
@@ -384,7 +390,10 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       // GitHub:AcknowledgeSingleReplica=true fail-closed acknowledgement of this pin. See
       // docs/adr/005 and docs/security.md.
       scale: {
-        minReplicas: 0
+        // A cold start blocks SignalR and stalls the first chat, which reads as an
+        // outage rather than a scale event. The MCP server matters as much as the API:
+        // a warm API still stalls on its first tool call if MCP is cold.
+        minReplicas: alwaysWarm ? 1 : 0
         maxReplicas: 1
       }
     }

--- a/tests/RetailPulse.Tests/Security/ContainerAppScaleContractTests.cs
+++ b/tests/RetailPulse.Tests/Security/ContainerAppScaleContractTests.cs
@@ -1,0 +1,110 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+
+namespace RetailPulse.Tests.Security;
+
+/// <summary>
+/// Deployment-contract coverage over the scale settings in
+/// <c>infra/modules/container-apps.bicep</c>.
+/// </summary>
+/// <remarks>
+/// The API and MCP server were deployed with <c>minReplicas: 0</c>. After an idle period
+/// the first visitor paid a cold start: the container app controller logged twenty
+/// consecutive <c>startup probe failed: connection refused</c> events over twenty seconds,
+/// during which SignalR could not connect (the telemetry pill read "Off") and the first
+/// chat hung on "Thinking...". That is indistinguishable from an outage to anyone looking
+/// at the screen, and it is the first thing a visitor sees.
+///
+/// A warm replica is a cost decision, so it stays configurable — but the default has to be
+/// the one that does not look broken. No unit test could catch this; the behaviour lives
+/// entirely in the deployment manifest.
+/// </remarks>
+public sealed partial class ContainerAppScaleContractTests
+{
+    [GeneratedRegex(@"minReplicas:\s*(?<value>[^\r\n]+)")]
+    private static partial Regex MinReplicasAssignment();
+
+    [GeneratedRegex(@"param\s+alwaysWarm\s+bool\s*=\s*(?<value>true|false)")]
+    private static partial Regex AlwaysWarmDefault();
+
+    private static string ReadBicep(string relativePath)
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "RetailPulse.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("the repository root must be discoverable from the test output directory");
+        string path = Path.Combine(directory.FullName, relativePath);
+        File.Exists(path).Should().BeTrue($"{relativePath} must exist");
+
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void ApiAndMcp_AreWarmByDefault_NotPinnedToZero()
+    {
+        string bicep = ReadBicep(Path.Combine("infra", "modules", "container-apps.bicep"));
+
+        IReadOnlyList<string> values = [.. MinReplicasAssignment()
+            .Matches(bicep)
+            .Select(m => m.Groups["value"].Value.Trim())];
+
+        values.Should().NotBeEmpty("the container apps must declare a scale floor");
+
+        // A bare `minReplicas: 0` is the regression: it hardcodes scale-to-zero with no
+        // way to keep a customer-facing environment warm.
+        values.Should().NotContain(
+            "0",
+            "a hardcoded scale floor of zero makes the first request after idle look like an outage");
+    }
+
+    [Fact]
+    public void WarmReplicas_RemainConfigurable()
+    {
+        string bicep = ReadBicep(Path.Combine("infra", "modules", "container-apps.bicep"));
+
+        // Keeping replicas warm costs money continuously, so an operator running a
+        // non-customer-facing environment must be able to opt out.
+        bicep.Should().Contain(
+            "alwaysWarm",
+            "the scale floor must stay configurable rather than being pinned warm");
+    }
+
+    [Fact]
+    public void WarmReplicas_DefaultToOn()
+    {
+        string main = ReadBicep(Path.Combine("infra", "main.bicep"));
+
+        Match match = AlwaysWarmDefault().Match(main);
+
+        match.Success.Should().BeTrue("main.bicep must declare the alwaysWarm parameter");
+        match.Groups["value"].Value.Should().Be(
+            "true",
+            "the default has to be the setting that does not greet a visitor with a cold start");
+    }
+
+    [Fact]
+    public void TeamsBot_StaysWarm_WhenABotIsConfigured()
+    {
+        string bicep = ReadBicep(Path.Combine("infra", "modules", "container-apps.bicep"));
+
+        // The Bot Framework retries a cold-start timeout, but a scale-to-zero bot drops
+        // the first message of a conversation often enough to look broken.
+        bicep.Should().Contain(
+            "minReplicas: botConfigured ? 1 : 0",
+            "a configured bot must keep a warm replica, while an unconfigured one costs nothing");
+    }
+
+    [Fact]
+    public void AlwaysWarm_IsReadableFromTheEnvironment()
+    {
+        string bicepparam = ReadBicep(Path.Combine("infra", "main.bicepparam"));
+
+        bicepparam.Should().Contain(
+            "AZURE_ALWAYS_WARM",
+            "an operator must be able to opt out with azd env set, without editing the template");
+    }
+}


### PR DESCRIPTION
Prod was not broken — it was **cold-starting**, which looks identical from the browser.

## Evidence

The container app controller logged, at exactly the moment of the report:

```
2026-08-28 16:55:48 UTC  startup probe failed: connection refused   Count: 11
2026-08-28 16:55:49 UTC  startup probe failed: connection refused   Count: 12
...
2026-08-28 16:55:57 UTC  startup probe failed: connection refused   Count: 20
```

That is 12:55:48–12:55:57 EDT. During that window SignalR cannot connect (the telemetry pill reads **Off**) and the first chat hangs on **Thinking…**. Once warm, the same question answered in ~3 seconds.

## Cause

`ca-retailpulse-api` and `ca-retailpulse-mcp` were both pinned to `minReplicas: 0`. After an idle period the first visitor pays the full container start — and that visitor is, by definition, seeing the demo for the first time.

The MCP server matters as much as the API: a warm API still stalls on its first tool call if MCP is cold.

## Change

`alwaysWarm` keeps one replica of each running. It defaults to **true**, because the default has to be the setting that does not look like an outage. Keeping replicas warm costs money continuously, so an operator running a non-customer-facing environment can opt out with `azd env set AZURE_ALWAYS_WARM false`.

The Teams bot was already pinned warm for the same reason when a bot is configured.

## Verification

Five deployment-contract tests, in the same style as the existing container-app contract coverage: no hardcoded zero floor, the setting stays configurable, the default is on, the bot keeps its conditional warm replica, and the environment override is wired. No unit test could have caught this — the behaviour lives entirely in the deployment manifest.

`dotnet test`: 3499 passed / 0 failed. `dotnet format --verify-no-changes`: exit 0. Bicep compiles.
