### PR TITLE
Stop caching answers that failed to satisfy the request

### DIFF
--- a/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/ChatEndpoints.cs
@@ -9,6 +9,7 @@ using RetailPulse.Api.Agents.Planning;
 using RetailPulse.Api.Agents.Routing;
 using RetailPulse.Api.Auth;
 using RetailPulse.Api.Cards;
+using RetailPulse.Api.Charts;
 using RetailPulse.Api.Configuration;
 using RetailPulse.Api.Consensus;
 using RetailPulse.Api.Guardrails;
@@ -909,7 +910,21 @@ public static class ChatEndpoints
                 response = response with { Routing = isErrorResponse ? null : routingInfo };
 
                 // ── Cache: store response for deterministic queries ──────────────
-                if (!cacheDisabled && CacheHelpers.IsCacheable(request.Message))
+                //
+                // Only a response that actually satisfied the request is cacheable. A
+                // degraded answer used to be stored and replayed for the full TTL, which
+                // turned one transient model wobble into a prompt that failed identically
+                // for every subsequent visitor — observed live as a curated chart prompt
+                // returning "Chart unavailable" on a cache.hit span with no tool calls at
+                // all. Failing once is a model problem; failing repeatably from cache is
+                // ours.
+                if (!cacheDisabled
+                    && CacheHelpers.IsCacheable(request.Message)
+                    && CacheHelpers.IsCacheableOutcome(
+                        response.Reply,
+                        response.Charts?.Count ?? 0,
+                        isErrorResponse,
+                        ChartRequestDetector.Detect(request.Message).IsExplicitChartRequest))
                 {
                     string cacheKey = CacheHelpers.BuildCacheKey("pre-route", request.Message);
                     await responseCache.SetAsync(cacheKey,
@@ -919,8 +934,8 @@ public static class ChatEndpoints
                             DateTime.UtcNow,
                             cacheKey,
                             // Charts and routing travel with the reply so a hit replays the
-                            // whole answer (issue #170). Copy the list — the cache must not
-                            // alias a collection the pipeline may still mutate.
+                            // whole answer. Copy the list — the cache must not alias a
+                            // collection the pipeline may still mutate.
                             response.Charts is { Count: > 0 } c ? [.. c] : null,
                             response.Routing),
                         TimeSpan.FromMinutes(5), ct);

--- a/src/RetailPulse.Api/Middleware/StreamingMiddleware.cs
+++ b/src/RetailPulse.Api/Middleware/StreamingMiddleware.cs
@@ -211,4 +211,34 @@ public static partial class CacheHelpers
         string lower = query.ToLowerInvariant();
         return !_nonDeterministicKeywords.Any(kw => lower.Contains(kw));
     }
+
+    /// <summary>
+    /// Returns true when a produced answer is good enough to serve to somebody else.
+    /// </summary>
+    /// <remarks>
+    /// A cacheable QUESTION is not the same thing as a cacheable ANSWER. Responses were
+    /// stored unconditionally, so a degraded reply was replayed for the full TTL and one
+    /// transient model wobble became a prompt that failed identically for every later
+    /// visitor. Observed live: a curated chart prompt returning "Chart unavailable" on a
+    /// <c>cache.hit</c> span with no tool calls at all.
+    ///
+    /// Two things disqualify an answer:
+    /// <list type="bullet">
+    ///   <item>The pipeline flagged it as an error (a ⏳ or ⚠️ prefixed reply).</item>
+    ///   <item>The reply narrates a chart it did not actually produce. A request that
+    ///     asked for a chart and came back with none is a failure worth retrying, not a
+    ///     result worth keeping.</item>
+    /// </list>
+    /// </remarks>
+    public static bool IsCacheableOutcome(string reply, int chartCount, bool isErrorResponse, bool chartWasRequested)
+    {
+        if (isErrorResponse) return false;
+        if (string.IsNullOrWhiteSpace(reply)) return false;
+
+        // The pipeline's own fail-closed diagnostics. These are legitimate, honest
+        // responses — they just must not be the permanent answer to that prompt.
+        return !reply.Contains("Chart unavailable", StringComparison.OrdinalIgnoreCase)
+            && !reply.Contains("wasn't able to generate a response", StringComparison.OrdinalIgnoreCase)
+            && (!chartWasRequested || chartCount > 0);
+    }
 }

--- a/tests/RetailPulse.Tests/Caching/CacheableOutcomeTests.cs
+++ b/tests/RetailPulse.Tests/Caching/CacheableOutcomeTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using RetailPulse.Api.Middleware;
+
+namespace RetailPulse.Tests.Caching;
+
+/// <summary>
+/// A cacheable QUESTION is not the same thing as a cacheable ANSWER.
+/// </summary>
+/// <remarks>
+/// Chat responses were stored unconditionally whenever the prompt looked deterministic,
+/// so a degraded reply was replayed for the full five-minute TTL. One transient model
+/// wobble became a prompt that failed identically for every subsequent visitor.
+///
+/// Observed live on a curated prompt shipped in the welcome grid: "Show a horizontal bar
+/// chart ranking all brands by depletion growth rate" returned "Chart unavailable" with a
+/// single <c>cache.hit</c> span and no tool calls at all — the failure was being served
+/// from cache, not recomputed. Failing once is a model problem; failing repeatably from
+/// cache is ours.
+/// </remarks>
+public class CacheableOutcomeTests
+{
+    private const string GoodReply = "FreshMart depletions in the Northeast are up 3.5% year over year.";
+
+    [Fact]
+    public void CachesAGoodProseAnswer()
+    {
+        CacheHelpers.IsCacheableOutcome(GoodReply, chartCount: 0, isErrorResponse: false, chartWasRequested: false)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void CachesAChartAnswerThatActuallyProducedAChart()
+    {
+        CacheHelpers.IsCacheableOutcome(GoodReply, chartCount: 1, isErrorResponse: false, chartWasRequested: true)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoesNotCacheAChartRequestThatProducedNoChart()
+    {
+        // This is the exact shape of the live failure: the prompt asked for a chart, the
+        // pipeline failed closed, and the empty result was then served to everyone else.
+        CacheHelpers.IsCacheableOutcome(GoodReply, chartCount: 0, isErrorResponse: false, chartWasRequested: true)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void DoesNotCacheThePipelinesChartUnavailableDiagnostic()
+    {
+        const string diagnostic =
+            "⚠️ Chart unavailable: a portfolio ranking must cover every configured brand "
+            + "(12 total for this tenant), but the following were not returned by the underlying data tools.";
+
+        CacheHelpers.IsCacheableOutcome(diagnostic, chartCount: 0, isErrorResponse: false, chartWasRequested: true)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void DoesNotCacheTheCouldNotGenerateApology()
+    {
+        CacheHelpers.IsCacheableOutcome(
+            "I wasn't able to generate a response.", chartCount: 0, isErrorResponse: false, chartWasRequested: false)
+            .Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("⏳ The request timed out. Please try again.")]
+    [InlineData("⚠️ Rate limit reached.")]
+    public void DoesNotCacheAResponseThePipelineFlaggedAsAnError(string reply)
+    {
+        CacheHelpers.IsCacheableOutcome(reply, chartCount: 0, isErrorResponse: true, chartWasRequested: false)
+            .Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DoesNotCacheAnEmptyReply(string reply)
+    {
+        CacheHelpers.IsCacheableOutcome(reply, chartCount: 0, isErrorResponse: false, chartWasRequested: false)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void StillCachesProseThatMerelyMentionsCharts()
+    {
+        // A prose answer that happens to discuss charts is not a failed chart request.
+        CacheHelpers.IsCacheableOutcome(
+            "The bar chart in last quarter's deck showed a similar trend.",
+            chartCount: 0, isErrorResponse: false, chartWasRequested: false)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoesNotDependOnCasingOfTheDiagnostic()
+    {
+        CacheHelpers.IsCacheableOutcome(
+            "chart unavailable: no chartable values", chartCount: 0, isErrorResponse: false, chartWasRequested: true)
+            .Should().BeFalse();
+    }
+}


### PR DESCRIPTION
A curated prompt shipped in the welcome grid — *"Show a grouped bar chart comparing FreshMart and Harvest Table across all regions"* — returned **Chart unavailable**. I swept **all 26 curated prompts** against live prod to find out how widespread it was.

## Sweep result

**25 of 26 passed.** All 9 chart prompts produced a correctly-typed chart except one:

| Prompt | Expected | Charts |
|---|---|---|
| Show a horizontal bar chart ranking all brands by depletion growth rate | `horizontalBar` | **0** |

Notably, the prompt originally reported **passed** on this run. That inconsistency was the real clue.

## Root cause: failures were being cached

The failing response came back with a single `cache:cache.hit` span and **no tool calls at all**. It was not being recomputed — it was being replayed.

Chat responses were stored whenever the *prompt* looked deterministic:

```csharp
if (!cacheDisabled && CacheHelpers.IsCacheable(request.Message))
```

`isErrorResponse` was computed three lines earlier (to strip routing metadata) but never consulted here. So a degraded reply was cached for the full five-minute TTL, and one transient model wobble became a prompt that failed identically for every subsequent visitor. That is exactly the intermittency observed: whichever outcome landed first got pinned.

**A cacheable question is not the same thing as a cacheable answer.**

## Change

`IsCacheableOutcome` gates storage. An answer is not cached when:

- the pipeline flagged it as an error (⏳ / ⚠️ prefixed),
- the reply is one of the pipeline's own fail-closed diagnostics (`Chart unavailable`, `wasn't able to generate a response`),
- the reply is empty, or
- a chart was explicitly requested and none was produced.

Chart intent uses `ChartRequestDetector.Detect`, the same detector the fulfillment pipeline uses, rather than a second guess at what counts as a chart request.

The underlying guard is left alone — it is correct. It refuses to emit a partial ranking because a partial ranking would silently mis-rank the portfolio. The bug was persisting that refusal, not producing it.

## Verification

11 tests, including the exact live failure shape (chart requested, zero charts, no error flag) and that prose merely *mentioning* charts still caches.

`dotnet test`: 3510 passed / 0 failed. `dotnet format --verify-no-changes`: exit 0.
