### PR TITLE
Resolve portfolio-wide region phrasings to the National aggregate

### DIFF
--- a/src/RetailPulse.McpServer/Data/RetailPulseDb.cs
+++ b/src/RetailPulse.McpServer/Data/RetailPulseDb.cs
@@ -699,6 +699,35 @@ public class RetailPulseDb
 
     // ── Query Methods (public API — matches SimulatedMetricsData surface) ─
 
+    /// <summary>
+    /// True when a region argument means "the whole portfolio" rather than one region.
+    /// </summary>
+    /// <remarks>
+    /// Region is matched with SQL <c>LIKE</c>, so an unrecognised portfolio-wide phrasing
+    /// does not fail loudly — it simply matches no row and returns "No data found" for
+    /// every brand. The curated ranking prompt ("rank all brands by depletion growth
+    /// rate") drove the model to pass "all regions", which only the exact strings "all",
+    /// "aggregate" and "portfolio" were normalised for. Every brand came back an error,
+    /// the ranking chart could not be built, and the coverage guard correctly reported all
+    /// twelve brands missing — a data-shape problem presenting as a chart failure.
+    ///
+    /// "across all regions" is the phrasing used throughout the shipped prompt library,
+    /// so these variants are the expected input, not an edge case.
+    /// </remarks>
+    internal static bool IsPortfolioWideRegion(string? region)
+    {
+        if (string.IsNullOrWhiteSpace(region)) return true;
+
+        string normalized = region.Trim().TrimEnd('.').ToLowerInvariant();
+        normalized = normalized.StartsWith("across ", StringComparison.Ordinal)
+            ? normalized["across ".Length..].Trim()
+            : normalized;
+
+        return normalized is "national" or "all" or "aggregate" or "portfolio"
+            or "all regions" or "the portfolio" or "nationwide" or "overall"
+            or "total" or "everywhere";
+    }
+
     public object GetDepletionStats(string brand, string region, string period)
     {
         if (string.IsNullOrWhiteSpace(brand))
@@ -706,8 +735,7 @@ public class RetailPulseDb
         if (string.IsNullOrWhiteSpace(region))
             return new { error = "Parameter 'region' is required.", available_regions = GetAvailableRegions() };
 
-        if (region.Trim().Equals("National", StringComparison.OrdinalIgnoreCase) ||
-            region.Trim().Equals("All", StringComparison.OrdinalIgnoreCase))
+        if (IsPortfolioWideRegion(region))
         {
             return GetNationalDepletionStats(brand.Trim(), period);
         }
@@ -761,13 +789,9 @@ public class RetailPulseDb
         // missing/blank/"all"/"aggregate" region as the National aggregate. This is what
         // the horizontal-bar "rank all brands by depletion growth rate" prompt drives
         // through the tool: one call, per-brand YoY answered from complete seeded data.
-        string normalizedRegion = string.IsNullOrWhiteSpace(region) ? "National" : region.Trim();
-        if (normalizedRegion.Equals("all", StringComparison.OrdinalIgnoreCase)
-            || normalizedRegion.Equals("aggregate", StringComparison.OrdinalIgnoreCase)
-            || normalizedRegion.Equals("portfolio", StringComparison.OrdinalIgnoreCase))
-        {
-            normalizedRegion = "National";
-        }
+        // Share one definition of "the whole portfolio" with GetDepletionStats, so a
+        // phrasing accepted here cannot be rejected one call deeper.
+        string normalizedRegion = IsPortfolioWideRegion(region) ? "National" : region.Trim();
 
         string normalizedPeriod = string.IsNullOrWhiteSpace(period) ? "YTD" : period.Trim();
 

--- a/tests/RetailPulse.Tests/Data/PortfolioRegionNormalizationTests.cs
+++ b/tests/RetailPulse.Tests/Data/PortfolioRegionNormalizationTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using RetailPulse.McpServer.Data;
+
+namespace RetailPulse.Tests.Data;
+
+/// <summary>
+/// Region arguments that mean "the whole portfolio" must resolve to the National
+/// aggregate rather than falling through to a per-region lookup.
+/// </summary>
+/// <remarks>
+/// Region is matched with SQL <c>LIKE</c>, so an unrecognised portfolio-wide phrasing does
+/// not fail loudly — it matches no row and returns "No data found" for every brand. Only
+/// the exact strings "National", "All", "aggregate" and "portfolio" were normalised, so
+/// the curated prompt "Show a horizontal bar chart ranking all brands by depletion growth
+/// rate" — which drove the model to pass <c>"all regions"</c> — produced an error for all
+/// twelve brands. The ranking chart could not be built and the coverage guard correctly
+/// reported the whole portfolio missing: a data-shape problem presenting as a chart bug.
+///
+/// "across all regions" is the phrasing used throughout the shipped prompt library, so
+/// these are the expected inputs rather than edge cases.
+/// </remarks>
+public class PortfolioRegionNormalizationTests
+{
+    [Theory]
+    [InlineData("all regions")]
+    [InlineData("All Regions")]
+    [InlineData("ALL REGIONS")]
+    [InlineData("across all regions")]
+    [InlineData("national")]
+    [InlineData("National")]
+    [InlineData("all")]
+    [InlineData("aggregate")]
+    [InlineData("portfolio")]
+    [InlineData("the portfolio")]
+    [InlineData("nationwide")]
+    [InlineData("overall")]
+    [InlineData("total")]
+    [InlineData("everywhere")]
+    [InlineData("all regions.")]
+    [InlineData("  all regions  ")]
+    public void TreatsPortfolioWidePhrasingAsNational(string region) =>
+        RetailPulseDb.IsPortfolioWideRegion(region).Should().BeTrue();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    // A portfolio-wide growth ranking has no natural region qualifier.
+    public void TreatsAMissingRegionAsPortfolioWide(string? region) =>
+        RetailPulseDb.IsPortfolioWideRegion(region).Should().BeTrue();
+
+    [Theory]
+    [InlineData("Northeast")]
+    [InlineData("Southeast")]
+    [InlineData("Midwest")]
+    [InlineData("Southwest")]
+    [InlineData("West Coast")]
+    [InlineData("Pacific Northwest")]
+    // Every region configured in the default pack must still scope the query.
+    public void LeavesARealRegionAlone(string region) =>
+        RetailPulseDb.IsPortfolioWideRegion(region).Should().BeFalse();
+
+    [Fact]
+    public void MatchesTheWholeArgumentNotASubstring()
+    {
+        // A future region whose name merely contains a keyword must not collapse to
+        // National — the match is on the entire argument, not a contains() check.
+        RetailPulseDb.IsPortfolioWideRegion("Total Wine Region").Should().BeFalse();
+        RetailPulseDb.IsPortfolioWideRegion("All Saints District").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
The curated prompt *'Show a horizontal bar chart ranking all brands by depletion growth rate'* never produced a chart. With the caching fix in place it was proven deterministic — four consecutive runs, no cache hits, eight real tool calls each, zero charts.

## Root cause

Region is matched with SQL \LIKE\, so an unrecognised portfolio-wide phrasing does not fail loudly — it matches no row and returns \No data found\ for that brand. Only the exact strings \National\, \All\, \ggregate\ and \portfolio\ were normalised, and this prompt drove the model to pass **\ll regions\**.

All twelve brands came back an error, so the ranking chart could not be built, and the coverage guard correctly reported the whole portfolio missing. A data-shape problem presenting as a chart bug.

\cross all regions\ is the phrasing used throughout the shipped prompt library, so these are the expected inputs rather than edge cases.

## Change

One shared \IsPortfolioWideRegion\ used by both \GetDepletionStats\ and \GetPortfolioDepletionStats\, so a phrasing accepted by the portfolio tool cannot be rejected one call deeper. Matching is on the **whole argument**, not a substring, so a future region named \Total Wine Region\ does not collapse to National.

The coverage guard is untouched — refusing a partial ranking is correct behaviour.

## Verification

26 tests: every portfolio-wide phrasing, every configured pack region left alone, missing/blank treated as portfolio-wide, and the substring guard.

\dotnet test\: 3536 passed / 0 failed. \dotnet format --verify-no-changes\: exit 0.