### PR TITLE
Segment text for Content Safety instead of failing on oversized tool results

### DIFF
--- a/src/RetailPulse.Api/Guardrails/ContentSafety/AzureContentSafetyEvaluator.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/AzureContentSafetyEvaluator.cs
@@ -77,8 +77,7 @@ internal sealed class AzureContentSafetyEvaluator : IContentSafetyEvaluator
             return ContentSafetyResult.Passed;
         }
 
-        ContentSafetyConfig config = _guardrails.ContentSafety;
-        using Activity? activity = AgentTelemetry.Source.StartActivity(
+        ContentSafetyConfig config = _guardrails.ContentSafety; using Activity? activity = AgentTelemetry.Source.StartActivity(
             SpanName(stage),
             ActivityKind.Client);
         activity?.SetTag("guardrails.contentsafety.stage", stage.ToString());
@@ -102,17 +101,39 @@ internal sealed class AzureContentSafetyEvaluator : IContentSafetyEvaluator
                 correlation = shield.CorrelationId;
             }
 
-            AnalyzeTextResult analysis = await _client.AnalyzeTextAsync(
-                new AnalyzeTextOptions(text),
-                cts.Token).ConfigureAwait(false);
+            // Azure Content Safety rejects any single AnalyzeText request over 10,000
+            // characters with a 400. Sending the whole text meant the largest tool
+            // results — a twelve-brand portfolio payload is ~14,000 characters — threw,
+            // the tool invocation failed, and the caller silently lost every brand. The
+            // curated portfolio-ranking prompt could therefore never draw its chart, and
+            // the failure looked like a charting bug rather than a guardrail one.
+            //
+            // Scanning a truncated prefix would have been a hole in the guardrail, so the
+            // text is segmented and every segment is analysed. Severity is the maximum
+            // across segments: any segment tripping a category trips the whole text.
+            Dictionary<string, int> maxByCategory = new(StringComparer.OrdinalIgnoreCase);
 
-            foreach (TextCategoriesAnalysis categoryAnalysis in analysis.CategoriesAnalysis)
+            foreach (string segment in SegmentForAnalysis(text))
             {
-                int severity = categoryAnalysis.Severity ?? 0;
-                if (severity > 0)
+                AnalyzeTextResult analysis = await _client.AnalyzeTextAsync(
+                    new AnalyzeTextOptions(segment),
+                    cts.Token).ConfigureAwait(false);
+
+                foreach (TextCategoriesAnalysis categoryAnalysis in analysis.CategoriesAnalysis)
                 {
-                    hits.Add(new ContentSafetyCategoryHit(categoryAnalysis.Category.ToString(), severity));
+                    int severity = categoryAnalysis.Severity ?? 0;
+                    if (severity <= 0) continue;
+
+                    string category = categoryAnalysis.Category.ToString();
+                    maxByCategory[category] = maxByCategory.TryGetValue(category, out int existing)
+                        ? Math.Max(existing, severity)
+                        : severity;
                 }
+            }
+
+            foreach ((string category, int severity) in maxByCategory)
+            {
+                hits.Add(new ContentSafetyCategoryHit(category, severity));
             }
 
             ContentSafetyResult result = Decide(config, hits, jailbreak, indirect, startTicks, correlation);
@@ -281,6 +302,51 @@ internal sealed class AzureContentSafetyEvaluator : IContentSafetyEvaluator
 
     private static ContentSafetyResult WithLatency(ContentSafetyResult template, long startTicks) =>
         template with { Latency = Stopwatch.GetElapsedTime(startTicks) };
+
+    /// <summary>
+    /// Splits text into segments the Content Safety AnalyzeText API will accept.
+    /// </summary>
+    /// <remarks>
+    /// The service rejects any single request over 10,000 characters with a 400, and the
+    /// exception propagated out of the tool-invocation path — so an oversized tool result
+    /// did not merely skip scanning, it destroyed the result. A twelve-brand portfolio
+    /// payload (~14,000 characters) failed every time.
+    ///
+    /// Every segment is analysed rather than a truncated prefix, because scanning only the
+    /// first 10,000 characters would leave the remainder unscanned — a hole in the
+    /// guardrail rather than a fix for it. Segments overlap slightly so content straddling
+    /// a boundary is still seen whole by at least one call.
+    /// </remarks>
+    internal static IEnumerable<string> SegmentForAnalysis(string text)
+    {
+        if (string.IsNullOrEmpty(text) || text.Length <= _maxAnalyzeChars)
+        {
+            yield return text;
+            yield break;
+        }
+
+        int start = 0;
+        while (start < text.Length)
+        {
+            int length = Math.Min(_maxAnalyzeChars, text.Length - start);
+            yield return text.Substring(start, length);
+
+            if (start + length >= text.Length) yield break;
+
+            // Step forward by less than a full segment so a phrase spanning the cut is
+            // present in its entirety in the following segment.
+            start += _maxAnalyzeChars - _segmentOverlapChars;
+        }
+    }
+
+    /// <summary>
+    /// Segment size, held below the service's 10,000-character request limit so a
+    /// multi-byte boundary or future header cannot push a request over it.
+    /// </summary>
+    private const int _maxAnalyzeChars = 9_000;
+
+    /// <summary>Overlap between consecutive segments, so a boundary cannot hide content.</summary>
+    private const int _segmentOverlapChars = 500;
 
     private static bool IsServiceUnavailable(RequestFailedException ex) =>
         ex.Status is 0 or 408 or 429 or 500 or 502 or 503 or 504;

--- a/src/RetailPulse.Api/Tools/PortfolioDepletionStatsTool.cs
+++ b/src/RetailPulse.Api/Tools/PortfolioDepletionStatsTool.cs
@@ -16,24 +16,30 @@ public class PortfolioDepletionStatsTool
 
     [Description("Get depletion statistics for ALL brands in the portfolio in a single call. Use this for portfolio-wide comparisons, rankings, and cross-brand analysis instead of calling GetDepletionStats per brand.")]
     public async Task<string> GetPortfolioDepletionStats(
-        [Description("Region (e.g. 'Northeast', 'West Coast', 'National')")] string region,
+        [Description("Optional region (e.g. 'Northeast', 'West Coast'). Omit it for a portfolio-wide ranking or comparison — the result is then the National aggregate.")] string? region = null,
         [Description("Period (e.g. 'YTD', 'Q1', 'Q2')")] string period = "YTD",
         CancellationToken cancellationToken = default)
     {
+        // A portfolio-wide ranking has no region. Declaring region required meant the
+        // model could not call this tool at all for "rank all brands by growth rate" —
+        // the invocation failed before reaching the server, every brand came back
+        // missing, and the coverage guard refused to draw the chart.
+        string effectiveRegion = string.IsNullOrWhiteSpace(region) ? "National" : region;
+
         try
         {
             HttpResponseMessage response = await _httpClient.GetAsync(
-                $"/api/portfolio-depletion-stats?region={Uri.EscapeDataString(region)}&period={Uri.EscapeDataString(period)}",
+                $"/api/portfolio-depletion-stats?region={Uri.EscapeDataString(effectiveRegion)}&period={Uri.EscapeDataString(period)}",
                 cancellationToken);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync(cancellationToken);
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning(ex, "PortfolioDepletionStatsTool failed for {Region}/{Period} — returning fallback", region, period);
+            _logger?.LogWarning(ex, "PortfolioDepletionStatsTool failed for {Region}/{Period} — returning fallback", effectiveRegion, period);
             return JsonSerializer.Serialize(new
             {
-                region,
+                region = effectiveRegion,
                 period,
                 brandCount = 0,
                 brands = Array.Empty<object>(),

--- a/src/RetailPulse.McpServer/Program.cs
+++ b/src/RetailPulse.McpServer/Program.cs
@@ -122,9 +122,13 @@ app.MapGet("/api/depletion-stats", (string brand, string region, RetailPulseDb d
 })
 .WithName("GetDepletionStats");
 
-app.MapGet("/api/portfolio-depletion-stats", (string region, RetailPulseDb data, string period = "YTD") =>
+// `region` is optional: a portfolio-wide ranking ("rank all brands by growth rate") has
+// no natural region qualifier, and the data layer already resolves a missing or
+// portfolio-wide region to the National aggregate. Declaring it required made the tool
+// call fail outright for exactly the prompt the endpoint exists to serve.
+app.MapGet("/api/portfolio-depletion-stats", (RetailPulseDb data, string? region = null, string period = "YTD") =>
 {
-    object result = data.GetPortfolioDepletionStats(region, period);
+    object result = data.GetPortfolioDepletionStats(region ?? string.Empty, period);
     return Results.Ok(result);
 })
 .WithName("GetPortfolioDepletionStats");

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetySegmentationTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetySegmentationTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using RetailPulse.Api.Guardrails.ContentSafety;
+
+namespace RetailPulse.Tests.Guardrails.ContentSafety;
+
+/// <summary>
+/// Text sent to Azure Content Safety must be segmented under the service's request limit.
+/// </summary>
+/// <remarks>
+/// AnalyzeText rejects any single request over 10,000 characters with
+/// <c>400 InvalidRequestBody: "The length of given text 14336 exceeds the limit 10000"</c>.
+/// The exception propagated out of the tool-invocation path, so an oversized tool result
+/// did not merely skip scanning — it destroyed the result. A twelve-brand portfolio
+/// payload is roughly 14,000 characters, so the curated prompt "Show a horizontal bar
+/// chart ranking all brands by depletion growth rate" lost all twelve brands on every
+/// single run and could never draw its chart. It presented as a charting bug.
+///
+/// Segmenting rather than truncating matters: scanning only the first 10,000 characters
+/// would leave the remainder unscanned, which is a hole in the guardrail rather than a fix.
+/// </remarks>
+public class ContentSafetySegmentationTests
+{
+    private const int ServiceLimit = 10_000;
+
+    private static string Text(int length, char fill = 'a') => new(fill, length);
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(9_000)]
+    public void ShortTextIsSentAsASingleSegment(int length)
+    {
+        AzureContentSafetyEvaluator.SegmentForAnalysis(Text(length))
+            .Should().ContainSingle();
+    }
+
+    [Fact]
+    public void TheRealFailingPayloadSizeIsSegmented()
+    {
+        // 14,336 characters is the exact size from the live 400.
+        IReadOnlyList<string> segments = [.. AzureContentSafetyEvaluator.SegmentForAnalysis(Text(14_336))];
+
+        segments.Count.Should().BeGreaterThan(1);
+    }
+
+    [Theory]
+    [InlineData(10_001)]
+    [InlineData(14_336)]
+    [InlineData(50_000)]
+    [InlineData(250_000)]
+    public void NoSegmentEverExceedsTheServiceLimit(int length)
+    {
+        foreach (string segment in AzureContentSafetyEvaluator.SegmentForAnalysis(Text(length)))
+        {
+            segment.Length.Should().BeLessThan(ServiceLimit);
+        }
+    }
+
+    [Fact]
+    public void EveryCharacterIsCoveredBySomeSegment()
+    {
+        // Truncation would be the tempting shortcut and would silently stop scanning the
+        // tail. Each position carries a distinct marker so coverage can be checked
+        // without relying on ambiguous substring searches.
+        string original = string.Concat(Enumerable.Range(0, 3_000).Select(i => $"{i:D9} "));
+
+        IReadOnlyList<string> segments = [.. AzureContentSafetyEvaluator.SegmentForAnalysis(original)];
+
+        original.Should().StartWith(segments[0], "the first segment must begin at the start of the text");
+        original.Should().EndWith(segments[^1], "the last segment must reach the end of the text");
+
+        // Every marker must appear in at least one segment.
+        foreach (int marker in new[] { 0, 500, 1_500, 2_500, 2_999 })
+        {
+            string needle = $"{marker:D9}";
+            segments.Should().Contain(
+                s => s.Contains(needle, StringComparison.Ordinal),
+                $"the marker at position {marker} must be scanned");
+        }
+    }
+
+    [Fact]
+    public void SegmentsOverlapSoContentCannotHideOnABoundary()
+    {
+        string original = Text(20_000);
+
+        IReadOnlyList<string> segments = [.. AzureContentSafetyEvaluator.SegmentForAnalysis(original)];
+
+        // Total segment length exceeding the original proves the windows overlap rather
+        // than butting up against each other.
+        segments.Sum(s => s.Length).Should().BeGreaterThan(original.Length);
+    }
+
+    [Fact]
+    public void SegmentationTerminatesOnVeryLargeInput()
+    {
+        // A step size that failed to advance would loop forever and hang the request.
+        IReadOnlyList<string> segments = [.. AzureContentSafetyEvaluator.SegmentForAnalysis(Text(1_000_000))];
+
+        segments.Should().NotBeEmpty();
+        segments.Count.Should().BeLessThan(1_000, "segments must advance meaningfully through the text");
+    }
+}


### PR DESCRIPTION
The curated prompt *"Show a horizontal bar chart ranking all brands by depletion growth rate"* failed on **every** run. With the caching fix in place it was provably deterministic — no cache hits, eight real tool calls, zero charts, every time.

## Root cause

Not a charting bug. The API log:

```
Azure.RequestFailedException: The length of given text 14336 exceeds the limit 10000.
Status: 400 (Bad Request)  ErrorCode: InvalidRequestBody
System.Net.Http.HttpClient.ContentSafety
→ GetPortfolioDepletionStats invocation failed.
→ Chart-fulfillment: portfolio ranking missing 12 brand(s) — failing closed.
```

Azure AI Content Safety rejects any single `AnalyzeText` request over **10,000 characters**. A twelve-brand portfolio payload is ~14,300. The exception propagated out of the tool-invocation path, so the oversized result was not merely left unscanned — it was **destroyed**. All twelve brands vanished, and the coverage guard correctly refused to draw a partial ranking.

The failure surfaced as *"Chart unavailable"*, which is why it read as a charting problem. It was a guardrail problem, and it would have hit **any** tool result over 10k characters.

## Change

Segment the text and analyse every segment, taking the maximum severity per category — any segment tripping a category trips the whole text.

Truncating to the first 10,000 characters would have been the easy fix and a hole in the guardrail: the tail would go unscanned. Segments are 9,000 characters with a 500-character overlap, so content straddling a boundary is still seen whole by at least one call.

## Verification

Live, three consecutive runs after deploy:

| Attempt | Charts | Type | Marks | Cache |
|---|---|---|---|---|
| 1 | 1 | `horizontalBar` | **12** | miss |
| 2 | 1 | `horizontalBar` | **12** | hit |
| 3 | 1 | `horizontalBar` | **12** | hit |

Twelve marks is all twelve brands. Attempts 2–3 being cache hits confirms the companion caching change is behaving correctly — successes are now cached, failures are not.

11 tests: the exact 14,336-character failing size, no segment ever reaching the service limit, full coverage of the text, overlap between windows, and termination on very large input.

`dotnet test`: 3547 passed / 0 failed. `dotnet format --verify-no-changes`: exit 0.

## Also included

`region` is now optional on `GetPortfolioDepletionStats` and its MCP route. The data layer already documented that a portfolio-wide ask has no natural region qualifier, but both the HTTP route and the tool signature declared it required.
