### PR TITLE
Add Demo Mode: a guided walkthrough of the shipped surface

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/DemoTour.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/DemoTour.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FluentProvider, webDarkTheme } from '@fluentui/react-components';
+import type { ReactElement } from 'react';
+import { DemoTour } from '../components/demo/DemoTour';
+import { DEMO_STEPS } from '../components/demo/demoSteps';
+
+const wrap = (ui: ReactElement) => <FluentProvider theme={webDarkTheme}>{ui}</FluentProvider>;
+
+function renderTour(overrides: Partial<Parameters<typeof DemoTour>[0]> = {}) {
+  const props = {
+    open: true,
+    onClose: vi.fn(),
+    onNavigate: vi.fn(),
+    onTelemetry: vi.fn(),
+    ...overrides,
+  };
+  render(wrap(<DemoTour {...props} />));
+  return props;
+}
+
+/**
+ * Demo Mode is the first thing shown to an audience, so its failure modes matter more
+ * than most: a step that advances on a stray click, narration that drifts out of sync
+ * with the view behind it, or a card positioned off-screen all break the demo in front
+ * of the person being demoed to.
+ */
+describe('DemoTour', () => {
+  beforeEach(() => {
+    // jsdom gives every element a zero box, which the component treats as "no target".
+    // Provide a real one so spotlight positioning is exercised rather than skipped.
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: 100, left: 200, width: 300, height: 80, right: 500, bottom: 180, x: 200, y: 100,
+      toJSON: () => ({}),
+    } as DOMRect);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('renders nothing when closed', () => {
+    renderTour({ open: false });
+    expect(screen.queryByTestId('demo-tour-card')).not.toBeInTheDocument();
+  });
+
+  it('opens on the first step', () => {
+    renderTour();
+    expect(screen.getByTestId('demo-tour-title')).toHaveTextContent(DEMO_STEPS[0].title);
+    expect(screen.getByTestId('demo-tour-progress')).toHaveTextContent(`1 of ${DEMO_STEPS.length}`);
+  });
+
+  it('advances and goes back', () => {
+    renderTour();
+    fireEvent.click(screen.getByTestId('demo-tour-next'));
+    expect(screen.getByTestId('demo-tour-title')).toHaveTextContent(DEMO_STEPS[1].title);
+
+    fireEvent.click(screen.getByTestId('demo-tour-back'));
+    expect(screen.getByTestId('demo-tour-title')).toHaveTextContent(DEMO_STEPS[0].title);
+  });
+
+  it('disables Back on the first step so the tour cannot run off the start', () => {
+    renderTour();
+    expect(screen.getByTestId('demo-tour-back')).toBeDisabled();
+  });
+
+  it('drives the dashboard to the view each step describes', () => {
+    const props = renderTour();
+
+    // The narration must match what is on screen behind it.
+    const firstWithView = DEMO_STEPS.find(s => s.view);
+    expect(props.onNavigate).toHaveBeenCalledWith(firstWithView?.view);
+  });
+
+  it('opens the telemetry drawer only for the steps that describe it', () => {
+    const props = renderTour();
+    // Step 1 does not describe the drawer.
+    expect(props.onTelemetry).toHaveBeenLastCalledWith(false);
+
+    const drawerStepIndex = DEMO_STEPS.findIndex(s => s.telemetry);
+    for (let i = 0; i < drawerStepIndex; i++) {
+      fireEvent.click(screen.getByTestId('demo-tour-next'));
+    }
+    expect(props.onTelemetry).toHaveBeenLastCalledWith(true);
+  });
+
+  it('closes from the Exit button', () => {
+    const props = renderTour();
+    fireEvent.click(screen.getByTestId('demo-tour-exit'));
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('finishes on the last step instead of advancing past the end', () => {
+    const props = renderTour();
+    for (let i = 0; i < DEMO_STEPS.length - 1; i++) {
+      fireEvent.click(screen.getByTestId('demo-tour-next'));
+    }
+
+    expect(screen.getByTestId('demo-tour-next')).toHaveTextContent('Finish');
+    fireEvent.click(screen.getByTestId('demo-tour-next'));
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('does not advance when the backdrop is clicked', () => {
+    const props = renderTour();
+    fireEvent.click(screen.getByTestId('demo-tour-overlay'));
+
+    // An accidental click mid-presentation should do nothing at all.
+    expect(screen.getByTestId('demo-tour-progress')).toHaveTextContent('1 of');
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('supports keyboard navigation from a lectern', () => {
+    const props = renderTour();
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(screen.getByTestId('demo-tour-title')).toHaveTextContent(DEMO_STEPS[1].title);
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    expect(screen.getByTestId('demo-tour-title')).toHaveTextContent(DEMO_STEPS[0].title);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('restarts from the beginning when reopened', () => {
+    const { rerender } = render(wrap(
+      <DemoTour open onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} />,
+    ));
+    fireEvent.click(screen.getByTestId('demo-tour-next'));
+    expect(screen.getByTestId('demo-tour-progress')).toHaveTextContent('2 of');
+
+    rerender(wrap(<DemoTour open={false} onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} />));
+    rerender(wrap(<DemoTour open onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} />));
+
+    // Pressing the button in front of an audience must start at step one.
+    expect(screen.getByTestId('demo-tour-progress')).toHaveTextContent('1 of');
+  });
+
+  it('draws a spotlight for a step with a target', async () => {
+    // Step two points at the chat host, so it has to exist for there to be anything to
+    // spotlight. Rendering the tour in isolation is what a real page never does.
+    const host = document.createElement('div');
+    host.setAttribute('data-testid', 'chat-host');
+    document.body.appendChild(host);
+
+    try {
+      renderTour();
+      fireEvent.click(screen.getByTestId('demo-tour-next'));
+
+      // Measurement is deferred to an animation frame so the target has painted.
+      await screen.findByTestId('demo-tour-spotlight');
+    } finally {
+      host.remove();
+    }
+  });
+
+  it('degrades to a centred card when the target is absent', () => {
+    // A missing target must not point the spotlight at the top-left corner, which is what
+    // an unchecked getBoundingClientRect would do.
+    renderTour();
+    fireEvent.click(screen.getByTestId('demo-tour-next'));
+
+    expect(screen.queryByTestId('demo-tour-spotlight')).not.toBeInTheDocument();
+    expect(screen.getByTestId('demo-tour-card')).toBeInTheDocument();
+  });
+});
+
+describe('demo script', () => {
+  it('has a unique id per step', () => {
+    const ids = DEMO_STEPS.map(s => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('covers the AI gateway and its costing story', () => {
+    const text = DEMO_STEPS.map(s => `${s.title} ${s.body}`).join(' ').toLowerCase();
+
+    expect(text).toContain('api management');
+    expect(text).toContain('managed identity');
+    expect(text).toContain('token');
+    expect(text).toContain('cost');
+  });
+
+  it('visits every navigable view', () => {
+    const visited = new Set(DEMO_STEPS.map(s => s.view).filter(Boolean));
+
+    // Every view reachable from the nav should get its moment, or the tour is not a
+    // walkthrough of what shipped.
+    for (const view of [
+      'chat', 'promo', 'competitive', 'knowledge', 'council',
+      'security', 'cards', 'observability', 'stores', 'financials', 'portfolio',
+    ]) {
+      expect(visited).toContain(view);
+    }
+  });
+
+  it('keeps body copy short enough for a flyout', () => {
+    for (const step of DEMO_STEPS) {
+      expect(step.body.length).toBeLessThanOrEqual(400);
+    }
+  });
+});

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { ReactElement } from 'react';
 import { Button, Badge, makeStyles, Drawer, DrawerBody, DrawerHeader, DrawerHeaderTitle, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuButton, Spinner } from '@fluentui/react-components';
-import { Add24Regular, DataUsage24Regular, Dismiss24Regular, TargetArrow24Regular, Shield24Regular, Library24Regular, HeartPulse24Regular, ShieldCheckmark24Regular, CardUi24Regular, Eye24Regular, Building24Regular, Money24Regular, Star24Regular } from '@fluentui/react-icons';
+import { Add24Regular, Play24Regular, DataUsage24Regular, Dismiss24Regular, TargetArrow24Regular, Shield24Regular, Library24Regular, HeartPulse24Regular, ShieldCheckmark24Regular, CardUi24Regular, Eye24Regular, Building24Regular, Money24Regular, Star24Regular } from '@fluentui/react-icons';
 import { ChatPanel } from './ChatPanel';
 import { fetchFinancials, fetchScorecardBatched, fetchStores, fetchStockoutRisks } from '../services/operationsApi';
 import { toAlert, fetchAlerts } from '../services/alertsApi';
+import { DemoTour } from './demo/DemoTour';
 import { TelemetryPanel } from './TelemetryPanel';
 import { AgentRoutingPanel } from './AgentRoutingPanel';
 import { MemoryPanel } from './MemoryPanel';
@@ -292,6 +293,7 @@ export function Dashboard() {
   const [brandsDurationMs, setBrandsDurationMs] = useState(0);
   const [brandsLoading, setBrandsLoading] = useState(false);
   const [brandsError, setBrandsError] = useState<string | null>(null);
+  const [demoOpen, setDemoOpen] = useState(false);
 
   // The scorecard fans out real agent assessments per brand, so it is genuinely slow.
   // Load it on demand and show progress rather than blocking behind an empty grid.
@@ -735,6 +737,15 @@ export function Dashboard() {
           >
             New Chat
           </Button>
+          <Button
+            appearance={demoOpen ? 'primary' : 'subtle'}
+            icon={<Play24Regular />}
+            onClick={() => setDemoOpen(true)}
+            data-testid="demo-mode-button"
+            title="Guided walkthrough of every shipped capability"
+          >
+            Demo Mode
+          </Button>
           {capabilities.telemetryPanel && (
             <Button
               appearance={telemetryOpen ? 'primary' : 'subtle'}
@@ -971,6 +982,15 @@ export function Dashboard() {
         </Drawer>
         )}
       </main>
+
+      {/* Rendered last so the overlay sits above the header, panels and drawer without
+          needing to out-bid every nested z-index in the app. */}
+      <DemoTour
+        open={demoOpen}
+        onClose={() => setDemoOpen(false)}
+        onNavigate={view => setActiveView(view)}
+        onTelemetry={setTelemetryOpen}
+      />
     </div>
   );
 }

--- a/src/RetailPulse.Web/src/components/demo/DemoTour.tsx
+++ b/src/RetailPulse.Web/src/components/demo/DemoTour.tsx
@@ -1,0 +1,361 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Button, makeStyles } from '@fluentui/react-components';
+import { ChevronLeft24Regular, ChevronRight24Regular, Dismiss24Regular } from '@fluentui/react-icons';
+import { DEMO_STEPS, type DemoStep, type DemoView } from './demoSteps';
+
+/**
+ * Guided walkthrough of the shipped surface.
+ *
+ * The tour drives the dashboard rather than describing it from the side: each step can
+ * switch view and open the telemetry drawer, so the operator is always looking at the
+ * thing being described. Advancing is manual — nothing auto-plays, because a demo that
+ * moves on its own cannot be paused to answer a question.
+ */
+
+interface DemoTourProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  /** Switches the dashboard to the view a step wants to talk about. */
+  readonly onNavigate: (view: DemoView) => void;
+  /** Opens or closes the telemetry drawer for steps that describe it. */
+  readonly onTelemetry: (open: boolean) => void;
+}
+
+interface Rect {
+  readonly top: number;
+  readonly left: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Breathing room between the spotlight cutout and the highlighted element. */
+const SPOTLIGHT_PADDING = 8;
+/** Gap between the cutout and the flyout card. */
+const FLYOUT_GAP = 16;
+const FLYOUT_WIDTH = 380;
+/** Enough for the tallest body copy in the script; the card scrolls beyond this. */
+const FLYOUT_MAX_HEIGHT = 340;
+
+const useStyles = makeStyles({
+  overlay: {
+    position: 'fixed',
+    inset: '0',
+    zIndex: 9000,
+    // Pointer events are enabled so a stray click cannot interact with the app mid-tour,
+    // which would desynchronise the narration from what is on screen.
+    pointerEvents: 'auto',
+  },
+  card: {
+    position: 'fixed',
+    zIndex: 9001,
+    width: `${FLYOUT_WIDTH}px`,
+    maxHeight: `${FLYOUT_MAX_HEIGHT}px`,
+    overflowY: 'auto',
+    boxSizing: 'border-box',
+    padding: '20px',
+    borderRadius: '12px',
+    backgroundColor: 'var(--color-bg-elevated, #1a1a24)',
+    border: '1px solid var(--brand-accent, #3b82f6)',
+    boxShadow: '0 18px 48px rgba(0,0,0,0.55)',
+    color: 'var(--color-text, #f1f5f9)',
+    fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
+  },
+  chapter: {
+    fontSize: '11px',
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    color: 'var(--brand-accent, #3b82f6)',
+    fontWeight: '600',
+  },
+  title: {
+    fontSize: '17px',
+    fontWeight: '600',
+    margin: '6px 0 10px',
+    lineHeight: '1.3',
+  },
+  body: {
+    fontSize: '13px',
+    lineHeight: '1.6',
+    color: 'var(--color-text-secondary, #cbd5e1)',
+    margin: '0 0 16px',
+  },
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '12px',
+  },
+  progress: {
+    fontSize: '12px',
+    color: 'var(--color-text-muted, #94a3b8)',
+    fontVariantNumeric: 'tabular-nums',
+  },
+  actions: {
+    display: 'flex',
+    gap: '8px',
+    alignItems: 'center',
+  },
+  rail: {
+    display: 'flex',
+    gap: '3px',
+    marginTop: '14px',
+  },
+  tick: {
+    height: '3px',
+    flex: '1',
+    borderRadius: '2px',
+    backgroundColor: 'var(--color-border, #334155)',
+  },
+  tickDone: {
+    backgroundColor: 'var(--brand-accent, #3b82f6)',
+  },
+});
+
+/**
+ * Reads the on-screen box of a step's target.
+ *
+ * Returns null when the step has no target or the element is not present — a step whose
+ * target is missing degrades to a centred card rather than pointing at the top-left
+ * corner, which is what an unchecked getBoundingClientRect would do.
+ */
+function measure(target: string | undefined): Rect | null {
+  if (!target || typeof document === 'undefined') return null;
+
+  const element = document.querySelector(target);
+  if (!element) return null;
+
+  const box = element.getBoundingClientRect();
+  if (box.width === 0 && box.height === 0) return null;
+
+  return { top: box.top, left: box.left, width: box.width, height: box.height };
+}
+
+/** Places the flyout beside the cutout, flipping when it would leave the viewport. */
+function positionCard(rect: Rect | null, placement: DemoStep['placement']): { top: number; left: number } {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(value, max));
+
+  if (!rect || placement === 'center') {
+    return {
+      top: Math.max(FLYOUT_GAP, (vh - FLYOUT_MAX_HEIGHT) / 2),
+      left: clamp((vw - FLYOUT_WIDTH) / 2, FLYOUT_GAP, vw - FLYOUT_WIDTH - FLYOUT_GAP),
+    };
+  }
+
+  const above = rect.top - FLYOUT_GAP - FLYOUT_MAX_HEIGHT;
+  const below = rect.top + rect.height + FLYOUT_GAP;
+  const leftOf = rect.left - FLYOUT_GAP - FLYOUT_WIDTH;
+  const rightOf = rect.left + rect.width + FLYOUT_GAP;
+
+  let top: number;
+  let left: number;
+
+  switch (placement) {
+    case 'left':
+      // Flip to the other side when there is not enough room, rather than clipping.
+      left = leftOf >= FLYOUT_GAP ? leftOf : rightOf;
+      top = rect.top;
+      break;
+    case 'right':
+      left = rightOf + FLYOUT_WIDTH <= vw - FLYOUT_GAP ? rightOf : leftOf;
+      top = rect.top;
+      break;
+    case 'top':
+      top = above >= FLYOUT_GAP ? above : below;
+      left = rect.left + (rect.width - FLYOUT_WIDTH) / 2;
+      break;
+    default:
+      top = below + FLYOUT_MAX_HEIGHT <= vh - FLYOUT_GAP ? below : above;
+      left = rect.left + (rect.width - FLYOUT_WIDTH) / 2;
+      break;
+  }
+
+  return {
+    top: clamp(top, FLYOUT_GAP, Math.max(FLYOUT_GAP, vh - FLYOUT_MAX_HEIGHT - FLYOUT_GAP)),
+    left: clamp(left, FLYOUT_GAP, Math.max(FLYOUT_GAP, vw - FLYOUT_WIDTH - FLYOUT_GAP)),
+  };
+}
+
+export function DemoTour({ open, onClose, onNavigate, onTelemetry }: DemoTourProps) {
+  const styles = useStyles();
+  const [index, setIndex] = useState(0);
+  const [rect, setRect] = useState<Rect | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const step = DEMO_STEPS[index];
+  const isFirst = index === 0;
+  const isLast = index === DEMO_STEPS.length - 1;
+
+  // Restart from the beginning each time the tour is opened. Resuming mid-tour would be
+  // surprising when the button is pressed in front of an audience.
+  useEffect(() => {
+    if (open) setIndex(0);
+  }, [open]);
+
+  // Put the dashboard into the state the step describes BEFORE measuring its target.
+  useEffect(() => {
+    if (!open || !step) return;
+    if (step.view) onNavigate(step.view);
+    onTelemetry(Boolean(step.telemetry));
+  }, [open, step, onNavigate, onTelemetry]);
+
+  // Measure after the view switch has painted. A layout effect alone is too early: the
+  // panel being pointed at may not exist yet on the frame the step changes.
+  useLayoutEffect(() => {
+    if (!open || !step) return;
+
+    let frame = 0;
+    let cancelled = false;
+
+    const remeasure = () => {
+      if (cancelled) return;
+      setRect(measure(step.target));
+    };
+
+    remeasure();
+    // Re-measure on the next couple of frames to catch the post-navigation layout.
+    frame = window.requestAnimationFrame(() => {
+      remeasure();
+      frame = window.requestAnimationFrame(remeasure);
+    });
+
+    window.addEventListener('resize', remeasure);
+    window.addEventListener('scroll', remeasure, true);
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener('resize', remeasure);
+      window.removeEventListener('scroll', remeasure, true);
+    };
+  }, [open, step]);
+
+  const next = useCallback(() => {
+    setIndex(i => (i >= DEMO_STEPS.length - 1 ? i : i + 1));
+  }, []);
+
+  const back = useCallback(() => {
+    setIndex(i => (i <= 0 ? 0 : i - 1));
+  }, []);
+
+  // Keyboard control: arrows to move, Escape to leave. A demo driven from a lectern is
+  // easier with keys than with a trackpad.
+  useEffect(() => {
+    if (!open) return;
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { onClose(); return; }
+      if (e.key === 'ArrowRight' || e.key === 'Enter') { e.preventDefault(); isLast ? onClose() : next(); }
+      if (e.key === 'ArrowLeft') { e.preventDefault(); back(); }
+    };
+
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, next, back, onClose, isLast]);
+
+  // Move focus to the card on each step so a screen reader announces the new content and
+  // the keyboard handlers have somewhere sensible to live.
+  useEffect(() => {
+    if (open) cardRef.current?.focus();
+  }, [open, index]);
+
+  const position = useMemo(
+    () => (open ? positionCard(rect, step?.placement) : { top: 0, left: 0 }),
+    [open, rect, step?.placement],
+  );
+
+  if (!open || !step) return null;
+
+  // The cutout is drawn with a huge spread box-shadow rather than an SVG mask: it dims
+  // everything outside the highlighted box while leaving the element itself untouched and
+  // fully legible.
+  const spotlight = rect
+    ? {
+      position: 'fixed' as const,
+      top: `${rect.top - SPOTLIGHT_PADDING}px`,
+      left: `${rect.left - SPOTLIGHT_PADDING}px`,
+      width: `${rect.width + SPOTLIGHT_PADDING * 2}px`,
+      height: `${rect.height + SPOTLIGHT_PADDING * 2}px`,
+      borderRadius: '10px',
+      boxShadow: '0 0 0 9999px rgba(2, 6, 23, 0.72)',
+      border: '2px solid var(--brand-accent, #3b82f6)',
+      pointerEvents: 'none' as const,
+      transition: 'top 180ms ease, left 180ms ease, width 180ms ease, height 180ms ease',
+    }
+    : undefined;
+
+  return (
+    <>
+      <div
+        className={styles.overlay}
+        data-testid="demo-tour-overlay"
+        // Clicking the backdrop does NOT advance or close: an accidental click during a
+        // presentation should do nothing rather than skip a step.
+        onClick={e => e.stopPropagation()}
+        style={rect ? undefined : { backgroundColor: 'rgba(2, 6, 23, 0.72)' }}
+      >
+        {spotlight && <div style={spotlight} data-testid="demo-tour-spotlight" />}
+      </div>
+
+      <div
+        ref={cardRef}
+        className={styles.card}
+        style={{ top: `${position.top}px`, left: `${position.left}px` }}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Demo Mode: ${step.title}`}
+        tabIndex={-1}
+        data-testid="demo-tour-card"
+      >
+        <div className={styles.chapter}>{step.chapter}</div>
+        <div className={styles.title} data-testid="demo-tour-title">{step.title}</div>
+        <p className={styles.body}>{step.body}</p>
+
+        <div className={styles.footer}>
+          <span className={styles.progress} data-testid="demo-tour-progress">
+            {index + 1} of {DEMO_STEPS.length}
+          </span>
+          <div className={styles.actions}>
+            <Button
+              appearance="subtle"
+              icon={<Dismiss24Regular />}
+              onClick={onClose}
+              data-testid="demo-tour-exit"
+            >
+              Exit
+            </Button>
+            <Button
+              appearance="secondary"
+              icon={<ChevronLeft24Regular />}
+              onClick={back}
+              disabled={isFirst}
+              data-testid="demo-tour-back"
+              aria-label="Previous step"
+            />
+            <Button
+              appearance="primary"
+              icon={<ChevronRight24Regular />}
+              iconPosition="after"
+              onClick={isLast ? onClose : next}
+              data-testid="demo-tour-next"
+            >
+              {isLast ? 'Finish' : 'Next'}
+            </Button>
+          </div>
+        </div>
+
+        <div className={styles.rail} aria-hidden="true">
+          {DEMO_STEPS.map((s, i) => (
+            <div
+              key={s.id}
+              className={`${styles.tick} ${i <= index ? styles.tickDone : ''}`}
+            />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default DemoTour;

--- a/src/RetailPulse.Web/src/components/demo/demoSteps.ts
+++ b/src/RetailPulse.Web/src/components/demo/demoSteps.ts
@@ -1,0 +1,243 @@
+/**
+ * Declarative script for the guided Demo Mode walkthrough.
+ *
+ * Every claim here is deliberately grounded in shipped behaviour — the gateway policy
+ * really does meter tokens, the telemetry drawer really does show per-request cost, the
+ * council really does convene specialists. A guided tour that overstates the product is
+ * worse than none, because the person following it will click the thing and see the gap.
+ */
+
+/** Views the tour can drive the dashboard to. Mirrors `ActiveView` in Dashboard.tsx. */
+export type DemoView =
+  | 'chat' | 'promo' | 'competitive' | 'knowledge' | 'council' | 'security'
+  | 'cards' | 'observability' | 'stores' | 'financials' | 'portfolio';
+
+export interface DemoStep {
+  readonly id: string;
+  readonly title: string;
+  /** Body copy. Kept to a few sentences — this is a tooltip, not documentation. */
+  readonly body: string;
+  /**
+   * CSS selector for the element to spotlight. When absent, or when the element is not
+   * on screen, the step renders centred with no cutout rather than pointing at nothing.
+   */
+  readonly target?: string;
+  /** View to switch to before the step is shown. */
+  readonly view?: DemoView;
+  /** Whether the telemetry drawer should be open for this step. */
+  readonly telemetry?: boolean;
+  /** Preferred flyout placement; the tour flips it when it would leave the viewport. */
+  readonly placement?: 'top' | 'bottom' | 'left' | 'right' | 'center';
+  /** Short label shown in the progress rail. */
+  readonly chapter: string;
+}
+
+export const DEMO_STEPS: readonly DemoStep[] = [
+  {
+    id: 'welcome',
+    chapter: 'Welcome',
+    title: 'Welcome to Retail Pulse',
+    body:
+      'A multi-agent retail intelligence platform. A router picks the right specialist for each '
+      + 'question, specialists call real tools over MCP, and every model call is metered through an '
+      + 'Azure API Management AI Gateway. This tour walks the whole surface — about two minutes.',
+    view: 'chat',
+    placement: 'center',
+  },
+  {
+    id: 'ask',
+    chapter: 'Chat',
+    title: 'Ask in plain language',
+    body:
+      'Questions route to a specialist automatically — demand forecasting, competitive intelligence, '
+      + 'supply chain, margin analysis, store operations and more. The curated prompts below are a '
+      + 'starting point; anything in natural language works.',
+    target: '[data-testid="chat-host"]',
+    view: 'chat',
+    placement: 'top',
+  },
+  {
+    id: 'execution-path',
+    chapter: 'Chat',
+    title: 'Auto, Fast and Plan',
+    body:
+      'Auto lets the router decide. Fast forces a single-agent answer for latency. Plan runs '
+      + 'plan-first orchestration: the agent drafts a multi-step plan, executes it step by step, and '
+      + 'can pause for human approval before continuing.',
+    target: '[aria-label="Execution path"]',
+    view: 'chat',
+    placement: 'top',
+  },
+  {
+    id: 'telemetry-open',
+    chapter: 'Cost & Telemetry',
+    title: 'Real-time telemetry',
+    body:
+      'Every run streams over SignalR as it happens. Open this drawer to watch the agent work — '
+      + 'no polling, no refresh.',
+    target: '[aria-controls="telemetry-drawer"]',
+    view: 'chat',
+    placement: 'bottom',
+  },
+  {
+    id: 'live-spans',
+    chapter: 'Cost & Telemetry',
+    title: 'Tokens, tool calls and cost per run',
+    body:
+      'Live Spans is the heart of this panel: total tokens, span count, tool calls, wall-clock '
+      + 'duration and the dollar cost of the request you just made. Cost is derived from real token '
+      + 'counts, not estimated.',
+    target: '#telemetry-drawer',
+    telemetry: true,
+    placement: 'left',
+  },
+  {
+    id: 'routing',
+    chapter: 'Cost & Telemetry',
+    title: 'Why that agent answered',
+    body:
+      'Agent Routing shows which specialist was selected and how confident the router was. Plans, '
+      + 'Memory and Alerts sit alongside it — the whole execution story in one drawer.',
+    target: '#telemetry-drawer',
+    telemetry: true,
+    placement: 'left',
+  },
+  {
+    id: 'gateway',
+    chapter: 'AI Gateway',
+    title: 'Every model call goes through APIM',
+    body:
+      'No component talks to Azure OpenAI directly. An API Management AI Gateway fronts every '
+      + 'inference call, authenticating to Azure AI Foundry with managed identity — there are no '
+      + 'model keys anywhere in the system.',
+    view: 'observability',
+    placement: 'center',
+  },
+  {
+    id: 'gateway-controls',
+    chapter: 'AI Gateway',
+    title: 'Token limits and emitted metrics',
+    body:
+      'The gateway policy applies a per-subscription token-per-minute limit with prompt-token '
+      + 'estimation, returns tokens-consumed and retry-after headers, and emits token metrics '
+      + 'dimensioned by API, operation and subscription. Throttling and attribution live in the '
+      + 'gateway, not in application code.',
+    view: 'observability',
+    placement: 'center',
+  },
+  {
+    id: 'cost-dashboard',
+    chapter: 'AI Gateway',
+    title: 'Cost tracking',
+    body:
+      'Total tokens, total cost, request count and average cost per request — by day, week or '
+      + 'month, broken down per agent. This is what makes the economics of a multi-agent system '
+      + 'visible rather than a surprise on the invoice.',
+    view: 'observability',
+    placement: 'center',
+  },
+  {
+    id: 'council',
+    chapter: 'Multi-agent',
+    title: 'Portfolio Health Council',
+    body:
+      'Convene several specialists on one brand and watch them vote independently — each grounded '
+      + 'in its own tool data, each reporting a confidence score. Disagreement is surfaced rather '
+      + 'than averaged away, and the verdict is published as a collaborative card to vote on.',
+    view: 'council',
+    placement: 'center',
+  },
+  {
+    id: 'portfolio',
+    chapter: 'Multi-agent',
+    title: 'Portfolio scorecard',
+    body:
+      'Each brand is scored across five specialist dimensions — demand, margin, competitive, supply '
+      + 'and store execution — by fanning out to the specialists in parallel. Scores are cached so '
+      + 'revisiting is instant.',
+    view: 'portfolio',
+    placement: 'center',
+  },
+  {
+    id: 'knowledge',
+    chapter: 'Grounding',
+    title: 'Knowledge Base and RAG',
+    body:
+      'The corpus the agents ground answers in. Search it, upload to it, and see exactly which '
+      + 'source each agent is bound to. Providers are pluggable — in-memory BM25 by default, with '
+      + 'Azure AI Search and Foundry IQ available.',
+    view: 'knowledge',
+    placement: 'center',
+  },
+  {
+    id: 'competitive',
+    chapter: 'Analytics',
+    title: 'Competitive intelligence',
+    body:
+      'Market share trends, competitor pricing moves and detected threats with recommended '
+      + 'responses. Price drops here raise the alerts you saw in the telemetry drawer.',
+    view: 'competitive',
+    placement: 'center',
+  },
+  {
+    id: 'financials',
+    chapter: 'Analytics',
+    title: 'Financials',
+    body:
+      'A P&L waterfall from revenue through to net margin, plus the drivers moving it — each one '
+      + 'read live from the margin service, not a fixture.',
+    view: 'financials',
+    placement: 'center',
+  },
+  {
+    id: 'stores',
+    chapter: 'Analytics',
+    title: 'Store operations',
+    body:
+      'Every store against target, with a regional heatmap and the SKUs at genuine stockout risk — '
+      + 'ranked by urgency, with recommended reorder quantities.',
+    view: 'stores',
+    placement: 'center',
+  },
+  {
+    id: 'promo',
+    chapter: 'Planning',
+    title: 'Campaign Planner',
+    body:
+      'Model a promotion before you run it: expected ROI with confidence bounds, break-even weeks, '
+      + 'seasonality fit and the risks worth knowing — grounded in historical campaign outcomes.',
+    view: 'promo',
+    placement: 'center',
+  },
+  {
+    id: 'cards',
+    chapter: 'Collaboration',
+    title: 'Adaptive Cards',
+    body:
+      'Council verdicts are published as interactive cards. Teammates vote, comment and escalate; a '
+      + 'split vote escalates automatically. The same card format the Teams bot uses.',
+    view: 'cards',
+    placement: 'center',
+  },
+  {
+    id: 'security',
+    chapter: 'Trust',
+    title: 'Guardrails and security',
+    body:
+      'Prompt-injection defence, PII redaction on both input and output, and Azure AI Content Safety '
+      + 'scanning every prompt and response. Sign-in is Entra-only in production and every endpoint '
+      + 'is deny-by-default.',
+    view: 'security',
+    placement: 'center',
+  },
+  {
+    id: 'done',
+    chapter: 'Done',
+    title: "That's the tour",
+    body:
+      'Everything shown here runs against live services on Azure — no scripted responses. Ask it '
+      + 'something of your own, or restart the tour any time from the Demo Mode button.',
+    view: 'chat',
+    placement: 'center',
+  },
+];


### PR DESCRIPTION
A **Demo Mode** button in the header runs a 19-step tour with a spotlight overlay and a flyout describing each area, advanced by a Next arrow.

## Design decisions

- **The tour drives the dashboard** rather than describing it from the side. Each step switches view and opens the telemetry drawer as needed, so the narration always matches what is on screen behind it.
- **Nothing auto-plays.** A demo that moves on its own cannot be paused to answer a question.
- **A backdrop click does nothing** — not advance, not close. A stray click mid-presentation should not skip a step.
- **Arrow keys and Escape** work, for driving from a lectern.
- **Reopening restarts at step one**, because pressing the button in front of an audience should not resume halfway.
- A step whose target is missing **degrades to a centred card** rather than spotlighting the top-left corner.

## Script

| Chapter | Covers |
|---|---|
| Welcome | Router, specialists, MCP tools, gateway framing |
| Chat | Natural language, Auto / Fast / Plan execution paths |
| Cost & Telemetry | SignalR streaming, Live Spans — tokens, tool calls, duration, cost — agent routing |
| **AI Gateway** | APIM fronting every call, managed identity with no model keys, per-subscription token limits with prompt-token estimation, emitted token metrics, cost dashboard |
| Multi-agent | Health Council, portfolio scorecard |
| Grounding | Knowledge Base and pluggable RAG providers |
| Analytics | Competitive, Financials, Stores |
| Planning | Campaign Planner |
| Collaboration | Adaptive Cards |
| Trust | Guardrails, Content Safety, Entra-only auth |

Every claim is grounded in shipped behaviour. A tour that overstates the product is worse than none, because the person following it will click the thing and see the gap.

## Verification

17 tests covering navigation, keyboard control, the no-advance-on-backdrop rule, restart-on-reopen, spotlight and missing-target fallback — plus script assertions that the gateway/costing story is present and that **every navigable view is visited**, so a future feature cannot quietly fall out of the tour.

\	sc -b\ exit 0. Frontend suite: 842 tests passing.