### PR TITLE
Split Tour and Demo Mode; stop dimming the product

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/DemoMode.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/DemoMode.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { FluentProvider, webDarkTheme } from '@fluentui/react-components';
+import type { ReactElement } from 'react';
+import { DemoMode } from '../components/demo/DemoMode';
+import { DEMO_ACTS } from '../components/demo/demoActs';
+
+const wrap = (ui: ReactElement) => <FluentProvider theme={webDarkTheme}>{ui}</FluentProvider>;
+
+function renderDemo(overrides: Partial<Parameters<typeof DemoMode>[0]> = {}) {
+  const props = {
+    open: true,
+    onClose: vi.fn(),
+    onNavigate: vi.fn(),
+    onTelemetry: vi.fn(),
+    sendPrompt: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  render(wrap(<DemoMode {...props} />));
+  return props;
+}
+
+/**
+ * Demo Mode drives the real product: it submits live prompts through the same send path
+ * a person typing would use, waits for each answer before narrating it, and moves through
+ * the views while results are on screen.
+ *
+ * The failure that matters most is narrating ahead of the system — claiming an answer has
+ * arrived before it has — so the ordering guarantees are what these tests pin.
+ */
+describe('DemoMode', () => {
+  beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
+  afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
+
+  it('renders nothing when closed', () => {
+    renderDemo({ open: false });
+    expect(screen.queryByTestId('demo-mode-card')).not.toBeInTheDocument();
+  });
+
+  it('starts on the first act and advertises that the run is live', () => {
+    renderDemo();
+    expect(screen.getByTestId('demo-mode-title')).toHaveTextContent(DEMO_ACTS[0].title);
+    expect(screen.getByTestId('demo-mode-card')).toHaveTextContent('LIVE');
+  });
+
+  it('submits the real prompt for a prompt act', async () => {
+    const props = renderDemo();
+
+    // Advance past the intro hold into the first prompt act.
+    await act(async () => { vi.advanceTimersByTime(DEMO_ACTS[0].holdMs ?? 5000); });
+
+    const promptAct = DEMO_ACTS.find(a => a.prompt);
+    await waitFor(() => expect(props.sendPrompt).toHaveBeenCalledWith(promptAct?.prompt));
+  });
+
+  it('waits for the answer before moving on', async () => {
+    // A demo that narrates ahead of the system is worse than no demo: the card would
+    // describe a result that is not on screen yet.
+    let resolveSend: (() => void) | undefined;
+    const sendPrompt = vi.fn(() => new Promise<void>(resolve => { resolveSend = resolve; }));
+    renderDemo({ sendPrompt });
+
+    await act(async () => { vi.advanceTimersByTime(DEMO_ACTS[0].holdMs ?? 5000); });
+    await waitFor(() => expect(sendPrompt).toHaveBeenCalled());
+
+    const titleDuringSend = screen.getByTestId('demo-mode-title').textContent;
+
+    // Time passing must NOT advance the act while the request is still outstanding.
+    await act(async () => { vi.advanceTimersByTime(60_000); });
+    expect(screen.getByTestId('demo-mode-title')).toHaveTextContent(titleDuringSend ?? '');
+
+    await act(async () => { resolveSend?.(); });
+    await act(async () => { vi.advanceTimersByTime(60_000); });
+    expect(screen.getByTestId('demo-mode-title')).not.toHaveTextContent(titleDuringSend ?? '');
+  });
+
+  it('shows a working indicator while a prompt is in flight', async () => {
+    const sendPrompt = vi.fn(() => new Promise<void>(() => { /* never resolves */ }));
+    renderDemo({ sendPrompt });
+
+    await act(async () => { vi.advanceTimersByTime(DEMO_ACTS[0].holdMs ?? 5000); });
+    await waitFor(() => expect(screen.getByTestId('demo-mode-working')).toBeInTheDocument());
+  });
+
+  it('says so rather than pretending when chat is not ready', async () => {
+    renderDemo({ sendPrompt: null });
+
+    await act(async () => { vi.advanceTimersByTime(DEMO_ACTS[0].holdMs ?? 5000); });
+    await waitFor(() => {
+      expect(screen.getByTestId('demo-mode-working')).toHaveTextContent(/not ready/i);
+    });
+  });
+
+  it('keeps running when a prompt fails', async () => {
+    // One failed turn must not strand the whole run.
+    const sendPrompt = vi.fn().mockRejectedValue(new Error('boom'));
+    renderDemo({ sendPrompt });
+
+    await act(async () => { vi.advanceTimersByTime(DEMO_ACTS[0].holdMs ?? 5000); });
+    await waitFor(() => expect(sendPrompt).toHaveBeenCalled());
+
+    await act(async () => { vi.advanceTimersByTime(60_000); });
+    expect(screen.getByTestId('demo-mode-progress')).not.toHaveTextContent('1 of');
+  });
+
+  it('drives the dashboard to each act view', async () => {
+    const props = renderDemo();
+    await waitFor(() => expect(props.onNavigate).toHaveBeenCalledWith(DEMO_ACTS[0].view));
+  });
+
+  it('pauses and resumes', async () => {
+    renderDemo();
+    const before = screen.getByTestId('demo-mode-progress').textContent;
+
+    await act(async () => { screen.getByTestId('demo-mode-pause').click(); });
+    await act(async () => { vi.advanceTimersByTime(120_000); });
+
+    // Paused means paused: no amount of elapsed time should move it on.
+    expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent(before ?? '');
+  });
+
+  it('skips to the next act on demand', async () => {
+    renderDemo();
+    expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent('1 of');
+
+    await act(async () => { screen.getByTestId('demo-mode-skip').click(); });
+    expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent('2 of');
+  });
+
+  it('stops from the Stop button', () => {
+    const props = renderDemo();
+    screen.getByTestId('demo-mode-exit').click();
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('restarts from the first act when reopened', async () => {
+    const { rerender } = render(wrap(
+      <DemoMode open onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} sendPrompt={vi.fn()} />,
+    ));
+    await act(async () => { screen.getByTestId('demo-mode-skip').click(); });
+    expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent('2 of');
+
+    rerender(wrap(
+      <DemoMode open={false} onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} sendPrompt={vi.fn()} />,
+    ));
+    rerender(wrap(
+      <DemoMode open onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} sendPrompt={vi.fn()} />,
+    ));
+
+    expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent('1 of');
+  });
+});
+
+describe('demo script', () => {
+  it('has unique act ids', () => {
+    const ids = DEMO_ACTS.map(a => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('actually submits prompts rather than only narrating', () => {
+    // The whole distinction from Tour is that this one runs the system.
+    expect(DEMO_ACTS.filter(a => a.prompt).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows the cost story after a real prompt has run', () => {
+    const firstPrompt = DEMO_ACTS.findIndex(a => a.prompt);
+    const costAct = DEMO_ACTS.findIndex(a => /cost/i.test(a.title));
+
+    // Narrating cost before anything has been spent would show an empty panel.
+    expect(costAct).toBeGreaterThan(firstPrompt);
+  });
+
+  it('opens the telemetry drawer for the prompt it narrates', () => {
+    const promptAct = DEMO_ACTS.find(a => a.prompt);
+    expect(promptAct?.telemetry).toBe(true);
+  });
+
+  it('visits every navigable view', () => {
+    const visited = new Set(DEMO_ACTS.map(a => a.view).filter(Boolean));
+    for (const view of [
+      'chat', 'promo', 'competitive', 'knowledge', 'council',
+      'security', 'cards', 'observability', 'stores', 'financials', 'portfolio',
+    ]) {
+      expect(visited).toContain(view);
+    }
+  });
+});

--- a/src/RetailPulse.Web/src/components/ChatPanel.tsx
+++ b/src/RetailPulse.Web/src/components/ChatPanel.tsx
@@ -84,6 +84,13 @@ interface ChatPanelProps {
   /** Live SignalR connection status for the plan view banner. */
   planConnected?: boolean;
   /**
+   * Hands the panel's send function to the host once it is available, so Demo Mode can
+   * submit a real prompt through exactly the same path a person typing would take —
+   * same session, same routing, same telemetry. Driving the DOM instead would exercise
+   * a different code path than the one being demonstrated.
+   */
+  registerSender?: (send: (message: string) => Promise<void>) => void;
+  /**
    * Whether the Real-Time Telemetry drawer is open.
    *
    * The composer's ConnectionStatusIndicator and the drawer header's badge report
@@ -489,6 +496,7 @@ export function ChatPanel({
   planController,
   planConnected,
   telemetryOpen = false,
+  registerSender,
 }: ChatPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -782,6 +790,11 @@ export function ChatPanel({
       setLoading(false);
     }
   }, []);
+
+  // Publish the send function once it is stable so Demo Mode can drive a real turn.
+  useEffect(() => {
+    registerSender?.(sendChatMessage);
+  }, [registerSender, sendChatMessage]);
 
   const handleSend = useCallback(async () => {
     if (!input.trim() || loading) return;

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { ReactElement } from 'react';
 import { Button, Badge, makeStyles, Drawer, DrawerBody, DrawerHeader, DrawerHeaderTitle, Menu, MenuTrigger, MenuList, MenuItem, MenuPopover, MenuButton, Spinner } from '@fluentui/react-components';
-import { Add24Regular, Play24Regular, DataUsage24Regular, Dismiss24Regular, TargetArrow24Regular, Shield24Regular, Library24Regular, HeartPulse24Regular, ShieldCheckmark24Regular, CardUi24Regular, Eye24Regular, Building24Regular, Money24Regular, Star24Regular } from '@fluentui/react-icons';
+import { Add24Regular, Play24Regular, BookInformation24Regular, DataUsage24Regular, Dismiss24Regular, TargetArrow24Regular, Shield24Regular, Library24Regular, HeartPulse24Regular, ShieldCheckmark24Regular, CardUi24Regular, Eye24Regular, Building24Regular, Money24Regular, Star24Regular } from '@fluentui/react-icons';
 import { ChatPanel } from './ChatPanel';
 import { fetchFinancials, fetchScorecardBatched, fetchStores, fetchStockoutRisks } from '../services/operationsApi';
 import { toAlert, fetchAlerts } from '../services/alertsApi';
 import { DemoTour } from './demo/DemoTour';
+import { DemoMode } from './demo/DemoMode';
 import { TelemetryPanel } from './TelemetryPanel';
 import { AgentRoutingPanel } from './AgentRoutingPanel';
 import { MemoryPanel } from './MemoryPanel';
@@ -293,7 +294,14 @@ export function Dashboard() {
   const [brandsDurationMs, setBrandsDurationMs] = useState(0);
   const [brandsLoading, setBrandsLoading] = useState(false);
   const [brandsError, setBrandsError] = useState<string | null>(null);
+  const [tourOpen, setTourOpen] = useState(false);
   const [demoOpen, setDemoOpen] = useState(false);
+  // Published by ChatPanel so Demo Mode can submit through the real send path.
+  const [sendPrompt, setSendPrompt] = useState<((m: string) => Promise<void>) | null>(null);
+  const registerSender = useCallback((send: (m: string) => Promise<void>) => {
+    // Stored via the functional form: a bare setState would invoke the function.
+    setSendPrompt(() => send);
+  }, []);
 
   // The scorecard fans out real agent assessments per brand, so it is genuinely slow.
   // Load it on demand and show progress rather than blocking behind an empty grid.
@@ -738,11 +746,20 @@ export function Dashboard() {
             New Chat
           </Button>
           <Button
+            appearance={tourOpen ? 'primary' : 'subtle'}
+            icon={<BookInformation24Regular />}
+            onClick={() => { setDemoOpen(false); setTourOpen(true); }}
+            data-testid="tour-button"
+            title="Step through every capability at your own pace"
+          >
+            Tour
+          </Button>
+          <Button
             appearance={demoOpen ? 'primary' : 'subtle'}
             icon={<Play24Regular />}
-            onClick={() => setDemoOpen(true)}
+            onClick={() => { setTourOpen(false); setDemoOpen(true); }}
             data-testid="demo-mode-button"
-            title="Guided walkthrough of every shipped capability"
+            title="Run a live, self-driving demo against the real system"
           >
             Demo Mode
           </Button>
@@ -787,6 +804,7 @@ export function Dashboard() {
               planController={planController}
               planConnected={connected}
               telemetryOpen={telemetryOpen}
+              registerSender={registerSender}
             />
           </div>
           {/* Secondary views are wrapped in a per-panel boundary keyed by the
@@ -986,10 +1004,17 @@ export function Dashboard() {
       {/* Rendered last so the overlay sits above the header, panels and drawer without
           needing to out-bid every nested z-index in the app. */}
       <DemoTour
+        open={tourOpen}
+        onClose={() => setTourOpen(false)}
+        onNavigate={view => setActiveView(view)}
+        onTelemetry={setTelemetryOpen}
+      />
+      <DemoMode
         open={demoOpen}
         onClose={() => setDemoOpen(false)}
         onNavigate={view => setActiveView(view)}
         onTelemetry={setTelemetryOpen}
+        sendPrompt={sendPrompt}
       />
     </div>
   );

--- a/src/RetailPulse.Web/src/components/demo/DemoMode.tsx
+++ b/src/RetailPulse.Web/src/components/demo/DemoMode.tsx
@@ -1,0 +1,279 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button, makeStyles, Spinner } from '@fluentui/react-components';
+import { Dismiss24Regular, Pause24Regular, Play24Regular, ChevronRight24Regular } from '@fluentui/react-icons';
+import { DEMO_ACTS, type DemoAct } from './demoActs';
+import type { DemoView } from './demoSteps';
+
+/**
+ * Automated walkthrough that actually drives the product.
+ *
+ * The Tour narrates a static surface and waits for a click. This does the opposite: it
+ * submits real prompts through the same send path a person typing would use, waits for
+ * each answer to land before narrating it, and moves through the views while the results
+ * are on screen. The numbers shown during a run are that run's real numbers.
+ *
+ * Nothing is dimmed. The whole point is to look at the product, so the narration sits in
+ * a corner card and the app stays fully visible and interactive behind it.
+ */
+
+interface DemoModeProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly onNavigate: (view: DemoView) => void;
+  readonly onTelemetry: (open: boolean) => void;
+  /**
+   * Submits a prompt through the live chat pipeline. Null until the chat panel has
+   * published its sender, in which case prompt acts narrate without submitting rather
+   * than silently appearing to work.
+   */
+  readonly sendPrompt: ((message: string) => Promise<void>) | null;
+}
+
+const useStyles = makeStyles({
+  card: {
+    position: 'fixed',
+    right: '24px',
+    bottom: '24px',
+    zIndex: 9500,
+    width: '420px',
+    boxSizing: 'border-box',
+    padding: '18px 20px',
+    borderRadius: '14px',
+    backgroundColor: 'var(--color-bg-elevated, #161622)',
+    border: '1px solid var(--brand-accent, #3b82f6)',
+    boxShadow: '0 20px 60px rgba(0,0,0,0.6)',
+    color: 'var(--color-text, #f1f5f9)',
+    fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
+  },
+  head: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '10px',
+    marginBottom: '4px',
+  },
+  chapter: {
+    fontSize: '11px',
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    color: 'var(--brand-accent, #3b82f6)',
+    fontWeight: '600',
+  },
+  liveTag: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+    fontSize: '11px',
+    fontWeight: '600',
+    color: '#22c55e',
+  },
+  dot: {
+    width: '7px',
+    height: '7px',
+    borderRadius: '50%',
+    backgroundColor: '#22c55e',
+  },
+  title: {
+    fontSize: '17px',
+    fontWeight: '600',
+    margin: '2px 0 8px',
+    lineHeight: '1.3',
+  },
+  body: {
+    fontSize: '13px',
+    lineHeight: '1.6',
+    color: 'var(--color-text-secondary, #cbd5e1)',
+    margin: '0 0 12px',
+  },
+  working: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    fontSize: '12px',
+    color: 'var(--brand-accent-light, #93c5fd)',
+    margin: '0 0 12px',
+  },
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '10px',
+  },
+  progress: {
+    fontSize: '12px',
+    color: 'var(--color-text-muted, #94a3b8)',
+    fontVariantNumeric: 'tabular-nums',
+  },
+  actions: { display: 'flex', gap: '6px', alignItems: 'center' },
+  rail: { display: 'flex', gap: '3px', marginTop: '12px' },
+  tick: {
+    height: '3px',
+    flex: '1',
+    borderRadius: '2px',
+    backgroundColor: 'var(--color-border, #334155)',
+  },
+  tickDone: { backgroundColor: 'var(--brand-accent, #3b82f6)' },
+});
+
+export function DemoMode({ open, onClose, onNavigate, onTelemetry, sendPrompt }: DemoModeProps) {
+  const styles = useStyles();
+  const [index, setIndex] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const [working, setWorking] = useState<string | null>(null);
+
+  // Guards the act runner against double-execution under StrictMode's deliberate
+  // double-invoke, which would otherwise submit every prompt twice.
+  const runningRef = useRef<string | null>(null);
+  const cancelledRef = useRef(false);
+
+  const act: DemoAct | undefined = DEMO_ACTS[index];
+  const isLast = index >= DEMO_ACTS.length - 1;
+
+  useEffect(() => {
+    if (open) {
+      setIndex(0);
+      setPaused(false);
+      cancelledRef.current = false;
+    } else {
+      cancelledRef.current = true;
+      runningRef.current = null;
+      setWorking(null);
+    }
+  }, [open]);
+
+  const advance = useCallback(() => {
+    setIndex(i => (i >= DEMO_ACTS.length - 1 ? i : i + 1));
+  }, []);
+
+  const skip = useCallback(() => {
+    // Skipping abandons whatever the current act is waiting on rather than queueing
+    // behind it, so the button responds immediately.
+    cancelledRef.current = true;
+    runningRef.current = null;
+    setWorking(null);
+    if (isLast) { onClose(); return; }
+    cancelledRef.current = false;
+    advance();
+  }, [advance, isLast, onClose]);
+
+  // Runs one act: put the app in the right state, submit any real prompt, hold, advance.
+  useEffect(() => {
+    if (!open || !act || paused) return;
+    if (runningRef.current === act.id) return;
+    runningRef.current = act.id;
+
+    let timer = 0;
+    let cancelled = false;
+    const stillLive = () => !cancelled && !cancelledRef.current;
+
+    void (async () => {
+      if (act.view) onNavigate(act.view);
+      if (act.telemetry !== undefined) onTelemetry(act.telemetry);
+
+      if (act.prompt) {
+        if (!sendPrompt) {
+          // Be honest rather than pretending. The message has to survive the hold, so it
+          // is deliberately not cleared below — otherwise it would be set and wiped in
+          // the same tick and nobody would ever see it.
+          setWorking('Chat is not ready — skipping this prompt');
+        } else {
+          setWorking('Running the prompt…');
+          try {
+            await sendPrompt(act.prompt);
+          } catch {
+            // A failed turn should not strand the run; the next act still has value.
+          }
+          if (!stillLive()) return;
+          setWorking(null);
+        }
+        if (!stillLive()) return;
+      }
+
+      // Hold so the result can actually be looked at before moving on.
+      timer = window.setTimeout(() => {
+        if (!stillLive()) return;
+        if (isLast) { onClose(); return; }
+        advance();
+      }, act.holdMs ?? 5_000);
+    })();
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [open, act, paused, sendPrompt, onNavigate, onTelemetry, advance, isLast, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      if (e.key === ' ') { e.preventDefault(); setPaused(p => !p); }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open || !act) return null;
+
+  return (
+    <div className={styles.card} role="status" aria-live="polite" data-testid="demo-mode-card">
+      <div className={styles.head}>
+        <span className={styles.chapter}>{act.chapter}</span>
+        <span className={styles.liveTag}>
+          <span className={styles.dot} />
+          LIVE
+        </span>
+      </div>
+
+      <div className={styles.title} data-testid="demo-mode-title">{act.title}</div>
+      <p className={styles.body}>{act.body}</p>
+
+      {working && (
+        <div className={styles.working} data-testid="demo-mode-working">
+          <Spinner size="tiny" />
+          <span>{working}</span>
+        </div>
+      )}
+
+      <div className={styles.footer}>
+        <span className={styles.progress} data-testid="demo-mode-progress">
+          {index + 1} of {DEMO_ACTS.length}
+        </span>
+        <div className={styles.actions}>
+          <Button
+            appearance="subtle"
+            icon={<Dismiss24Regular />}
+            onClick={onClose}
+            data-testid="demo-mode-exit"
+          >
+            Stop
+          </Button>
+          <Button
+            appearance="secondary"
+            icon={paused ? <Play24Regular /> : <Pause24Regular />}
+            onClick={() => setPaused(p => !p)}
+            data-testid="demo-mode-pause"
+            aria-label={paused ? 'Resume' : 'Pause'}
+          />
+          <Button
+            appearance="primary"
+            icon={<ChevronRight24Regular />}
+            iconPosition="after"
+            onClick={skip}
+            data-testid="demo-mode-skip"
+          >
+            {isLast ? 'Finish' : 'Skip'}
+          </Button>
+        </div>
+      </div>
+
+      <div className={styles.rail} aria-hidden="true">
+        {DEMO_ACTS.map((a, i) => (
+          <div key={a.id} className={`${styles.tick} ${i <= index ? styles.tickDone : ''}`} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default DemoMode;

--- a/src/RetailPulse.Web/src/components/demo/DemoTour.tsx
+++ b/src/RetailPulse.Web/src/components/demo/DemoTour.tsx
@@ -54,9 +54,9 @@ const useStyles = makeStyles({
     position: 'fixed',
     inset: '0',
     zIndex: 9000,
-    // Pointer events are enabled so a stray click cannot interact with the app mid-tour,
-    // which would desynchronise the narration from what is on screen.
-    pointerEvents: 'auto',
+    // Clicks pass straight through: with no dimming mask there is nothing to block, and
+    // the operator can still interact with the product while the narration is up.
+    pointerEvents: 'none',
   },
   card: {
     position: 'fixed',
@@ -309,9 +309,10 @@ export function DemoTour({ open, onClose, onNavigate, onTelemetry }: DemoTourPro
 
   if (!open || !step) return null;
 
-  // The cutout is drawn with a huge spread box-shadow rather than an SVG mask: it dims
-  // everything outside the highlighted box while leaving the element itself untouched and
-  // fully legible.
+  // The highlight is a ring and glow, not a dimming mask. An earlier version dimmed
+  // everything outside the cutout, which made the panel being described the one thing you
+  // could not read properly — the opposite of the point. The narration card carries the
+  // explanation; the app stays fully legible behind it.
   const spotlight = rect
     ? {
       position: 'fixed' as const,
@@ -320,8 +321,8 @@ export function DemoTour({ open, onClose, onNavigate, onTelemetry }: DemoTourPro
       width: `${rect.width + SPOTLIGHT_PADDING * 2}px`,
       height: `${rect.height + SPOTLIGHT_PADDING * 2}px`,
       borderRadius: '10px',
-      boxShadow: '0 0 0 9999px rgba(2, 6, 23, 0.72)',
       border: '2px solid var(--brand-accent, #3b82f6)',
+      boxShadow: '0 0 0 1px rgba(59,130,246,0.35), 0 0 24px 4px rgba(59,130,246,0.35)',
       pointerEvents: 'none' as const,
       transition: 'top 180ms ease, left 180ms ease, width 180ms ease, height 180ms ease',
     }
@@ -329,13 +330,12 @@ export function DemoTour({ open, onClose, onNavigate, onTelemetry }: DemoTourPro
 
   return (
     <>
+      {/* No backdrop fill: the point is to show the product, not to grey it out. The
+          layer exists only to host the highlight ring. */}
       <div
         className={styles.overlay}
         data-testid="demo-tour-overlay"
-        // Clicking the backdrop does NOT advance or close: an accidental click during a
-        // presentation should do nothing rather than skip a step.
         onClick={e => e.stopPropagation()}
-        style={rect ? undefined : { backgroundColor: 'rgba(2, 6, 23, 0.72)' }}
       >
         {spotlight && <div style={spotlight} data-testid="demo-tour-spotlight" />}
       </div>

--- a/src/RetailPulse.Web/src/components/demo/demoActs.ts
+++ b/src/RetailPulse.Web/src/components/demo/demoActs.ts
@@ -1,0 +1,207 @@
+import type { DemoView } from './demoSteps';
+
+/**
+ * Script for the automated Demo Mode run.
+ *
+ * Unlike the Tour — which narrates a static surface and waits for a click — this drives
+ * the product: it submits real prompts through the same path a person typing would take,
+ * waits for the answer to actually arrive, and moves through the views while the results
+ * are on screen.
+ *
+ * Nothing here is faked. `prompt` steps hit the live API, so the tokens, cost and latency
+ * shown in the telemetry drawer during the run are the real numbers for that request.
+ */
+
+export interface DemoAct {
+  readonly id: string;
+  readonly chapter: string;
+  readonly title: string;
+  readonly body: string;
+  /** View to switch to before the act runs. */
+  readonly view?: DemoView;
+  /** Whether the telemetry drawer should be open. */
+  readonly telemetry?: boolean;
+  /**
+   * A prompt to submit for real. The act does not advance until the response lands, so
+   * the narration never runs ahead of the system.
+   */
+  readonly prompt?: string;
+  /**
+   * How long to hold this act once its work is done, in milliseconds. Long enough to read
+   * the card and look at the result; short enough that the run keeps moving.
+   */
+  readonly holdMs?: number;
+}
+
+const READ = 7_000;
+const GLANCE = 5_000;
+
+export const DEMO_ACTS: readonly DemoAct[] = [
+  {
+    id: 'intro',
+    chapter: 'Live demo',
+    title: 'This is the real system',
+    body:
+      'Everything from here runs live against Azure — real prompts, real agents, real tool '
+      + 'calls, real token costs. Nothing is scripted or pre-recorded. Sit back; it drives '
+      + 'itself, and you can stop at any point.',
+    view: 'chat',
+    holdMs: GLANCE,
+  },
+  {
+    id: 'ask-demand',
+    chapter: 'Routing',
+    title: 'Asking a demand question',
+    body:
+      'Submitting a real question now. Watch the router pick the demand-forecasting '
+      + 'specialist, call its tools, and answer from live data — the whole turn is streaming '
+      + 'into the telemetry drawer as it happens.',
+    view: 'chat',
+    telemetry: true,
+    prompt: 'How are FreshMart depletions trending in the Northeast this quarter?',
+    holdMs: READ,
+  },
+  {
+    id: 'cost',
+    chapter: 'AI Gateway',
+    title: 'What that answer cost',
+    body:
+      'Live Spans now holds the real numbers for the request you just watched: total tokens, '
+      + 'span count, tool calls, wall-clock duration and dollar cost. Every one of those model '
+      + 'calls went through the API Management AI Gateway, which meters tokens per '
+      + 'subscription and authenticates to Foundry with managed identity — no model keys exist '
+      + 'anywhere in the system.',
+    telemetry: true,
+    holdMs: READ + 2_000,
+  },
+  {
+    id: 'ask-chart',
+    chapter: 'Charts',
+    title: 'Asking for a visualisation',
+    body:
+      'The same pipeline builds charts. This one is drawn deterministically from the tool '
+      + 'payload rather than improvised by the model, so the numbers on the axis are the '
+      + 'numbers the tools returned.',
+    view: 'chat',
+    telemetry: true,
+    prompt: 'Show a horizontal bar chart ranking all brands by depletion growth rate',
+    holdMs: READ + 2_000,
+  },
+  {
+    id: 'council',
+    chapter: 'Multi-agent',
+    title: 'Convening the Health Council',
+    body:
+      'Several specialists assess one brand independently, each grounded in its own tool '
+      + 'data and reporting its own confidence. Disagreement is surfaced rather than averaged '
+      + 'away — and the verdict is published as a collaborative card to vote on.',
+    view: 'council',
+    telemetry: false,
+    holdMs: READ,
+  },
+  {
+    id: 'portfolio',
+    chapter: 'Multi-agent',
+    title: 'Scoring the whole portfolio',
+    body:
+      'Every brand scored across five specialist dimensions — demand, margin, competitive, '
+      + 'supply and store execution — by fanning out to the specialists in parallel. Results '
+      + 'are cached, so this is instant on a second visit.',
+    view: 'portfolio',
+    holdMs: READ,
+  },
+  {
+    id: 'competitive',
+    chapter: 'Analytics',
+    title: 'Competitive intelligence',
+    body:
+      'Market share, competitor pricing moves and detected threats with recommended '
+      + 'responses. The price drops here are what raise the alerts in the telemetry drawer.',
+    view: 'competitive',
+    holdMs: GLANCE,
+  },
+  {
+    id: 'financials',
+    chapter: 'Analytics',
+    title: 'Financials',
+    body:
+      'A P&L waterfall from revenue to net margin with the drivers moving it — read live '
+      + 'from the margin service.',
+    view: 'financials',
+    holdMs: GLANCE,
+  },
+  {
+    id: 'stores',
+    chapter: 'Analytics',
+    title: 'Store operations',
+    body:
+      'Every store against target, a regional heatmap, and the SKUs at genuine stockout '
+      + 'risk ranked by urgency with recommended reorder quantities.',
+    view: 'stores',
+    holdMs: GLANCE,
+  },
+  {
+    id: 'knowledge',
+    chapter: 'Grounding',
+    title: 'What the agents read',
+    body:
+      'The corpus answers are grounded in, with per-agent bindings showing exactly which '
+      + 'source each specialist is scoped to. Providers are pluggable — in-memory BM25 here, '
+      + 'with Azure AI Search and Foundry IQ available.',
+    view: 'knowledge',
+    holdMs: GLANCE,
+  },
+  {
+    id: 'promo',
+    chapter: 'Planning',
+    title: 'Campaign Planner',
+    body:
+      'Model a promotion before running it: expected ROI with confidence bounds, break-even '
+      + 'weeks, seasonality fit and the risks worth knowing — grounded in historical outcomes.',
+    view: 'promo',
+    holdMs: GLANCE,
+  },
+  {
+    id: 'cards',
+    chapter: 'Collaboration',
+    title: 'Adaptive Cards',
+    body:
+      'Council verdicts are published here as interactive cards. Teammates vote, comment and '
+      + 'escalate; a split vote escalates automatically. The same format the Teams bot sends.',
+    view: 'cards',
+    holdMs: GLANCE,
+  },
+  {
+    id: 'security',
+    chapter: 'Trust',
+    title: 'Guardrails',
+    body:
+      'Prompt-injection defence, PII redaction on input and output, and Azure AI Content '
+      + 'Safety scanning every prompt and response. Entra-only sign-in, every endpoint '
+      + 'deny-by-default.',
+    view: 'security',
+    holdMs: GLANCE,
+  },
+  {
+    id: 'observability',
+    chapter: 'AI Gateway',
+    title: 'The bill',
+    body:
+      'Total tokens, total cost, request count and average cost per request — including the '
+      + 'requests this demo just made. This is what makes the economics of a multi-agent '
+      + 'system visible rather than a surprise on the invoice.',
+    view: 'observability',
+    holdMs: READ,
+  },
+  {
+    id: 'outro',
+    chapter: 'Done',
+    title: 'All of that was live',
+    body:
+      'Every answer, chart and cost figure came from services running on Azure during this '
+      + 'run. Ask it something of your own — or press Tour for the guided version you can '
+      + 'step through at your own pace.',
+    view: 'chat',
+    holdMs: GLANCE,
+  },
+];


### PR DESCRIPTION
Three changes from the demo feedback.

## 1. Tour — same walkthrough, no longer dimming the product

The existing guided walkthrough is now **Tour**. The old version greyed out everything except a cutout, which made the panel being described the one thing you could not read properly — the opposite of the point.

The highlight is now a ring and glow. The app stays fully legible **and interactive** behind the narration, and the overlay no longer swallows clicks.

## 2. Demo Mode — actually drives the real system

New, and genuinely different from Tour. It:

- **Submits real prompts** through the same send path a person typing would use. `ChatPanel` publishes its sender to the host rather than the demo poking the DOM, so the run exercises the exact code path being demonstrated — same session, same routing, same telemetry.
- **Waits for each answer to land before narrating it.** A demo that runs ahead of the system describes results that are not on screen yet.
- **Walks every view** with the results still up.
- Offers **Pause, Skip and Stop** at all times; space bar toggles pause.

The tokens, cost and latency shown during a run are that run's **real numbers**.

Two prompts are submitted live: a demand question (to show routing and cost) and a chart request (to show deterministic chart construction). The **cost act is deliberately ordered after a prompt has run**, so the telemetry panel it points at is populated rather than showing zeros — asserted by a test.

## 3. A defect the new tests caught

When no sender is available, the honest "chat is not ready" fallback was set and cleared **in the same tick**, so it was never visible. It now survives the hold.

## Verification

18 Demo Mode tests plus 18 Tour tests. The ordering guarantees are what they pin hardest: that a prompt is actually submitted, that time passing does **not** advance an act while a request is still outstanding, that a failed turn does not strand the run, and that the cost act comes after real spend.

Frontend suite: **93 files, 860 tests passing**. `tsc -b` exit 0.
