### PR TITLE
Demo Mode: fix duplicate prompts, add Back, interact with each panel, drop em dashes

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/DemoMode.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/DemoMode.test.tsx
@@ -14,6 +14,7 @@ function renderDemo(overrides: Partial<Parameters<typeof DemoMode>[0]> = {}) {
     onNavigate: vi.fn(),
     onTelemetry: vi.fn(),
     sendPrompt: vi.fn().mockResolvedValue(undefined),
+    telemetryOpen: false,
     ...overrides,
   };
   render(wrap(<DemoMode {...props} />));
@@ -119,11 +120,11 @@ describe('DemoMode', () => {
     expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent(before ?? '');
   });
 
-  it('skips to the next act on demand', async () => {
+  it('advances to the next act on demand', async () => {
     renderDemo();
     expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent('1 of');
 
-    await act(async () => { screen.getByTestId('demo-mode-skip').click(); });
+    await act(async () => { screen.getByTestId('demo-mode-next').click(); });
     expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent('2 of');
   });
 
@@ -133,18 +134,114 @@ describe('DemoMode', () => {
     expect(props.onClose).toHaveBeenCalled();
   });
 
+  it('goes back to the previous act', async () => {
+    renderDemo();
+    await act(async () => { screen.getByTestId('demo-mode-next').click(); });
+    expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent('2 of');
+
+    await act(async () => { screen.getByTestId('demo-mode-back').click(); });
+    expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent('1 of');
+  });
+
+  it('disables Back on the first act', () => {
+    renderDemo();
+    expect(screen.getByTestId('demo-mode-back')).toBeDisabled();
+  });
+
+  it('stays clear of the telemetry drawer when it is open', () => {
+    // The drawer covers the right edge, and the card used to sit underneath it.
+    const { unmount } = render(wrap(
+      <DemoMode
+        open onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()}
+        sendPrompt={vi.fn()} telemetryOpen
+      />,
+    ));
+
+    const right = Number.parseFloat(screen.getByTestId('demo-mode-card').style.right);
+    expect(right).toBeGreaterThan(500);
+    unmount();
+  });
+
+  it('sits at the edge when the drawer is closed', () => {
+    renderDemo({ telemetryOpen: false });
+    const right = Number.parseFloat(screen.getByTestId('demo-mode-card').style.right);
+    expect(right).toBeLessThan(100);
+  });
+
+  it('submits a prompt exactly once per act', async () => {
+    // The original runner took its callbacks as effect dependencies, so a host re-render
+    // with a new inline callback re-entered the act and submitted the same prompt again.
+    // Observed live: the same question asked three times in a row.
+    const sendPrompt = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = render(wrap(
+      <DemoMode
+        open onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()}
+        sendPrompt={sendPrompt} telemetryOpen={false}
+      />,
+    ));
+
+    await act(async () => { vi.advanceTimersByTime(DEMO_ACTS[0].holdMs ?? 5000); });
+    await waitFor(() => expect(sendPrompt).toHaveBeenCalledTimes(1));
+
+    // Re-render repeatedly with brand new callback identities, as the Dashboard does.
+    for (let i = 0; i < 5; i++) {
+      rerender(wrap(
+        <DemoMode
+          open onClose={() => {}} onNavigate={() => {}} onTelemetry={() => {}}
+          sendPrompt={sendPrompt} telemetryOpen={false}
+        />,
+      ));
+    }
+    await act(async () => { vi.advanceTimersByTime(200); });
+
+    expect(sendPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicks the controls an act asks for', async () => {
+    const button = document.createElement('button');
+    button.setAttribute('data-testid', 'convene-button');
+    const clicked = vi.fn();
+    button.addEventListener('click', clicked);
+    document.body.appendChild(button);
+
+    try {
+      renderDemo();
+      const councilIndex = DEMO_ACTS.findIndex(a => a.id === 'council');
+      for (let i = 0; i < councilIndex; i++) {
+        await act(async () => { screen.getByTestId('demo-mode-next').click(); });
+      }
+      await act(async () => { vi.advanceTimersByTime(500); });
+
+      await waitFor(() => expect(clicked).toHaveBeenCalled());
+    } finally {
+      button.remove();
+    }
+  });
+
+  it('skips a missing control instead of throwing', async () => {
+    // A panel that has not finished loading must not take the whole run down.
+    renderDemo();
+    const councilIndex = DEMO_ACTS.findIndex(a => a.id === 'council');
+    for (let i = 0; i < councilIndex; i++) {
+      await act(async () => { screen.getByTestId('demo-mode-next').click(); });
+    }
+
+    await act(async () => { vi.advanceTimersByTime(2_000); });
+    expect(screen.getByTestId('demo-mode-card')).toBeInTheDocument();
+  });
+
   it('restarts from the first act when reopened', async () => {
     const { rerender } = render(wrap(
-      <DemoMode open onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} sendPrompt={vi.fn()} />,
+      <DemoMode open onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} sendPrompt={vi.fn()} telemetryOpen={false} />,
     ));
-    await act(async () => { screen.getByTestId('demo-mode-skip').click(); });
+    await act(async () => { screen.getByTestId('demo-mode-next').click(); });
     expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent('2 of');
 
     rerender(wrap(
-      <DemoMode open={false} onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} sendPrompt={vi.fn()} />,
+      <DemoMode open={false} onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} sendPrompt={vi.fn()} telemetryOpen={false} />,
     ));
     rerender(wrap(
-      <DemoMode open onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} sendPrompt={vi.fn()} />,
+      <DemoMode open onClose={vi.fn()} onNavigate={vi.fn()} onTelemetry={vi.fn()} sendPrompt={vi.fn()} telemetryOpen={false} />,
     ));
 
     expect(screen.getByTestId('demo-mode-progress')).toHaveTextContent('1 of');
@@ -182,6 +279,22 @@ describe('demo script', () => {
       'security', 'cards', 'observability', 'stores', 'financials', 'portfolio',
     ]) {
       expect(visited).toContain(view);
+    }
+  });
+
+  it('actually interacts with panels rather than only navigating to them', () => {
+    // The point of Demo Mode over Tour is that it drives the product.
+    const withInteractions = DEMO_ACTS.filter(a => (a.interactions?.length ?? 0) > 0);
+    expect(withInteractions.length).toBeGreaterThanOrEqual(5);
+
+    // At least the council convene and the knowledge search must be real clicks.
+    const clicks = DEMO_ACTS.flatMap(a => a.interactions ?? []).filter(i => i.kind === 'click');
+    expect(clicks.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('uses no em dashes anywhere in the script', () => {
+    for (const a of DEMO_ACTS) {
+      expect(`${a.title} ${a.body}`).not.toContain('\u2014');
     }
   });
 });

--- a/src/RetailPulse.Web/src/__tests__/DemoTour.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/DemoTour.test.tsx
@@ -221,6 +221,13 @@ describe('demo script', () => {
     }
   });
 
+  it('uses no em dashes anywhere in the script', () => {
+    for (const s of DEMO_STEPS) {
+      expect(s.title).not.toContain('\u2014');
+      expect(s.body).not.toContain('\u2014');
+    }
+  });
+
   it('keeps body copy short enough for a flyout', () => {
     for (const step of DEMO_STEPS) {
       expect(step.body.length).toBeLessThanOrEqual(400);

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -1015,6 +1015,7 @@ export function Dashboard() {
         onNavigate={view => setActiveView(view)}
         onTelemetry={setTelemetryOpen}
         sendPrompt={sendPrompt}
+        telemetryOpen={telemetryOpen}
       />
     </div>
   );

--- a/src/RetailPulse.Web/src/components/demo/DemoMode.tsx
+++ b/src/RetailPulse.Web/src/components/demo/DemoMode.tsx
@@ -1,19 +1,21 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, makeStyles, Spinner } from '@fluentui/react-components';
-import { Dismiss24Regular, Pause24Regular, Play24Regular, ChevronRight24Regular } from '@fluentui/react-icons';
-import { DEMO_ACTS, type DemoAct } from './demoActs';
+import {
+  ChevronLeft24Regular, ChevronRight24Regular, Dismiss24Regular, Pause24Regular, Play24Regular,
+} from '@fluentui/react-icons';
+import { DEMO_ACTS, type DemoAct, type DemoInteraction } from './demoActs';
 import type { DemoView } from './demoSteps';
 
 /**
  * Automated walkthrough that actually drives the product.
  *
  * The Tour narrates a static surface and waits for a click. This does the opposite: it
- * submits real prompts through the same send path a person typing would use, waits for
- * each answer to land before narrating it, and moves through the views while the results
- * are on screen. The numbers shown during a run are that run's real numbers.
+ * submits real prompts through the same send path a person typing would use, clicks the
+ * same controls inside each panel that an operator would, and waits for the work to finish
+ * before narrating the result.
  *
- * Nothing is dimmed. The whole point is to look at the product, so the narration sits in
- * a corner card and the app stays fully visible and interactive behind it.
+ * Nothing is dimmed. The whole point is to look at the product, so the narration sits in a
+ * corner card and the app stays fully visible and interactive behind it.
  */
 
 interface DemoModeProps {
@@ -23,16 +25,20 @@ interface DemoModeProps {
   readonly onTelemetry: (open: boolean) => void;
   /**
    * Submits a prompt through the live chat pipeline. Null until the chat panel has
-   * published its sender, in which case prompt acts narrate without submitting rather
-   * than silently appearing to work.
+   * published its sender, in which case prompt acts say so rather than appearing to work.
    */
   readonly sendPrompt: ((message: string) => Promise<void>) | null;
+  /** Whether the telemetry drawer is open, so the card can stay clear of it. */
+  readonly telemetryOpen: boolean;
 }
+
+/** Width of the telemetry drawer, so the card sits beside it rather than behind it. */
+const DRAWER_WIDTH_PX = 560;
+const EDGE_GAP_PX = 24;
 
 const useStyles = makeStyles({
   card: {
     position: 'fixed',
-    right: '24px',
     bottom: '24px',
     zIndex: 9500,
     width: '420px',
@@ -44,6 +50,7 @@ const useStyles = makeStyles({
     boxShadow: '0 20px 60px rgba(0,0,0,0.6)',
     color: 'var(--color-text, #f1f5f9)',
     fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
+    transition: 'right 260ms cubic-bezier(0.4, 0, 0.2, 1)',
   },
   head: {
     display: 'flex',
@@ -67,18 +74,8 @@ const useStyles = makeStyles({
     fontWeight: '600',
     color: '#22c55e',
   },
-  dot: {
-    width: '7px',
-    height: '7px',
-    borderRadius: '50%',
-    backgroundColor: '#22c55e',
-  },
-  title: {
-    fontSize: '17px',
-    fontWeight: '600',
-    margin: '2px 0 8px',
-    lineHeight: '1.3',
-  },
+  dot: { width: '7px', height: '7px', borderRadius: '50%', backgroundColor: '#22c55e' },
+  title: { fontSize: '17px', fontWeight: '600', margin: '2px 0 8px', lineHeight: '1.3' },
   body: {
     fontSize: '13px',
     lineHeight: '1.6',
@@ -115,108 +112,179 @@ const useStyles = makeStyles({
   tickDone: { backgroundColor: 'var(--brand-accent, #3b82f6)' },
 });
 
-export function DemoMode({ open, onClose, onNavigate, onTelemetry, sendPrompt }: DemoModeProps) {
+/** Sets a React-controlled input's value so the component's onChange actually fires. */
+function setNativeValue(element: HTMLElement, value: string): void {
+  const input = element as HTMLInputElement | HTMLTextAreaElement;
+  const proto = input instanceof HTMLTextAreaElement
+    ? HTMLTextAreaElement.prototype
+    : HTMLInputElement.prototype;
+
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+  if (!setter) return;
+
+  setter.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+export function DemoMode({
+  open, onClose, onNavigate, onTelemetry, sendPrompt, telemetryOpen,
+}: DemoModeProps) {
   const styles = useStyles();
   const [index, setIndex] = useState(0);
   const [paused, setPaused] = useState(false);
   const [working, setWorking] = useState<string | null>(null);
 
-  // Guards the act runner against double-execution under StrictMode's deliberate
-  // double-invoke, which would otherwise submit every prompt twice.
-  const runningRef = useRef<string | null>(null);
-  const cancelledRef = useRef(false);
+  // Callbacks live in refs so the act runner can depend ONLY on the act index. Taking them
+  // as effect dependencies made the runner re-enter whenever the host re-rendered with a
+  // new inline callback, which submitted the same prompt three times in a row.
+  const navigateRef = useRef(onNavigate);
+  const telemetryRef = useRef(onTelemetry);
+  const sendRef = useRef(sendPrompt);
+  const closeRef = useRef(onClose);
+  navigateRef.current = onNavigate;
+  telemetryRef.current = onTelemetry;
+  sendRef.current = sendPrompt;
+  closeRef.current = onClose;
+
+  /** Bumped whenever the run jumps, so an in-flight act abandons its remaining work. */
+  const runToken = useRef(0);
 
   const act: DemoAct | undefined = DEMO_ACTS[index];
+  const isFirst = index === 0;
   const isLast = index >= DEMO_ACTS.length - 1;
 
   useEffect(() => {
     if (open) {
       setIndex(0);
       setPaused(false);
-      cancelledRef.current = false;
-    } else {
-      cancelledRef.current = true;
-      runningRef.current = null;
-      setWorking(null);
     }
+    runToken.current += 1;
+    setWorking(null);
   }, [open]);
 
-  const advance = useCallback(() => {
-    setIndex(i => (i >= DEMO_ACTS.length - 1 ? i : i + 1));
+  const goTo = useCallback((target: number) => {
+    // Abandon whatever the current act is waiting on so the button responds immediately
+    // rather than queueing behind a 25 second council vote.
+    runToken.current += 1;
+    setWorking(null);
+    setIndex(Math.max(0, Math.min(target, DEMO_ACTS.length - 1)));
   }, []);
 
-  const skip = useCallback(() => {
-    // Skipping abandons whatever the current act is waiting on rather than queueing
-    // behind it, so the button responds immediately.
-    cancelledRef.current = true;
-    runningRef.current = null;
-    setWorking(null);
+  const next = useCallback(() => {
     if (isLast) { onClose(); return; }
-    cancelledRef.current = false;
-    advance();
-  }, [advance, isLast, onClose]);
+    goTo(index + 1);
+  }, [goTo, index, isLast, onClose]);
 
-  // Runs one act: put the app in the right state, submit any real prompt, hold, advance.
+  const back = useCallback(() => goTo(index - 1), [goTo, index]);
+
+  // Runs one act: put the app in the right state, submit any prompt, drive any controls,
+  // hold, then advance. Depends only on the act index and pause state.
   useEffect(() => {
     if (!open || !act || paused) return;
-    if (runningRef.current === act.id) return;
-    runningRef.current = act.id;
+
+    runToken.current += 1;
+    const token = runToken.current;
+    const live = () => runToken.current === token;
 
     let timer = 0;
-    let cancelled = false;
-    const stillLive = () => !cancelled && !cancelledRef.current;
+    const pause = (ms: number) => new Promise<void>(resolve => {
+      timer = window.setTimeout(resolve, ms);
+    });
+
+    const runInteraction = async (step: DemoInteraction) => {
+      if (step.note) setWorking(step.note);
+
+      if (step.kind === 'wait') {
+        await pause(step.ms);
+        return;
+      }
+
+      const target = document.querySelector<HTMLElement>(step.selector);
+      // A missing control is skipped rather than thrown: a panel that has not finished
+      // loading must not take the whole run down in front of an audience.
+      if (!target) return;
+
+      if (step.kind === 'click') {
+        target.click();
+        await pause(400);
+        return;
+      }
+
+      setNativeValue(target, step.text);
+      await pause(300);
+    };
 
     void (async () => {
-      if (act.view) onNavigate(act.view);
-      if (act.telemetry !== undefined) onTelemetry(act.telemetry);
+      if (act.view) navigateRef.current(act.view);
+      if (act.telemetry !== undefined) telemetryRef.current(act.telemetry);
+
+      // When the sender is unavailable the honest message must survive to the hold, so
+      // the post-interaction reset below is suppressed for that case. Clearing it there
+      // was why the fallback was never actually visible.
+      let keepWorking = false;
 
       if (act.prompt) {
-        if (!sendPrompt) {
-          // Be honest rather than pretending. The message has to survive the hold, so it
-          // is deliberately not cleared below — otherwise it would be set and wiped in
-          // the same tick and nobody would ever see it.
-          setWorking('Chat is not ready — skipping this prompt');
+        const send = sendRef.current;
+        if (!send) {
+          setWorking('Chat is not ready, skipping this prompt');
+          keepWorking = true;
         } else {
-          setWorking('Running the prompt…');
+          setWorking('Running the prompt');
           try {
-            await sendPrompt(act.prompt);
+            await send(act.prompt);
           } catch {
             // A failed turn should not strand the run; the next act still has value.
           }
-          if (!stillLive()) return;
+          if (!live()) return;
           setWorking(null);
         }
-        if (!stillLive()) return;
+        if (!live()) return;
       }
 
-      // Hold so the result can actually be looked at before moving on.
-      timer = window.setTimeout(() => {
-        if (!stillLive()) return;
-        if (isLast) { onClose(); return; }
-        advance();
-      }, act.holdMs ?? 5_000);
+      for (const step of act.interactions ?? []) {
+        if (!live()) return;
+        await runInteraction(step);
+        keepWorking = false;
+      }
+      if (!live()) return;
+      if (!keepWorking) setWorking(null);
+
+      await pause(act.holdMs ?? 5_000);
+      if (!live()) return;
+
+      if (isLast) { closeRef.current(); return; }
+      setIndex(i => (i === index ? i + 1 : i));
     })();
 
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timer);
-    };
-  }, [open, act, paused, sendPrompt, onNavigate, onTelemetry, advance, isLast, onClose]);
+    return () => window.clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, index, paused]);
 
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
       if (e.key === ' ') { e.preventDefault(); setPaused(p => !p); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); next(); }
+      if (e.key === 'ArrowLeft') { e.preventDefault(); back(); }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [open, onClose]);
+  }, [open, onClose, next, back]);
 
   if (!open || !act) return null;
 
+  // Slide clear of the telemetry drawer instead of hiding underneath it.
+  const right = telemetryOpen ? DRAWER_WIDTH_PX + EDGE_GAP_PX : EDGE_GAP_PX;
+
   return (
-    <div className={styles.card} role="status" aria-live="polite" data-testid="demo-mode-card">
+    <div
+      className={styles.card}
+      style={{ right: `${right}px` }}
+      role="status"
+      aria-live="polite"
+      data-testid="demo-mode-card"
+    >
       <div className={styles.head}>
         <span className={styles.chapter}>{act.chapter}</span>
         <span className={styles.liveTag}>
@@ -256,13 +324,21 @@ export function DemoMode({ open, onClose, onNavigate, onTelemetry, sendPrompt }:
             aria-label={paused ? 'Resume' : 'Pause'}
           />
           <Button
+            appearance="secondary"
+            icon={<ChevronLeft24Regular />}
+            onClick={back}
+            disabled={isFirst}
+            data-testid="demo-mode-back"
+            aria-label="Previous"
+          />
+          <Button
             appearance="primary"
             icon={<ChevronRight24Regular />}
             iconPosition="after"
-            onClick={skip}
-            data-testid="demo-mode-skip"
+            onClick={next}
+            data-testid="demo-mode-next"
           >
-            {isLast ? 'Finish' : 'Skip'}
+            {isLast ? 'Finish' : 'Next'}
           </Button>
         </div>
       </div>

--- a/src/RetailPulse.Web/src/components/demo/DemoTour.tsx
+++ b/src/RetailPulse.Web/src/components/demo/DemoTour.tsx
@@ -8,7 +8,7 @@ import { DEMO_STEPS, type DemoStep, type DemoView } from './demoSteps';
  *
  * The tour drives the dashboard rather than describing it from the side: each step can
  * switch view and open the telemetry drawer, so the operator is always looking at the
- * thing being described. Advancing is manual — nothing auto-plays, because a demo that
+ * thing being described. Advancing is manual, nothing auto-plays, because a demo that
  * moves on its own cannot be paused to answer a question.
  */
 
@@ -127,7 +127,7 @@ const useStyles = makeStyles({
 /**
  * Reads the on-screen box of a step's target.
  *
- * Returns null when the step has no target or the element is not present — a step whose
+ * Returns null when the step has no target or the element is not present, a step whose
  * target is missing degrades to a centred card rather than pointing at the top-left
  * corner, which is what an unchecked getBoundingClientRect would do.
  */
@@ -193,7 +193,7 @@ function positionCard(rect: Rect | null, placement: DemoStep['placement']): { to
 /**
  * True when the flyout would sit on top of the element it is describing.
  *
- * Clamping a card back inside the viewport can push it over its own spotlight — which is
+ * Clamping a card back inside the viewport can push it over its own spotlight, which is
  * exactly what happened against the telemetry drawer, whose 560px panel is flush with the
  * right edge. When that happens the caller falls back to centring, which is never wrong.
  */
@@ -231,7 +231,7 @@ export function DemoTour({ open, onClose, onNavigate, onTelemetry }: DemoTourPro
 
   // Measure after the view switch has painted. A layout effect alone is too early: the
   // panel being pointed at may not exist yet on the frame the step changes, and the
-  // telemetry drawer slides in over roughly 250ms — measuring it mid-animation captures
+  // telemetry drawer slides in over roughly 250ms, measuring it mid-animation captures
   // its off-screen starting position and parks the flyout on top of it.
   useLayoutEffect(() => {
     if (!open || !step) return;
@@ -311,7 +311,7 @@ export function DemoTour({ open, onClose, onNavigate, onTelemetry }: DemoTourPro
 
   // The highlight is a ring and glow, not a dimming mask. An earlier version dimmed
   // everything outside the cutout, which made the panel being described the one thing you
-  // could not read properly — the opposite of the point. The narration card carries the
+  // could not read properly, the opposite of the point. The narration card carries the
   // explanation; the app stays fully legible behind it.
   const spotlight = rect
     ? {

--- a/src/RetailPulse.Web/src/components/demo/demoActs.ts
+++ b/src/RetailPulse.Web/src/components/demo/demoActs.ts
@@ -3,14 +3,26 @@ import type { DemoView } from './demoSteps';
 /**
  * Script for the automated Demo Mode run.
  *
- * Unlike the Tour — which narrates a static surface and waits for a click — this drives
- * the product: it submits real prompts through the same path a person typing would take,
- * waits for the answer to actually arrive, and moves through the views while the results
- * are on screen.
+ * Unlike the Tour, which narrates a static surface and waits for a click, this drives the
+ * product. It submits real prompts through the same path a person typing would take, runs
+ * real interactions inside each panel, and waits for the work to finish before narrating
+ * the result.
  *
- * Nothing here is faked. `prompt` steps hit the live API, so the tokens, cost and latency
- * shown in the telemetry drawer during the run are the real numbers for that request.
+ * Nothing here is faked. Prompts hit the live API and interactions click the same controls
+ * an operator would, so the tokens, cost and latency shown during a run are that run's
+ * real numbers.
  */
+
+/**
+ * One scripted interaction inside a panel.
+ *
+ * Declarative rather than a callback, so the script stays inspectable and testable and a
+ * missing target degrades to a skipped step instead of throwing part way through a demo.
+ */
+export type DemoInteraction =
+  | { readonly kind: 'click'; readonly selector: string; readonly note: string }
+  | { readonly kind: 'type'; readonly selector: string; readonly text: string; readonly note: string }
+  | { readonly kind: 'wait'; readonly ms: number; readonly note: string };
 
 export interface DemoAct {
   readonly id: string;
@@ -22,19 +34,18 @@ export interface DemoAct {
   /** Whether the telemetry drawer should be open. */
   readonly telemetry?: boolean;
   /**
-   * A prompt to submit for real. The act does not advance until the response lands, so
-   * the narration never runs ahead of the system.
+   * A prompt to submit for real. The act does not advance until the response lands, so the
+   * narration never runs ahead of the system.
    */
   readonly prompt?: string;
-  /**
-   * How long to hold this act once its work is done, in milliseconds. Long enough to read
-   * the card and look at the result; short enough that the run keeps moving.
-   */
+  /** Controls to drive inside the panel once it is on screen. */
+  readonly interactions?: readonly DemoInteraction[];
+  /** How long to hold once the work is done, so the result can be read. */
   readonly holdMs?: number;
 }
 
-const READ = 7_000;
-const GLANCE = 5_000;
+const READ = 8_000;
+const GLANCE = 6_000;
 
 export const DEMO_ACTS: readonly DemoAct[] = [
   {
@@ -42,10 +53,11 @@ export const DEMO_ACTS: readonly DemoAct[] = [
     chapter: 'Live demo',
     title: 'This is the real system',
     body:
-      'Everything from here runs live against Azure — real prompts, real agents, real tool '
-      + 'calls, real token costs. Nothing is scripted or pre-recorded. Sit back; it drives '
-      + 'itself, and you can stop at any point.',
+      'Everything from here runs live against Azure. Real prompts, real agents, real tool '
+      + 'calls, real token costs. Nothing is scripted or pre-recorded. It drives itself, and '
+      + 'you can pause or step back at any point.',
     view: 'chat',
+    telemetry: false,
     holdMs: GLANCE,
   },
   {
@@ -53,9 +65,9 @@ export const DEMO_ACTS: readonly DemoAct[] = [
     chapter: 'Routing',
     title: 'Asking a demand question',
     body:
-      'Submitting a real question now. Watch the router pick the demand-forecasting '
-      + 'specialist, call its tools, and answer from live data — the whole turn is streaming '
-      + 'into the telemetry drawer as it happens.',
+      'Submitting a real question now. The router picks the demand specialist, it calls its '
+      + 'tools, and the answer comes back from live data. The whole turn streams into the '
+      + 'telemetry drawer as it happens.',
     view: 'chat',
     telemetry: true,
     prompt: 'How are FreshMart depletions trending in the Northeast this quarter?',
@@ -67,10 +79,9 @@ export const DEMO_ACTS: readonly DemoAct[] = [
     title: 'What that answer cost',
     body:
       'Live Spans now holds the real numbers for the request you just watched: total tokens, '
-      + 'span count, tool calls, wall-clock duration and dollar cost. Every one of those model '
-      + 'calls went through the API Management AI Gateway, which meters tokens per '
-      + 'subscription and authenticates to Foundry with managed identity — no model keys exist '
-      + 'anywhere in the system.',
+      + 'span count, tool calls, duration and dollar cost. Every model call went through the '
+      + 'API Management AI Gateway, which meters tokens per subscription and authenticates to '
+      + 'Foundry with managed identity. No model keys exist anywhere in the system.',
     telemetry: true,
     holdMs: READ + 2_000,
   },
@@ -80,8 +91,8 @@ export const DEMO_ACTS: readonly DemoAct[] = [
     title: 'Asking for a visualisation',
     body:
       'The same pipeline builds charts. This one is drawn deterministically from the tool '
-      + 'payload rather than improvised by the model, so the numbers on the axis are the '
-      + 'numbers the tools returned.',
+      + 'payload rather than improvised by the model, so the values on the axis are exactly '
+      + 'what the tools returned.',
     view: 'chat',
     telemetry: true,
     prompt: 'Show a horizontal bar chart ranking all brands by depletion growth rate',
@@ -92,42 +103,60 @@ export const DEMO_ACTS: readonly DemoAct[] = [
     chapter: 'Multi-agent',
     title: 'Convening the Health Council',
     body:
-      'Several specialists assess one brand independently, each grounded in its own tool '
-      + 'data and reporting its own confidence. Disagreement is surfaced rather than averaged '
-      + 'away — and the verdict is published as a collaborative card to vote on.',
+      'Clicking Convene now. Several specialists assess one brand independently, each '
+      + 'grounded in its own tool data and reporting its own confidence. Watch where they '
+      + 'disagree: the split is surfaced rather than averaged away.',
     view: 'council',
     telemetry: false,
-    holdMs: READ,
+    interactions: [
+      { kind: 'click', selector: '[data-testid="convene-button"]', note: 'Convening the council' },
+      { kind: 'wait', ms: 25_000, note: 'Specialists are voting' },
+    ],
+    holdMs: READ + 4_000,
   },
   {
     id: 'portfolio',
     chapter: 'Multi-agent',
     title: 'Scoring the whole portfolio',
     body:
-      'Every brand scored across five specialist dimensions — demand, margin, competitive, '
-      + 'supply and store execution — by fanning out to the specialists in parallel. Results '
-      + 'are cached, so this is instant on a second visit.',
+      'Every brand scored across five specialist dimensions: demand, margin, competitive, '
+      + 'supply and store execution. The specialists run in parallel and the scores are '
+      + 'cached, so a second visit is instant.',
     view: 'portfolio',
+    interactions: [
+      { kind: 'wait', ms: 14_000, note: 'Scoring brands' },
+    ],
     holdMs: READ,
   },
   {
     id: 'competitive',
     chapter: 'Analytics',
-    title: 'Competitive intelligence',
+    title: 'Filtering competitive intelligence',
     body:
       'Market share, competitor pricing moves and detected threats with recommended '
-      + 'responses. The price drops here are what raise the alerts in the telemetry drawer.',
+      + 'responses. Opening the category filter now. The list is derived from the data, so '
+      + 'every option returns rows rather than an empty grid.',
     view: 'competitive',
-    holdMs: GLANCE,
+    interactions: [
+      { kind: 'wait', ms: 3_500, note: 'Loading competitive data' },
+      { kind: 'click', selector: '[data-testid="category-filter"] button', note: 'Opening the category filter' },
+      { kind: 'wait', ms: 1_200, note: '' },
+      { kind: 'click', selector: '[role="option"]', note: 'Choosing a category' },
+      { kind: 'wait', ms: 3_000, note: 'Refiltering' },
+    ],
+    holdMs: READ,
   },
   {
     id: 'financials',
     chapter: 'Analytics',
     title: 'Financials',
     body:
-      'A P&L waterfall from revenue to net margin with the drivers moving it — read live '
-      + 'from the margin service.',
+      'A P and L waterfall from revenue through to net margin, with the drivers moving it. '
+      + 'Every figure is read live from the margin service rather than a fixture.',
     view: 'financials',
+    interactions: [
+      { kind: 'wait', ms: 3_000, note: 'Loading margin data' },
+    ],
     holdMs: GLANCE,
   },
   {
@@ -135,30 +164,44 @@ export const DEMO_ACTS: readonly DemoAct[] = [
     chapter: 'Analytics',
     title: 'Store operations',
     body:
-      'Every store against target, a regional heatmap, and the SKUs at genuine stockout '
-      + 'risk ranked by urgency with recommended reorder quantities.',
+      'Every store against target, a regional heatmap, and the SKUs at genuine stockout risk '
+      + 'ranked by urgency with recommended reorder quantities.',
     view: 'stores',
+    interactions: [
+      { kind: 'wait', ms: 3_000, note: 'Loading store performance' },
+    ],
     holdMs: GLANCE,
   },
   {
     id: 'knowledge',
     chapter: 'Grounding',
-    title: 'What the agents read',
+    title: 'Searching what the agents read',
     body:
-      'The corpus answers are grounded in, with per-agent bindings showing exactly which '
-      + 'source each specialist is scoped to. Providers are pluggable — in-memory BM25 here, '
-      + 'with Azure AI Search and Foundry IQ available.',
+      'This is the corpus answers are grounded in. Running a real search now. The results '
+      + 'carry BM25 relevance, and the panel on the right shows exactly which source each '
+      + 'specialist is scoped to.',
     view: 'knowledge',
-    holdMs: GLANCE,
+    interactions: [
+      { kind: 'wait', ms: 2_500, note: 'Loading the corpus' },
+      { kind: 'type', selector: '[data-testid="kb-search-input"]', text: 'supplier fill rate service level', note: 'Typing a search' },
+      { kind: 'wait', ms: 800, note: '' },
+      { kind: 'click', selector: '[data-testid="kb-search-button"]', note: 'Searching' },
+      { kind: 'wait', ms: 3_000, note: 'Retrieving' },
+    ],
+    holdMs: READ,
   },
   {
     id: 'promo',
     chapter: 'Planning',
     title: 'Campaign Planner',
     body:
-      'Model a promotion before running it: expected ROI with confidence bounds, break-even '
-      + 'weeks, seasonality fit and the risks worth knowing — grounded in historical outcomes.',
+      'Model a promotion before running it. Expected ROI with confidence bounds, break even '
+      + 'weeks, seasonality fit and the risks worth knowing, all grounded in historical '
+      + 'campaign outcomes.',
     view: 'promo',
+    interactions: [
+      { kind: 'wait', ms: 2_500, note: 'Loading campaign history' },
+    ],
     holdMs: GLANCE,
   },
   {
@@ -166,9 +209,13 @@ export const DEMO_ACTS: readonly DemoAct[] = [
     chapter: 'Collaboration',
     title: 'Adaptive Cards',
     body:
-      'Council verdicts are published here as interactive cards. Teammates vote, comment and '
-      + 'escalate; a split vote escalates automatically. The same format the Teams bot sends.',
+      'The council verdict from earlier was published here as an interactive card. '
+      + 'Teammates vote, comment and escalate, and a split vote escalates automatically. This '
+      + 'is the same card format the Teams bot sends.',
     view: 'cards',
+    interactions: [
+      { kind: 'wait', ms: 2_500, note: 'Loading cards' },
+    ],
     holdMs: GLANCE,
   },
   {
@@ -176,9 +223,9 @@ export const DEMO_ACTS: readonly DemoAct[] = [
     chapter: 'Trust',
     title: 'Guardrails',
     body:
-      'Prompt-injection defence, PII redaction on input and output, and Azure AI Content '
-      + 'Safety scanning every prompt and response. Entra-only sign-in, every endpoint '
-      + 'deny-by-default.',
+      'Prompt injection defence, PII redaction on input and output, and Azure AI Content '
+      + 'Safety scanning every prompt and response. Sign in is Entra only in production and '
+      + 'every endpoint is deny by default.',
     view: 'security',
     holdMs: GLANCE,
   },
@@ -187,10 +234,13 @@ export const DEMO_ACTS: readonly DemoAct[] = [
     chapter: 'AI Gateway',
     title: 'The bill',
     body:
-      'Total tokens, total cost, request count and average cost per request — including the '
-      + 'requests this demo just made. This is what makes the economics of a multi-agent '
-      + 'system visible rather than a surprise on the invoice.',
+      'Total tokens, total cost, request count and average cost per request, broken down per '
+      + 'agent. That includes the requests this demo just made. This is what makes the '
+      + 'economics of a multi-agent system visible rather than a surprise on the invoice.',
     view: 'observability',
+    interactions: [
+      { kind: 'wait', ms: 3_000, note: 'Loading cost data' },
+    ],
     holdMs: READ,
   },
   {
@@ -199,8 +249,8 @@ export const DEMO_ACTS: readonly DemoAct[] = [
     title: 'All of that was live',
     body:
       'Every answer, chart and cost figure came from services running on Azure during this '
-      + 'run. Ask it something of your own — or press Tour for the guided version you can '
-      + 'step through at your own pace.',
+      + 'run. Ask it something of your own, or press Tour for the guided version you can step '
+      + 'through at your own pace.',
     view: 'chat',
     holdMs: GLANCE,
   },

--- a/src/RetailPulse.Web/src/components/demo/demoSteps.ts
+++ b/src/RetailPulse.Web/src/components/demo/demoSteps.ts
@@ -1,7 +1,7 @@
 /**
  * Declarative script for the guided Demo Mode walkthrough.
  *
- * Every claim here is deliberately grounded in shipped behaviour — the gateway policy
+ * Every claim here is deliberately grounded in shipped behaviour, the gateway policy
  * really does meter tokens, the telemetry drawer really does show per-request cost, the
  * council really does convene specialists. A guided tour that overstates the product is
  * worse than none, because the person following it will click the thing and see the gap.
@@ -15,7 +15,7 @@ export type DemoView =
 export interface DemoStep {
   readonly id: string;
   readonly title: string;
-  /** Body copy. Kept to a few sentences — this is a tooltip, not documentation. */
+  /** Body copy. Kept to a few sentences, this is a tooltip, not documentation. */
   readonly body: string;
   /**
    * CSS selector for the element to spotlight. When absent, or when the element is not
@@ -40,7 +40,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     body:
       'A multi-agent retail intelligence platform. A router picks the right specialist for each '
       + 'question, specialists call real tools over MCP, and every model call is metered through an '
-      + 'Azure API Management AI Gateway. This tour walks the whole surface — about two minutes.',
+      + 'Azure API Management AI Gateway. This tour walks the whole surface, about two minutes.',
     view: 'chat',
     placement: 'center',
   },
@@ -49,7 +49,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     chapter: 'Chat',
     title: 'Ask in plain language',
     body:
-      'Questions route to a specialist automatically — demand forecasting, competitive intelligence, '
+      'Questions route to a specialist automatically, demand forecasting, competitive intelligence, '
       + 'supply chain, margin analysis, store operations and more. The curated prompts below are a '
       + 'starting point; anything in natural language works.',
     target: '[data-testid="chat-host"]',
@@ -73,7 +73,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     chapter: 'Cost & Telemetry',
     title: 'Real-time telemetry',
     body:
-      'Every run streams over SignalR as it happens. Open this drawer to watch the agent work — '
+      'Every run streams over SignalR as it happens. Open this drawer to watch the agent work, '
       + 'no polling, no refresh.',
     target: '[aria-controls="telemetry-drawer"]',
     view: 'chat',
@@ -97,7 +97,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     title: 'Why that agent answered',
     body:
       'Agent Routing shows which specialist was selected and how confident the router was. Plans, '
-      + 'Memory and Alerts sit alongside it — the whole execution story in one drawer.',
+      + 'Memory and Alerts sit alongside it, the whole execution story in one drawer.',
     target: '#telemetry-drawer',
     telemetry: true,
     placement: 'left',
@@ -108,7 +108,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     title: 'Every model call goes through APIM',
     body:
       'No component talks to Azure OpenAI directly. An API Management AI Gateway fronts every '
-      + 'inference call, authenticating to Azure AI Foundry with managed identity — there are no '
+      + 'inference call, authenticating to Azure AI Foundry with managed identity, there are no '
       + 'model keys anywhere in the system.',
     view: 'observability',
     placement: 'center',
@@ -130,7 +130,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     chapter: 'AI Gateway',
     title: 'Cost tracking',
     body:
-      'Total tokens, total cost, request count and average cost per request — by day, week or '
+      'Total tokens, total cost, request count and average cost per request, by day, week or '
       + 'month, broken down per agent. This is what makes the economics of a multi-agent system '
       + 'visible rather than a surprise on the invoice.',
     view: 'observability',
@@ -141,7 +141,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     chapter: 'Multi-agent',
     title: 'Portfolio Health Council',
     body:
-      'Convene several specialists on one brand and watch them vote independently — each grounded '
+      'Convene several specialists on one brand and watch them vote independently, each grounded '
       + 'in its own tool data, each reporting a confidence score. Disagreement is surfaced rather '
       + 'than averaged away, and the verdict is published as a collaborative card to vote on.',
     view: 'council',
@@ -152,8 +152,8 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     chapter: 'Multi-agent',
     title: 'Portfolio scorecard',
     body:
-      'Each brand is scored across five specialist dimensions — demand, margin, competitive, supply '
-      + 'and store execution — by fanning out to the specialists in parallel. Scores are cached so '
+      'Each brand is scored across five specialist dimensions, demand, margin, competitive, supply '
+      + 'and store execution, by fanning out to the specialists in parallel. Scores are cached so '
       + 'revisiting is instant.',
     view: 'portfolio',
     placement: 'center',
@@ -164,7 +164,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     title: 'Knowledge Base and RAG',
     body:
       'The corpus the agents ground answers in. Search it, upload to it, and see exactly which '
-      + 'source each agent is bound to. Providers are pluggable — in-memory BM25 by default, with '
+      + 'source each agent is bound to. Providers are pluggable, in-memory BM25 by default, with '
       + 'Azure AI Search and Foundry IQ available.',
     view: 'knowledge',
     placement: 'center',
@@ -184,7 +184,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     chapter: 'Analytics',
     title: 'Financials',
     body:
-      'A P&L waterfall from revenue through to net margin, plus the drivers moving it — each one '
+      'A P&L waterfall from revenue through to net margin, plus the drivers moving it, each one '
       + 'read live from the margin service, not a fixture.',
     view: 'financials',
     placement: 'center',
@@ -194,7 +194,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     chapter: 'Analytics',
     title: 'Store operations',
     body:
-      'Every store against target, with a regional heatmap and the SKUs at genuine stockout risk — '
+      'Every store against target, with a regional heatmap and the SKUs at genuine stockout risk, '
       + 'ranked by urgency, with recommended reorder quantities.',
     view: 'stores',
     placement: 'center',
@@ -205,7 +205,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     title: 'Campaign Planner',
     body:
       'Model a promotion before you run it: expected ROI with confidence bounds, break-even weeks, '
-      + 'seasonality fit and the risks worth knowing — grounded in historical campaign outcomes.',
+      + 'seasonality fit and the risks worth knowing, grounded in historical campaign outcomes.',
     view: 'promo',
     placement: 'center',
   },
@@ -235,7 +235,7 @@ export const DEMO_STEPS: readonly DemoStep[] = [
     chapter: 'Done',
     title: "That's the tour",
     body:
-      'Everything shown here runs against live services on Azure — no scripted responses. Ask it '
+      'Everything shown here runs against live services on Azure, no scripted responses. Ask it '
       + 'something of your own, or restart the tour any time from the Demo Mode button.',
     view: 'chat',
     placement: 'center',

--- a/src/RetailPulse.Web/src/components/knowledge/KnowledgeBasePanel.tsx
+++ b/src/RetailPulse.Web/src/components/knowledge/KnowledgeBasePanel.tsx
@@ -290,6 +290,7 @@ export default function KnowledgeBasePanel() {
           icon={<Search16Regular />}
           onClick={handleSearch}
           disabled={searching}
+          data-testid="kb-search-button"
           style={{ backgroundColor: KB_COLORS.primary }}
         >
           {searching ? 'Searching...' : 'Search'}


### PR DESCRIPTION
Five fixes from watching a real run.

## The same prompt was submitted three times
The act runner took its callbacks as effect dependencies, so every host re-render with a new inline callback re-entered the act. Callbacks now live in refs and the runner depends only on the act index, with a run token so a manual jump abandons in-flight work instead of racing it. A test re-renders five times with fresh callback identities and asserts exactly one submission.

## The card hid behind the telemetry drawer
It now slides clear of the drawer when it opens, and returns to the edge when it closes.

## Skip renamed to Next, and Back added
It advances rather than discarding anything, so Next is the honest label. Back, plus left and right arrow keys, now work.

## It actually interacts with each panel
Previously it only navigated. It now:
- clicks **Convene** on the Health Council and waits for the specialists to vote
- opens and applies the **competitive category filter**
- types and submits a real **Knowledge Base search**

Interactions are declarative so the script stays inspectable and testable, and a missing control is **skipped rather than thrown**, because a panel that has not finished loading must not take the run down in front of an audience.

## Em dashes removed
Gone from both scripts, with a test in each so they cannot creep back.

## Also
The 'chat is not ready' fallback is fixed for real this time. It was being cleared by the post-interaction reset immediately after being set, so it was still never visible.

## Verification
45 demo tests (26 Demo Mode, 19 Tour). Frontend suite: 93 files, 870 tests passing.