### PR TITLE
Make demo clicks reach React, and rank market share when there is no trend

### DIFF
--- a/scripts/walk-demo.cjs
+++ b/scripts/walk-demo.cjs
@@ -1,0 +1,142 @@
+/**
+ * Walks Demo Mode against the deployed app and captures a screenshot per act.
+ *
+ * The app's MSAL tokens live in sessionStorage, so a freshly launched browser always
+ * starts at the sign-in gate and no amount of profile copying carries the session across.
+ * The script therefore pauses for an interactive sign-in, then runs unattended.
+ *
+ *   node scripts/walk-demo.cjs [outputDir] [profileDir]
+ *
+ * Sign in when the window opens; capture begins automatically once the app is up.
+ */
+const { chromium } = require('playwright');
+const fs = require('fs');
+const path = require('path');
+
+const URL = 'https://calm-wave-04edb640f.7.azurestaticapps.net/';
+const OUT = process.argv[2] || path.join(process.cwd(), 'demo-shots');
+const PROFILE = process.argv[3] || path.join(process.env.TEMP || '/tmp', 'rp-demo-profile');
+/** How long to wait for a human to complete sign-in before giving up. */
+const SIGN_IN_TIMEOUT_MS = 3 * 60 * 1000;
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+(async () => {
+  fs.mkdirSync(OUT, { recursive: true });
+
+  const ctx = await chromium.launchPersistentContext(PROFILE, {
+    headless: false,
+    viewport: { width: 1600, height: 950 },
+  });
+
+  const page = ctx.pages()[0] || await ctx.newPage();
+  const log = [];
+
+  page.on('console', m => {
+    if (m.type() === 'error') log.push(`CONSOLE ERROR: ${m.text().slice(0, 160)}`);
+  });
+
+  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+  await sleep(3000);
+
+  if (await page.$('[data-testid="auth-signin-button"]')) {
+    console.log('\n  Sign in in the browser window. Capture starts automatically.\n');
+    log.push('Waited for interactive sign-in');
+  }
+
+  await page.waitForSelector('[data-testid="demo-mode-button"]', { timeout: SIGN_IN_TIMEOUT_MS });
+  log.push('App loaded, starting Demo Mode');
+
+  await page.click('[data-testid="demo-mode-button"]');
+  await sleep(1500);
+
+  const shots = [];
+  let lastTitle = '';
+  const deadline = Date.now() + 10 * 60 * 1000;
+
+  while (Date.now() < deadline) {
+    const card = await page.$('[data-testid="demo-mode-card"]');
+    if (!card) { log.push('Demo card gone (finished or stopped)'); break; }
+
+    const read = () => page.evaluate(() => {
+      const q = s => document.querySelector(s);
+      const cardEl = q('[data-testid="demo-mode-card"]');
+      const drawer = q('#telemetry-drawer');
+      const cr = cardEl ? cardEl.getBoundingClientRect() : null;
+      const dr = drawer ? drawer.getBoundingClientRect() : null;
+      return {
+        title: q('[data-testid="demo-mode-title"]')?.textContent ?? '',
+        progress: q('[data-testid="demo-mode-progress"]')?.textContent ?? '',
+        working: q('[data-testid="demo-mode-working"]')?.textContent ?? null,
+        overlapsDrawer: cr && dr ? !(cr.right <= dr.left || cr.left >= dr.right) : false,
+        onScreen: cr ? cr.left >= 0 && cr.top >= 0 && cr.right <= innerWidth + 2 && cr.bottom <= innerHeight + 2 : false,
+      };
+    });
+
+    let info = await read();
+
+    if (info.title && info.title !== lastTitle) {
+      lastTitle = info.title;
+
+      // Capture the RESULT, not the act starting. The working indicator is present while
+      // a prompt is in flight or an interaction is running, so wait for it to clear
+      // before the screenshot; otherwise every panel is caught mid-load.
+      const settleBy = Date.now() + 60_000;
+      while (info.working && Date.now() < settleBy) {
+        await sleep(1000);
+        const nextInfo = await read();
+        // The act may have advanced past this one while waiting.
+        if (nextInfo.title !== info.title) { info = nextInfo; break; }
+        info = nextInfo;
+      }
+
+      // A further beat so the panel paints its freshly loaded data.
+      await sleep(2500);
+
+      const n = String(shots.length + 1).padStart(2, '0');
+      const safe = info.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40);
+      const file = path.join(OUT, `${n}-${safe}.png`);
+      await page.screenshot({ path: file });
+
+      shots.push({ n, ...info, file });
+      log.push(`${info.progress} | ${info.title} | drawerOverlap=${info.overlapsDrawer} onScreen=${info.onScreen}`);
+      lastTitle = info.title;
+    }
+
+    await sleep(1200);
+  }
+
+  // Count how many times each prompt was actually submitted, to prove the duplicate bug
+  // is gone, and capture the market-share data shape while a session is available.
+  const diagnostics = await page.evaluate(async () => {
+    const text = document.body.innerText;
+    const count = needle => text.split(needle).length - 1;
+
+    let share = null;
+    try {
+      const rows = await (await fetch('/api/competitive/market-share')).json();
+      const quarters = [...new Set(rows.map(d => d.quarter))];
+      share = {
+        rows: rows.length,
+        quarters,
+        brands: new Set(rows.map(d => d.brand)).size,
+        perQuarter: Object.fromEntries(quarters.map(q => [q, rows.filter(d => d.quarter === q).length])),
+      };
+    } catch { /* diagnostic only */ }
+
+    return {
+      demand: count('How are FreshMart depletions trending in the Northeast this quarter?'),
+      chart: count('Show a horizontal bar chart ranking all brands by depletion growth rate'),
+      share,
+    };
+  });
+
+  log.push(`PROMPT SUBMISSIONS: demand=${diagnostics.demand} chart=${diagnostics.chart}`);
+  log.push(`MARKET SHARE: ${JSON.stringify(diagnostics.share)}`);
+  log.push(`SHOTS: ${shots.length}`);
+
+  fs.writeFileSync(path.join(OUT, 'run-log.txt'), log.join('\n'), 'utf8');
+  console.log(log.join('\n'));
+
+  await ctx.close();
+})().catch(e => { console.error('FAILED:', e.message); process.exit(1); });

--- a/src/RetailPulse.Web/src/__tests__/MarketShareChart.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/MarketShareChart.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FluentProvider, webDarkTheme } from '@fluentui/react-components';
+import type { ReactElement } from 'react';
+import MarketShareChart from '../components/competitive/MarketShareChart';
+import type { MarketShareEntry } from '../types';
+
+// Recharts needs a real box; jsdom gives every element zero size.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 400 }}>{children}</div>
+    ),
+  };
+});
+
+const wrap = (ui: ReactElement) => <FluentProvider theme={webDarkTheme}>{ui}</FluentProvider>;
+
+function rows(quarters: string[], brands: number): MarketShareEntry[] {
+  const out: MarketShareEntry[] = [];
+  for (const q of quarters) {
+    for (let i = 0; i < brands; i++) {
+      out.push({ quarter: q, brand: `Brand ${i}`, share: 40 - i, isOurBrand: i === 0 });
+    }
+  }
+  return out;
+}
+
+/**
+ * The live feed carries a single quarter across 41 brands. An area chart draws that as one
+ * vertical stripe of 41 overlapping points: technically correct and completely unreadable.
+ * When there is nothing to trend, the panel ranks instead, which is the honest view of a
+ * single-period snapshot.
+ */
+describe('MarketShareChart', () => {
+  it('ranks brands when the feed carries only one period', () => {
+    render(wrap(<MarketShareChart data={rows(['2026-Q2'], 41)} />));
+
+    expect(screen.getByText(/Market Share by Brand/)).toBeInTheDocument();
+    expect(screen.queryByText(/Market Share Trends/)).not.toBeInTheDocument();
+  });
+
+  it('says how much of the portfolio the ranking shows', () => {
+    render(wrap(<MarketShareChart data={rows(['2026-Q2'], 41)} />));
+
+    // Claiming "41 brands" over a top-12 ranking would misrepresent the chart.
+    expect(screen.getByText(/Top \d+ of 41/)).toBeInTheDocument();
+  });
+
+  it('draws a trend when there are multiple periods', () => {
+    render(wrap(<MarketShareChart data={rows(['2026-Q1', '2026-Q2', '2026-Q3'], 4)} />));
+
+    expect(screen.getByText(/Market Share Trends/)).toBeInTheDocument();
+    expect(screen.getByText('4 brands')).toBeInTheDocument();
+  });
+
+  it('still reports an empty feed as empty', () => {
+    render(wrap(<MarketShareChart data={[]} />));
+    expect(screen.getByTestId('market-share-empty')).toBeInTheDocument();
+  });
+
+  it('shows fewer bars in compact mode', () => {
+    const { container: full } = render(wrap(<MarketShareChart data={rows(['2026-Q2'], 41)} />));
+    const { container: compact } = render(wrap(<MarketShareChart data={rows(['2026-Q2'], 41)} compact />));
+
+    const count = (el: HTMLElement) => el.querySelectorAll('.recharts-rectangle').length;
+    expect(count(compact)).toBeLessThanOrEqual(count(full));
+  });
+});

--- a/src/RetailPulse.Web/src/components/competitive/MarketShareChart.tsx
+++ b/src/RetailPulse.Web/src/components/competitive/MarketShareChart.tsx
@@ -3,6 +3,9 @@ import {
   ResponsiveContainer,
   AreaChart,
   Area,
+  BarChart,
+  Bar,
+  Cell,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -72,8 +75,28 @@ export default function MarketShareChart({ data, compact }: MarketShareChartProp
       return row;
     });
 
-    return { chartData: rows, brands: brandSet };
+    return { chartData: rows, brands: brandSet, quarters };
   }, [data]);
+
+  /**
+   * A trend needs at least two periods and a readable number of series.
+   *
+   * The live feed carries a single quarter across 41 brands, which an area chart draws as
+   * one vertical stripe of 41 overlapping points: technically correct, completely
+   * unreadable. When there is nothing to trend, rank instead, which is the honest view of
+   * a single-period snapshot.
+   */
+  const { isSnapshot, snapshotRows } = useMemo(() => {
+    const periods = new Set(data.map(d => d.quarter)).size;
+    if (periods > 1) return { isSnapshot: false, snapshotRows: [] };
+
+    const rows = [...data]
+      .sort((a, b) => b.share - a.share)
+      .slice(0, compact ? 8 : 12)
+      .map(d => ({ brand: d.brand, share: d.share, isOurBrand: d.isOurBrand }));
+
+    return { isSnapshot: true, snapshotRows: rows };
+  }, [data, compact]);
 
   const ourBrands = useMemo(() => {
     const set = new Set(data.filter(d => d.isOurBrand).map(d => d.brand));
@@ -96,13 +119,40 @@ export default function MarketShareChart({ data, compact }: MarketShareChartProp
   return (
     <div className={styles.wrapper} data-testid="market-share-chart">
       <div className={styles.titleRow}>
-        <span className={styles.title}>📈 Market Share Trends</span>
+        <span className={styles.title}>
+          {isSnapshot ? '📊 Market Share by Brand' : '📈 Market Share Trends'}
+        </span>
         <Badge appearance="filled" style={{ background: 'rgba(59,130,246,0.15)', color: '#93c5fd' }}>
-          {brands.length} brands
+          {isSnapshot ? `Top ${snapshotRows.length} of ${brands.length}` : `${brands.length} brands`}
         </Badge>
       </div>
 
-      <ResponsiveContainer width="100%" height={compact ? 220 : 360}>
+      {isSnapshot ? (
+        <ResponsiveContainer width="100%" height={compact ? 240 : 380}>
+          <BarChart
+            data={snapshotRows}
+            layout="vertical"
+            margin={{ top: 8, right: 24, bottom: 8, left: 8 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke={COMPETITIVE_COLORS.gridLine} horizontal={false} />
+            <XAxis type="number" tick={AXIS_TICK} unit="%" />
+            <YAxis type="category" dataKey="brand" tick={AXIS_TICK} width={130} />
+            <Tooltip
+              contentStyle={tooltipContentStyle}
+              formatter={(v) => [`${Number(v).toFixed(1)}%`, 'Share']}
+            />
+            <Bar dataKey="share" radius={[0, 4, 4, 0]}>
+              {snapshotRows.map(row => (
+                <Cell
+                  key={row.brand}
+                  fill={row.isOurBrand ? COMPETITIVE_COLORS.ourBrand : COMPETITOR_PALETTE[0]}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      ) : (
+        <ResponsiveContainer width="100%" height={compact ? 220 : 360}>
         <AreaChart data={chartData} margin={{ top: 10, right: 20, bottom: 24, left: 10 }}>
           <defs>
             {brands.map(b => {
@@ -142,6 +192,7 @@ export default function MarketShareChart({ data, compact }: MarketShareChartProp
           })}
         </AreaChart>
       </ResponsiveContainer>
+      )}
     </div>
   );
 }

--- a/src/RetailPulse.Web/src/components/demo/DemoMode.tsx
+++ b/src/RetailPulse.Web/src/components/demo/DemoMode.tsx
@@ -205,8 +205,28 @@ export function DemoMode({
       if (!target) return;
 
       if (step.kind === 'click') {
+        // A bare element.click() dispatches only a click event. React components that key
+        // off pointer or mouse events, as Fluent buttons do, can ignore it entirely, which
+        // is why the council never actually convened. Send the sequence a real pointer
+        // produces, tolerating environments where PointerEvent is absent or stricter about
+        // its init members.
+        const base = { bubbles: true, cancelable: true, composed: true };
+        const fire = (Ctor: typeof MouseEvent, type: string) => {
+          try {
+            target.dispatchEvent(new Ctor(type, base));
+          } catch {
+            // Never let a synthetic event stop the run; the plain click below still fires.
+          }
+        };
+
+        const Pointer = typeof PointerEvent === 'function' ? PointerEvent : MouseEvent;
+        fire(Pointer as typeof MouseEvent, 'pointerdown');
+        fire(MouseEvent, 'mousedown');
+        target.focus?.();
+        fire(Pointer as typeof MouseEvent, 'pointerup');
+        fire(MouseEvent, 'mouseup');
         target.click();
-        await pause(400);
+        await pause(600);
         return;
       }
 


### PR DESCRIPTION
Found by walking the deployed demo and screenshotting every act.

## The Health Council never actually convened
A bare \lement.click()\ dispatches only a click event. Fluent buttons key off pointer and mouse events, so the handler never ran and the panel stayed on its empty state while the narration claimed specialists were voting.

The demo now sends the sequence a real pointer produces. It tolerates environments where \PointerEvent\ is absent or stricter about its init members, which the test suite caught immediately: constructing one with a \iew\ member throws in jsdom.

## Market share drew 41 brands on one quarter
Confirmed against live data rather than guessed: **300 rows, 41 brands, 1 quarter**. An area chart renders that as a single vertical stripe of overlapping points, technically correct and completely unreadable.

A trend needs at least two periods. With one, the panel now ranks the top brands by share, retitles itself *Market Share by Brand*, and reports \Top 12 of 41\ rather than claiming 41 brands over a twelve-bar chart.

## Tooling
Adds \scripts/walk-demo.cjs\, which walks Demo Mode against the deployed app and captures a screenshot per act. It waits for each act's work to finish before snapping, so panels are caught settled rather than mid-load, and reports prompt submission counts and drawer overlap per act.

That harness is what produced the evidence for both fixes above, and confirmed on a live run: \demand=1 chart=1\, no act overlapping the drawer, all 15 cards on screen.

## Verification
Frontend suite: 94 files, 875 tests passing. \	sc -b\ exit 0.