### PR TITLE
Wait for a control to mount before the demo clicks it

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/DemoMode.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/DemoMode.test.tsx
@@ -218,6 +218,34 @@ describe('DemoMode', () => {
     }
   });
 
+  it('waits for a control that mounts after the view switches', async () => {
+    // Switching view only schedules a render, so a control queried on the next line does
+    // not exist yet. Every interaction was silently skipped because of this, which is why
+    // the council never convened even though the click itself worked.
+    const clicked = vi.fn();
+
+    renderDemo();
+    const councilIndex = DEMO_ACTS.findIndex(a => a.id === 'council');
+    for (let i = 0; i < councilIndex; i++) {
+      await act(async () => { screen.getByTestId('demo-mode-next').click(); });
+    }
+
+    // Mount the target only AFTER the act has already started looking for it.
+    await act(async () => { vi.advanceTimersByTime(600); });
+
+    const button = document.createElement('button');
+    button.setAttribute('data-testid', 'convene-button');
+    button.addEventListener('click', clicked);
+    document.body.appendChild(button);
+
+    try {
+      await act(async () => { vi.advanceTimersByTime(1_500); });
+      await waitFor(() => expect(clicked).toHaveBeenCalled());
+    } finally {
+      button.remove();
+    }
+  });
+
   it('skips a missing control instead of throwing', async () => {
     // A panel that has not finished loading must not take the whole run down.
     renderDemo();

--- a/src/RetailPulse.Web/src/components/demo/DemoMode.tsx
+++ b/src/RetailPulse.Web/src/components/demo/DemoMode.tsx
@@ -191,6 +191,25 @@ export function DemoMode({
       timer = window.setTimeout(resolve, ms);
     });
 
+    /**
+     * Waits for a control to appear before acting on it.
+     *
+     * Switching view only schedules a React render, so querying the DOM on the very next
+     * line finds nothing: the panel has not mounted yet. Every interaction was therefore
+     * skipped silently, which is why the council never convened even though the click
+     * itself worked perfectly when tested against a mounted panel.
+     */
+    const waitFor = async (selector: string, timeoutMs = 12_000) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const found = document.querySelector<HTMLElement>(selector);
+        if (found) return found;
+        if (!live()) return null;
+        await pause(200);
+      }
+      return null;
+    };
+
     const runInteraction = async (step: DemoInteraction) => {
       if (step.note) setWorking(step.note);
 
@@ -199,11 +218,10 @@ export function DemoMode({
         return;
       }
 
-      const target = document.querySelector<HTMLElement>(step.selector);
-      // A missing control is skipped rather than thrown: a panel that has not finished
-      // loading must not take the whole run down in front of an audience.
+      const target = await waitFor(step.selector);
+      // A control that never appears is skipped rather than thrown: a panel that failed to
+      // load must not take the whole run down in front of an audience.
       if (!target) return;
-
       if (step.kind === 'click') {
         // A bare element.click() dispatches only a click event. React components that key
         // off pointer or mouse events, as Fluent buttons do, can ignore it entirely, which


### PR DESCRIPTION
The Health Council still never convened after the previous fix.

## Evidence first this time
I instrumented the exact click path inside the deployed app rather than guessing again. The click was **fine**:

\\\
{ pointerdown: ok, mousedown: ok, pointerup: ok, mouseup: ok,
  handlerFired: true }
AFTER 30s: ... Portfolio Health Council | MULTI-AGENT BRAND ASSESSMENT | Apex Grill ...
\\\

The council assembled. So the click was never the problem, and my two previous attempts at it were both wrong.

## Actual cause
Switching view only **schedules** a React render. Querying the DOM on the very next line finds nothing, because the panel has not mounted yet. Every interaction hit the missing-control guard and was skipped silently.

That guard is right to exist, but it was hiding a timing bug rather than reporting a missing panel.

## Fix
Interactions poll for their target for up to twelve seconds before acting, and still skip if it genuinely never appears.

A test mounts the target **only after** the act has already started looking for it, so it fails against the old code and passes against the new.

## Verification
The four touched test files pass in isolation: 59 tests. The full suite is currently unreliable on this machine (a different test fails each run and vitest workers intermittently fail to start under load), so CI on a clean runner is the arbiter here.