### PR TITLE
Show sub-millisecond tool timings as <1ms rather than 0ms

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/CostDashboard.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/CostDashboard.test.tsx
@@ -41,6 +41,7 @@ const mockData: CostDashboardData = {
   topTools: [
     { toolName: 'GetDepletionStats', callCount: 42, totalDurationMs: 35700, avgDurationMs: 850 },
     { toolName: 'CreateChart', callCount: 28, totalDurationMs: 840, avgDurationMs: 30 },
+    { toolName: 'GetMarketShare', callCount: 4, totalDurationMs: 0.4, avgDurationMs: 0.1 },
   ],
 };
 
@@ -107,6 +108,17 @@ describe('CostDashboard', () => {
       .toEqual(['Tool', 'Calls', 'Total Time', 'Avg Duration']);
     expect(within(table).getByText('35.7s')).toBeInTheDocument();
     expect(within(table).getByText('840ms')).toBeInTheDocument();
+  });
+
+  // A tool that ran four times cannot honestly report 0ms, and a row reading "4 calls,
+  // 0ms" is indistinguishable from the dead token column this one replaced.
+  it('shows sub-millisecond timings as <1ms rather than rounding them to zero', async () => {
+    render(wrap(<CostDashboard />));
+    const table = await screen.findByTestId('tools-table');
+    const row = within(table).getByText('GetMarketShare').closest('tr')!;
+
+    expect(within(row).getAllByText('<1ms')).toHaveLength(2);
+    expect(within(row).queryByText('0ms')).not.toBeInTheDocument();
   });
 
   it('renders friendly empty states for idle chart sections', async () => {

--- a/src/RetailPulse.Web/src/components/observability/CostDashboard.tsx
+++ b/src/RetailPulse.Web/src/components/observability/CostDashboard.tsx
@@ -200,9 +200,17 @@ const METRIC_CARDS = [
   { key: 'avgCostPerRequest', label: 'Avg Cost / Req', icon: '📊', color: OBSERVABILITY_COLORS.avgCost, fmt: (v: number) => `$${v.toFixed(4)}` },
 ] as const;
 
-/** Sub-second tools are common, so seconds only once the total is worth reading in seconds. */
+/**
+ * Tool timings span four orders of magnitude, so the unit follows the value.
+ *
+ * A measured but sub-millisecond figure renders as "<1ms" rather than "0ms". Several of
+ * these tools genuinely run in well under a millisecond, and a row reading "2 calls, 0ms"
+ * is indistinguishable from the dead column this one replaced, where every tool reported
+ * zero tokens because tool spans never carry any. Zero is reserved for a real zero.
+ */
 function formatToolDuration(ms: number): string {
   if (ms >= 1_000) return `${(ms / 1_000).toFixed(1)}s`;
+  if (ms > 0 && ms < 1) return '<1ms';
   return `${Math.round(ms).toLocaleString()}ms`;
 }
 
@@ -425,7 +433,7 @@ export default function CostDashboard() {
                       <td className={styles.tableCell} style={{ fontWeight: 600 }}>{tool.toolName}</td>
                       <td className={styles.tableCellMuted}>{tool.callCount.toLocaleString()}</td>
                       <td className={styles.tableCellMuted}>{formatToolDuration(tool.totalDurationMs)}</td>
-                      <td className={styles.tableCellMuted}>{tool.avgDurationMs.toFixed(0)}ms</td>
+                      <td className={styles.tableCellMuted}>{formatToolDuration(tool.avgDurationMs)}</td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
Fixes #233.

## Problem

`45a76ea` replaced the Top Tools "Total Tokens" column with "Total Time", because tool spans are MCP round trips and never carry model tokens, so the old column could only ever read zero.

The new column is correct, but several tools genuinely execute in under a millisecond and `formatToolDuration` rounded those to `0ms`. In the 29 Aug walkthrough recording the table read:

| Tool | Calls | Total Time | Avg Duration |
|---|---|---|---|
| GetDepletionStats | 4 | 13ms | 3ms |
| GetPortfolioDepletionStats | 2 | 0ms | 1ms |
| CreateChart | 2 | 0ms | 0ms |

A row showing 2 calls and `0ms` is indistinguishable from the dead column it replaced, which defeats the point of the change.

## Change

`formatToolDuration` now renders a measured but sub-millisecond value as `<1ms`, and reserves `0ms` for a genuine zero. Avg Duration now goes through the same formatter: it was doing its own `toFixed(0)` and had exactly the same problem.

## Verification

- New test `shows sub-millisecond timings as <1ms rather than rounding them to zero` pins both cells on a row with sub-millisecond totals. It cannot pass against the old formatter, which had no such branch.
- `npx vitest run src/__tests__/CostDashboard.test.tsx` — 10 passed
- `npx tsc --noEmit` — clean
