### PR TITLE
test: remove background waiter from plan review scoping test

### DIFF
--- a/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
+++ b/tests/RetailPulse.Tests/Approval/PlanReviewCoordinatorTests.cs
@@ -385,13 +385,14 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
     // ── Cross-subject denial (at the persistence layer) ─────────────────
 
     /// <summary>
-    /// Subject scoping asserted with NO dependency on background scheduling.
+    /// Subject scoping at the gate is the primary security guard because it has
+    /// no dependency on background scheduling.
     ///
     /// <para>
-    /// The coordinator-driven variant below exercises the real path, but it has to wait for
-    /// a background task to write its row first — which makes a security assertion hostage
-    /// to the thread pool. This test seeds the rows directly through the gate, so it is
-    /// fully deterministic: if it ever fails, subject scoping is genuinely broken.
+    /// This test seeds the rows directly, so it is fully deterministic: if it ever fails,
+    /// subject scoping is genuinely broken. The later coordinator-loop variant keeps
+    /// integration coverage for the blocking path, but it is intentionally secondary
+    /// because it still pays a scheduler cost.
     /// </para>
     /// </summary>
     [Fact]
@@ -465,22 +466,57 @@ public sealed class PlanReviewCoordinatorTests : IDisposable
         PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System);
 
         PlanReviewCoordinationInput input = SampleInput() with { Subject = "alice" };
-        Task<PlanReviewOutcome> coordination = coord.CoordinateAsync(input, _backgroundCts.Token);
-        _backgroundTasks.Add(coordination);
+        PlanReviewRoundHandle handle = await coord.OpenRoundAsync(new PlanReviewOpenInput
+        {
+            PlanId = input.PlanId,
+            Subject = input.Subject,
+            SessionId = input.SessionId,
+            Request = input.Request,
+            CurrentSteps = input.InitialSteps,
+            SpecialistKeys = input.SpecialistKeys,
+            DetectedIntents = input.DetectedIntents,
+            RoundNumber = 0,
+            TenantId = input.TenantId,
+            TraceId = input.TraceId,
+            ParentSpanId = input.ParentSpanId,
+            PrincipalKey = input.PrincipalKey,
+        });
 
-        // Pass the background task in so a wait timeout can report WHY the row never
-        // arrived. This test has been intermittently flaky under full parallel load and
-        // a bare "timed out" told us nothing; if the coordinator faulted, the exception
-        // is now surfaced instead of being swallowed by the fixture's Dispose.
-        ApprovalRequest aliceRow = await WaitForPending(gate, input.Subject, coordination);
-
-        // Guard the arrange step explicitly: prove alice's row really is present before
-        // concluding anything from bob's empty result. Without this, a scheduling timeout
-        // that produced no rows at all would look like a passing security assertion.
+        // Await the production row-opening seam directly. This keeps the subject-isolation
+        // assertion independent from the blocking coordinator loop's background waiter.
+        ApprovalRequest aliceRow = (await gate.GetPendingAsync(input.Subject)).Should()
+            .ContainSingle("the coordinator must write exactly one pending row for alice before bob is queried")
+            .Which;
+        aliceRow.RequestId.Should().Be(handle.RequestId);
         aliceRow.Context.UserId.Should().Be("alice");
 
         (await gate.GetPendingAsync("bob")).Should().BeEmpty(
-            "GetPendingAsync is subject-scoped at SQL — bob must never see alice's plan review.");
+            "GetPendingAsync is subject-scoped at SQL; bob must never see alice's plan review.");
+    }
+
+    [Fact]
+    public async Task CoordinateAsync_pending_query_does_not_expose_another_subject_row()
+    {
+        SqliteApprovalGate gate = CreateSystemGate();
+        var options = new PlanReviewOptions();
+        PlanReviewCoordinator coord = CreateCoordinator(gate, options, TimeProvider.System);
+
+        PlanReviewCoordinationInput input = SampleInput() with { Subject = "alice" };
+        Task<PlanReviewOutcome> coordination = coord.CoordinateAsync(input, _backgroundCts.Token);
+        _backgroundTasks.Add(coordination);
+
+        // This integration check intentionally covers the blocking coordinator loop. The
+        // deterministic tests above are the primary guard because this arrange step still
+        // depends on the background waiter being scheduled under full-suite load.
+        ApprovalRequest aliceRow = await WaitForPending(gate, input.Subject, coordination);
+        aliceRow.Context.UserId.Should().Be("alice");
+
+        (await gate.GetPendingAsync("bob")).Should().BeEmpty(
+            "the blocking coordinator loop must not widen pending-row visibility.");
+
+        await Approve(gate, aliceRow.RequestId);
+        PlanReviewOutcome outcome = await coordination;
+        outcome.IsApproved.Should().BeTrue();
     }
 
     // ── Audit trail across paths ────────────────────────────────────────


### PR DESCRIPTION
## Findings

Root cause is in the test fixture, not production code.

The production pending query remains subject-scoped with `WHERE UserId = @userId AND Decision = 'Pending'` and a bound parameter. `PlanReviewCoordinator.OpenRoundAsync` writes `input.Subject` into `ApprovalContext.UserId`. I found no mutable static state in the coordinator or gate that can make one subject read another subject's row, and each test gets a unique SQLite path.

The flaky test still started `CoordinateAsync` on a background task and then polled for the row. That made the security assertion depend on a background waiter being scheduled under full-suite xUnit parallel load.

## Coverage in this PR

- Keeps deterministic gate-level tests as the primary security guard.
- Changes `Cross_subject_pending_query_does_not_expose_another_subject_row` to await `OpenRoundAsync` directly, then asserts the row id from the pending query matches the coordinator handle before querying bob.
- Adds `CoordinateAsync_pending_query_does_not_expose_another_subject_row` as a separate integration-style check for the blocking `CoordinateAsync` loop. It still uses the background waiter, and it passes that producer task into the existing diagnostic wait so a future failure reports whether the coordinator faulted, was canceled, completed without writing, or was still running.

## Reproduction note

I could not reproduce the original #234 failure. Before changing the test, I attempted 4 full-suite runs with `dotnet test .\RetailPulse.slnx --nologo -v q`: 3 passed, and the 4th aborted with `The active test run was aborted. Reason: Test host process crashed` after 1881 passed tests, with no PlanReviewCoordinator failure reported.

So this fix is based on removing a plausible scheduling dependency from the primary security assertion, not on a confirmed live reproduction. The green runs below are regression checks, not proof that a roughly intermittent failure has been eliminated.

## Verification

Latest checks after restoring coordinator-loop coverage:

- `dotnet test .\tests\RetailPulse.Tests\RetailPulse.Tests.csproj --no-restore --filter "FullyQualifiedName~PlanReviewCoordinator" --nologo -v q` passed: 24 tests
- `dotnet test .\tests\RetailPulse.Tests\RetailPulse.Tests.csproj --no-restore --filter "FullyQualifiedName~RetailPulse.Tests.Approval" --nologo -v q` passed: 139 tests
- `dotnet test .\RetailPulse.slnx --nologo -v q` passed: 3549 passed, 9 skipped in `RetailPulse.Tests`; 3 skipped in `RetailPulse.LoadTests`
- `dotnet format .\RetailPulse.slnx --verify-no-changes --no-restore --verbosity minimal` exited 0

Fixes #234