### PR TITLE
Fix npm install lockfile idempotency

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/lockfileIntegrity.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/lockfileIntegrity.test.ts
@@ -4,15 +4,18 @@ import { dirname, resolve } from 'node:path';
 import { describe, it, expect } from 'vitest';
 
 /**
- * Supply-chain guard for the auth (MSAL) packages introduced by the Entra work.
+ * Supply-chain and cross-platform guard for the auth (MSAL) packages introduced by the
+ * Entra work.
  *
- * The original lockfile shipped the MSAL entries resolved through an internal Azure DevOps
- * proxy with weak SHA-1 `integrity` and `@azure/msal-browser` recorded as a peer-only
- * dependency. That is a supply-chain risk: SHA-1 is collision-broken and a non-canonical
- * resolve URL bypasses the official registry's provenance. This test fails the build if any
- * newly introduced auth package regresses to non-`sha512` integrity or a non-canonical
- * resolution — and, because the baseline is now clean, it also holds the ENTIRE lockfile to
- * `sha512` so no future dependency can sneak in with a weaker hash.
+ * This test fails the build if any auth package regresses to non-`sha512` integrity or a
+ * non-canonical registry URL. Because the baseline is now clean, it also holds the ENTIRE
+ * lockfile to `sha512` so no future dependency can sneak in with a weaker hash.
+ *
+ * It also protects the Linux CI install graph. npm 11.6.2 on Windows rewrites this lockfile
+ * by marking `@azure/msal-browser` as a peer edge and pruning the top-level optional peer
+ * `@emnapi/*` entries that Linux `npm ci` requires. The MSAL peer marker is harmless by
+ * itself when the root dependency remains, but in this npm rewrite it is a reliable signal
+ * that the lockfile was regenerated on Windows and is no longer cross-platform.
  */
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -23,6 +26,7 @@ interface LockPackage {
   resolved?: string;
   integrity?: string;
   peer?: boolean;
+  optional?: boolean;
   dev?: boolean;
   link?: boolean;
   dependencies?: Record<string, string>;
@@ -40,6 +44,12 @@ const AUTH_PACKAGES = [
   'node_modules/@azure/msal-browser',
   'node_modules/@azure/msal-common',
   'node_modules/@azure/msal-react',
+] as const;
+
+/** Top-level optional peer packages that Linux `npm ci` requires to validate the lockfile. */
+const CROSS_PLATFORM_OPTIONAL_PEERS = [
+  'node_modules/@emnapi/core',
+  'node_modules/@emnapi/runtime',
 ] as const;
 
 const CANONICAL_REGISTRY = 'https://registry.npmjs.org/';
@@ -63,7 +73,7 @@ describe('package-lock.json auth supply-chain integrity', () => {
     ).toBe(true);
   });
 
-  it('records @azure/msal-browser as a normal direct dependency (not peer-only)', () => {
+  it('keeps the cross-platform MSAL lockfile shape', () => {
     const root = lock.packages[''];
     expect(root.dependencies).toBeDefined();
     expect(
@@ -74,8 +84,18 @@ describe('package-lock.json auth supply-chain integrity', () => {
     const browser = lock.packages['node_modules/@azure/msal-browser'];
     expect(
       browser.peer,
-      '@azure/msal-browser must not be recorded as a peer-only dependency',
+      '@azure/msal-browser peer metadata indicates this lockfile was rewritten on Windows',
     ).not.toBe(true);
+  });
+
+  it.each(CROSS_PLATFORM_OPTIONAL_PEERS)('%s stays in the cross-platform lockfile', (key) => {
+    const pkg = lock.packages[key];
+    expect(
+      pkg,
+      `${key} must stay in package-lock.json because Linux npm ci validates it`,
+    ).toBeDefined();
+    expect(pkg.optional, `${key} must remain an optional dependency entry`).toBe(true);
+    expect(pkg.peer, `${key} must remain a peer dependency entry`).toBe(true);
   });
 
   it('rejects any non-sha512 integrity anywhere in the lockfile', () => {


### PR DESCRIPTION
Fixes #232

## Corrected conclusion
The first Windows-only `npm ci` experiment was insufficient. It proved that `peer: true` on `node_modules/@azure/msal-browser` is benign when the root package still declares `@azure/msal-browser`, but it did not test the Linux platform used by CI.

Linux CI disproved the earlier conclusion. Both the Frontend (React/Vite) and Auth Provider Matrix jobs failed in about eleven seconds with:

```text
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: @emnapi/core@1.11.3 from lock file
npm error Missing: @emnapi/runtime@1.11.3 from lock file
```

## Root cause
The real hazard is a platform-dependent lockfile. npm 11.6.2 on Windows rewrites the committed cross-platform lockfile by:

- adding `peer: true` to `node_modules/@azure/msal-browser`, which is harmless by itself because the root dependency remains
- pruning `node_modules/@emnapi/core` and `node_modules/@emnapi/runtime`, which are optional peer dev entries that Linux `npm ci` still validates

A Windows-generated lockfile can therefore pass Windows `npm ci` and still break Linux CI.

## Changed
- Reverted `src/RetailPulse.Web/package-lock.json` back to the main branch version. This PR no longer commits a Windows-generated lockfile.
- Restored the MSAL peer marker assertion with corrected wording: it now documents that the marker is used as a signal that Windows npm rewrote the lockfile.
- Added explicit assertions that `node_modules/@emnapi/core` and `node_modules/@emnapi/runtime` remain in the lockfile.
- Checked the lockfile for other top-level optional peer entries. Only those two currently match this exposure.
- Left `@azure/msal-react` and all auth runtime code untouched.

## Source prevention checked
I could not find an npm option that prevents the Windows mutation:

- `npm install --include=optional` still added the MSAL peer marker and pruned both `@emnapi/*` entries.
- `npm install --include=optional --include=peer` did the same.
- `.npmrc` with `include=optional` did the same.
- `npm install --os=linux --cpu=x64` did the same.
- From no `node_modules`, `npm install --os=linux --cpu=x64 --include=optional --include=peer` also did the same.

So the practical guard is: do not commit the Windows-mutated lockfile. The test now makes that failure explicit.

## Deploy recommendation
Use `npm ci` for deployment packaging wherever the install command is configurable. This repo's azd frontend service is `host: staticwebapp` with `language: js`, and `azure.yaml` does not expose a frontend install command switch, so this PR does not add an azd config change.

## Verification
- `npm ci` passed on Windows with the restored lockfile.
- `npm run build` passed on Windows with the restored lockfile.
- `npx vitest run src\__tests__\lockfileIntegrity.test.ts` passed after rebasing on current `origin/main`.
- Full `npx vitest run` passed on Windows with the restored lockfile.
- `npx tsc --noEmit -p tsconfig.json` passed on Windows with the restored lockfile.
- GitHub CI is green, including Frontend (React/Vite) and Auth Provider Matrix.