### PR TITLE
Fix council history wire mapping

### DIFF
--- a/src/RetailPulse.Web/src/__tests__/Council.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/Council.test.tsx
@@ -100,7 +100,7 @@ vi.mock('../services/councilApi', () => ({
   fetchCouncilHistory: vi.fn(),
 }));
 
-import { conveneCouncil } from '../services/councilApi';
+import { conveneCouncil, fetchCouncilHistory } from '../services/councilApi';
 import VoteCard from '../components/council/VoteCard';
 import CouncilVerdictView from '../components/council/CouncilVerdict';
 import CouncilPanel from '../components/council/CouncilPanel';
@@ -287,5 +287,17 @@ describe('CouncilPanel', () => {
     expect(screen.getByTestId('brand-selector')).toBeDisabled();
     expect(screen.getByTestId('region-selector')).toBeDisabled();
     expect(screen.getByTestId('convene-button')).toBeDisabled();
+  });
+
+  it('distinguishes a failed history load from an empty history', async () => {
+    vi.mocked(fetchCouncilHistory).mockRejectedValue(new Error('Network error'));
+    render(<CouncilPanel />, { wrapper });
+
+    fireEvent.click(screen.getByText('Load History'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('history-error')).toHaveTextContent('Unable to load previous council sessions');
+      expect(screen.queryByTestId('history-empty')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/RetailPulse.Web/src/__tests__/councilApi.mapping.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/councilApi.mapping.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchCouncilHistory, toCouncilSession } from '../services/councilApi';
+
+describe('councilApi wire mapping', () => {
+  // Captured from the GET /api/council/history response shape in ChatEndpoints.
+  const wire = {
+    id: 'Summit Vodka-2026-08-28T02:40:50.2235061Z',
+    brand: 'Summit Vodka',
+    region: 'All Regions',
+    convened_at: '2026-08-28T02:40:50.2235061Z',
+    overall_rating: 'Red',
+    synthesis: 'Supply reliability is the binding constraint.',
+    is_unanimous: false,
+    disagreements: [
+      'Supply Chain rated Red, while Demand Forecasting rated Green.',
+    ],
+    action_items: [
+      '1. Immediately restore Northeast allocation.',
+      '2. Monitor out-of-stock risk.',
+    ],
+    total_duration_ms: 4200,
+    votes: [
+      {
+        agent_id: 'supply-chain',
+        agent_name: 'Supply Chain',
+        rating: 'Red',
+        reasoning: 'Northeast allocation is below the operating floor.',
+        confidence: 0.82,
+        key_metrics: ['Fill Rate 78%', 'Inventory Weeks 1.1'],
+        response_time_ms: 940,
+      },
+      {
+        agent_id: 'demand-forecasting',
+        agent_name: 'Demand Forecasting',
+        rating: 'Green',
+        reasoning: 'Demand is stable.',
+        confidence: 0.91,
+        key_metrics: ['Forecast Accuracy 94%'],
+        response_time_ms: 880,
+      },
+    ],
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('nests the flat history payload into the panel view model', () => {
+    const session = toCouncilSession(wire);
+
+    expect(session.id).toBe(wire.id);
+    expect(session.convenedAt).toBe(wire.convened_at);
+    expect(session.verdict.overallRating).toBe('red');
+    expect(session.verdict.synthesisText).toBe(wire.synthesis);
+    expect(session.verdict.unanimous).toBe(false);
+    expect(session.verdict.totalConveneTimeMs).toBe(4200);
+  });
+
+  it('maps votes and action items into the fields the panel renders', () => {
+    const session = toCouncilSession(wire);
+
+    expect(session.votes[0]).toMatchObject({
+      agentId: 'supply-chain',
+      agentName: 'Supply Chain',
+      domain: 'supply',
+      rating: 'red',
+      keyMetrics: ['Fill Rate 78%', 'Inventory Weeks 1.1'],
+      responseTimeMs: 940,
+    });
+    expect(session.verdict.actionItems[0]).toEqual({
+      priority: 1,
+      text: 'Immediately restore Northeast allocation.',
+    });
+    expect(session.verdict.disagreements[0].topic).toBe(wire.disagreements[0]);
+  });
+
+  it('also accepts integer rating enums so serializer changes do not break styles', () => {
+    const session = toCouncilSession({
+      ...wire,
+      overall_rating: 2,
+      votes: [{ ...wire.votes[0], rating: 0 }],
+    });
+
+    expect(session.verdict.overallRating).toBe('red');
+    expect(session.votes[0].rating).toBe('green');
+  });
+
+  it('maps fetchCouncilHistory at the API boundary', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [wire],
+    }));
+
+    await expect(fetchCouncilHistory()).resolves.toMatchObject([
+      {
+        brand: 'Summit Vodka',
+        verdict: {
+          overallRating: 'red',
+          actionItems: [
+            { priority: 1, text: 'Immediately restore Northeast allocation.' },
+            { priority: 2, text: 'Monitor out-of-stock risk.' },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('turns a malformed row into readable defaults rather than throwing', () => {
+    expect(() => toCouncilSession({ id: 'bad-row', votes: null, action_items: null })).not.toThrow();
+
+    const session = toCouncilSession({ id: 'bad-row', votes: null, action_items: null });
+    expect(session.brand).toBe('Unknown brand');
+    expect(session.verdict.overallRating).toBe('yellow');
+    expect(session.verdict.synthesisText).toBe('No synthesis is available for this council session.');
+    expect(session.votes).toEqual([]);
+    expect(session.verdict.actionItems).toEqual([]);
+  });
+});

--- a/src/RetailPulse.Web/src/components/council/CouncilHistory.tsx
+++ b/src/RetailPulse.Web/src/components/council/CouncilHistory.tsx
@@ -111,6 +111,8 @@ function HistoryItem({ session }: { session: CouncilSession }) {
   const styles = useStyles();
   const [expanded, setExpanded] = useState(false);
   const v = session.verdict;
+  const date = new Date(session.convenedAt);
+  const displayDate = Number.isNaN(date.getTime()) ? 'Unknown date' : date.toLocaleString();
 
   return (
     <div>
@@ -131,7 +133,7 @@ function HistoryItem({ session }: { session: CouncilSession }) {
             {RATING_EMOJIS[v.overallRating]} {session.brand}
             {session.region && ` · ${session.region}`}
           </span>
-          <span className={styles.date}>{new Date(session.convenedAt).toLocaleString()}</span>
+          <span className={styles.date}>{displayDate}</span>
         </div>
         <div className={styles.badges}>
           <Badge
@@ -171,15 +173,18 @@ export default function CouncilHistory() {
   const [sessions, setSessions] = useState<CouncilSession[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const handleLoad = useCallback(async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const data = await fetchCouncilHistory();
       setSessions(data);
       setLoaded(true);
     } catch {
       setSessions([]);
+      setLoadError('Unable to load previous council sessions. Please try again.');
       setLoaded(true);
     } finally {
       setLoading(false);
@@ -201,6 +206,18 @@ export default function CouncilHistory() {
         >
           {loading ? '⏳ Loading...' : 'Load History'}
         </Button>
+      ) : loadError ? (
+        <div className={styles.empty} data-testid="history-error">
+          <div>{loadError}</div>
+          <Button
+            className={styles.loadBtn}
+            appearance="subtle"
+            onClick={handleLoad}
+            disabled={loading}
+          >
+            {loading ? '⏳ Loading...' : 'Try again'}
+          </Button>
+        </div>
       ) : sessions.length === 0 ? (
         <div className={styles.empty} data-testid="history-empty">
           No previous council sessions found

--- a/src/RetailPulse.Web/src/services/councilApi.ts
+++ b/src/RetailPulse.Web/src/services/councilApi.ts
@@ -8,77 +8,105 @@ import type {
   HealthRating,
 } from '../types';
 
+const HEALTH_RATINGS: readonly HealthRating[] = ['green', 'yellow', 'red'];
+
 /**
- * Wire shapes returned by `POST /api/council/convene`.
+ * Wire shapes returned by the council endpoints.
  *
- * The API answers in flat snake_case (see ChatEndpoints) while the UI models a
- * nested camelCase `{ votes, verdict }`. Nothing translated between them, so
- * `response.verdict` was always `undefined` — the executive verdict never
- * rendered — and every vote arrived without a `domain`, which is the key
- * CouncilVoting matches its three cards on, so all three sat on
- * "DELIBERATING…" forever even though the council had already reported.
+ * The API answers in flat snake_case while the UI models a nested camelCase
+ * `{ votes, verdict }`. Nothing translated the history response, so
+ * `session.verdict` was undefined and the history panel threw as soon as it
+ * rendered a real row.
  *
  * The mapping lives here, at the edge, so components keep consuming one stable
  * view model.
  */
 interface WireVote {
-  readonly agent_id?: string;
-  readonly agent_name?: string;
-  readonly rating?: string;
-  readonly reasoning?: string;
-  readonly confidence?: number;
-  readonly key_metrics?: readonly string[];
-  readonly response_time_ms?: number;
+  readonly agent_id?: unknown;
+  readonly agent_name?: unknown;
+  readonly rating?: unknown;
+  readonly reasoning?: unknown;
+  readonly confidence?: unknown;
+  readonly key_metrics?: unknown;
+  readonly response_time_ms?: unknown;
 }
 
-interface WireConveneResponse {
-  readonly brand?: string;
-  readonly region?: string;
-  readonly overall_rating?: string;
-  readonly synthesis?: string;
-  readonly is_unanimous?: boolean;
-  readonly disagreements?: readonly string[];
-  readonly action_items?: readonly string[];
-  readonly convened_at?: string;
-  readonly total_duration_ms?: number;
-  readonly votes?: readonly WireVote[];
+interface WireCouncilResponse {
+  readonly id?: unknown;
+  readonly brand?: unknown;
+  readonly region?: unknown;
+  readonly overall_rating?: unknown;
+  readonly synthesis?: unknown;
+  readonly is_unanimous?: unknown;
+  readonly disagreements?: unknown;
+  readonly action_items?: unknown;
+  readonly convened_at?: unknown;
+  readonly total_duration_ms?: unknown;
+  readonly votes?: unknown;
 }
 
-/** `HealthRating` is lowercase in the UI; the API sends the C# enum name ("Yellow"). */
-function toRating(value: string | undefined): HealthRating {
-  switch ((value ?? '').trim().toLowerCase()) {
-    case 'green':
-      return 'green';
-    case 'red':
-      return 'red';
-    default:
-      return 'yellow';
+function toStringValue(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function toNumberValue(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function toArray(value: unknown): readonly unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function toWireVote(value: unknown): WireVote {
+  return value && typeof value === 'object' ? value as WireVote : {};
+}
+
+function toWireCouncilResponse(value: unknown): WireCouncilResponse {
+  return value && typeof value === 'object' ? value as WireCouncilResponse : {};
+}
+
+/**
+ * Accept both the C# enum name and its numeric ordinal so a serializer change
+ * cannot break style-map lookups again.
+ */
+function toRating(value: unknown): HealthRating {
+  if (typeof value === 'number') return HEALTH_RATINGS[value] ?? 'yellow';
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    const match = HEALTH_RATINGS.find((rating) => rating === normalized);
+    if (match) return match;
   }
+  return 'yellow';
 }
 
 /**
  * CouncilVoting keys its three cards on `domain`, which the wire format does not
  * carry. Derive it from the agent id (falling back to the display name) so a vote
  * binds to its card. Unknown agents fall back to 'demand' rather than being
- * dropped — a rendered card with a real rating beats one stuck deliberating.
+ * dropped. A rendered card with a real rating beats one stuck deliberating.
  */
 function toDomain(vote: WireVote): CouncilAgentVote['domain'] {
-  const key = `${vote.agent_id ?? ''} ${vote.agent_name ?? ''}`.toLowerCase();
+  const key = `${toStringValue(vote.agent_id)} ${toStringValue(vote.agent_name)}`.toLowerCase();
   if (key.includes('supply')) return 'supply';
   if (key.includes('competitive')) return 'competitive';
   return 'demand';
 }
 
-function toVote(vote: WireVote): CouncilAgentVote {
+function toVote(value: unknown): CouncilAgentVote {
+  const vote = toWireVote(value);
   return {
-    agentId: vote.agent_id ?? '',
-    agentName: vote.agent_name ?? 'Specialist',
+    agentId: toStringValue(vote.agent_id),
+    agentName: toStringValue(vote.agent_name, 'Specialist'),
     domain: toDomain(vote),
     rating: toRating(vote.rating),
-    confidence: vote.confidence ?? 0,
-    reasoning: vote.reasoning ?? '',
-    keyMetrics: [...(vote.key_metrics ?? [])],
-    responseTimeMs: vote.response_time_ms ?? 0,
+    confidence: toNumberValue(vote.confidence),
+    reasoning: toStringValue(vote.reasoning),
+    keyMetrics: toArray(vote.key_metrics).map((metric) => toStringValue(metric)).filter(Boolean),
+    responseTimeMs: toNumberValue(vote.response_time_ms),
   };
 }
 
@@ -105,7 +133,18 @@ function toDisagreement(text: string): CouncilDisagreement {
  * Lift the ordinal into `priority` so the badge shows a number and the text is
  * not duplicated.
  */
-function toActionItem(text: string, index: number): { priority: number; text: string } {
+function toDisagreementItem(value: unknown): CouncilDisagreement {
+  return toDisagreement(toStringValue(value, 'Unspecified disagreement.'));
+}
+
+function toActionItem(value: unknown, index: number): { priority: number; text: string } {
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const text = toStringValue(record['text'], 'Review this council action.');
+    return { priority: toNumberValue(record['priority'], index + 1), text };
+  }
+
+  const text = toStringValue(value, 'Review this council action.');
   const match = /^\s*(\d+)[.)]\s*([\s\S]*)$/.exec(text);
   if (match) {
     return { priority: Number(match[1]), text: match[2].trim() };
@@ -113,23 +152,37 @@ function toActionItem(text: string, index: number): { priority: number; text: st
   return { priority: index + 1, text: text.trim() };
 }
 
-function toVerdict(wire: WireConveneResponse): CouncilVerdict {
+function toVerdict(wire: WireCouncilResponse): CouncilVerdict {
   return {
     overallRating: toRating(wire.overall_rating),
-    unanimous: wire.is_unanimous ?? false,
-    synthesisText: wire.synthesis ?? '',
-    disagreements: (wire.disagreements ?? []).map(toDisagreement),
-    actionItems: (wire.action_items ?? []).map(toActionItem),
-    totalConveneTimeMs: wire.total_duration_ms ?? 0,
+    unanimous: wire.is_unanimous === true,
+    synthesisText: toStringValue(wire.synthesis, 'No synthesis is available for this council session.'),
+    disagreements: toArray(wire.disagreements).map(toDisagreementItem),
+    actionItems: toArray(wire.action_items).map(toActionItem),
+    totalConveneTimeMs: toNumberValue(wire.total_duration_ms),
   };
 }
 
-export function mapConveneResponse(wire: WireConveneResponse): CouncilConveneResponse {
+export function mapConveneResponse(value: unknown): CouncilConveneResponse {
+  const wire = toWireCouncilResponse(value);
   return {
-    sessionId: wire.convened_at ?? '',
-    brand: wire.brand ?? '',
-    region: wire.region,
-    votes: (wire.votes ?? []).map(toVote),
+    sessionId: toStringValue(wire.convened_at),
+    brand: toStringValue(wire.brand),
+    region: toOptionalString(wire.region),
+    votes: toArray(wire.votes).map(toVote),
+    verdict: toVerdict(wire),
+  };
+}
+
+export function toCouncilSession(value: unknown): CouncilSession {
+  const wire = toWireCouncilResponse(value);
+  const convenedAt = toStringValue(wire.convened_at);
+  return {
+    id: toStringValue(wire.id, convenedAt || 'unknown-council-session'),
+    brand: toStringValue(wire.brand, 'Unknown brand'),
+    region: toOptionalString(wire.region),
+    convenedAt,
+    votes: toArray(wire.votes).map(toVote),
     verdict: toVerdict(wire),
   };
 }
@@ -141,7 +194,7 @@ export async function conveneCouncil(brand: string, region?: string): Promise<Co
     body: JSON.stringify({ brand, region }),
   });
   if (!res.ok) throw new Error(`Council convene failed: ${res.status}`);
-  return mapConveneResponse((await res.json()) as WireConveneResponse);
+  return mapConveneResponse(await res.json());
 }
 
 export async function fetchCouncilHistory(limit = 20): Promise<CouncilSession[]> {
@@ -150,5 +203,6 @@ export async function fetchCouncilHistory(limit = 20): Promise<CouncilSession[]>
   // empty history rather than surfacing a raw 404 inside the panel.
   if (res.status === 404) return [];
   if (!res.ok) throw new Error(`Failed to fetch council history: ${res.status}`);
-  return res.json();
+  const wire = await res.json();
+  return toArray(wire).map(toCouncilSession);
 }


### PR DESCRIPTION
Fixes #239

Root cause:
- A direct GET to the deployed API returned 401 without app auth, so I used the server source as authoritative as requested.
- `ChatEndpoints.cs` maps `GET /api/council/history` to flat snake_case rows with `convened_at`, `overall_rating`, `synthesis`, `is_unanimous`, `action_items`, and `votes`.
- `CouncilHistory` consumes `CouncilSession` with nested `verdict.overallRating`, `verdict.synthesisText`, and `verdict.actionItems`. `fetchCouncilHistory` returned the raw JSON, so `session.verdict` was undefined and `HistoryItem` threw during render.

Changes:
- Map history rows in `councilApi` to `CouncilSession`, normalize string or integer ratings, and default malformed rows.
- Show a distinct load failure message instead of the empty-history state.
- Add mapping tests for the history payload shape.

Validation:
- `npx tsc --noEmit -p tsconfig.json`
- `npx vitest run`