### PR TITLE
Fix guardrails config save contract

### DIFF
--- a/src/RetailPulse.Api/Endpoints/GuardrailEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/GuardrailEndpoints.cs
@@ -46,36 +46,71 @@ public static class GuardrailEndpoints
         app.MapGet("/api/guardrails/config", (GuardrailsConfig config) => Results.Ok(ProjectConfig(config)))
         .WithName("GetGuardrailsConfig").RequireAuthorization().RequireRateLimiting("relaxed");
 
-        app.MapPut("/api/guardrails/config", (GuardrailsConfigUpdateDto body, GuardrailsConfig config) =>
+        app.MapPut("/api/guardrails/config", IResult (GuardrailsConfigUpdateDto body, GuardrailsConfig config) =>
         {
+            bool applied = false;
             if (body.PiiDetectionEnabled.HasValue)
+            {
                 config.PiiDetectionEnabled = body.PiiDetectionEnabled.Value;
+                applied = true;
+            }
             if (body.JailbreakDetectionEnabled.HasValue)
+            {
                 config.JailbreakDetectionEnabled = body.JailbreakDetectionEnabled.Value;
+                applied = true;
+            }
             if (body.AutoRedactPii.HasValue)
+            {
                 config.AutoRedactPii = body.AutoRedactPii.Value;
+                applied = true;
+            }
             if (body.MaxInputLength.HasValue)
+            {
                 config.MaxInputLength = body.MaxInputLength.Value;
+                applied = true;
+            }
 
-            // Content Safety runtime toggles — the endpoint URL and any
+            // Content Safety runtime toggles - the endpoint URL and any
             // credentials are deliberately server-side only. Thresholds and
             // fail-policy are safe to mutate at runtime because the evaluator
             // reads the live GuardrailsConfig on every call.
             if (body.ContentSafety is { } cs)
             {
                 if (cs.FailPolicy is not null && Enum.TryParse(cs.FailPolicy, ignoreCase: true, out ContentSafetyFailPolicy policy))
+                {
                     config.ContentSafety.OnUnavailable = policy;
+                    applied = true;
+                }
                 if (cs.HateThreshold.HasValue)
+                {
                     config.ContentSafety.Thresholds.Hate = cs.HateThreshold.Value;
+                    applied = true;
+                }
                 if (cs.SexualThreshold.HasValue)
+                {
                     config.ContentSafety.Thresholds.Sexual = cs.SexualThreshold.Value;
+                    applied = true;
+                }
                 if (cs.ViolenceThreshold.HasValue)
+                {
                     config.ContentSafety.Thresholds.Violence = cs.ViolenceThreshold.Value;
+                    applied = true;
+                }
                 if (cs.SelfHarmThreshold.HasValue)
+                {
                     config.ContentSafety.Thresholds.SelfHarm = cs.SelfHarmThreshold.Value;
+                    applied = true;
+                }
             }
 
-            return Results.Ok(ProjectConfig(config) with { Status = "updated" });
+            GuardrailsConfigResponse current = ProjectConfig(config);
+            return !applied
+                ? Results.BadRequest(new
+                {
+                    error = "No supported guardrails configuration fields were provided.",
+                    config = current
+                })
+                : Results.Ok(current with { Status = "updated" });
         })
         .WithName("UpdateGuardrailsConfig").RequireAuthorization().RequireRateLimiting("moderate");
 
@@ -152,7 +187,7 @@ internal record ContentSafetyConfigResponse(
 
 /// <summary>
 /// Public projection of the agent-definition load-time policy. Only surfaces
-/// operator-facing fields — <c>AllowedModels</c>, <c>AllowedTools</c>, and
+/// operator-facing fields - <c>AllowedModels</c>, <c>AllowedTools</c>, and
 /// <c>PrivilegedTools</c> are deployment configuration and are never returned.
 /// </summary>
 internal record AgentDefinitionPolicyResponse(

--- a/src/RetailPulse.Web/src/__tests__/GuardrailsConfig.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/GuardrailsConfig.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { FluentProvider, teamsDarkTheme } from '@fluentui/react-components';
 import { GuardrailsConfig } from '../components/guardrails/GuardrailsConfig';
 import type { GuardrailsConfigData } from '../types';
@@ -10,10 +11,12 @@ function renderWithTheme(ui: React.ReactElement) {
 
 function baseConfig(overrides?: Partial<GuardrailsConfigData>): GuardrailsConfigData {
   return {
-    jailbreakEnabled: true,
-    piiEnabled: true,
-    accessControlEnabled: true,
-    blockedPatterns: 'ignore all previous instructions\nyou are now DAN',
+    piiDetectionEnabled: true,
+    jailbreakDetectionEnabled: true,
+    autoRedactPii: true,
+    maxInputLength: 10000,
+    piiPatterns: ['SSN', 'Email', 'Phone', 'CreditCard'],
+    jailbreakPatterns: ['IgnoreInstructions', 'RolePlay'],
     contentSafety: {
       enabled: true,
       failPolicy: 'FailClosed',
@@ -69,5 +72,67 @@ describe('GuardrailsConfig content-safety runtime panel', () => {
     // Read-only rows are hidden when disabled so users can't infer runtime
     // config that isn't in effect.
     expect(screen.queryByTestId('cs-check-input')).not.toBeInTheDocument();
+  });
+
+  it('renders protection toggles from the backend config contract', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => baseConfig({
+        piiDetectionEnabled: true,
+        jailbreakDetectionEnabled: true,
+        autoRedactPii: false,
+      }),
+    } as Response);
+
+    renderWithTheme(<GuardrailsConfig />);
+
+    expect(await screen.findByLabelText('Toggle jailbreak detection')).toBeChecked();
+    expect(screen.getByLabelText('Toggle PII detection')).toBeChecked();
+    expect(screen.getByLabelText('Toggle auto-redact PII')).not.toBeChecked();
+    expect(screen.queryByLabelText('Toggle access control')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Blocked patterns')).not.toBeInTheDocument();
+  });
+
+  it('saves with the backend contract and reloads the changed state', async () => {
+    const user = userEvent.setup();
+    let serverConfig = baseConfig({ jailbreakDetectionEnabled: true });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/api/guardrails/config' && init?.method === 'PUT') {
+        const payload = JSON.parse(String(init.body)) as Partial<GuardrailsConfigData> & {
+          jailbreakEnabled?: boolean;
+          piiEnabled?: boolean;
+        };
+        expect(payload).toHaveProperty('jailbreakDetectionEnabled', false);
+        expect(payload).not.toHaveProperty('jailbreakEnabled');
+        expect(payload).not.toHaveProperty('piiEnabled');
+        serverConfig = { ...serverConfig, ...payload, status: 'updated' };
+        return {
+          ok: true,
+          json: async () => serverConfig,
+        } as Response;
+      }
+      if (url === '/api/guardrails/config') {
+        return {
+          ok: true,
+          json: async () => serverConfig,
+        } as Response;
+      }
+      throw new Error(`Unmocked fetch: ${url}`);
+    });
+
+    const first = renderWithTheme(<GuardrailsConfig />);
+    const jailbreakSwitch = await screen.findByLabelText('Toggle jailbreak detection');
+    expect(jailbreakSwitch).toBeChecked();
+
+    await user.click(jailbreakSwitch);
+    await user.click(screen.getByRole('button', { name: 'Save Configuration' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/guardrails/config', expect.objectContaining({ method: 'PUT' })));
+    first.unmount();
+
+    renderWithTheme(<GuardrailsConfig />);
+
+    expect(await screen.findByLabelText('Toggle jailbreak detection')).not.toBeChecked();
   });
 });

--- a/src/RetailPulse.Web/src/__tests__/guardrailsApi.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/guardrailsApi.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateGuardrailsConfig } from '../services/guardrailsApi';
+import type { GuardrailsConfigData } from '../types';
+
+function baseConfig(overrides?: Partial<GuardrailsConfigData>): GuardrailsConfigData {
+  return {
+    piiDetectionEnabled: true,
+    jailbreakDetectionEnabled: true,
+    autoRedactPii: true,
+    maxInputLength: 10000,
+    piiPatterns: ['SSN', 'Email'],
+    jailbreakPatterns: ['IgnoreInstructions'],
+    contentSafety: {
+      enabled: true,
+      failPolicy: 'FailClosed',
+      promptShieldsEnabled: true,
+      checkInput: true,
+      checkOutput: true,
+      checkRetrievedKnowledge: true,
+      checkToolResults: true,
+      hateThreshold: 4,
+      sexualThreshold: 4,
+      violenceThreshold: 4,
+      selfHarmThreshold: 4,
+    },
+    ...overrides,
+  };
+}
+
+describe('guardrailsApi config contract', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends only backend config fields on update', async () => {
+    const nextConfig = baseConfig({ jailbreakDetectionEnabled: false });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body).toMatchObject({
+        piiDetectionEnabled: true,
+        jailbreakDetectionEnabled: false,
+        autoRedactPii: true,
+        maxInputLength: 10000,
+      });
+      expect(body).not.toHaveProperty('jailbreakEnabled');
+      expect(body).not.toHaveProperty('piiEnabled');
+      expect(body).not.toHaveProperty('accessControlEnabled');
+      expect(body).not.toHaveProperty('blockedPatterns');
+      return {
+        ok: true,
+        json: async () => nextConfig,
+      } as Response;
+    });
+
+    await expect(updateGuardrailsConfig(nextConfig)).resolves.toMatchObject({
+      jailbreakDetectionEnabled: false,
+    });
+  });
+
+  it('rejects a save when the returned config does not match the requested value', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => baseConfig({ jailbreakDetectionEnabled: true }),
+    } as Response);
+
+    await expect(updateGuardrailsConfig(baseConfig({ jailbreakDetectionEnabled: false })))
+      .rejects.toThrow(/jailbreakDetectionEnabled/);
+  });
+});

--- a/src/RetailPulse.Web/src/components/guardrails/GuardrailsConfig.tsx
+++ b/src/RetailPulse.Web/src/components/guardrails/GuardrailsConfig.tsx
@@ -133,7 +133,8 @@ export function GuardrailsConfig() {
     setSuccess(false);
     setError(null);
     try {
-      await updateGuardrailsConfig(config);
+      const saved = await updateGuardrailsConfig(config);
+      setConfig(saved);
       setSuccess(true);
       setTimeout(() => setSuccess(false), 3000);
     } catch (err) {
@@ -244,8 +245,8 @@ export function GuardrailsConfig() {
             <span className={styles.toggleDescription}>Block prompt injection and jailbreak attempts</span>
           </div>
           <Switch
-            checked={config.jailbreakEnabled}
-            onChange={(_e, data) => setConfig(prev => prev ? { ...prev, jailbreakEnabled: data.checked } : prev)}
+            checked={config.jailbreakDetectionEnabled}
+            onChange={(_e, data) => setConfig(prev => prev ? { ...prev, jailbreakDetectionEnabled: data.checked } : prev)}
             aria-label="Toggle jailbreak detection"
           />
         </div>
@@ -256,37 +257,47 @@ export function GuardrailsConfig() {
             <span className={styles.toggleDescription}>Automatically redact personal identifiable information</span>
           </div>
           <Switch
-            checked={config.piiEnabled}
-            onChange={(_e, data) => setConfig(prev => prev ? { ...prev, piiEnabled: data.checked } : prev)}
+            checked={config.piiDetectionEnabled}
+            onChange={(_e, data) => setConfig(prev => prev ? { ...prev, piiDetectionEnabled: data.checked } : prev)}
             aria-label="Toggle PII detection"
           />
         </div>
 
         <div className={styles.toggleRow}>
           <div className={styles.toggleLabel}>
-            <Text weight="semibold">🔒 Access Control</Text>
-            <span className={styles.toggleDescription}>Enforce role-based access restrictions on data queries</span>
+            <Text weight="semibold">🧹 Auto-redact PII</Text>
+            <span className={styles.toggleDescription}>Redact detected PII in responses instead of leaving it unchanged</span>
           </div>
           <Switch
-            checked={config.accessControlEnabled}
-            onChange={(_e, data) => setConfig(prev => prev ? { ...prev, accessControlEnabled: data.checked } : prev)}
-            aria-label="Toggle access control"
+            checked={config.autoRedactPii}
+            onChange={(_e, data) => setConfig(prev => prev ? { ...prev, autoRedactPii: data.checked } : prev)}
+            aria-label="Toggle auto-redact PII"
           />
         </div>
       </div>
 
       <div className={styles.section}>
-        <span className={styles.sectionTitle}>Blocked Patterns</span>
+        <span className={styles.sectionTitle}>Input Limits</span>
         <Text size={200} style={{ color: 'var(--color-text-muted)' }}>
-          One pattern per line. Regex supported.
+          Requests longer than this value are rejected by the guardrails middleware.
         </Text>
-        <textarea
+        <input
+          type="number"
+          min={1}
           className={styles.textarea}
-          value={config.blockedPatterns}
-          onChange={e => setConfig(prev => prev ? { ...prev, blockedPatterns: e.target.value } : prev)}
-          placeholder="Enter blocked patterns, one per line..."
-          aria-label="Blocked patterns"
+          value={config.maxInputLength}
+          onChange={e => setConfig(prev => prev ? { ...prev, maxInputLength: Number(e.target.value) } : prev)}
+          aria-label="Maximum input length"
         />
+      </div>
+
+      <div className={styles.section}>
+        <span className={styles.sectionTitle}>Pattern Catalog</span>
+        <Text size={200} style={{ color: 'var(--color-text-muted)' }}>
+          Custom blocked patterns are not runtime-configurable. The API exposes the active built-in pattern families as read-only metadata.
+        </Text>
+        <Text size={200}>PII: {config.piiPatterns.join(', ') || 'None'}</Text>
+        <Text size={200}>Jailbreak: {config.jailbreakPatterns.join(', ') || 'None'}</Text>
       </div>
 
       {error && (

--- a/src/RetailPulse.Web/src/services/guardrailsApi.ts
+++ b/src/RetailPulse.Web/src/services/guardrailsApi.ts
@@ -1,5 +1,18 @@
 import type { BlockedRequest, GuardrailsStats, GuardrailsConfigData } from '../types';
 
+type GuardrailsConfigUpdatePayload = Pick<
+  GuardrailsConfigData,
+  'piiDetectionEnabled' | 'jailbreakDetectionEnabled' | 'autoRedactPii' | 'maxInputLength'
+> & {
+  contentSafety?: {
+    failPolicy: NonNullable<GuardrailsConfigData['contentSafety']>['failPolicy'];
+    hateThreshold: number;
+    sexualThreshold: number;
+    violenceThreshold: number;
+    selfHarmThreshold: number;
+  };
+};
+
 export async function fetchGuardrailsStats(): Promise<GuardrailsStats> {
   const res = await fetch('/api/guardrails/stats');
   if (!res.ok) throw new Error(`Failed to fetch guardrails stats: ${res.status}`);
@@ -14,7 +27,7 @@ export async function fetchGuardrailsStats(): Promise<GuardrailsStats> {
 /**
  * Fetches the raw suspicious-request audit log so the dashboard can render
  * category / severity / decision per entry. The `/api/guardrails/stats`
- * endpoint only returns aggregate counters — the per-entry fields required
+ * endpoint only returns aggregate counters - the per-entry fields required
  * for the pattern-vs-model split live behind `/api/guardrails/log`.
  */
 export async function fetchGuardrailsLog(count = 50): Promise<BlockedRequest[]> {
@@ -40,22 +53,79 @@ export async function fetchGuardrailsLog(count = 50): Promise<BlockedRequest[]> 
 
 export async function fetchGuardrailsConfig(): Promise<GuardrailsConfigData> {
   const res = await fetch('/api/guardrails/config');
-  if (res.status === 404) return { jailbreakEnabled: false, piiEnabled: false, accessControlEnabled: false, blockedPatterns: '' };
+  if (res.status === 404) return defaultGuardrailsConfig();
   if (!res.ok) throw new Error(`Failed to fetch guardrails config: ${res.status}`);
   return res.json();
 }
 
-export async function updateGuardrailsConfig(config: GuardrailsConfigData): Promise<void> {
+export async function updateGuardrailsConfig(config: GuardrailsConfigData): Promise<GuardrailsConfigData> {
+  const body = toUpdatePayload(config);
   const res = await fetch('/api/guardrails/config', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(config),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`Failed to update guardrails config: ${res.status}`);
+  const saved = await res.json() as GuardrailsConfigData;
+  assertAppliedConfig(body, saved);
+  return saved;
 }
 
 export async function resetGuardrailsConfig(): Promise<GuardrailsConfigData> {
   const res = await fetch('/api/guardrails/config/reset', { method: 'POST' });
   if (!res.ok) throw new Error(`Failed to reset guardrails config: ${res.status}`);
   return res.json();
+}
+
+function defaultGuardrailsConfig(): GuardrailsConfigData {
+  return {
+    piiDetectionEnabled: false,
+    jailbreakDetectionEnabled: false,
+    autoRedactPii: false,
+    maxInputLength: 0,
+    piiPatterns: [],
+    jailbreakPatterns: [],
+  };
+}
+
+function toUpdatePayload(config: GuardrailsConfigData): GuardrailsConfigUpdatePayload {
+  const payload: GuardrailsConfigUpdatePayload = {
+    piiDetectionEnabled: config.piiDetectionEnabled,
+    jailbreakDetectionEnabled: config.jailbreakDetectionEnabled,
+    autoRedactPii: config.autoRedactPii,
+    maxInputLength: config.maxInputLength,
+  };
+  if (config.contentSafety) {
+    payload.contentSafety = {
+      failPolicy: config.contentSafety.failPolicy,
+      hateThreshold: config.contentSafety.hateThreshold,
+      sexualThreshold: config.contentSafety.sexualThreshold,
+      violenceThreshold: config.contentSafety.violenceThreshold,
+      selfHarmThreshold: config.contentSafety.selfHarmThreshold,
+    };
+  }
+  return payload;
+}
+
+function assertAppliedConfig(requested: GuardrailsConfigUpdatePayload, saved: GuardrailsConfigData): void {
+  const expected: Array<[keyof GuardrailsConfigUpdatePayload, unknown]> = [
+    ['piiDetectionEnabled', requested.piiDetectionEnabled],
+    ['jailbreakDetectionEnabled', requested.jailbreakDetectionEnabled],
+    ['autoRedactPii', requested.autoRedactPii],
+    ['maxInputLength', requested.maxInputLength],
+  ];
+  const mismatch = expected.find(([key, value]) => saved[key] !== value);
+  if (mismatch) {
+    throw new Error(`Guardrails config update was not applied for ${String(mismatch[0])}`);
+  }
+  if (requested.contentSafety && !saved.contentSafety) {
+    throw new Error('Guardrails config update was not applied for contentSafety');
+  }
+  if (requested.contentSafety && saved.contentSafety) {
+    const contentSafetyMismatch = Object.entries(requested.contentSafety)
+      .find(([key, value]) => saved.contentSafety?.[key as keyof typeof requested.contentSafety] !== value);
+    if (contentSafetyMismatch) {
+      throw new Error(`Guardrails config update was not applied for contentSafety.${contentSafetyMismatch[0]}`);
+    }
+  }
 }

--- a/src/RetailPulse.Web/src/types/index.ts
+++ b/src/RetailPulse.Web/src/types/index.ts
@@ -6,16 +6,16 @@ export interface ChatHistoryMessage {
 /**
  * Hybrid execution decision (issue #95). Mirrors the stable UI + telemetry
  * contract values in `RetailPulse.Contracts.Routing.ExecutionPath`:
- *   - `fast`    — single-specialist single-shot path (today's default)
- *   - `plan`    — plan-first workflow path (issue #93)
- *   - `council` — dedicated portfolio-health council interception
+ *   - `fast`    - single-specialist single-shot path (today's default)
+ *   - `plan`    - plan-first workflow path (issue #93)
+ *   - `council` - dedicated portfolio-health council interception
  */
 export type ExecutionPath = 'fast' | 'plan' | 'council';
 
 /**
  * Paths the UI is allowed to force via the composer. Council is a
  * router-controlled destination with its own dedicated trigger and is never
- * a user override — the backend validator rejects it with a 400.
+ * a user override - the backend validator rejects it with a 400.
  */
 export type ForceableExecutionPath = 'fast' | 'plan';
 
@@ -433,7 +433,7 @@ export interface Citation {
 
 // --- Knowledge provider snapshot (issue #106) ---
 // Aligned with GET /api/knowledge/provider, backed by the KnowledgeBaseCapabilities
-// record on the backend. Scores are provider-local — the frontend never compares
+// record on the backend. Scores are provider-local - the frontend never compares
 // them across providers, and `scoreSemantics` MUST be surfaced verbatim so the
 // user reads honest, provider-specific relevance meaning.
 
@@ -525,17 +525,17 @@ export interface BlockedRequest {
   /**
    * Content-safety category (Hate/Sexual/Violence/SelfHarm) when the block
    * originated from the model-based Content Safety layer. Populated by the
-   * backend `SuspiciousRequest.Category` field — see
+   * backend `SuspiciousRequest.Category` field - see
    * `RetailPulse.Contracts.Guardrails.SuspiciousRequest`.
    */
   category?: string;
   /**
    * Severity on the Content Safety 0/2/4/6 axis when a category hit is present.
-   * Never a raw threshold value — this is the hit severity only.
+   * Never a raw threshold value - this is the hit severity only.
    */
   severity?: number;
   /**
-   * Decision label — one of `Blocked`, `Flagged`, `ServiceUnavailable`. Used by
+   * Decision label - one of `Blocked`, `Flagged`, `ServiceUnavailable`. Used by
    * the dashboard to split the pattern-family and model-family aggregates.
    */
   decision?: string;
@@ -553,17 +553,28 @@ export interface GuardrailsStats {
 }
 
 export interface GuardrailsConfigData {
-  jailbreakEnabled: boolean;
-  piiEnabled: boolean;
-  accessControlEnabled: boolean;
-  blockedPatterns: string;
+  piiDetectionEnabled: boolean;
+  jailbreakDetectionEnabled: boolean;
+  autoRedactPii: boolean;
+  maxInputLength: number;
+  piiPatterns: string[];
+  jailbreakPatterns: string[];
   contentSafety?: ContentSafetyConfigData;
+  agentDefinition?: AgentDefinitionPolicyData;
+  status?: string | null;
+}
+
+export interface AgentDefinitionPolicyData {
+  onValidationFailure: string;
+  safetyChecksEnabled: boolean;
+  temperatureMin: number;
+  temperatureMax: number;
 }
 
 export type ContentSafetyFailPolicy = 'FailOpen' | 'FailClosed';
 
 // Aligned with `ContentSafetyConfigResponse` in
-// src/RetailPulse.Api/Endpoints/GuardrailEndpoints.cs — thresholds are
+// src/RetailPulse.Api/Endpoints/GuardrailEndpoints.cs - thresholds are
 // serialised as flat fields (`hateThreshold`, `sexualThreshold`, etc.), not a
 // nested object.
 export interface ContentSafetyConfigData {
@@ -621,7 +632,7 @@ export type SafetyBlockFamily = 'pattern' | 'model' | 'unknown';
 /**
  * Whitelisted display model used by every safety-related component. The
  * fields on this shape are the ONLY things the UI is allowed to render for a
- * safety decision — no raw pattern, threshold, rule ID, or provider payload
+ * safety decision - no raw pattern, threshold, rule ID, or provider payload
  * may ever be added here.
  */
 export interface SafetyBlockDisplayModel {
@@ -633,11 +644,11 @@ export interface SafetyBlockDisplayModel {
   suggestion?: string;
   /** Plain-language category label, e.g. "Hateful content". */
   categoryLabel?: string;
-  /** Original category name for testids / analytics — never a rule name. */
+  /** Original category name for testids / analytics - never a rule name. */
   categoryName?: SafetyCategoryName;
   /** Plain-language severity descriptor, e.g. "high". */
   severityLabel?: 'low' | 'medium' | 'high' | 'severe';
-  /** Original decision label — Blocked / Flagged / ServiceUnavailable. */
+  /** Original decision label - Blocked / Flagged / ServiceUnavailable. */
   decision?: SafetyDecisionKind;
   /**
    * When true, the block came from the model-based Content Safety layer.
@@ -879,7 +890,7 @@ export interface ExplanationData {
 // Mirrors backend contracts in RetailPulse.Contracts.Persistence.PlanDtos and
 // RetailPulse.Contracts.Approval.PlanReview. Every terminal/lifecycle string is
 // kept as a discriminated union so the reducer, UI, and tests share one source
-// of truth. New backend states are additive — the union widens rather than
+// of truth. New backend states are additive - the union widens rather than
 // silently accepting `string`.
 
 export type PlanStatus =
@@ -983,7 +994,7 @@ export interface PlanReviewDecisionResponse {
   round: number;
 }
 
-/** Shape returned by GET /api/plans/{planId}/reviews — one open review. */
+/** Shape returned by GET /api/plans/{planId}/reviews - one open review. */
 export interface PlanReviewOpen {
   requestId: string;
   planId: string;

--- a/tests/RetailPulse.Tests/Guardrails/GuardrailsConfigEndpointTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/GuardrailsConfigEndpointTests.cs
@@ -1,0 +1,130 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Threading.RateLimiting;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RetailPulse.Api.Endpoints;
+using RetailPulse.Api.Guardrails;
+using RetailPulse.Contracts.Guardrails;
+
+namespace RetailPulse.Tests.Guardrails;
+
+public sealed class GuardrailsConfigEndpointTests
+{
+    [Fact]
+    public async Task PutConfig_WithBackendContract_ThenGetReturnsChangedValue()
+    {
+        await using Host host = await Host.CreateAsync();
+
+        HttpResponseMessage put = await host.Client.PutAsJsonAsync("/api/guardrails/config", new
+        {
+            jailbreakDetectionEnabled = false
+        });
+
+        put.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var putBody = JsonDocument.Parse(await put.Content.ReadAsStringAsync());
+        putBody.RootElement.GetProperty("jailbreakDetectionEnabled").GetBoolean().Should().BeFalse();
+        putBody.RootElement.GetProperty("status").GetString().Should().Be("updated");
+
+        HttpResponseMessage get = await host.Client.GetAsync("/api/guardrails/config");
+
+        get.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var getBody = JsonDocument.Parse(await get.Content.ReadAsStringAsync());
+        getBody.RootElement.GetProperty("jailbreakDetectionEnabled").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PutConfig_WithLegacyClientNames_ReturnsBadRequestAndDoesNotApply()
+    {
+        await using Host host = await Host.CreateAsync();
+
+        HttpResponseMessage put = await host.Client.PutAsJsonAsync("/api/guardrails/config", new
+        {
+            jailbreakEnabled = false,
+            piiEnabled = false
+        });
+
+        put.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        HttpResponseMessage get = await host.Client.GetAsync("/api/guardrails/config");
+        get.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var getBody = JsonDocument.Parse(await get.Content.ReadAsStringAsync());
+        getBody.RootElement.GetProperty("jailbreakDetectionEnabled").GetBoolean().Should().BeTrue();
+        getBody.RootElement.GetProperty("piiDetectionEnabled").GetBoolean().Should().BeTrue();
+    }
+
+    private sealed class Host : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+
+        private Host(WebApplication app)
+        {
+            _app = app;
+            Client = app.GetTestClient();
+        }
+
+        public HttpClient Client { get; }
+
+        public static async Task<Host> CreateAsync()
+        {
+            WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
+            builder.WebHost.UseTestServer();
+            builder.Logging.ClearProviders();
+
+            builder.Services.AddAuthentication("Test")
+                .AddScheme<AuthenticationSchemeOptions, StubAuthHandler>("Test", _ => { });
+            builder.Services.AddAuthorization();
+            builder.Services.AddRateLimiter(o =>
+            {
+                o.AddPolicy("relaxed", _ => RateLimitPartition.GetNoLimiter("all"));
+                o.AddPolicy("moderate", _ => RateLimitPartition.GetNoLimiter("all"));
+            });
+            builder.Services.AddSingleton(new GuardrailsConfig
+            {
+                PiiDetectionEnabled = true,
+                JailbreakDetectionEnabled = true,
+                AutoRedactPii = true,
+                MaxInputLength = 10000
+            });
+            builder.Services.AddSingleton<ISuspiciousRequestLog, InMemorySuspiciousRequestLog>();
+
+            WebApplication app = builder.Build();
+            app.UseAuthentication();
+            app.UseAuthorization();
+            app.UseRateLimiter();
+            app.MapGuardrailEndpoints();
+            await app.StartAsync();
+            return new Host(app);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await _app.DisposeAsync();
+        }
+    }
+
+    private sealed class StubAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var identity = new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, "test-user")],
+                "Test");
+            return Task.FromResult(AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(identity), "Test")));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #238

## Root cause
The web client sent and read legacy guardrails fields such as `jailbreakEnabled` and `piiEnabled`, while the API binds and returns `jailbreakDetectionEnabled`, `piiDetectionEnabled`, `autoRedactPii`, and `maxInputLength`. The old payload had no matching mutable fields, so saves were accepted without changing server state, and GET responses rendered as off.

## What changed
- Updated the web guardrails config type, UI, and service to use the backend contract.
- The client now sends only mutable backend fields and renders the config returned by PUT.
- The API now returns 400 when a PUT contains no supported config fields.
- Added web tests for real contract names, save payloads, non-applied saves, and PUT then GET reload behavior.
- Added API tests for accepted backend contract updates and rejected legacy client names.

## Access Control and Blocked Patterns
Access Control has an isolated `AccessControlGuard`, but it is not part of `GuardrailsConfig` or the guardrails middleware runtime path, so there is no real config field to wire without expanding scope. Blocked Patterns are exposed by the API as read-only built-in pattern family names, not runtime-editable custom patterns. I removed both nonfunctional controls and replaced custom blocked patterns with a read-only Pattern Catalog.

## Stats and audit endpoint check
`fetchGuardrailsStats` already matches the backend stats names. `fetchGuardrailsLog` maps the backend `requestText` and `action` fields and keeps fallbacks for older mocks. I did not find the same class of config contract mismatch there.

## Verification
- `npx tsc --noEmit -p tsconfig.json`
- `npx vitest run`
- `dotnet build RetailPulse.slnx --nologo`
- `dotnet test tests\RetailPulse.Tests\RetailPulse.Tests.csproj --filter "FullyQualifiedName~Guardrails" --nologo`

Note: `dotnet build RetailPulse.sln` could not run because this worktree contains `RetailPulse.slnx`, not `RetailPulse.sln`.