### PR TITLE
Mitigate store payload Content Safety false positive

### DIFF
--- a/packs/default/seed/scenario.yaml
+++ b/packs/default/seed/scenario.yaml
@@ -286,7 +286,7 @@ supply:
       - Regional event driving above-forecast consumption
 
 stores:
-  types: [Flagship, Mall, Strip Center, Downtown, Outlet]
+  types: [Flagship, Mall, Shopping Center, Downtown, Outlet]
 
 margin:
   driverCategories: [Raw Materials, Labor, Logistics, Marketing, Packaging, Overhead]

--- a/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyToolResultInspector.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyToolResultInspector.cs
@@ -88,7 +88,7 @@ public sealed class ContentSafetyToolResultInspector
                         "Content Safety blocked tool result from '{Tool}' (decision={Decision}, categories={CategoryCount})",
                         toolName, evaluation.Decision, evaluation.Categories.Count);
 
-                    string substitute = BuildBlockedSubstitute(toolName, detectionType);
+                    string substitute = BuildBlockedSubstitute(toolName, detectionType, category, severity);
                     return ContentSafetyToolResultOutcome.Blocked(substitute, detectionType);
                 }
             case ContentSafetyDecision.ServiceUnavailable:
@@ -110,7 +110,11 @@ public sealed class ContentSafetyToolResultInspector
 
                     if (cfg.OnUnavailable == ContentSafetyFailPolicy.FailClosed)
                     {
-                        string substitute = BuildBlockedSubstitute(toolName, ContentSafetyDetectionTypes.Unavailable);
+                        string substitute = BuildBlockedSubstitute(
+                            toolName,
+                            ContentSafetyDetectionTypes.Unavailable,
+                            category: null,
+                            severity: null);
                         return ContentSafetyToolResultOutcome.Blocked(substitute, ContentSafetyDetectionTypes.Unavailable);
                     }
                     return ContentSafetyToolResultOutcome.PassThrough(toolResultJson);
@@ -137,8 +141,13 @@ public sealed class ContentSafetyToolResultInspector
         }
     }
 
-    private static string BuildBlockedSubstitute(string toolName, string detectionType)
+    private static string BuildBlockedSubstitute(
+        string toolName,
+        string detectionType,
+        string? category,
+        int? severity)
     {
+        string reason = BuildBlockedReason(category, severity, detectionType);
         var envelope = new JsonObject
         {
             ["_content_safety"] = new JsonObject
@@ -146,12 +155,42 @@ public sealed class ContentSafetyToolResultInspector
                 ["blocked"] = true,
                 ["tool"] = toolName,
                 ["detection_type"] = detectionType,
+                ["category"] = category,
+                ["severity"] = severity,
+                ["reason"] = reason,
+                ["message_for_user"] = $"The result from {toolName} was withheld because {reason}.",
                 ["note"] = "The tool result was blocked by the Content Safety layer. Do not re-issue the "
-                    + "same call. Explain to the user that the requested data cannot be included.",
+                    + "same call. Tell the user that the requested data was withheld and why.",
             }
         };
         return envelope.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
     }
+
+    private static string BuildBlockedReason(string? category, int? severity, string detectionType)
+    {
+        if (string.Equals(detectionType, ContentSafetyDetectionTypes.Unavailable, StringComparison.Ordinal))
+        {
+            return "the Content Safety service was unavailable and this deployment is configured to fail closed";
+        }
+
+        string categoryText = string.IsNullOrWhiteSpace(category)
+            ? "a configured Content Safety category"
+            : $"{category} content";
+
+        string severityText = severity.HasValue
+            ? $" at {DescribeSeverity(severity.Value)} severity"
+            : string.Empty;
+
+        return $"Content Safety classified it as {categoryText}{severityText}";
+    }
+
+    private static string DescribeSeverity(int severity) => severity switch
+    {
+        <= 0 => "low",
+        <= 2 => "medium",
+        <= 4 => "high",
+        _ => "severe",
+    };
 
     private static (string? Category, int? Severity) PickCategoryAndSeverity(ContentSafetyResult evaluation)
     {

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyRetailPayloadTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyRetailPayloadTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Azure.AI.ContentSafety;
+using Azure.Core.Pipeline;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using RetailPulse.Api.Guardrails.ContentSafety;
+using RetailPulse.Contracts;
+using RetailPulse.Contracts.Guardrails;
+using RetailPulse.McpServer.Data;
+using RetailPulse.Tests.TestInfrastructure;
+
+namespace RetailPulse.Tests.Guardrails.ContentSafety;
+
+[Collection("AzureContentSafetyEvaluatorActivity")]
+public sealed class ContentSafetyRetailPayloadTests : IDisposable
+{
+    private readonly string _dbPath = SqliteTestCleanup.NewDbPath("rp_contentsafety_retail_payloads");
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        SqliteTestCleanup.ReleaseAndDelete(_dbPath);
+    }
+
+    [Fact]
+    public async Task GetStorePerformancePayload_PassesToolResultContentSafetyEvaluation()
+    {
+        string payload = BuildGetStorePerformancePayload();
+        var handler = new RetailPayloadHandler();
+        AzureContentSafetyEvaluator evaluator = BuildEvaluator(handler);
+
+        ContentSafetyResult result = await evaluator.EvaluateAsync(
+            payload,
+            ContentSafetyStage.ToolResult,
+            new ContentSafetyEvaluationContext(UserId: "test-user", SourceId: "GetStorePerformance"),
+            CancellationToken.None);
+
+        result.Decision.Should().Be(ContentSafetyDecision.Passed);
+        handler.AnalyzedTexts.Should().ContainSingle().Which.Should().Be(payload);
+        payload.Should().NotContain("Strip Center", "the generated retail real-estate term triggers a sexual-content false positive");
+        payload.Should().Contain("Shopping Center");
+    }
+
+    [Theory]
+    [InlineData(/*lang=json,strict*/ """{"stores":[{"storeName":"Apex Retail Group Shopping Center #11","region":"Southwest","revenue":1835988.67,"target":1997181.15,"performanceIndex":0.919}],"count":1}""")]
+    [InlineData(/*lang=json,strict*/ """{"stores":[{"storeName":"Apex Retail Group Outlet #1","region":"Northeast","revenue":1508629.63,"target":1799874.22,"performanceIndex":0.838,"issues":["Below target"]}],"count":1}""")]
+    public async Task RepresentativeRetailToolPayloads_PassContentSafetyEvaluation(string payload)
+    {
+        var handler = new RetailPayloadHandler();
+        AzureContentSafetyEvaluator evaluator = BuildEvaluator(handler);
+
+        ContentSafetyResult result = await evaluator.EvaluateAsync(
+            payload,
+            ContentSafetyStage.ToolResult,
+            new ContentSafetyEvaluationContext(UserId: "test-user", SourceId: "GetStorePerformance"),
+            CancellationToken.None);
+
+        result.Decision.Should().Be(ContentSafetyDecision.Passed);
+    }
+
+    [Theory]
+    [InlineData(/*lang=json,strict*/ """{"categories":[{"name":"Intimate Apparel","sales":143200,"target":150000,"region":"Northeast"}]}""")]
+    [InlineData(/*lang=json,strict*/ """{"categories":[{"name":"Adult Beverage","sales":219500,"target":205000,"region":"West Coast"}]}""")]
+    [InlineData(/*lang=json,strict*/ """{"categories":[{"name":"Body Care","sales":98200,"target":96000,"region":"Southeast"}]}""")]
+    [InlineData(/*lang=json,strict*/ """{"categories":[{"name":"Breast Pump Accessories","sales":65200,"target":64000,"region":"Midwest"}]}""")]
+    public async Task AmbiguousRetailVocabulary_WithLowContentSafetyScores_DoesNotBlock(string payload)
+    {
+        var handler = new RetailPayloadHandler
+        {
+            DefaultCategories =
+            [
+                new { category = "Sexual", severity = 2 }
+            ]
+        };
+        AzureContentSafetyEvaluator evaluator = BuildEvaluator(handler);
+
+        ContentSafetyResult result = await evaluator.EvaluateAsync(
+            payload,
+            ContentSafetyStage.ToolResult,
+            new ContentSafetyEvaluationContext(UserId: "test-user", SourceId: "GetRetailMetrics"),
+            CancellationToken.None);
+
+        result.Decision.Should().NotBe(ContentSafetyDecision.Blocked);
+    }
+
+    private string BuildGetStorePerformancePayload()
+    {
+        string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+        string tenantConfigPath = Path.Combine(repoRoot, "tenant.yaml");
+        var tenantProvider = new FileTenantProvider(tenantConfigPath);
+        var db = new RetailPulseDb(tenantProvider, _dbPath, tenantConfigPath);
+
+        return JsonSerializer.Serialize(db.GetStorePerformance());
+    }
+
+    private static AzureContentSafetyEvaluator BuildEvaluator(RetailPayloadHandler handler)
+    {
+        var http = new HttpClient(handler, disposeHandler: false)
+        {
+            BaseAddress = new Uri("https://fake.cognitiveservices.azure.com")
+        };
+        var credential = new FakeTokenCredential();
+        var sdk = new ContentSafetyClient(
+            http.BaseAddress,
+            credential,
+            new ContentSafetyClientOptions { Transport = new HttpClientTransport(http) });
+        var config = new GuardrailsConfig
+        {
+            ContentSafety = new ContentSafetyConfig
+            {
+                Enabled = true,
+                Endpoint = http.BaseAddress.ToString(),
+                PromptShieldsEnabled = false
+            }
+        };
+
+        return new AzureContentSafetyEvaluator(
+            sdk,
+            http,
+            new ContentSafetyTokenProvider(credential),
+            config,
+            NullLoggerFactory.Instance.CreateLogger<AzureContentSafetyEvaluator>());
+    }
+
+    private sealed class RetailPayloadHandler : HttpMessageHandler
+    {
+        public List<string> AnalyzedTexts { get; } = [];
+        public IReadOnlyList<object> DefaultCategories { get; init; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (!request.RequestUri!.AbsolutePath.EndsWith("text:analyze", StringComparison.Ordinal))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new
+                    {
+                        userPromptAnalysis = new { attackDetected = false },
+                        documentsAnalysis = Array.Empty<object>()
+                    })
+                };
+            }
+
+            string requestBody = request.Content is null
+                ? "{}"
+                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            string text = JsonDocument.Parse(requestBody).RootElement.GetProperty("text").GetString() ?? "";
+            AnalyzedTexts.Add(text);
+
+            object[] categories = text.Contains("Strip Center", StringComparison.OrdinalIgnoreCase)
+                ? [new { category = "Sexual", severity = 4 }]
+                : [.. DefaultCategories];
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new { categoriesAnalysis = categories })
+            };
+        }
+    }
+}

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyToolResultTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyToolResultTests.cs
@@ -67,6 +67,9 @@ public class ContentSafetyToolResultTests
         outcome.WasBlocked.Should().BeTrue();
         outcome.Payload.Should().NotContain("blocked content");
         outcome.Payload.Should().Contain("_content_safety");
+        outcome.Payload.Should().Contain("Violence");
+        outcome.Payload.Should().Contain("severe severity");
+        outcome.Payload.Should().Contain("withheld");
         (await log.GetRecentAsync(10)).Should().Contain(r =>
             r.DetectionType == ContentSafetyDetectionTypes.Violence
             && r.Action == ContentSafetyActions.Blocked);

--- a/tests/RetailPulse.Tests/Packs/DefaultPackSeedGoldenTests.cs
+++ b/tests/RetailPulse.Tests/Packs/DefaultPackSeedGoldenTests.cs
@@ -68,7 +68,7 @@ public sealed class DefaultPackSeedGoldenTests : IDisposable
 
         // Store types.
         seed.Stores.Types.Should().Equal(
-            "Flagship", "Mall", "Strip Center", "Downtown", "Outlet");
+            "Flagship", "Mall", "Shopping Center", "Downtown", "Outlet");
 
         // Margin driver vocabulary.
         seed.Margin.DriverCategories.Should().Equal(


### PR DESCRIPTION
## Summary
- Mitigates the observed GetStorePerformance false positive by renaming the generated default-pack store type from Strip Center to Shopping Center.
- Preserves Content Safety and tool-result scanning behavior. This PR does not disable, bypass, or loosen guardrails.
- Makes blocked tool-result substitutes explicit about the withheld data, category, severity, reason, and user-facing message.
- Adds regression coverage for the real generated GetStorePerformance payload and for ambiguous retail vocabulary with low Content Safety scores.

## Mitigation, not cure
This is intentionally a mitigation for the observed demo-pack trigger, not a complete fix for the broader class. Strip Center is a normal US commercial real-estate term, so this change trades a small amount of sample-data authenticity for demo reliability. Other legitimate retail terms, product categories, brand names, store formats, or customer names could still trip conversational harm classifiers when scanned as raw structured tool-result JSON.

The broader policy question is documented on #244 and tracked separately in https://github.com/swigerb/retail-pulse/issues/248.

## Evidence
- Tool-result path: BudgetedAIFunction sends budgeted finalJson to ContentSafetyToolResultInspector, which calls AzureContentSafetyEvaluator with ContentSafetyStage.ToolResult and CheckPromptShield set to false.
- What was sent before the mitigation: raw JSON from GetStorePerformance, 4,747 characters, including store KPI fields and Apex Retail Group Strip Center #11, #12, #18, and #19.
- What is sent after the mitigation: raw JSON from GetStorePerformance, 4,759 characters, same KPI fields, with Apex Retail Group Shopping Center #11, #12, #18, and #19.
- Content Safety response evidence available here: issue audit rows reported MODEL / SEXUAL CONTENT / HIGH / blocked for GetStorePerformance.
- Live score limitation: I could not measure live category scores because this machine has no configured azd environment, no Content Safety endpoint environment variable, and the signed-in Azure account lists no ContentSafety resources.
- Why this was blocked: threshold comparison is correct for Azure's 0, 2, 4, 6 scale, and the payload is below the #226 segmentation threshold. The only plausible sexual-content trigger in the raw payload was the generated store type Strip Center.

## Validation
- dotnet build .\RetailPulse.slnx --no-restore --verbosity minimal
- dotnet test .\tests\RetailPulse.Tests\RetailPulse.Tests.csproj --filter "FullyQualifiedName~ContentSafety|FullyQualifiedName~Guardrails|FullyQualifiedName~DefaultPackSeedGoldenTests|FullyQualifiedName~StoreOpsToolTests" --no-restore --logger "console;verbosity=minimal"

Refs #244