### PR TITLE
Fix Campaign Planner ROI evaluation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -476,7 +476,7 @@ Full promotional evaluation task module. Orchestrates all four promo MCP tools i
   "budget": 150000,
   "startDate": "2026-06-01",
   "endDate": "2026-06-28",
-  "targetLift": 15.0
+  "targetLiftPercent": 15.0
 }
 ```
 
@@ -488,7 +488,7 @@ Full promotional evaluation task module. Orchestrates all four promo MCP tools i
 | `budget` | double | ✅ | Budget in dollars (must be > 0) |
 | `startDate` | string | ✅ | ISO date (yyyy-MM-dd) |
 | `endDate` | string | ✅ | ISO date (yyyy-MM-dd) |
-| `targetLift` | double | | Target lift percentage (optional) |
+| `targetLiftPercent` | double | | Target lift percentage (optional) |
 
 **Approval Triggers:**
 - Budget > $500,000 → always requires approval
@@ -504,10 +504,17 @@ Full promotional evaluation task module. Orchestrates all four promo MCP tools i
   "promo_type": "discount",
   "budget": 150000,
   "period": { "start": "2026-06-01", "end": "2026-06-28", "duration_weeks": 4 },
-  "roi_estimate": { "expected_roi": 2.85, "upper_bound": 3.4, "lower_bound": 2.1 },
+  "target_lift": 12,
+  "roi_estimate": {
+    "roi": { "expected": 2.85, "upper_bound": 3.4, "lower_bound": 2.1 },
+    "break_even_days": 18,
+    "similar_campaigns": 8,
+    "historical_avg_roi": 2.42,
+    "basis": "brand, region and promotion type"
+  },
   "timing_assessment": { "timing_score": 0.82, "conflicts": [], "risks": [] },
   "lift_analysis": { "expected_lift_pct": 12.5, "confidence": "high" },
-  "historical_context": { "campaigns": [...] },
+  "historical_context": { "total_campaigns": 8, "avg_roi": 2.42, "campaigns": [...] },
   "risk_factors": [],
   "approval": { "required": false, "request_id": null, "reason": null }
 }

--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -258,7 +258,8 @@ Full ROI estimation combining lift, timing, and spend effectiveness.
 | `region` | string | ✅ | | Region |
 | `promoType` | string | ✅ | | Promo type |
 | `spend` | double | ✅ | | Planned spend |
-| `durationWeeks` | int | ✅ | | Duration (1–12 weeks) |
+| `durationWeeks` | int | ✅ | | Duration (1 to 52 weeks) |
+| `targetLiftPercent` | double | | | Optional planner target lift |
 
 **Returns:** Expected ROI with confidence bounds and breakeven analysis.
 
@@ -266,12 +267,12 @@ Full ROI estimation combining lift, timing, and spend effectiveness.
 
 ```json
 {
-  "expected_roi": 2.85,
-  "upper_bound": 3.40,
-  "lower_bound": 2.10,
-  "confidence": "high",
-  "breakeven_spend": 52000,
-  "incremental_revenue": 427500
+  "roi": { "expected": 2.85, "lower_bound": 2.10, "upper_bound": 3.40 },
+  "break_even_days": 18,
+  "similar_campaigns": 8,
+  "historical_avg_roi": 2.42,
+  "basis": "brand, region and promotion type",
+  "incremental": { "revenue": 427500 }
 }
 ```
 

--- a/src/RetailPulse.Api/Endpoints/PromoEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/PromoEndpoints.cs
@@ -149,13 +149,17 @@ public static class PromoEndpoints
 
             double? expectedRoi = ReadExpectedRoi(roiDoc.RootElement);
             bool insufficientHistory = ReadBoolean(roiDoc.RootElement, "insufficient_history") || expectedRoi is null;
+            int? breakEvenDays = ReadNullableInt(roiDoc.RootElement, "break_even_days");
+            int durationDays = durationWeeks * 7;
+            bool breaksEvenWithinWindow = breakEvenDays is not null && breakEvenDays.Value <= durationDays;
 
-            // Determine recommendation
-            string recommendation = insufficientHistory ? "insufficient_history" : expectedRoi!.Value switch
+            string recommendation = insufficientHistory ? "insufficient_history"
+                : !breaksEvenWithinWindow ? "not_recommended"
+                : expectedRoi!.Value switch
             {
                 >= 3.0 => "strongly_recommended",
                 >= 2.0 => "recommended",
-                >= 0.95 => "proceed_with_caution",
+                >= 1.0 => "proceed_with_caution",
                 _ => "not_recommended"
             };
 
@@ -172,14 +176,14 @@ public static class PromoEndpoints
                         riskFactors.Add(detail.GetString() ?? "Unknown risk");
                 }
             }
-            if (!insufficientHistory && expectedRoi!.Value < 0.95)
-                riskFactors.Add("Expected ROI below breakeven (1.0x)");
+            if (!insufficientHistory && !breaksEvenWithinWindow)
+                riskFactors.Add("Campaign does not recoup planned spend within the proposed window");
             if (request.Budget > 500000)
                 riskFactors.Add("High-budget campaign (>$500K) requires executive approval");
 
             // Check approval gate trigger
             string? approvalRequestId = null;
-            bool requiresApproval = !insufficientHistory && (request.Budget > 500000 || (expectedRoi!.Value < 2.0 && request.Budget > 100000));
+            bool requiresApproval = !insufficientHistory && (request.Budget > 500000 || (!breaksEvenWithinWindow && request.Budget > 100000) || (expectedRoi!.Value < 2.0 && request.Budget > 100000));
             if (requiresApproval)
             {
                 string reason = request.Budget > 500000
@@ -258,6 +262,13 @@ public static class PromoEndpoints
     private static bool ReadBoolean(JsonElement root, string name) =>
         root.TryGetProperty(name, out JsonElement value)
         && value.ValueKind == JsonValueKind.True;
+
+    private static int? ReadNullableInt(JsonElement root, string name) =>
+        root.TryGetProperty(name, out JsonElement value)
+        && value.ValueKind == JsonValueKind.Number
+        && value.TryGetInt32(out int parsed)
+            ? parsed
+            : null;
 
     private static double? ReadExpectedRoi(JsonElement root)
     {

--- a/src/RetailPulse.Api/Endpoints/PromoEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/PromoEndpoints.cs
@@ -28,7 +28,7 @@ public static class PromoEndpoints
 
         // Existing campaigns for the Campaign Planner panel.
         //
-        // The SPA has always called GET /api/campaigns, which was never mapped —
+        // The SPA has always called GET /api/campaigns, which was never mapped,
         // it 404'd, promoApi.fetchExistingCampaigns threw on the non-OK status,
         // and the uncaught error took the whole dashboard down through the
         // app-level ErrorBoundary. The data it wants is the promo calendar, so
@@ -113,18 +113,25 @@ public static class PromoEndpoints
                 return Results.BadRequest(new { error = "startDate and endDate must be valid ISO dates (yyyy-MM-dd)." });
             }
 
-            int durationWeeks = Math.Max(1, (endDate.DayNumber - startDate.DayNumber) / 7);
-            HttpClient client = httpFactory.CreateClient("McpServer");
+            if (endDate <= startDate)
+            {
+                return Results.BadRequest(new { error = "endDate must be after startDate." });
+            }
 
-            // Orchestrate: call all promo tools in parallel
+            int durationWeeks = Math.Max(1, (int)Math.Ceiling((endDate.DayNumber - startDate.DayNumber) / 7.0));
+            HttpClient client = httpFactory.CreateClient("McpServer");
+            string roiUrl = $"/api/promo/estimate-roi?brand={Uri.EscapeDataString(request.Brand)}&region={Uri.EscapeDataString(request.Region)}&promoType={Uri.EscapeDataString(request.PromoType)}&spend={request.Budget}&durationWeeks={durationWeeks}";
+            if (request.TargetLiftPercent is > 0)
+                roiUrl += $"&targetLiftPercent={request.TargetLiftPercent.Value}";
+
+            // Call all promo tools in parallel so the planner stays responsive.
             Task<string> historyTask = client.GetStringAsync(
-                $"/api/promo/history?brand={Uri.EscapeDataString(request.Brand)}&region={Uri.EscapeDataString(request.Region)}&promoType={Uri.EscapeDataString(request.PromoType)}&months=12", ct);
+                $"/api/promo/history?brand={Uri.EscapeDataString(request.Brand)}&region={Uri.EscapeDataString(request.Region)}&promoType={Uri.EscapeDataString(request.PromoType)}&months=24", ct);
             Task<string> liftTask = client.GetStringAsync(
                 $"/api/promo/calculate-lift?brand={Uri.EscapeDataString(request.Brand)}&region={Uri.EscapeDataString(request.Region)}&promoType={Uri.EscapeDataString(request.PromoType)}&spend={request.Budget}", ct);
             Task<string> timingTask = client.GetStringAsync(
                 $"/api/promo/evaluate-timing?brand={Uri.EscapeDataString(request.Brand)}&region={Uri.EscapeDataString(request.Region)}&startDate={Uri.EscapeDataString(request.StartDate)}&endDate={Uri.EscapeDataString(request.EndDate)}", ct);
-            Task<string> roiTask = client.GetStringAsync(
-                $"/api/promo/estimate-roi?brand={Uri.EscapeDataString(request.Brand)}&region={Uri.EscapeDataString(request.Region)}&promoType={Uri.EscapeDataString(request.PromoType)}&spend={request.Budget}&durationWeeks={durationWeeks}", ct);
+            Task<string> roiTask = client.GetStringAsync(roiUrl, ct);
 
             await Task.WhenAll(historyTask, liftTask, timingTask, roiTask);
 
@@ -133,16 +140,22 @@ public static class PromoEndpoints
             string timingJson = await timingTask;
             string roiJson = await roiTask;
 
-            // Parse ROI for approval gate decision
+            // Parse ROI for approval gate decision.
             using var roiDoc = JsonDocument.Parse(roiJson);
-            double expectedRoi = roiDoc.RootElement.TryGetProperty("expected_roi", out JsonElement roiProp) ? roiProp.GetDouble() : 0;
+            if (TryReadError(roiDoc.RootElement, out string? roiError))
+            {
+                return Results.UnprocessableEntity(new { error = roiError });
+            }
+
+            double? expectedRoi = ReadExpectedRoi(roiDoc.RootElement);
+            bool insufficientHistory = ReadBoolean(roiDoc.RootElement, "insufficient_history") || expectedRoi is null;
 
             // Determine recommendation
-            string recommendation = expectedRoi switch
+            string recommendation = insufficientHistory ? "insufficient_history" : expectedRoi!.Value switch
             {
                 >= 3.0 => "strongly_recommended",
                 >= 2.0 => "recommended",
-                >= 1.0 => "proceed_with_caution",
+                >= 0.95 => "proceed_with_caution",
                 _ => "not_recommended"
             };
 
@@ -159,25 +172,25 @@ public static class PromoEndpoints
                         riskFactors.Add(detail.GetString() ?? "Unknown risk");
                 }
             }
-            if (expectedRoi < 1.0)
+            if (!insufficientHistory && expectedRoi!.Value < 0.95)
                 riskFactors.Add("Expected ROI below breakeven (1.0x)");
             if (request.Budget > 500000)
-                riskFactors.Add("High-budget campaign (>$500K) — requires executive approval");
+                riskFactors.Add("High-budget campaign (>$500K) requires executive approval");
 
             // Check approval gate trigger
             string? approvalRequestId = null;
-            bool requiresApproval = request.Budget > 500000 || (expectedRoi < 2.0 && request.Budget > 100000);
+            bool requiresApproval = !insufficientHistory && (request.Budget > 500000 || (expectedRoi!.Value < 2.0 && request.Budget > 100000));
             if (requiresApproval)
             {
                 string reason = request.Budget > 500000
                     ? $"High-budget promo: ${request.Budget:N0} for {request.Brand} in {request.Region}"
-                    : $"Low-ROI risk: {expectedRoi:F2}x ROI with ${request.Budget:N0} budget for {request.Brand}";
+                    : $"Low-ROI risk: {expectedRoi!.Value:F2}x ROI with ${request.Budget:N0} budget for {request.Brand}";
 
                 ApprovalRequest approvalRequest = await approvalGate.RequestApprovalAsync(new ApprovalContext(
                     AgentId: "promo-planning",
                     UserId: "taskmodule",
                     Action: $"Execute {request.PromoType} promotion for {request.Brand} in {request.Region}",
-                    Impact: $"Budget: ${request.Budget:N0}, Expected ROI: {expectedRoi:F2}x, Duration: {durationWeeks} weeks",
+                    Impact: $"Budget: ${request.Budget:N0}, Expected ROI: {expectedRoi!.Value:F2}x, Duration: {durationWeeks} weeks",
                     Urgency: request.Budget > 500000 ? "high" : "medium",
                     Reasoning: reason
                 ), ct);
@@ -194,7 +207,7 @@ public static class PromoEndpoints
                 promo_type = request.PromoType,
                 budget = request.Budget,
                 period = new { start = request.StartDate, end = request.EndDate, duration_weeks = durationWeeks },
-                target_lift = request.TargetLift,
+                target_lift = request.TargetLiftPercent,
                 roi_estimate = JsonSerializer.Deserialize<object>(roiJson),
                 timing_assessment = JsonSerializer.Deserialize<object>(timingJson),
                 lift_analysis = JsonSerializer.Deserialize<object>(liftJson),
@@ -230,6 +243,35 @@ public static class PromoEndpoints
             ? parsed
             : 0d;
 
+    private static bool TryReadError(JsonElement root, out string? error)
+    {
+        if (root.TryGetProperty("error", out JsonElement value) && value.ValueKind == JsonValueKind.String)
+        {
+            error = value.GetString();
+            return !string.IsNullOrWhiteSpace(error);
+        }
+
+        error = null;
+        return false;
+    }
+
+    private static bool ReadBoolean(JsonElement root, string name) =>
+        root.TryGetProperty(name, out JsonElement value)
+        && value.ValueKind == JsonValueKind.True;
+
+    private static double? ReadExpectedRoi(JsonElement root)
+    {
+        return root.TryGetProperty("roi", out JsonElement roi)
+            && roi.ValueKind == JsonValueKind.Object
+            && roi.TryGetProperty("expected", out JsonElement nestedExpected)
+            && nestedExpected.TryGetDouble(out double nestedValue)
+            ? nestedValue
+            : root.TryGetProperty("expected_roi", out JsonElement flatExpected)
+                && flatExpected.TryGetDouble(out double flatValue)
+                ? flatValue
+                : null;
+    }
+
     /// <summary>
     /// The promo calendar carries dates but no lifecycle state, while the planner's
     /// PromoCampaign contract requires one. Derive it from the window so the panel can
@@ -254,5 +296,5 @@ record PromoEvaluationRequest(
     double Budget,
     string StartDate,
     string EndDate,
-    double? TargetLift = null
+    double? TargetLiftPercent = null
 );

--- a/src/RetailPulse.Api/Endpoints/PromoEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/PromoEndpoints.cs
@@ -153,15 +153,17 @@ public static class PromoEndpoints
             int durationDays = durationWeeks * 7;
             bool breaksEvenWithinWindow = breakEvenDays is not null && breakEvenDays.Value <= durationDays;
 
-            string recommendation = insufficientHistory ? "insufficient_history"
-                : !breaksEvenWithinWindow ? "not_recommended"
-                : expectedRoi!.Value switch
-            {
-                >= 3.0 => "strongly_recommended",
-                >= 2.0 => "recommended",
-                >= 1.0 => "proceed_with_caution",
-                _ => "not_recommended"
-            };
+            string recommendation = insufficientHistory
+                ? "insufficient_history"
+                : !breaksEvenWithinWindow
+                    ? "not_recommended"
+                    : expectedRoi!.Value switch
+                    {
+                        >= 3.0 => "strongly_recommended",
+                        >= 2.0 => "recommended",
+                        >= 1.0 => "proceed_with_caution",
+                        _ => "not_recommended"
+                    };
 
             // Build risk factors
             var riskFactors = new List<string>();

--- a/src/RetailPulse.McpServer/Data/RetailPulseDb.cs
+++ b/src/RetailPulse.McpServer/Data/RetailPulseDb.cs
@@ -2665,19 +2665,24 @@ public class RetailPulseDb
         double revenuePerUnit = GetRevenuePerUnit(brandConfig.Category);
         double incrementalRevenue = incrementalUnits * revenuePerUnit;
         double modeledRoi = incrementalRevenue / spend;
-        double expectedRoi = Math.Round((modeledRoi * 0.65) + (basis.AverageRoi * 0.35), 2);
+        double historicalPriorRoi = basis.AverageRoi * spendEfficiency * durationEfficiency;
+        double expectedRoi = Math.Round((modeledRoi * 0.70) + (historicalPriorRoi * 0.30), 2);
 
         double lowerLift = Math.Max(0.1, effectiveLift - (1.96 * stdDev));
         double upperLift = effectiveLift + (1.96 * stdDev);
 
         double lowerModeledRoi = totalBaseline * (lowerLift / 100.0) * spendEfficiency * durationEfficiency * revenuePerUnit / spend;
         double upperModeledRoi = totalBaseline * (upperLift / 100.0) * spendEfficiency * durationEfficiency * revenuePerUnit / spend;
-        double historySpread = Math.Max(0.15, basis.StdDevRoi);
-        double lowerRoi = Math.Round(Math.Max(0.1, Math.Min(expectedRoi, (lowerModeledRoi * 0.65) + ((basis.AverageRoi - historySpread) * 0.35))), 2);
-        double upperRoi = Math.Round(Math.Max(expectedRoi + 0.1, (upperModeledRoi * 0.65) + ((basis.AverageRoi + historySpread) * 0.35)), 2);
+        double historySpread = Math.Max(0.15, basis.StdDevRoi * spendEfficiency * durationEfficiency);
+        double lowerHistoricalPrior = Math.Max(0.1, historicalPriorRoi - historySpread);
+        double upperHistoricalPrior = historicalPriorRoi + historySpread;
+        double lowerRoi = Math.Round(Math.Max(0.1, Math.Min(expectedRoi, (lowerModeledRoi * 0.70) + (lowerHistoricalPrior * 0.30))), 2);
+        double upperRoi = Math.Round(Math.Max(expectedRoi + 0.1, (upperModeledRoi * 0.70) + (upperHistoricalPrior * 0.30)), 2);
 
-        double dailyIncrementalRevenue = incrementalRevenue / Math.Max(1, durationWeeks * 7);
-        int breakEvenDays = Math.Max(1, (int)Math.Ceiling(spend / Math.Max(1.0, dailyIncrementalRevenue)));
+        int durationDays = Math.Max(1, durationWeeks * 7);
+        int? breakEvenDays = expectedRoi >= 1.0
+            ? Math.Max(1, (int)Math.Ceiling(durationDays / expectedRoi))
+            : null;
         double varianceFactor = Math.Round(stdDev / Math.Max(avgLift, 1.0), 2);
 
         return new
@@ -2694,7 +2699,7 @@ public class RetailPulseDb
             similar_campaigns = basis.Count,
             basis = basis.Basis,
             variance_factor = varianceFactor,
-            is_positive_roi = expectedRoi >= 0.95,
+            is_positive_roi = expectedRoi >= 1.0,
             requires_approval = spend > 500000,
             risk_level = varianceFactor > 0.5 ? "high" : varianceFactor > 0.3 ? "medium" : "low"
         };

--- a/src/RetailPulse.McpServer/Data/RetailPulseDb.cs
+++ b/src/RetailPulse.McpServer/Data/RetailPulseDb.cs
@@ -458,9 +458,8 @@ public class RetailPulseDb
     // to force a re-seed even if tenant.yaml hasn't changed.
     // Issue #108: v8 folds the pack's seed/scenario.yaml manifest into
     // the fingerprint so a scenario edit alone forces reseed. Upgrades
-    // from v7 stores always miss a v8 hash lookup and re-seed on first
-    // boot.
-    private const int SchemaVersion = 8;
+    // to v9 also reseed because promo ROI now stores multipliers.
+    private const int SchemaVersion = 9;
 
     private string ComputeTenantHash()
     {
@@ -1936,9 +1935,71 @@ public class RetailPulseDb
         }
     }
 
+    private static double GetRevenuePerUnit(string category) => category switch
+    {
+        "Spirits" => 12.0,
+        "Grocery" => 5.0,
+        "Quick-Serve Restaurant" => 4.0,
+        "Home Improvement" => 8.0,
+        "Office Supply" => 6.0,
+        "Furniture" => 18.0,
+        _ => 12.0
+    };
+
+    private static double GetPromoTypeRoiBenchmark(string promoType) => promoType switch
+    {
+        "BOGO" => 3.1,
+        "Discount" => 2.4,
+        "Display" => 1.8,
+        "Digital" => 2.9,
+        "Bundle" => 2.2,
+        _ => 1.5
+    };
+
+    private static bool IsNationalRegion(string region) =>
+        region.Trim().Equals("National", StringComparison.OrdinalIgnoreCase);
+
+    private sealed record PromoHistoryRow(
+        string Brand,
+        string Region,
+        string PromoType,
+        string CampaignName,
+        string StartDate,
+        string EndDate,
+        double Spend,
+        double BaselineVolume,
+        double ActualVolume,
+        double LiftPercent,
+        double Roi,
+        string SuccessRating)
+    {
+        public object ToDto() => new
+        {
+            brand = Brand,
+            region = Region,
+            promo_type = PromoType,
+            campaign_name = CampaignName,
+            start_date = StartDate,
+            end_date = EndDate,
+            spend = Spend,
+            baseline_volume = BaselineVolume,
+            actual_volume = ActualVolume,
+            lift_percent = LiftPercent,
+            roi = Roi,
+            success_rating = SuccessRating
+        };
+    }
+
+    private sealed record PromoBasis(
+        int Count,
+        double AverageRoi,
+        double StdDevRoi,
+        double AverageBaselineVolume,
+        string Basis);
+
     // ── Promo Seeding ────────────────────────────────────────────────────
     // Promo type names, success rating labels, and per-type lift/coef
-    // coefficients originate in the pack's seed/scenario.yaml — see
+    // coefficients originate in the pack's seed/scenario.yaml; see
     // _promoTypeNames, _successRatings, and the _seed.Promos.Types
     // lookup below.
 
@@ -1980,22 +2041,23 @@ public class RetailPulseDb
                     int durationDays = rng.Next(7, 45);
                     DateOnly campaignEnd = campaignStart.AddDays(durationDays);
 
-                    double spend = Math.Round(5000 + (rng.NextDouble() * 195000), 2);
                     double baselineVolume = Math.Round(1000 + (rng.NextDouble() * 9000), 0);
 
                     double baseLift = promoTypeConfig.LiftBase + (rng.NextDouble() * promoTypeConfig.LiftRange);
 
                     double liftPercent = Math.Round(baseLift, 1);
                     double actualVolume = Math.Round(baselineVolume * (1.0 + (liftPercent / 100.0)), 0);
-                    double incrementalRevenue = (actualVolume - baselineVolume) * (5.0 + (rng.NextDouble() * 15.0));
-                    double roi = Math.Round((incrementalRevenue - spend) / spend * 100.0, 1);
+                    double incrementalRevenue = (actualVolume - baselineVolume) * GetRevenuePerUnit(brand.Category);
+                    double targetRoi = GetPromoTypeRoiBenchmark(promoType) * (0.75 + (rng.NextDouble() * 0.50));
+                    double spend = Math.Round(Math.Max(1000.0, incrementalRevenue / targetRoi), 2);
+                    double roi = Math.Round(incrementalRevenue / spend, 2);
 
                     int ratingIndex = roi switch
                     {
-                        > 100 => 0,
-                        > 50 => 1,
-                        > 0 => 2,
-                        > -30 => 3,
+                        >= 3.0 => 0,
+                        >= 2.0 => 1,
+                        >= 1.0 => 2,
+                        >= 0.7 => 3,
                         _ => 4
                     };
                     // Clamp to the number of success ratings the pack ships. The
@@ -2290,16 +2352,51 @@ public class RetailPulseDb
         using SqliteConnection conn = OpenConnection();
         conn.Open();
 
-        var where = new List<string> { "StartDate >= @cutoff" };
+        List<PromoHistoryRow> campaigns = LoadPromoHistoryRows(conn, brand, region, promoType, cutoff);
+        string historyWindow = $"{months} months";
+        if (campaigns.Count == 0)
+        {
+            campaigns = LoadPromoHistoryRows(conn, brand, region, promoType, null);
+            historyWindow = "all available history";
+        }
+
+        double? avgRoi = campaigns.Count > 0
+            ? Math.Round(campaigns.Average(c => c.Roi), 2)
+            : null;
+
+        return new
+        {
+            filters = new { brand = brand ?? "all", region = region ?? "all", promo_type = promoType ?? "all", months },
+            history_window = historyWindow,
+            total_campaigns = campaigns.Count,
+            avg_roi = avgRoi,
+            message = campaigns.Count == 0 ? "Not enough comparable campaign history for these filters." : null,
+            campaigns = campaigns.Select(c => c.ToDto()).ToList()
+        };
+    }
+
+    private static List<PromoHistoryRow> LoadPromoHistoryRows(
+        SqliteConnection conn,
+        string? brand,
+        string? region,
+        string? promoType,
+        DateOnly? cutoff)
+    {
+        var where = new List<string>();
         using SqliteCommand cmd = conn.CreateCommand();
-        cmd.Parameters.AddWithValue("@cutoff", cutoff.ToString("yyyy-MM-dd"));
+
+        if (cutoff is not null)
+        {
+            where.Add("StartDate >= @cutoff");
+            cmd.Parameters.AddWithValue("@cutoff", cutoff.Value.ToString("yyyy-MM-dd"));
+        }
 
         if (!string.IsNullOrWhiteSpace(brand))
         {
             where.Add("Brand LIKE @brand");
             cmd.Parameters.AddWithValue("@brand", $"%{brand.Trim()}%");
         }
-        if (!string.IsNullOrWhiteSpace(region))
+        if (!string.IsNullOrWhiteSpace(region) && !IsNationalRegion(region))
         {
             where.Add("Region LIKE @region");
             cmd.Parameters.AddWithValue("@region", $"%{region.Trim()}%");
@@ -2310,41 +2407,36 @@ public class RetailPulseDb
             cmd.Parameters.AddWithValue("@type", $"%{promoType.Trim()}%");
         }
 
+        string predicate = where.Count == 0 ? "1 = 1" : string.Join(" AND ", where);
+
         cmd.CommandText = $"""
             SELECT Brand, Region, PromoType, CampaignName, StartDate, EndDate,
                    Spend, BaselineVolume, ActualVolume, LiftPercent, ROI, SuccessRating
             FROM PromoHistory
-            WHERE {string.Join(" AND ", where)}
+            WHERE {predicate}
             ORDER BY StartDate DESC
             """;
 
-        var campaigns = new List<object>();
+        var campaigns = new List<PromoHistoryRow>();
         using SqliteDataReader reader = cmd.ExecuteReader();
         while (reader.Read())
         {
-            campaigns.Add(new
-            {
-                brand = reader.GetString(0),
-                region = reader.GetString(1),
-                promo_type = reader.GetString(2),
-                campaign_name = reader.GetString(3),
-                start_date = reader.GetString(4),
-                end_date = reader.GetString(5),
-                spend = reader.GetDouble(6),
-                baseline_volume = reader.GetDouble(7),
-                actual_volume = reader.GetDouble(8),
-                lift_percent = reader.GetDouble(9),
-                roi = reader.GetDouble(10),
-                success_rating = reader.GetString(11)
-            });
+            campaigns.Add(new PromoHistoryRow(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                reader.GetString(5),
+                reader.GetDouble(6),
+                reader.GetDouble(7),
+                reader.GetDouble(8),
+                reader.GetDouble(9),
+                reader.GetDouble(10),
+                reader.GetString(11)));
         }
 
-        return new
-        {
-            filters = new { brand = brand ?? "all", region = region ?? "all", promo_type = promoType ?? "all", months },
-            total_campaigns = campaigns.Count,
-            campaigns
-        };
+        return campaigns;
     }
 
     public object CalculateLift(string brand, string region, string promoType, double spend)
@@ -2385,12 +2477,14 @@ public class RetailPulseDb
         reader.Close();
 
         using SqliteCommand countCmd = conn.CreateCommand();
-        countCmd.CommandText = """
+        string regionPredicate = IsNationalRegion(region) ? string.Empty : " AND Region LIKE @region";
+        countCmd.CommandText = $"""
             SELECT COUNT(*) FROM PromoHistory
-            WHERE Brand LIKE @brand AND Region LIKE @region AND PromoType LIKE @type
+            WHERE Brand LIKE @brand{regionPredicate} AND PromoType LIKE @type
             """;
         countCmd.Parameters.AddWithValue("@brand", $"%{brand.Trim()}%");
-        countCmd.Parameters.AddWithValue("@region", $"%{region.Trim()}%");
+        if (!IsNationalRegion(region))
+            countCmd.Parameters.AddWithValue("@region", $"%{region.Trim()}%");
         countCmd.Parameters.AddWithValue("@type", $"%{promoType.Trim()}%");
         int similarCount = Convert.ToInt32(countCmd.ExecuteScalar());
 
@@ -2422,20 +2516,26 @@ public class RetailPulseDb
             return new { error = "Parameter 'region' is required.", available_regions = GetAvailableRegions() };
         if (end <= start)
             return new { error = "End date must be after start date." };
+        BrandConfig? brandConfig = _tenant.Brands.FirstOrDefault(b =>
+            b.Name.Contains(brand.Trim(), StringComparison.OrdinalIgnoreCase));
+        if (brandConfig == null)
+            return new { error = $"Unknown brand '{brand}'.", available_brands = GetAvailableBrands() };
 
         using SqliteConnection conn = OpenConnection();
         conn.Open();
 
         using SqliteCommand overlapCmd = conn.CreateCommand();
-        overlapCmd.CommandText = """
+        string regionPredicate = IsNationalRegion(region) ? string.Empty : " AND Region LIKE @region";
+        overlapCmd.CommandText = $"""
             SELECT CampaignName, PromoType, StartDate, EndDate
             FROM PromoHistory
-            WHERE Brand LIKE @brand AND Region LIKE @region
+            WHERE Brand LIKE @brand{regionPredicate}
             AND StartDate <= @end AND EndDate >= @start
             ORDER BY StartDate
             """;
         overlapCmd.Parameters.AddWithValue("@brand", $"%{brand.Trim()}%");
-        overlapCmd.Parameters.AddWithValue("@region", $"%{region.Trim()}%");
+        if (!IsNationalRegion(region))
+            overlapCmd.Parameters.AddWithValue("@region", $"%{region.Trim()}%");
         overlapCmd.Parameters.AddWithValue("@start", start.ToString("yyyy-MM-dd"));
         overlapCmd.Parameters.AddWithValue("@end", end.ToString("yyyy-MM-dd"));
 
@@ -2448,15 +2548,16 @@ public class RetailPulseDb
 
         using SqliteCommand recentCmd = conn.CreateCommand();
         DateOnly lookbackStart = start.AddDays(-60);
-        recentCmd.CommandText = """
+        recentCmd.CommandText = $"""
             SELECT CampaignName, PromoType, EndDate
             FROM PromoHistory
-            WHERE Brand LIKE @brand AND Region LIKE @region
+            WHERE Brand LIKE @brand{regionPredicate}
             AND EndDate >= @lookback AND EndDate < @start
             ORDER BY EndDate DESC
             """;
         recentCmd.Parameters.AddWithValue("@brand", $"%{brand.Trim()}%");
-        recentCmd.Parameters.AddWithValue("@region", $"%{region.Trim()}%");
+        if (!IsNationalRegion(region))
+            recentCmd.Parameters.AddWithValue("@region", $"%{region.Trim()}%");
         recentCmd.Parameters.AddWithValue("@lookback", lookbackStart.ToString("yyyy-MM-dd"));
         recentCmd.Parameters.AddWithValue("@start", start.ToString("yyyy-MM-dd"));
 
@@ -2467,8 +2568,6 @@ public class RetailPulseDb
                 recentPromos.Add(new { campaign = reader.GetString(0), promo_type = reader.GetString(1), ended = reader.GetString(2) });
         }
 
-        BrandConfig? brandConfig = _tenant.Brands.FirstOrDefault(b =>
-            b.Name.Contains(brand.Trim(), StringComparison.OrdinalIgnoreCase));
         double seasonalityScore = GetSeasonalityScore(conn, brandConfig?.Category, start.Month);
 
         double proximityPenalty = recentPromos.Count > 0 ? Math.Min(recentPromos.Count * 0.15, 0.50) : 0.0;
@@ -2500,16 +2599,18 @@ public class RetailPulseDb
         return result is null or DBNull ? 0.6 : Math.Min(1.0, Math.Max(0.2, Convert.ToDouble(result) / 1.5));
     }
 
-    public object EstimateROI(string brand, string region, string promoType, double spend, int durationWeeks)
+    public object EstimateROI(string brand, string region, string promoType, double spend, int durationWeeks, double? targetLiftPercent = null)
     {
         if (string.IsNullOrWhiteSpace(brand))
             return new { error = "Parameter 'brand' is required.", available_brands = GetAvailableBrands() };
         if (string.IsNullOrWhiteSpace(region))
             return new { error = "Parameter 'region' is required.", available_regions = GetAvailableRegions() };
+        if (string.IsNullOrWhiteSpace(promoType))
+            return new { error = "Parameter 'promoType' is required.", available_types = _promoTypeNames };
         if (spend <= 0)
             return new { error = "Parameter 'spend' must be positive." };
-        if (durationWeeks is < 1 or > 12)
-            return new { error = "Parameter 'durationWeeks' must be between 1 and 12." };
+        if (durationWeeks is < 1 or > 52)
+            return new { error = "Parameter 'durationWeeks' must be between 1 and 52." };
 
         BrandConfig? brandConfig = _tenant.Brands.FirstOrDefault(b =>
             b.Name.Contains(brand.Trim(), StringComparison.OrdinalIgnoreCase));
@@ -2519,46 +2620,64 @@ public class RetailPulseDb
         using SqliteConnection conn = OpenConnection();
         conn.Open();
 
-        double avgLift = 10.0, stdDev = 5.0;
+        double avgLift;
+        double stdDev;
+        double minSpend;
+        double maxEffective;
         using (SqliteCommand cmd = conn.CreateCommand())
         {
-            cmd.CommandText = "SELECT AvgLiftPercent, StdDev FROM LiftCoefficients WHERE Category = @cat AND PromoType LIKE @type LIMIT 1";
+            cmd.CommandText = "SELECT AvgLiftPercent, StdDev, MinSpend, MaxEffectiveSpend FROM LiftCoefficients WHERE Category = @cat AND PromoType LIKE @type LIMIT 1";
             cmd.Parameters.AddWithValue("@cat", brandConfig.Category);
             cmd.Parameters.AddWithValue("@type", $"%{promoType.Trim()}%");
             using SqliteDataReader reader = cmd.ExecuteReader();
-            if (reader.Read())
-            {
-                avgLift = reader.GetDouble(0);
-                stdDev = reader.GetDouble(1);
-            }
+            if (!reader.Read())
+                return new { error = $"No lift data for category '{brandConfig.Category}' and promo type '{promoType}'.", available_types = _promoTypeNames };
+
+            avgLift = reader.GetDouble(0);
+            stdDev = reader.GetDouble(1);
+            minSpend = reader.GetDouble(2);
+            maxEffective = reader.GetDouble(3);
         }
 
-        double baselineVolume = 5000;
-        using (SqliteCommand cmd = conn.CreateCommand())
+        PromoBasis? basis = FindPromoBasis(conn, brandConfig, region, promoType);
+        if (basis == null)
         {
-            cmd.CommandText = "SELECT AVG(BaselineVolume) FROM PromoHistory WHERE Brand LIKE @brand AND Region LIKE @region";
-            cmd.Parameters.AddWithValue("@brand", $"%{brand.Trim()}%");
-            cmd.Parameters.AddWithValue("@region", $"%{region.Trim()}%");
-            object? result = cmd.ExecuteScalar();
-            if (result is not null and not DBNull)
-                baselineVolume = Convert.ToDouble(result);
+            return new
+            {
+                brand = brandConfig.Name,
+                region,
+                promo_type = promoType.Trim(),
+                duration_weeks = durationWeeks,
+                insufficient_history = true,
+                similar_campaigns = 0,
+                message = "Not enough comparable campaign history to model ROI for these inputs."
+            };
         }
 
-        double weeklyBaseline = baselineVolume / 4.0;
-        double totalBaseline = weeklyBaseline * durationWeeks;
+        double effectiveLift = targetLiftPercent is > 0
+            ? Math.Round((avgLift * 0.70) + (targetLiftPercent.Value * 0.30), 2)
+            : avgLift;
 
-        double incrementalUnits = totalBaseline * (avgLift / 100.0);
-        double revenuePerUnit = 8.0 + (brandConfig.Category == "Spirits" ? 12.0 : brandConfig.Category == "Grocery" ? 2.0 : 5.0);
+        double spendEfficiency = spend <= maxEffective ? 1.0 : Math.Sqrt(maxEffective / spend);
+        double durationEfficiency = durationWeeks <= 13 ? 1.0 : Math.Max(0.75, 1.0 - ((durationWeeks - 13) * 0.01));
+        double totalBaseline = basis.AverageBaselineVolume * durationWeeks;
+        double incrementalUnits = totalBaseline * (effectiveLift / 100.0) * spendEfficiency * durationEfficiency;
+        double revenuePerUnit = GetRevenuePerUnit(brandConfig.Category);
         double incrementalRevenue = incrementalUnits * revenuePerUnit;
-        double expectedRoi = Math.Round((incrementalRevenue - spend) / spend * 100.0, 2);
+        double modeledRoi = incrementalRevenue / spend;
+        double expectedRoi = Math.Round((modeledRoi * 0.65) + (basis.AverageRoi * 0.35), 2);
 
-        double lowerLift = Math.Max(0, avgLift - (1.96 * stdDev));
-        double upperLift = avgLift + (1.96 * stdDev);
+        double lowerLift = Math.Max(0.1, effectiveLift - (1.96 * stdDev));
+        double upperLift = effectiveLift + (1.96 * stdDev);
 
-        double lowerRoi = Math.Round(((totalBaseline * (lowerLift / 100.0) * revenuePerUnit) - spend) / spend * 100.0, 2);
-        double upperRoi = Math.Round(((totalBaseline * (upperLift / 100.0) * revenuePerUnit) - spend) / spend * 100.0, 2);
+        double lowerModeledRoi = totalBaseline * (lowerLift / 100.0) * spendEfficiency * durationEfficiency * revenuePerUnit / spend;
+        double upperModeledRoi = totalBaseline * (upperLift / 100.0) * spendEfficiency * durationEfficiency * revenuePerUnit / spend;
+        double historySpread = Math.Max(0.15, basis.StdDevRoi);
+        double lowerRoi = Math.Round(Math.Max(0.1, Math.Min(expectedRoi, (lowerModeledRoi * 0.65) + ((basis.AverageRoi - historySpread) * 0.35))), 2);
+        double upperRoi = Math.Round(Math.Max(expectedRoi + 0.1, (upperModeledRoi * 0.65) + ((basis.AverageRoi + historySpread) * 0.35)), 2);
 
-        double breakeven = Math.Round(spend / revenuePerUnit, 0);
+        double dailyIncrementalRevenue = incrementalRevenue / Math.Max(1, durationWeeks * 7);
+        int breakEvenDays = Math.Max(1, (int)Math.Ceiling(spend / Math.Max(1.0, dailyIncrementalRevenue)));
         double varianceFactor = Math.Round(stdDev / Math.Max(avgLift, 1.0), 2);
 
         return new
@@ -2567,15 +2686,99 @@ public class RetailPulseDb
             region,
             promo_type = promoType.Trim(),
             duration_weeks = durationWeeks,
-            inputs = new { spend, expected_lift_percent = avgLift, baseline_volume = totalBaseline, revenue_per_unit = revenuePerUnit },
+            inputs = new { spend, expected_lift_percent = effectiveLift, target_lift_percent = targetLiftPercent, baseline_volume = totalBaseline, revenue_per_unit = revenuePerUnit, min_spend = minSpend, max_effective_spend = maxEffective },
             roi = new { expected = expectedRoi, lower_bound = lowerRoi, upper_bound = upperRoi, confidence_interval_width = Math.Round(upperRoi - lowerRoi, 2) },
             incremental = new { units = Math.Round(incrementalUnits, 0), revenue = Math.Round(incrementalRevenue, 2) },
-            breakeven_units = breakeven,
+            break_even_days = breakEvenDays,
+            historical_avg_roi = basis.AverageRoi,
+            similar_campaigns = basis.Count,
+            basis = basis.Basis,
             variance_factor = varianceFactor,
-            is_positive_roi = expectedRoi > 0,
+            is_positive_roi = expectedRoi >= 0.95,
             requires_approval = spend > 500000,
             risk_level = varianceFactor > 0.5 ? "high" : varianceFactor > 0.3 ? "medium" : "low"
         };
+    }
+
+    private PromoBasis? FindPromoBasis(SqliteConnection conn, BrandConfig brand, string region, string promoType)
+    {
+        PromoBasis? exact = LoadPromoBasis(
+            conn,
+            "Brand LIKE @brand AND PromoType LIKE @type" + (IsNationalRegion(region) ? "" : " AND Region LIKE @region"),
+            cmd =>
+            {
+                cmd.Parameters.AddWithValue("@brand", $"%{brand.Name}%");
+                cmd.Parameters.AddWithValue("@type", $"%{promoType.Trim()}%");
+                if (!IsNationalRegion(region))
+                    cmd.Parameters.AddWithValue("@region", $"%{region.Trim()}%");
+            },
+            IsNationalRegion(region) ? "brand plus promotion type across all regions" : "brand, region and promotion type");
+        if (exact is not null) return exact;
+
+        PromoBasis? brandRegion = LoadPromoBasis(
+            conn,
+            "Brand LIKE @brand" + (IsNationalRegion(region) ? "" : " AND Region LIKE @region"),
+            cmd =>
+            {
+                cmd.Parameters.AddWithValue("@brand", $"%{brand.Name}%");
+                if (!IsNationalRegion(region))
+                    cmd.Parameters.AddWithValue("@region", $"%{region.Trim()}%");
+            },
+            IsNationalRegion(region) ? "brand across all promotion types and regions" : "brand and region across all promotion types");
+        if (brandRegion is not null) return brandRegion;
+
+        string[] categoryBrands = [.. _tenant.Brands
+            .Where(b => b.Category.Equals(brand.Category, StringComparison.OrdinalIgnoreCase))
+            .Select(b => b.Name)];
+        if (categoryBrands.Length == 0) return null;
+
+        string brandList = string.Join(", ", categoryBrands.Select((_, i) => $"@categoryBrand{i}"));
+        return LoadPromoBasis(
+            conn,
+            $"Brand IN ({brandList}) AND PromoType LIKE @type",
+            cmd =>
+            {
+                for (int i = 0; i < categoryBrands.Length; i++)
+                    cmd.Parameters.AddWithValue($"@categoryBrand{i}", categoryBrands[i]);
+                cmd.Parameters.AddWithValue("@type", $"%{promoType.Trim()}%");
+            },
+            "category and promotion type");
+    }
+
+    private static PromoBasis? LoadPromoBasis(
+        SqliteConnection conn,
+        string predicate,
+        Action<SqliteCommand> bind,
+        string basis)
+    {
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT ROI, BaselineVolume
+            FROM PromoHistory
+            WHERE {predicate}
+            """;
+        bind(cmd);
+
+        var rois = new List<double>();
+        var baselines = new List<double>();
+        using SqliteDataReader reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            rois.Add(reader.GetDouble(0));
+            baselines.Add(reader.GetDouble(1));
+        }
+
+        if (rois.Count == 0) return null;
+
+        double averageRoi = rois.Average();
+        double variance = rois.Sum(r => Math.Pow(r - averageRoi, 2)) / rois.Count;
+        double stdDev = Math.Sqrt(variance);
+        return new PromoBasis(
+            rois.Count,
+            Math.Round(averageRoi, 2),
+            Math.Round(stdDev, 2),
+            Math.Round(baselines.Average(), 0),
+            basis);
     }
 
     public object GetPromoCalendar(string? brand = null, string? region = null, int months = 6)

--- a/src/RetailPulse.McpServer/Program.cs
+++ b/src/RetailPulse.McpServer/Program.cs
@@ -249,9 +249,9 @@ app.MapGet("/api/promo/evaluate-timing", (string brand, string region, string st
 })
 .WithName("EvaluateTiming");
 
-app.MapGet("/api/promo/estimate-roi", (string brand, string region, string promoType, double spend, int durationWeeks, RetailPulseDb data) =>
+app.MapGet("/api/promo/estimate-roi", (string brand, string region, string promoType, double spend, int durationWeeks, double? targetLiftPercent, RetailPulseDb data) =>
 {
-    object result = data.EstimateROI(brand, region, promoType, spend, durationWeeks);
+    object result = data.EstimateROI(brand, region, promoType, spend, durationWeeks, targetLiftPercent);
     return Results.Ok(result);
 })
 .WithName("EstimateROI");

--- a/src/RetailPulse.McpServer/Tools/PromoTools.cs
+++ b/src/RetailPulse.McpServer/Tools/PromoTools.cs
@@ -62,7 +62,8 @@ public static class PromoTools
         [Description("Region (required)")] string region,
         [Description("Promotion type (required: 'discount', 'bogo', 'display', 'digital', 'bundle')")] string promoType,
         [Description("Planned spend in dollars (required)")] double spend,
-        [Description("Duration in weeks (required, 1-12)")] int durationWeeks)
+        [Description("Duration in weeks (required, 1-52)")] int durationWeeks,
+        [Description("Optional target lift percent supplied by the planner.")] double? targetLiftPercent = null)
     {
         if (string.IsNullOrWhiteSpace(brand))
             return new { error = "Parameter 'brand' is required." };
@@ -72,8 +73,8 @@ public static class PromoTools
             return new { error = "Parameter 'promoType' is required." };
         if (spend <= 0)
             return new { error = "Parameter 'spend' must be greater than 0." };
-        return durationWeeks is < 1 or > 12
-            ? (new { error = "Parameter 'durationWeeks' must be between 1 and 12." })
-            : data.EstimateROI(brand, region, promoType, spend, durationWeeks);
+        return durationWeeks is < 1 or > 52
+            ? (new { error = "Parameter 'durationWeeks' must be between 1 and 52." })
+            : data.EstimateROI(brand, region, promoType, spend, durationWeeks, targetLiftPercent);
     }
 }

--- a/src/RetailPulse.Web/src/__tests__/PromoRecommendation.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/PromoRecommendation.test.tsx
@@ -44,6 +44,19 @@ const notRecommendedEval: PromoEvaluation = {
   roiUpper: 0.9,
 };
 
+const insufficientEval: PromoEvaluation = {
+  ...recommendedEval,
+  recommendation: 'insufficient_history',
+  roi: null,
+  roiLower: null,
+  roiUpper: null,
+  similarCampaigns: 0,
+  breakEvenDays: null,
+  historicalAvgRoi: null,
+  insufficientHistory: true,
+  reasoning: 'Not enough comparable campaign history to model ROI for these inputs.',
+};
+
 describe('PromoRecommendation', () => {
   it('renders recommended state with green badge', () => {
     render(wrap(<PromoRecommendation evaluation={recommendedEval} budget={25000} />));
@@ -66,7 +79,17 @@ describe('PromoRecommendation', () => {
   it('displays ROI with confidence range', () => {
     render(wrap(<PromoRecommendation evaluation={recommendedEval} budget={25000} />));
     expect(screen.getByTestId('roi-value')).toHaveTextContent('3.2x ROI');
-    expect(screen.getByTestId('roi-range')).toHaveTextContent('(2.1x — 4.5x)');
+    expect(screen.getByTestId('roi-range')).toHaveTextContent('(2.1x to 4.5x)');
+  });
+
+  it('renders insufficient history without zero ROI placeholders', () => {
+    render(wrap(<PromoRecommendation evaluation={insufficientEval} budget={25000} />));
+    expect(screen.getByTestId('recommendation-badge')).toHaveTextContent('Not Enough History');
+    expect(screen.getByTestId('roi-value')).toHaveTextContent('Not enough history');
+    expect(screen.queryByTestId('roi-range')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Break-even:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Hist\. Avg:/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('credibility-note')).toHaveTextContent('No comparable campaigns found');
   });
 
   it('displays timing assessment details', () => {

--- a/src/RetailPulse.Web/src/__tests__/PromoRecommendation.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/PromoRecommendation.test.tsx
@@ -42,6 +42,7 @@ const notRecommendedEval: PromoEvaluation = {
   roi: 0.6,
   roiLower: 0.3,
   roiUpper: 0.9,
+  breakEvenDays: null,
 };
 
 const insufficientEval: PromoEvaluation = {
@@ -74,6 +75,12 @@ describe('PromoRecommendation', () => {
   it('renders not recommended state', () => {
     render(wrap(<PromoRecommendation evaluation={notRecommendedEval} budget={25000} />));
     expect(screen.getByTestId('recommendation-badge')).toHaveTextContent('Not Recommended');
+    expect(screen.getByTestId('roi-value')).toHaveTextContent('0.60x ROI');
+  });
+
+  it('shows that sub-breakeven campaigns do not break even', () => {
+    render(wrap(<PromoRecommendation evaluation={notRecommendedEval} budget={25000} />));
+    expect(screen.getByText(/Break-even: Does not break even/)).toBeInTheDocument();
   });
 
   it('displays ROI with confidence range', () => {

--- a/src/RetailPulse.Web/src/__tests__/PromoTaskModule.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/PromoTaskModule.test.tsx
@@ -10,7 +10,7 @@ const mockEvaluation: PromoEvaluation = {
   roiLower: 2.1,
   roiUpper: 4.5,
   reasoning: 'Strong historical performance for this brand-region pair.',
-  timingAssessment: 'Good timing — no major conflicts.',
+  timingAssessment: 'Good timing, no major conflicts.',
   conflicts: [],
   seasonalityFit: 'Peak season',
   risks: [{ type: 'Competition', detail: 'Rival promo active nearby', severity: 'medium' }],
@@ -57,6 +57,23 @@ describe('PromoTaskModule', () => {
     expect(screen.getByTestId('promo-type-display')).toBeInTheDocument();
     expect(screen.getByTestId('promo-type-digital')).toBeInTheDocument();
     expect(screen.getByTestId('promo-type-bundle')).toBeInTheDocument();
+  });
+
+  it('uses active pack brands and regions instead of stale planner defaults', async () => {
+    const user = userEvent.setup();
+    render(wrap(
+      <PromoTaskModule
+        brands={['Apex Grill', 'Coastline Tacos']}
+        regions={['Northeast', 'Southeast']}
+      />,
+    ));
+
+    await user.click(screen.getByTestId('brand-select'));
+    expect(screen.getByText('Coastline Tacos')).toBeInTheDocument();
+    expect(screen.queryByText('Coastal Catch')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('region-select'));
+    expect(screen.queryByText('National')).not.toBeInTheDocument();
   });
 
   // Helper to fill the entire form

--- a/src/RetailPulse.Web/src/__tests__/promoEvaluationMapping.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/promoEvaluationMapping.test.ts
@@ -5,7 +5,7 @@ import { mapPromoEvaluation } from '../services/promoApi';
  * `POST /api/taskmodule/promo` answers in flat snake_case; the planner UI models a
  * flattened camelCase `PromoEvaluation`. Nothing translated between them, so
  * `evaluation.risks` was `undefined` and `[...evaluation.risks]` in
- * PromoRecommendation threw "risks is not iterable" — which killed the Campaign
+ * PromoRecommendation threw "risks is not iterable", which killed the Campaign
  * Planner the moment an evaluation returned.
  *
  * These pin the mapping, and specifically that every array the component spreads or
@@ -84,6 +84,25 @@ describe('promo evaluation mapping', () => {
 
   it('falls back to a safe recommendation level for an unknown value', () => {
     expect(mapPromoEvaluation({ recommendation: 'nonsense' }).recommendation)
-      .toBe('proceed_with_caution');
+      .toBe('insufficient_history');
+  });
+
+  it('marks missing ROI as insufficient history instead of rendering a confident zero', () => {
+    const e = mapPromoEvaluation({
+      recommendation: 'not_recommended',
+      roi_estimate: {
+        insufficient_history: true,
+        message: 'Not enough comparable campaign history to model ROI for these inputs.',
+      },
+      historical_context: { total_campaigns: 0, campaigns: [] },
+    });
+
+    expect(e.recommendation).toBe('insufficient_history');
+    expect(e.insufficientHistory).toBe(true);
+    expect(e.roi).toBeNull();
+    expect(e.roiLower).toBeNull();
+    expect(e.roiUpper).toBeNull();
+    expect(e.breakEvenDays).toBeNull();
+    expect(e.historicalAvgRoi).toBeNull();
   });
 });

--- a/src/RetailPulse.Web/src/components/Dashboard.tsx
+++ b/src/RetailPulse.Web/src/components/Dashboard.tsx
@@ -861,7 +861,10 @@ export function Dashboard() {
           <PanelErrorBoundary key={activeView} name={VIEW_LABELS[activeView] ?? 'This view'}>
           {capabilities.alternateViews && activeView === 'promo' && featureFlags.campaignPlanner ? (
             <div style={{ overflow: 'auto', height: '100%', width: '100%', minWidth: 0, boxSizing: 'border-box' }}>
-              <PromoTaskModule />
+              <PromoTaskModule
+                brands={activePack.pack?.tenant.brands?.map(b => b.name)}
+                regions={activePack.pack?.tenant.regions}
+              />
             </div>
           ) : activeView === 'competitive' && featureFlags.competitive ? (
             <CompetitiveDashboard />

--- a/src/RetailPulse.Web/src/components/promo/PromoRecommendation.tsx
+++ b/src/RetailPulse.Web/src/components/promo/PromoRecommendation.tsx
@@ -13,6 +13,7 @@ const RECOMMENDATION_CONFIG: Record<PromoRecommendationLevel, { emoji: string; l
   recommended: { emoji: '✅', label: 'Recommended', color: '#22c55e', bgColor: 'rgba(34,197,94,0.08)', badge: 'success' },
   cautious: { emoji: '⚠️', label: 'Cautious', color: '#eab308', bgColor: 'rgba(234,179,8,0.08)', badge: 'warning' },
   not_recommended: { emoji: '❌', label: 'Not Recommended', color: '#ef4444', bgColor: 'rgba(239,68,68,0.08)', badge: 'danger' },
+  insufficient_history: { emoji: 'ℹ️', label: 'Not Enough History', color: '#eab308', bgColor: 'rgba(234,179,8,0.08)', badge: 'warning' },
 };
 
 const SEVERITY_ICONS: Record<string, string> = { high: '🔴', medium: '🟡', low: '🟢' };
@@ -180,11 +181,19 @@ function RiskCard({ risk }: { risk: PromoRisk }) {
 export default function PromoRecommendation({ evaluation, budget, onSubmitForApproval }: PromoRecommendationProps) {
   const styles = useStyles();
   const config = RECOMMENDATION_CONFIG[evaluation.recommendation];
-  const isHighSpend = budget >= HIGH_SPEND_THRESHOLD;
+  const hasModeledRoi = !evaluation.insufficientHistory
+    && evaluation.roi !== null
+    && evaluation.roiLower !== null
+    && evaluation.roiUpper !== null;
+  const isHighSpend = hasModeledRoi && budget >= HIGH_SPEND_THRESHOLD;
   const sortedRisks = [...evaluation.risks].sort(
     (a, b) => (SEVERITY_ORDER[a.severity] ?? 3) - (SEVERITY_ORDER[b.severity] ?? 3),
   );
-  const roiColor = evaluation.roi >= 1 ? PROMO_COLORS.recommended : PROMO_COLORS.notRecommended;
+  const roiColor = !hasModeledRoi
+    ? config.color
+    : evaluation.roi !== null && evaluation.roi >= 1
+      ? PROMO_COLORS.recommended
+      : PROMO_COLORS.notRecommended;
 
   return (
     <div
@@ -198,11 +207,15 @@ export default function PromoRecommendation({ evaluation, budget, onSubmitForApp
         </Badge>
         <div className={styles.roiDisplay}>
           <span className={styles.roiValue} style={{ color: roiColor }} data-testid="roi-value">
-            {evaluation.roi.toFixed(1)}x ROI
+            {hasModeledRoi && evaluation.roi !== null
+              ? `${evaluation.roi.toFixed(1)}x ROI`
+              : 'Not enough history'}
           </span>
-          <span className={styles.roiRange} data-testid="roi-range">
-            ({evaluation.roiLower.toFixed(1)}x — {evaluation.roiUpper.toFixed(1)}x)
-          </span>
+          {hasModeledRoi && evaluation.roiLower !== null && evaluation.roiUpper !== null && (
+            <span className={styles.roiRange} data-testid="roi-range">
+              ({evaluation.roiLower.toFixed(1)}x to {evaluation.roiUpper.toFixed(1)}x)
+            </span>
+          )}
         </div>
       </div>
 
@@ -215,8 +228,12 @@ export default function PromoRecommendation({ evaluation, budget, onSubmitForApp
         <span className={styles.sectionLabel}>Timing Assessment</span>
         <div className={styles.timingRow}>
           <span className={styles.timingChip}>🗓️ {evaluation.seasonalityFit}</span>
-          <span className={styles.timingChip}>⏱️ Break-even: {evaluation.breakEvenDays} days</span>
-          <span className={styles.timingChip}>📊 Hist. Avg: {evaluation.historicalAvgRoi.toFixed(1)}x</span>
+          {evaluation.breakEvenDays !== null && (
+            <span className={styles.timingChip}>⏱️ Break-even: {evaluation.breakEvenDays} days</span>
+          )}
+          {evaluation.historicalAvgRoi !== null && (
+            <span className={styles.timingChip}>📊 Hist. Avg: {evaluation.historicalAvgRoi.toFixed(1)}x</span>
+          )}
         </div>
         {evaluation.conflicts.length > 0 && (
           <div className={styles.timingRow} style={{ marginTop: '6px' }}>
@@ -248,7 +265,9 @@ export default function PromoRecommendation({ evaluation, budget, onSubmitForApp
       )}
 
       <div className={styles.credibility} data-testid="credibility-note">
-        Based on {evaluation.similarCampaigns} similar campaigns
+        {evaluation.similarCampaigns > 0
+          ? `Based on ${evaluation.similarCampaigns} similar campaigns${evaluation.dataBasis ? ` (${evaluation.dataBasis})` : ''}`
+          : 'No comparable campaigns found'}
       </div>
     </div>
   );

--- a/src/RetailPulse.Web/src/components/promo/PromoRecommendation.tsx
+++ b/src/RetailPulse.Web/src/components/promo/PromoRecommendation.tsx
@@ -21,6 +21,10 @@ const SEVERITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
 
 const HIGH_SPEND_THRESHOLD = 50_000;
 
+function formatRoi(value: number): string {
+  return value >= 1 ? value.toFixed(1) : value.toFixed(2);
+}
+
 const useStyles = makeStyles({
   container: {
     display: 'flex',
@@ -208,12 +212,12 @@ export default function PromoRecommendation({ evaluation, budget, onSubmitForApp
         <div className={styles.roiDisplay}>
           <span className={styles.roiValue} style={{ color: roiColor }} data-testid="roi-value">
             {hasModeledRoi && evaluation.roi !== null
-              ? `${evaluation.roi.toFixed(1)}x ROI`
+              ? `${formatRoi(evaluation.roi)}x ROI`
               : 'Not enough history'}
           </span>
           {hasModeledRoi && evaluation.roiLower !== null && evaluation.roiUpper !== null && (
             <span className={styles.roiRange} data-testid="roi-range">
-              ({evaluation.roiLower.toFixed(1)}x to {evaluation.roiUpper.toFixed(1)}x)
+              ({formatRoi(evaluation.roiLower)}x to {formatRoi(evaluation.roiUpper)}x)
             </span>
           )}
         </div>
@@ -230,6 +234,9 @@ export default function PromoRecommendation({ evaluation, budget, onSubmitForApp
           <span className={styles.timingChip}>🗓️ {evaluation.seasonalityFit}</span>
           {evaluation.breakEvenDays !== null && (
             <span className={styles.timingChip}>⏱️ Break-even: {evaluation.breakEvenDays} days</span>
+          )}
+          {hasModeledRoi && evaluation.breakEvenDays === null && (
+            <span className={styles.timingChip}>⏱️ Break-even: Does not break even</span>
           )}
           {evaluation.historicalAvgRoi !== null && (
             <span className={styles.timingChip}>📊 Hist. Avg: {evaluation.historicalAvgRoi.toFixed(1)}x</span>

--- a/src/RetailPulse.Web/src/components/promo/PromoTaskModule.tsx
+++ b/src/RetailPulse.Web/src/components/promo/PromoTaskModule.tsx
@@ -18,9 +18,13 @@ import ROIChart from './ROIChart';
 import { evaluatePromo, submitForApproval, fetchExistingCampaigns } from '../../services/promoApi';
 import { useEffect } from 'react';
 
-// Tenant-level defaults — would come from config in production
-const TENANT_BRANDS = ['Apex Grill', 'Coastal Catch', 'Mountain Roast', 'Prairie Farms', 'Urban Bites'];
-const TENANT_REGIONS = ['Northeast', 'Southeast', 'Midwest', 'Southwest', 'West Coast', 'National'];
+const FALLBACK_BRANDS = ['Sierra Gold Tequila', 'Ridgeline Bourbon', 'Summit Vodka', 'FreshMart', 'Harvest Table', 'Apex Grill', 'Coastline Tacos', 'Pinnacle Hardware', 'Summit Outdoor', 'ClearDesk', 'Urban Living', 'Foundry Home'];
+const FALLBACK_REGIONS = ['Northeast', 'Southeast', 'Midwest', 'Southwest', 'West Coast', 'Pacific Northwest'];
+
+interface PromoTaskModuleProps {
+  brands?: readonly string[];
+  regions?: readonly string[];
+}
 
 const useStyles = makeStyles({
   container: {
@@ -140,15 +144,17 @@ const useStyles = makeStyles({
   },
 });
 
-export default function PromoTaskModule() {
+export default function PromoTaskModule({ brands = FALLBACK_BRANDS, regions = FALLBACK_REGIONS }: PromoTaskModuleProps) {
   const styles = useStyles();
+  const brandOptions = brands.length > 0 ? brands : FALLBACK_BRANDS;
+  const regionOptions = regions.length > 0 ? regions : FALLBACK_REGIONS;
   const [brand, setBrand] = useState('');
   const [region, setRegion] = useState('');
   const [promoType, setPromoType] = useState<PromoType | ''>('');
   const [budget, setBudget] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
-  const [targetLift, setTargetLift] = useState(10);
+  const [targetLift, setTargetLift] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [evaluation, setEvaluation] = useState<PromoEvaluation | null>(null);
@@ -158,7 +164,7 @@ export default function PromoTaskModule() {
   // Fetch existing campaigns on mount
   useEffect(() => {
     fetchExistingCampaigns().then(setCampaigns).catch(() => {
-      // Silently fail — calendar will be empty
+      // Silently fail, calendar will be empty.
     });
   }, []);
 
@@ -188,7 +194,7 @@ export default function PromoTaskModule() {
       budget: Number(budget),
       startDate,
       endDate,
-      targetLiftPercent: targetLift,
+      targetLiftPercent: targetLift > 0 ? targetLift : undefined,
     };
 
     try {
@@ -206,7 +212,7 @@ export default function PromoTaskModule() {
     setSubmitting(true);
     try {
       await submitForApproval(
-        { brand, region, promoType: promoType as PromoType, budget: Number(budget), startDate, endDate, targetLiftPercent: targetLift },
+        { brand, region, promoType: promoType as PromoType, budget: Number(budget), startDate, endDate, targetLiftPercent: targetLift > 0 ? targetLift : undefined },
         evaluation,
       );
     } catch {
@@ -217,14 +223,14 @@ export default function PromoTaskModule() {
   }, [evaluation, brand, region, promoType, budget, startDate, endDate, targetLift]);
 
   const proposedCampaign = (brand && region && promoType && startDate && endDate) ? {
-    name: `${promoType} — ${brand}`,
+    name: `${promoType} - ${brand}`,
     brand,
     region,
     promoType: promoType as PromoType,
     budget: Number(budget) || 0,
     startDate,
     endDate,
-    roi: evaluation?.roi,
+    roi: evaluation?.roi ?? undefined,
   } : undefined;
 
   return (
@@ -257,7 +263,7 @@ export default function PromoTaskModule() {
               data-testid="brand-select"
               size="medium"
             >
-              {TENANT_BRANDS.map(b => (
+              {brandOptions.map(b => (
                 <Option key={b} value={b}>{b}</Option>
               ))}
             </Dropdown>
@@ -273,7 +279,7 @@ export default function PromoTaskModule() {
               data-testid="region-select"
               size="medium"
             >
-              {TENANT_REGIONS.map(r => (
+              {regionOptions.map(r => (
                 <Option key={r} value={r}>{r}</Option>
               ))}
             </Dropdown>
@@ -302,7 +308,7 @@ export default function PromoTaskModule() {
                 style={{ flex: 1 }}
                 data-testid="target-lift-slider"
               />
-              <span className={styles.sliderValue}>{targetLift}%</span>
+              <span className={styles.sliderValue}>{targetLift > 0 ? `${targetLift}%` : 'Not set'}</span>
             </div>
           </div>
 
@@ -370,13 +376,19 @@ export default function PromoTaskModule() {
             onSubmitForApproval={handleSubmitApproval}
           />
 
-          <ROIChart
-            proposedRoi={evaluation.roi}
-            proposedRoiLower={evaluation.roiLower}
-            proposedRoiUpper={evaluation.roiUpper}
-            historicalAvgRoi={evaluation.historicalAvgRoi}
-            promoType={promoType as string}
-          />
+          {!evaluation.insufficientHistory
+            && evaluation.roi !== null
+            && evaluation.roiLower !== null
+            && evaluation.roiUpper !== null
+            && evaluation.historicalAvgRoi !== null && (
+              <ROIChart
+                proposedRoi={evaluation.roi}
+                proposedRoiLower={evaluation.roiLower}
+                proposedRoiUpper={evaluation.roiUpper}
+                historicalAvgRoi={evaluation.historicalAvgRoi}
+                promoType={promoType as string}
+              />
+            )}
         </>
       )}
 

--- a/src/RetailPulse.Web/src/services/promoApi.ts
+++ b/src/RetailPulse.Web/src/services/promoApi.ts
@@ -16,6 +16,9 @@ interface WirePromoEvaluation {
   readonly recommendation?: string;
   readonly risk_factors?: readonly string[];
   readonly roi_estimate?: {
+    readonly expected_roi?: number;
+    readonly lower_bound?: number;
+    readonly upper_bound?: number;
     readonly roi?: {
       readonly expected?: number;
       readonly lower_bound?: number;
@@ -23,6 +26,11 @@ interface WirePromoEvaluation {
     };
     readonly break_even_weeks?: number;
     readonly break_even_days?: number;
+    readonly insufficient_history?: boolean;
+    readonly message?: string;
+    readonly similar_campaigns?: number;
+    readonly historical_avg_roi?: number;
+    readonly basis?: string;
     readonly inputs?: { readonly expected_lift_percent?: number };
   };
   readonly timing_assessment?: {
@@ -40,22 +48,24 @@ interface WirePromoEvaluation {
   readonly historical_context?: {
     readonly total_campaigns?: number;
     readonly avg_roi?: number;
+    readonly basis?: string;
+    readonly message?: string;
     readonly campaigns?: readonly { readonly roi?: number }[];
   };
 }
 
 const RECOMMENDATION_LEVELS: ReadonlySet<string> = new Set([
-  'strongly_recommended',
   'recommended',
-  'proceed_with_caution',
+  'cautious',
   'not_recommended',
+  'insufficient_history',
 ]);
 
 function toRecommendation(value: string | undefined): PromoRecommendationLevel {
   const normalized = (value ?? '').trim().toLowerCase();
-  return (RECOMMENDATION_LEVELS.has(normalized)
-    ? normalized
-    : 'proceed_with_caution') as PromoRecommendationLevel;
+  if (normalized === 'strongly_recommended') return 'recommended';
+  if (normalized === 'proceed_with_caution') return 'cautious';
+  return (RECOMMENDATION_LEVELS.has(normalized) ? normalized : 'cautious') as PromoRecommendationLevel;
 }
 
 function toSeverity(value: string | undefined): PromoRisk['severity'] {
@@ -77,13 +87,13 @@ function toRisks(wire: WirePromoEvaluation): PromoRisk[] {
   }));
 
   // RiskCard shows `type` as the headline and reveals `detail` on expand, so the
-  // flat sentences must carry their text in `type` — otherwise every planning risk
+  // flat sentences must carry their text in `type`, otherwise every planning risk
   // renders as the literal word "planning" with the real reason hidden behind a click.
   const flat: PromoRisk[] = (wire.risk_factors ?? []).map(text => ({
     type: text,
     detail: text,
     // The endpoint only emits a risk factor when a threshold was crossed, so
-    // "medium" is the honest floor — these are not advisory notes.
+    // "medium" is the honest floor because these are not advisory notes.
     severity: /below breakeven|executive approval/i.test(text) ? 'high' : 'medium',
   }));
 
@@ -114,42 +124,68 @@ function toSeasonalityFit(score: number | undefined): string {
   return `Weak seasonal fit (${Math.round(score * 100)}%)`;
 }
 
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
 export function mapPromoEvaluation(wire: WirePromoEvaluation): PromoEvaluation {
   const est = wire.roi_estimate ?? {};
-  const roi = est.roi ?? {};
+  const nestedRoi = est.roi ?? {};
   const hist = wire.historical_context ?? {};
+  const roi = numberOrNull(nestedRoi.expected) ?? numberOrNull(est.expected_roi);
+  const roiLower = numberOrNull(nestedRoi.lower_bound) ?? numberOrNull(est.lower_bound);
+  const roiUpper = numberOrNull(nestedRoi.upper_bound) ?? numberOrNull(est.upper_bound);
+  const historyCount = hist.total_campaigns ?? 0;
+  const modelCount = est.similar_campaigns ?? 0;
+  const similarCampaigns = modelCount > 0 ? modelCount : historyCount;
+  const hasModeledRoi = roi !== null && roiLower !== null && roiUpper !== null;
+  const insufficientHistory = est.insufficient_history === true || !hasModeledRoi;
 
   // The MCP payload reports break-even in weeks; the panel labels it in days.
-  const breakEvenDays = est.break_even_days
-    ?? (est.break_even_weeks !== undefined ? Math.round(est.break_even_weeks * 7) : 0);
+  const breakEvenDays = insufficientHistory
+    ? null
+    : est.break_even_days
+      ?? (est.break_even_weeks !== undefined ? Math.max(1, Math.round(est.break_even_weeks * 7)) : null);
 
   // No aggregate average is published, so derive it from the returned campaigns
   // rather than showing a hardcoded zero.
   const campaignRois = (hist.campaigns ?? [])
     .map(c => c.roi)
     .filter((r): r is number => typeof r === 'number');
-  const historicalAvgRoi = hist.avg_roi
-    ?? (campaignRois.length > 0
+  const historicalAvgRoi = insufficientHistory
+    ? null
+    : est.historical_avg_roi
+      ?? hist.avg_roi
+      ?? (campaignRois.length > 0
       ? campaignRois.reduce((a, b) => a + b, 0) / campaignRois.length
-      : 0);
+      : null);
+
+  const historyMessage = est.message
+    ?? hist.message
+    ?? 'Not enough comparable campaign history to model ROI for these inputs.';
 
   return {
-    recommendation: toRecommendation(wire.recommendation),
-    roi: roi.expected ?? 0,
-    roiLower: roi.lower_bound ?? roi.expected ?? 0,
-    roiUpper: roi.upper_bound ?? roi.expected ?? 0,
-    reasoning: wire.lift_analysis?.reasoning
-      ?? wire.lift_analysis?.summary
-      ?? (wire.lift_analysis?.expected_lift_percent !== undefined
-        ? `Modelled lift of ${wire.lift_analysis.expected_lift_percent}% against the regional baseline.`
-        : ''),
+    recommendation: insufficientHistory ? 'insufficient_history' : toRecommendation(wire.recommendation),
+    roi,
+    roiLower,
+    roiUpper,
+    reasoning: insufficientHistory
+      ? historyMessage
+      : wire.lift_analysis?.reasoning
+        ?? wire.lift_analysis?.summary
+        ?? (wire.lift_analysis?.expected_lift_percent !== undefined
+          ? `Modelled lift of ${wire.lift_analysis.expected_lift_percent}% against the regional baseline.`
+          : ''),
     timingAssessment: wire.timing_assessment?.recommendation ?? '',
     conflicts: toConflicts(wire),
     seasonalityFit: toSeasonalityFit(wire.timing_assessment?.seasonality_score),
     risks: toRisks(wire),
-    similarCampaigns: hist.total_campaigns ?? 0,
+    similarCampaigns,
     breakEvenDays,
     historicalAvgRoi,
+    insufficientHistory,
+    historyMessage,
+    dataBasis: est.basis ?? hist.basis,
   };
 }
 
@@ -166,7 +202,7 @@ export async function evaluatePromo(data: PromoFormData): Promise<PromoEvaluatio
 export async function fetchExistingCampaigns(): Promise<PromoCampaign[]> {
   const res = await fetch(resolveApiUrl('/api/campaigns'));
   // The campaign surface is optional. Treat "not mapped" as "no campaigns" rather
-  // than throwing — an unhandled rejection here used to take the panel down.
+  // than throwing because an unhandled rejection here used to take the panel down.
   if (res.status === 404) return [];
   if (!res.ok) throw new Error(`Failed to fetch campaigns: ${res.status}`);
   return res.json();

--- a/src/RetailPulse.Web/src/types/index.ts
+++ b/src/RetailPulse.Web/src/types/index.ts
@@ -239,7 +239,7 @@ export interface Trace {
 // --- Promotion Planning types (Sprint 2.1) ---
 
 export type PromoType = 'Discount' | 'BOGO' | 'Display' | 'Digital' | 'Bundle';
-export type PromoRecommendationLevel = 'recommended' | 'cautious' | 'not_recommended';
+export type PromoRecommendationLevel = 'recommended' | 'cautious' | 'not_recommended' | 'insufficient_history';
 
 export interface PromoRisk {
   type: string;
@@ -249,17 +249,20 @@ export interface PromoRisk {
 
 export interface PromoEvaluation {
   recommendation: PromoRecommendationLevel;
-  roi: number;
-  roiLower: number;
-  roiUpper: number;
+  roi: number | null;
+  roiLower: number | null;
+  roiUpper: number | null;
   reasoning: string;
   timingAssessment: string;
   conflicts: string[];
   seasonalityFit: string;
   risks: PromoRisk[];
   similarCampaigns: number;
-  breakEvenDays: number;
-  historicalAvgRoi: number;
+  breakEvenDays: number | null;
+  historicalAvgRoi: number | null;
+  insufficientHistory?: boolean;
+  historyMessage?: string;
+  dataBasis?: string;
 }
 
 export interface PromoCampaign {

--- a/tests/RetailPulse.Tests/Tools/PromoToolTests.cs
+++ b/tests/RetailPulse.Tests/Tools/PromoToolTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using RetailPulse.Contracts;
 using RetailPulse.McpServer.Data;
 using RetailPulse.Tests.TestInfrastructure;
@@ -34,6 +35,19 @@ public class PromoToolTests : IDisposable
 
     private static JsonElement Parse(object obj) =>
         JsonDocument.Parse(JsonSerializer.Serialize(obj)).RootElement;
+
+    private SqliteConnection OpenWritableConnection()
+    {
+        var conn = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = _dbPath,
+            Mode = SqliteOpenMode.ReadWrite,
+            Cache = SqliteCacheMode.Shared,
+            Pooling = false
+        }.ToString());
+        conn.Open();
+        return conn;
+    }
 
     #region GetPromoHistory
 
@@ -259,10 +273,16 @@ public class PromoToolTests : IDisposable
     [Fact]
     public void EstimateROI_ValidInputs_ReturnsRoiEstimate()
     {
-        JsonElement result = Parse(_db.EstimateROI("Sierra Gold Tequila", "Northeast", "BOGO", 100000, 4));
+        JsonElement result = Parse(_db.EstimateROI("Sierra Gold Tequila", "Northeast", "BOGO", 25000, 4));
 
         result.TryGetProperty("error", out _).Should().BeFalse();
         result.TryGetProperty("roi", out _).Should().BeTrue();
+        result.GetProperty("roi").GetProperty("expected").GetDouble().Should().BeGreaterThan(0);
+        result.GetProperty("roi").GetProperty("lower_bound").GetDouble().Should().BeGreaterThan(0);
+        result.GetProperty("roi").GetProperty("upper_bound").GetDouble().Should().BeGreaterThan(0);
+        result.GetProperty("break_even_days").GetInt32().Should().BeGreaterThan(0);
+        result.GetProperty("similar_campaigns").GetInt32().Should().BeGreaterThan(0);
+        result.GetProperty("historical_avg_roi").GetDouble().Should().BeGreaterThan(0);
     }
 
     [Fact]
@@ -283,11 +303,41 @@ public class PromoToolTests : IDisposable
     }
 
     [Fact]
-    public void EstimateROI_InvalidDuration_Over12_ReturnsError()
+    public void EstimateROI_QuarterDuration_ReturnsRoiEstimate()
     {
         JsonElement result = Parse(_db.EstimateROI("Sierra Gold Tequila", "Northeast", "BOGO", 100000, 15));
 
-        result.TryGetProperty("error", out _).Should().BeTrue();
+        result.TryGetProperty("error", out _).Should().BeFalse();
+        result.GetProperty("roi").GetProperty("expected").GetDouble().Should().BeGreaterThan(0);
+        result.GetProperty("break_even_days").GetInt32().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void EstimateROI_TargetLift_ChangesExpectedRoi()
+    {
+        JsonElement lowTarget = Parse(_db.EstimateROI("Sierra Gold Tequila", "Northeast", "BOGO", 25000, 4, 5));
+        JsonElement highTarget = Parse(_db.EstimateROI("Sierra Gold Tequila", "Northeast", "BOGO", 25000, 4, 40));
+
+        lowTarget.TryGetProperty("error", out _).Should().BeFalse();
+        highTarget.TryGetProperty("error", out _).Should().BeFalse();
+        highTarget.GetProperty("roi").GetProperty("expected").GetDouble()
+            .Should().BeGreaterThan(lowTarget.GetProperty("roi").GetProperty("expected").GetDouble());
+    }
+
+    [Fact]
+    public void EstimateROI_NoHistory_ReturnsInsufficientHistory()
+    {
+        using SqliteConnection conn = OpenWritableConnection();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = "DELETE FROM PromoHistory";
+        cmd.ExecuteNonQuery();
+
+        JsonElement result = Parse(_db.EstimateROI("Sierra Gold Tequila", "Northeast", "BOGO", 25000, 4));
+
+        result.TryGetProperty("error", out _).Should().BeFalse();
+        result.GetProperty("insufficient_history").GetBoolean().Should().BeTrue();
+        result.GetProperty("similar_campaigns").GetInt32().Should().Be(0);
+        result.TryGetProperty("roi", out _).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/RetailPulse.Tests/Tools/PromoToolTests.cs
+++ b/tests/RetailPulse.Tests/Tools/PromoToolTests.cs
@@ -325,6 +325,16 @@ public class PromoToolTests : IDisposable
     }
 
     [Fact]
+    public void EstimateROI_SubBreakeven_HasNoFiniteBreakEven()
+    {
+        JsonElement result = Parse(_db.EstimateROI("Ridgeline Bourbon", "Southeast", "Digital", 1_000_000, 1, 40));
+
+        result.TryGetProperty("error", out _).Should().BeFalse();
+        result.GetProperty("roi").GetProperty("expected").GetDouble().Should().BeLessThan(1.0);
+        result.GetProperty("break_even_days").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
     public void EstimateROI_NoHistory_ReturnsInsufficientHistory()
     {
         using SqliteConnection conn = OpenWritableConnection();


### PR DESCRIPTION
Fixes #240

## Root cause
The Campaign Planner UI used stale hardcoded brands and regions that did not match the active content pack. The repro brand Coastal Catch and the National region were not in the default tenant data, so the MCP promo tools returned error or empty payloads. The API also parsed the ROI response as a flat expected_roi even though the MCP server returns roi.expected, so valid runs were classified with a zero ROI. Missing ROI fields then mapped to 0 in the web client, which rendered 0.0x, 0.0x to 0.0x, Break-even 0 days and Not Recommended.

## Fix
- Source planner brands and regions from the active pack, with default-pack fallbacks.
- Parse the nested ROI payload correctly and pass targetLiftPercent through the API and MCP server.
- Rework seeded promo ROI into x multipliers and force a reseed with schema version 9.
- Use comparable campaign fallback scopes before declaring no history.
- Return and render an explicit Not Enough History state with no zero ROI, no zero range and no zero break-even.
- Treat sub-1.0x ROI as no finite break-even instead of a misleading payback day.
- Include break-even in recommendation banding. A campaign that does not break even within its proposed window is Not Recommended even if other priors are favorable.
- Scale the historical prior by spend and duration efficiency so very large budgets do not borrow small-budget history and look artificially cautious.
- Allow quarter length planner windows up to 52 weeks.

## Battle test matrix
Generated with a reproducible C# harness against RetailPulseDb using the default pack seed. H0 is a deliberate no-history validation row where PromoHistory was cleared in the test database after the normal matrix ran, so it is not the same comparable query as T1.

| ID | Type | Brand | Region | Budget | Weeks | Target | ROI | Recommendation | Break-even | Comparable count | Basis |
|---|---|---|---|---:|---:|---:|---:|---|---:|---:|---|
| T1 | Discount | Sierra Gold Tequila | Northeast | $5,000 | 1 | 5% | 2.81x | Recommended | 3 days | 1 | brand, region and promotion type |
| T2 | BOGO | Apex Grill | Southeast | $25,000 | 4 | 10% | 0.81x | Not Recommended | Does not break even | 1 | brand, region and promotion type |
| T3 | Display | ClearDesk | Midwest | $25,000 | 4 | None | 0.99x | Not Recommended | Does not break even | 2 | brand, region and promotion type |
| T4 | Digital | FreshMart | West Coast | $25,000 | 13 | 40% | 2.11x | Recommended | 44 days | 5 | brand and region across all promotion types |
| T5 | Bundle | Urban Living | Southwest | $25,000 | 4 | 15% | 2.46x | Recommended | 12 days | 5 | brand and region across all promotion types |
| T6 | Discount | Foundry Home | Pacific Northwest | $750,000 | 4 | 10% | 0.64x | Not Recommended | Does not break even | 5 | brand and region across all promotion types |
| T7 | BOGO | Coastline Tacos | National | $25,000 | 4 | 10% | 1.33x | Cautious | 22 days | 5 | brand plus promotion type across all regions |
| T8 | Digital | Summit Outdoor | Southeast | $25,000 | 2 | 5% | 0.88x | Not Recommended | Does not break even | 5 | brand and region across all promotion types |
| T9 | Bundle | Pinnacle Hardware | Northeast | $25,000 | 16 | 25% | 6.15x | Recommended | 19 days | 5 | brand and region across all promotion types |
| T10 | Display | Harvest Table | Southwest | $5,000 | 4 | 10% | 2.14x | Recommended | 14 days | 1 | brand, region and promotion type |
| T11 | Digital | Ridgeline Bourbon | Southeast | $100,000 | 1 | 40% | 0.76x | Not Recommended | Does not break even | 1 | brand, region and promotion type |
| H0 | No-history validation, promo history table cleared | All | All | $25,000 | 4 | None | N/A | Not Enough History | N/A | 0 | none |

## Reseed behavior
Already-deployed MCP servers migrate cleanly on restart. SchemaVersion is part of the seed fingerprint. A v8 database misses the v9 hash, then SeedIfNeeded deletes and rebuilds all seeded tables inside one SQLite transaction before the server finishes constructing RetailPulseDb. There is no path to a committed mix of old and new promo rows. A currently running server stays on its already-loaded database until restart, and if restart is interrupted during reseed SQLite rolls the transaction back rather than committing a partial seed.

## Still suspect
The default seed has only five campaigns per brand-region, so several valid scenarios need broader comparison scopes. The UI now makes that basis visible instead of implying exact comparables.

## Verification
- npx tsc --noEmit -p tsconfig.json
- npx vitest run
- dotnet test tests\RetailPulse.Tests\RetailPulse.Tests.csproj --filter "FullyQualifiedName~PromoToolTests|FullyQualifiedName~PromoDataTests" --no-restore
- dotnet build RetailPulse.slnx --no-restore

Note: RetailPulse.sln does not exist in this worktree, so I built RetailPulse.slnx after restore.