### PR TITLE
Fix guardrails audit readability

### DIFF
--- a/src/RetailPulse.Api/Endpoints/GuardrailEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/GuardrailEndpoints.cs
@@ -22,7 +22,10 @@ public static class GuardrailEndpoints
                 action = r.Action,
                 category = r.Category,
                 severity = r.Severity,
-                decision = r.Decision
+                decision = r.Decision,
+                stage = r.Stage,
+                threshold = r.Threshold,
+                reason = r.Reason
             }));
         })
         .WithName("GetGuardrailsLog").RequireAuthorization().RequireRateLimiting("relaxed");

--- a/src/RetailPulse.Api/Guardrails/AgentDefinition/AgentDefinitionValidator.cs
+++ b/src/RetailPulse.Api/Guardrails/AgentDefinition/AgentDefinitionValidator.cs
@@ -400,6 +400,9 @@ public sealed class AgentDefinitionValidator
 
             case ContentSafetyDecision.Blocked:
                 {
+                    string detectionType = ContentSafetyDetectionTypes.ForResultWithShield(result);
+                    (string? category, int? severity) = ContentSafetyAuditFields.PickCategoryAndSeverity(result);
+                    int? threshold = ContentSafetyAuditFields.ThresholdFor(_guardrails.ContentSafety, category);
                     string primary = result.PrimaryCategory
                         ?? (result.Categories.Count > 0 ? result.Categories[0].Category : "unknown");
                     string message = result.PromptShieldJailbreakDetected
@@ -407,10 +410,21 @@ public sealed class AgentDefinitionValidator
                         : result.PromptShieldIndirectInjectionDetected
                             ? $"Prompt Shields detected indirect-injection in {field}."
                             : $"Content Safety blocked {field} on category '{primary}'.";
+                    string reason = ContentSafetyAuditFields.BuildReason(
+                        result,
+                        ContentSafetyStage.AgentDefinition,
+                        detectionType,
+                        category,
+                        severity,
+                        threshold);
                     violations.Add(new AgentDefinitionViolation(
                         agentKey, field, "safety.content-safety-blocked",
-                        message,
-                        AgentDefinitionDetectionTypes.ContentSafety));
+                        $"{message} {reason}",
+                        AgentDefinitionDetectionTypes.ContentSafety,
+                        Category: category,
+                        Severity: severity,
+                        Decision: result.Decision.ToString(),
+                        Threshold: threshold));
                     break;
                 }
 
@@ -421,7 +435,8 @@ public sealed class AgentDefinitionValidator
                         violations.Add(new AgentDefinitionViolation(
                             agentKey, field, "safety.content-safety-unavailable",
                             $"Content Safety unavailable and FailClosed policy is active; refusing {field}.",
-                            AgentDefinitionDetectionTypes.ContentSafety));
+                            AgentDefinitionDetectionTypes.ContentSafety,
+                            Decision: result.Decision.ToString()));
                     }
                     else
                     {
@@ -430,13 +445,16 @@ public sealed class AgentDefinitionValidator
                         await _audit.LogAsync(new SuspiciousRequest(
                             Id: Guid.NewGuid().ToString("N"),
                             Timestamp: DateTime.UtcNow,
-                            RequestText: Truncate($"agent={agentKey} field={field} rule=safety.content-safety-unavailable"),
+                            RequestText: Truncate($"Content Safety unavailable while checking {field} for agent {agentKey}."),
                             DetectionType: AgentDefinitionDetectionTypes.ContentSafetyUnavailable,
                             UserContext: AgentDefinitionDetectionTypes.StartupValidatorContext,
                             Action: AgentDefinitionDetectionTypes.ActionFailOpenPassed,
                             Category: null,
                             Severity: null,
-                            Decision: ContentSafetyDecision.ServiceUnavailable.ToString()),
+                            Decision: ContentSafetyDecision.ServiceUnavailable.ToString(),
+                            Stage: ContentSafetyStage.AgentDefinition.ToString(),
+                            Threshold: null,
+                            Reason: $"Content Safety was unreachable while checking {field} for agent {agentKey}."),
                             cancellationToken).ConfigureAwait(false);
                     }
 
@@ -491,9 +509,12 @@ public sealed class AgentDefinitionValidator
             DetectionType: violation.DetectionType,
             UserContext: AgentDefinitionDetectionTypes.StartupValidatorContext,
             Action: action,
-            Category: null,
-            Severity: null,
-            Decision: null),
+            Category: violation.Category,
+            Severity: violation.Severity,
+            Decision: violation.Decision,
+            Stage: ContentSafetyStage.AgentDefinition.ToString(),
+            Threshold: violation.Threshold,
+            Reason: violation.Message),
             cancellationToken);
     }
 

--- a/src/RetailPulse.Api/Guardrails/AgentDefinition/AgentDefinitionViolation.cs
+++ b/src/RetailPulse.Api/Guardrails/AgentDefinition/AgentDefinitionViolation.cs
@@ -12,4 +12,8 @@ public sealed record AgentDefinitionViolation(
     string Field,
     string RuleId,
     string Message,
-    string DetectionType);
+    string DetectionType,
+    string? Category = null,
+    int? Severity = null,
+    string? Decision = null,
+    int? Threshold = null);

--- a/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyAuditFields.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyAuditFields.cs
@@ -1,0 +1,99 @@
+using RetailPulse.Contracts.Guardrails;
+
+namespace RetailPulse.Api.Guardrails.ContentSafety;
+
+internal static class ContentSafetyAuditFields
+{
+    public static (string? Category, int? Severity) PickCategoryAndSeverity(ContentSafetyResult evaluation)
+    {
+        if (evaluation.Categories.Count == 0) return (null, null);
+
+        string? primaryCategory = CategoryFromDetectionType(evaluation.PrimaryCategory);
+        if (primaryCategory is not null)
+        {
+            ContentSafetyCategoryHit? primaryHit = evaluation.Categories.FirstOrDefault(h =>
+                string.Equals(h.Category, primaryCategory, StringComparison.OrdinalIgnoreCase));
+            if (primaryHit is not null)
+            {
+                return (primaryHit.Category, primaryHit.Severity);
+            }
+        }
+
+        ContentSafetyCategoryHit top = evaluation.Categories[0];
+        for (int i = 1; i < evaluation.Categories.Count; i++)
+        {
+            if (evaluation.Categories[i].Severity > top.Severity)
+                top = evaluation.Categories[i];
+        }
+
+        return (top.Category, top.Severity);
+    }
+
+    public static int? ThresholdFor(ContentSafetyConfig config, string? category)
+    {
+        if (string.IsNullOrWhiteSpace(category)) return null;
+
+        int threshold = config.Thresholds.Resolve(category);
+        return threshold == int.MaxValue ? null : threshold;
+    }
+
+    public static string BuildReason(
+        ContentSafetyResult evaluation,
+        ContentSafetyStage stage,
+        string detectionType,
+        string? category,
+        int? severity,
+        int? threshold)
+    {
+        string target = FormatStageTarget(stage);
+
+        if (evaluation.Decision == ContentSafetyDecision.ServiceUnavailable
+            || string.Equals(detectionType, ContentSafetyDetectionTypes.Unavailable, StringComparison.Ordinal))
+        {
+            return $"Content Safety was unreachable while checking {target}.";
+        }
+
+        if (string.Equals(detectionType, ContentSafetyDetectionTypes.PromptShield, StringComparison.Ordinal))
+        {
+            return $"Prompt Shields detected an instruction override attempt in {target}.";
+        }
+
+        if (string.Equals(detectionType, ContentSafetyDetectionTypes.IndirectInjection, StringComparison.Ordinal))
+        {
+            return $"Prompt Shields detected an indirect injection attempt in {target}.";
+        }
+
+        string categoryText = string.IsNullOrWhiteSpace(category)
+            ? "a configured category"
+            : $"{category} content";
+
+        if (severity.HasValue && threshold.HasValue)
+        {
+            string comparison = severity.Value >= threshold.Value ? "met" : "did not meet";
+            return $"Content Safety classified {target} as {categoryText} at severity {severity.Value}, which {comparison} threshold {threshold.Value}.";
+        }
+
+        return severity.HasValue
+            ? $"Content Safety classified {target} as {categoryText} at severity {severity.Value}."
+            : $"Content Safety classified {target} as {categoryText}.";
+    }
+
+    private static string FormatStageTarget(ContentSafetyStage stage) => stage switch
+    {
+        ContentSafetyStage.Input => "the input",
+        ContentSafetyStage.Output => "the output",
+        ContentSafetyStage.RetrievedKnowledge => "retrieved knowledge",
+        ContentSafetyStage.ToolResult => "the tool result",
+        ContentSafetyStage.AgentDefinition => "the agent definition",
+        _ => "the content",
+    };
+
+    private static string? CategoryFromDetectionType(string? detectionType) => detectionType switch
+    {
+        ContentSafetyDetectionTypes.Hate => "Hate",
+        ContentSafetyDetectionTypes.Sexual => "Sexual",
+        ContentSafetyDetectionTypes.Violence => "Violence",
+        ContentSafetyDetectionTypes.SelfHarm => "SelfHarm",
+        _ => null,
+    };
+}

--- a/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyToolResultInspector.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyToolResultInspector.cs
@@ -71,7 +71,8 @@ public sealed class ContentSafetyToolResultInspector
                     // Tool-result stage does not run Prompt Shields, so a
                     // block without a category is never a prompt-shield hit.
                     string detectionType = ContentSafetyDetectionTypes.ForResultWithoutShield(evaluation);
-                    (string? category, int? severity) = PickCategoryAndSeverity(evaluation);
+                    (string? category, int? severity) = ContentSafetyAuditFields.PickCategoryAndSeverity(evaluation);
+                    int? threshold = ContentSafetyAuditFields.ThresholdFor(cfg, category);
 
                     await _log.LogAsync(new SuspiciousRequest(
                         Guid.NewGuid().ToString("N"),
@@ -82,7 +83,16 @@ public sealed class ContentSafetyToolResultInspector
                         ContentSafetyActions.Blocked,
                         Category: category,
                         Severity: severity,
-                        Decision: evaluation.Decision.ToString()), cancellationToken).ConfigureAwait(false);
+                        Decision: evaluation.Decision.ToString(),
+                        Stage: ContentSafetyStage.ToolResult.ToString(),
+                        Threshold: threshold,
+                        Reason: ContentSafetyAuditFields.BuildReason(
+                            evaluation,
+                            ContentSafetyStage.ToolResult,
+                            detectionType,
+                            category,
+                            severity,
+                            threshold)), cancellationToken).ConfigureAwait(false);
 
                     _logger.LogWarning(
                         "Content Safety blocked tool result from '{Tool}' (decision={Decision}, categories={CategoryCount})",
@@ -106,7 +116,16 @@ public sealed class ContentSafetyToolResultInspector
                         action,
                         Category: null,
                         Severity: null,
-                        Decision: evaluation.Decision.ToString()), cancellationToken).ConfigureAwait(false);
+                        Decision: evaluation.Decision.ToString(),
+                        Stage: ContentSafetyStage.ToolResult.ToString(),
+                        Threshold: null,
+                        Reason: ContentSafetyAuditFields.BuildReason(
+                            evaluation,
+                            ContentSafetyStage.ToolResult,
+                            ContentSafetyDetectionTypes.Unavailable,
+                            category: null,
+                            severity: null,
+                            threshold: null)), cancellationToken).ConfigureAwait(false);
 
                     if (cfg.OnUnavailable == ContentSafetyFailPolicy.FailClosed)
                     {
@@ -121,17 +140,28 @@ public sealed class ContentSafetyToolResultInspector
                 }
             case ContentSafetyDecision.Flagged:
                 {
-                    (string? category, int? severity) = PickCategoryAndSeverity(evaluation);
+                    (string? category, int? severity) = ContentSafetyAuditFields.PickCategoryAndSeverity(evaluation);
+                    string detectionType = ContentSafetyDetectionTypes.ForResultWithoutShield(evaluation);
+                    int? threshold = ContentSafetyAuditFields.ThresholdFor(cfg, category);
                     await _log.LogAsync(new SuspiciousRequest(
                         Guid.NewGuid().ToString("N"),
                         DateTime.UtcNow,
                         $"Tool result from '{toolName}' flagged by Content Safety",
-                        ContentSafetyDetectionTypes.ForResultWithoutShield(evaluation),
+                        detectionType,
                         userId,
                         ContentSafetyActions.Flagged,
                         Category: category,
                         Severity: severity,
-                        Decision: evaluation.Decision.ToString()), cancellationToken).ConfigureAwait(false);
+                        Decision: evaluation.Decision.ToString(),
+                        Stage: ContentSafetyStage.ToolResult.ToString(),
+                        Threshold: threshold,
+                        Reason: ContentSafetyAuditFields.BuildReason(
+                            evaluation,
+                            ContentSafetyStage.ToolResult,
+                            detectionType,
+                            category,
+                            severity,
+                            threshold)), cancellationToken).ConfigureAwait(false);
                     return ContentSafetyToolResultOutcome.PassThrough(toolResultJson);
                 }
 
@@ -192,17 +222,6 @@ public sealed class ContentSafetyToolResultInspector
         _ => "severe",
     };
 
-    private static (string? Category, int? Severity) PickCategoryAndSeverity(ContentSafetyResult evaluation)
-    {
-        if (evaluation.Categories.Count == 0) return (null, null);
-        ContentSafetyCategoryHit top = evaluation.Categories[0];
-        for (int i = 1; i < evaluation.Categories.Count; i++)
-        {
-            if (evaluation.Categories[i].Severity > top.Severity)
-                top = evaluation.Categories[i];
-        }
-        return (top.Category, top.Severity);
-    }
 }
 
 /// <summary>Outcome returned by <see cref="ContentSafetyToolResultInspector.InspectAsync"/>.</summary>

--- a/src/RetailPulse.Api/Middleware/GuardrailsMiddleware.cs
+++ b/src/RetailPulse.Api/Middleware/GuardrailsMiddleware.cs
@@ -243,7 +243,8 @@ public class GuardrailsMiddleware
                 {
                     string detectionType =
                         ContentSafetyDetectionTypes.ForResultWithShield(evaluation);
-                    (string? category, int? severity) = PickCategoryAndSeverity(evaluation);
+                    (string? category, int? severity) = ContentSafetyAuditFields.PickCategoryAndSeverity(evaluation);
+                    int? threshold = ContentSafetyAuditFields.ThresholdFor(cs, category);
 
                     activity?.SetTag("guardrails.blocked", true);
                     activity?.SetTag("guardrails.type", detectionType);
@@ -257,7 +258,16 @@ public class GuardrailsMiddleware
                         ContentSafetyActions.Blocked,
                         Category: category,
                         Severity: severity,
-                        Decision: evaluation.Decision.ToString()), ct).ConfigureAwait(false);
+                        Decision: evaluation.Decision.ToString(),
+                        Stage: ContentSafetyStage.Input.ToString(),
+                        Threshold: threshold,
+                        Reason: ContentSafetyAuditFields.BuildReason(
+                            evaluation,
+                            ContentSafetyStage.Input,
+                            detectionType,
+                            category,
+                            severity,
+                            threshold)), ct).ConfigureAwait(false);
 
                     _logger.LogWarning(
                         "Content Safety blocked input from user {UserId}: type={DetectionType}, categories={CategoryCount}",
@@ -280,7 +290,16 @@ public class GuardrailsMiddleware
                         action,
                         Category: null,
                         Severity: null,
-                        Decision: evaluation.Decision.ToString()), ct).ConfigureAwait(false);
+                        Decision: evaluation.Decision.ToString(),
+                        Stage: ContentSafetyStage.Input.ToString(),
+                        Threshold: null,
+                        Reason: ContentSafetyAuditFields.BuildReason(
+                            evaluation,
+                            ContentSafetyStage.Input,
+                            ContentSafetyDetectionTypes.Unavailable,
+                            category: null,
+                            severity: null,
+                            threshold: null)), ct).ConfigureAwait(false);
 
                     if (cs.OnUnavailable == ContentSafetyFailPolicy.FailClosed)
                     {
@@ -299,7 +318,8 @@ public class GuardrailsMiddleware
                 }
             case ContentSafetyDecision.Flagged:
                 {
-                    (string? category, int? severity) = PickCategoryAndSeverity(evaluation);
+                    (string? category, int? severity) = ContentSafetyAuditFields.PickCategoryAndSeverity(evaluation);
+                    int? threshold = ContentSafetyAuditFields.ThresholdFor(cs, category);
                     await _suspiciousLog.LogAsync(new SuspiciousRequest(
                         Guid.NewGuid().ToString("N"),
                         DateTime.UtcNow,
@@ -309,7 +329,16 @@ public class GuardrailsMiddleware
                         ContentSafetyActions.Flagged,
                         Category: category,
                         Severity: severity,
-                        Decision: evaluation.Decision.ToString()), ct).ConfigureAwait(false);
+                        Decision: evaluation.Decision.ToString(),
+                        Stage: ContentSafetyStage.Input.ToString(),
+                        Threshold: threshold,
+                        Reason: ContentSafetyAuditFields.BuildReason(
+                            evaluation,
+                            ContentSafetyStage.Input,
+                            ContentSafetyDetectionTypes.ForResultWithShield(evaluation),
+                            category,
+                            severity,
+                            threshold)), ct).ConfigureAwait(false);
                     return null;
                 }
 
@@ -334,7 +363,8 @@ public class GuardrailsMiddleware
                     // Output stage never runs Prompt Shields, so an output-only
                     // block without a category must NEVER be labeled prompt-shield.
                     string detectionType = ContentSafetyDetectionTypes.ForResultWithoutShield(evaluation);
-                    (string? category, int? severity) = PickCategoryAndSeverity(evaluation);
+                    (string? category, int? severity) = ContentSafetyAuditFields.PickCategoryAndSeverity(evaluation);
+                    int? threshold = ContentSafetyAuditFields.ThresholdFor(cs, category);
                     activity?.SetTag("guardrails.output_blocked", true);
                     activity?.SetTag("guardrails.type", detectionType);
 
@@ -347,7 +377,16 @@ public class GuardrailsMiddleware
                         ContentSafetyActions.Blocked,
                         Category: category,
                         Severity: severity,
-                        Decision: evaluation.Decision.ToString()), ct).ConfigureAwait(false);
+                        Decision: evaluation.Decision.ToString(),
+                        Stage: ContentSafetyStage.Output.ToString(),
+                        Threshold: threshold,
+                        Reason: ContentSafetyAuditFields.BuildReason(
+                            evaluation,
+                            ContentSafetyStage.Output,
+                            detectionType,
+                            category,
+                            severity,
+                            threshold)), ct).ConfigureAwait(false);
 
                     _logger.LogWarning(
                         "Content Safety blocked model output for user {UserId}: type={DetectionType}",
@@ -370,7 +409,16 @@ public class GuardrailsMiddleware
                         action,
                         Category: null,
                         Severity: null,
-                        Decision: evaluation.Decision.ToString()), ct).ConfigureAwait(false);
+                        Decision: evaluation.Decision.ToString(),
+                        Stage: ContentSafetyStage.Output.ToString(),
+                        Threshold: null,
+                        Reason: ContentSafetyAuditFields.BuildReason(
+                            evaluation,
+                            ContentSafetyStage.Output,
+                            ContentSafetyDetectionTypes.Unavailable,
+                            category: null,
+                            severity: null,
+                            threshold: null)), ct).ConfigureAwait(false);
 
                     return cs.OnUnavailable == ContentSafetyFailPolicy.FailClosed
                         ? _unavailableRefusal
@@ -378,17 +426,28 @@ public class GuardrailsMiddleware
                 }
             case ContentSafetyDecision.Flagged:
                 {
-                    (string? category, int? severity) = PickCategoryAndSeverity(evaluation);
+                    (string? category, int? severity) = ContentSafetyAuditFields.PickCategoryAndSeverity(evaluation);
+                    string detectionType = ContentSafetyDetectionTypes.ForResultWithoutShield(evaluation);
+                    int? threshold = ContentSafetyAuditFields.ThresholdFor(cs, category);
                     await _suspiciousLog.LogAsync(new SuspiciousRequest(
                         Guid.NewGuid().ToString("N"),
                         DateTime.UtcNow,
                         Truncate(response, 200),
-                        ContentSafetyDetectionTypes.ForResultWithoutShield(evaluation),
+                        detectionType,
                         userId,
                         ContentSafetyActions.Flagged,
                         Category: category,
                         Severity: severity,
-                        Decision: evaluation.Decision.ToString()), ct).ConfigureAwait(false);
+                        Decision: evaluation.Decision.ToString(),
+                        Stage: ContentSafetyStage.Output.ToString(),
+                        Threshold: threshold,
+                        Reason: ContentSafetyAuditFields.BuildReason(
+                            evaluation,
+                            ContentSafetyStage.Output,
+                            detectionType,
+                            category,
+                            severity,
+                            threshold)), ct).ConfigureAwait(false);
                     return null;
                 }
 
@@ -401,19 +460,6 @@ public class GuardrailsMiddleware
     private static string Truncate(string text, int maxLength) =>
         text.Length <= maxLength ? text : text[..maxLength] + "...";
 
-    private static (string? Category, int? Severity) PickCategoryAndSeverity(ContentSafetyResult evaluation)
-    {
-        if (evaluation.Categories.Count == 0) return (null, null);
-        // Highest-severity category wins for audit — matches the "most
-        // severe hit" convention operators expect on the dashboard.
-        ContentSafetyCategoryHit top = evaluation.Categories[0];
-        for (int i = 1; i < evaluation.Categories.Count; i++)
-        {
-            if (evaluation.Categories[i].Severity > top.Severity)
-                top = evaluation.Categories[i];
-        }
-        return (top.Category, top.Severity);
-    }
 }
 
 /// <summary>

--- a/src/RetailPulse.Api/Rag/RagContextProvider.cs
+++ b/src/RetailPulse.Api/Rag/RagContextProvider.cs
@@ -270,7 +270,8 @@ public class RagContextProvider
                         // user-prompt jailbreak flag when both are set.
                         string detectionType = ContentSafetyDetectionTypes.ForResultWithShield(
                             evaluation, preferIndirect: true);
-                        (string? category, int? severity) = PickCategoryAndSeverity(evaluation);
+                        (string? category, int? severity) = ContentSafetyAuditFields.PickCategoryAndSeverity(evaluation);
+                        int? threshold = ContentSafetyAuditFields.ThresholdFor(cs, category);
                         await LogAsync(new SuspiciousRequest(
                             Guid.NewGuid().ToString("N"),
                             DateTime.UtcNow,
@@ -280,7 +281,16 @@ public class RagContextProvider
                             ContentSafetyActions.Dropped,
                             Category: category,
                             Severity: severity,
-                            Decision: evaluation.Decision.ToString()), ct).ConfigureAwait(false);
+                            Decision: evaluation.Decision.ToString(),
+                            Stage: ContentSafetyStage.RetrievedKnowledge.ToString(),
+                            Threshold: threshold,
+                            Reason: ContentSafetyAuditFields.BuildReason(
+                                evaluation,
+                                ContentSafetyStage.RetrievedKnowledge,
+                                detectionType,
+                                category,
+                                severity,
+                                threshold)), ct).ConfigureAwait(false);
                         _logger.LogWarning(
                             "Content Safety dropped RAG chunk '{Title}#{Chunk}' (type={Detection})",
                             chunk.Title, chunk.ChunkIndex, detectionType);
@@ -300,7 +310,16 @@ public class RagContextProvider
                             action,
                             Category: null,
                             Severity: null,
-                            Decision: evaluation.Decision.ToString()), ct).ConfigureAwait(false);
+                            Decision: evaluation.Decision.ToString(),
+                            Stage: ContentSafetyStage.RetrievedKnowledge.ToString(),
+                            Threshold: null,
+                            Reason: ContentSafetyAuditFields.BuildReason(
+                                evaluation,
+                                ContentSafetyStage.RetrievedKnowledge,
+                                ContentSafetyDetectionTypes.Unavailable,
+                                category: null,
+                                severity: null,
+                                threshold: null)), ct).ConfigureAwait(false);
                         if (cs.OnUnavailable == ContentSafetyFailPolicy.FailClosed)
                         {
                             _logger.LogWarning(
@@ -313,17 +332,28 @@ public class RagContextProvider
                     }
                 case ContentSafetyDecision.Flagged:
                     {
-                        (string? category, int? severity) = PickCategoryAndSeverity(evaluation);
+                        (string? category, int? severity) = ContentSafetyAuditFields.PickCategoryAndSeverity(evaluation);
+                        string detectionType = ContentSafetyDetectionTypes.ForResultWithShield(evaluation, preferIndirect: true);
+                        int? threshold = ContentSafetyAuditFields.ThresholdFor(cs, category);
                         await LogAsync(new SuspiciousRequest(
                             Guid.NewGuid().ToString("N"),
                             DateTime.UtcNow,
                             $"Retrieved-knowledge chunk '{chunk.Title}#{chunk.ChunkIndex}' flagged by Content Safety",
-                            ContentSafetyDetectionTypes.ForResultWithShield(evaluation, preferIndirect: true),
+                            detectionType,
                             userId,
                             ContentSafetyActions.Flagged,
                             Category: category,
                             Severity: severity,
-                            Decision: evaluation.Decision.ToString()), ct).ConfigureAwait(false);
+                            Decision: evaluation.Decision.ToString(),
+                            Stage: ContentSafetyStage.RetrievedKnowledge.ToString(),
+                            Threshold: threshold,
+                            Reason: ContentSafetyAuditFields.BuildReason(
+                                evaluation,
+                                ContentSafetyStage.RetrievedKnowledge,
+                                detectionType,
+                                category,
+                                severity,
+                                threshold)), ct).ConfigureAwait(false);
                         survivors.Add(chunk);
                         break;
                     }
@@ -339,15 +369,4 @@ public class RagContextProvider
     private Task LogAsync(SuspiciousRequest request, CancellationToken ct) =>
         _suspiciousLog?.LogAsync(request, ct) ?? Task.CompletedTask;
 
-    private static (string? Category, int? Severity) PickCategoryAndSeverity(ContentSafetyResult evaluation)
-    {
-        if (evaluation.Categories.Count == 0) return (null, null);
-        ContentSafetyCategoryHit top = evaluation.Categories[0];
-        for (int i = 1; i < evaluation.Categories.Count; i++)
-        {
-            if (evaluation.Categories[i].Severity > top.Severity)
-                top = evaluation.Categories[i];
-        }
-        return (top.Category, top.Severity);
-    }
 }

--- a/src/RetailPulse.Contracts/Guardrails/ISuspiciousRequestLog.cs
+++ b/src/RetailPulse.Contracts/Guardrails/ISuspiciousRequestLog.cs
@@ -39,7 +39,10 @@ public record SuspiciousRequest(
     string Action,
     string? Category = null,
     int? Severity = null,
-    string? Decision = null);
+    string? Decision = null,
+    string? Stage = null,
+    int? Threshold = null,
+    string? Reason = null);
 
 /// <summary>
 /// Aggregated guardrails activity metrics.

--- a/src/RetailPulse.Web/src/__tests__/GuardrailsDashboard.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/GuardrailsDashboard.test.tsx
@@ -44,6 +44,29 @@ const mockLog: BlockedRequest[] = [
   { id: 'l1', timestamp: '2026-05-13T14:00:00Z', requestPreview: 'log-preview-1', detectionType: 'jailbreak', reason: '', actionTaken: 'Blocked' },
   { id: 'l2', timestamp: '2026-05-13T13:30:00Z', requestPreview: 'log-preview-2', detectionType: 'content-safety-hate', reason: '', actionTaken: 'Blocked', category: 'Hate', severity: 4, decision: 'Blocked' },
   { id: 'l3', timestamp: '2026-05-13T13:15:00Z', requestPreview: 'log-preview-3', detectionType: 'content-safety-violence', reason: '', actionTaken: 'Blocked', category: 'Violence', severity: 6, decision: 'Blocked' },
+  {
+    id: 'l4',
+    timestamp: '2026-05-13T13:10:00Z',
+    requestPreview: "Tool result from 'GetStorePerformance' blocked by Content Safety",
+    detectionType: 'content-safety-selfharm',
+    reason: '',
+    actionTaken: 'blocked',
+    category: 'SelfHarm',
+    severity: 6,
+    decision: 'Blocked',
+    stage: 'ToolResult',
+    threshold: 4,
+  },
+  {
+    id: 'l5',
+    timestamp: '2026-05-13T13:05:00Z',
+    requestPreview: 'agent=general field=SystemPrompt rule=safety.content-safety-unavailable',
+    detectionType: 'agent-definition-content-safety-unavailable',
+    reason: '',
+    actionTaken: 'failopen-passed',
+    decision: 'ServiceUnavailable',
+    stage: 'AgentDefinition',
+  },
 ];
 
 const mockConfig: { contentSafety: GuardrailsConfigData['contentSafety'] } = {
@@ -229,5 +252,24 @@ describe('GuardrailsDashboard', () => {
     // No `content-safety-*` slug should appear in the rendered UI text.
     expect(rendered).not.toMatch(/content-safety-hate\b|content-safety-violence\b|content-safety-sexual\b|content-safety-selfharm\b|content-safety-prompt-shield\b|content-safety-indirect-injection\b|content-safety-unavailable\b/);
     expect(rendered).not.toMatch(/RULE_ID_|THRESHOLD_|SENSITIVE_PATTERN_/i);
+  });
+
+  it('explains content-safety category, severity, threshold, stage, and action', async () => {
+    installFetchMock();
+    renderWithTheme(<GuardrailsDashboard />);
+    expect(await screen.findByText('Tool result from GetStorePerformance was blocked by Content Safety.')).toBeInTheDocument();
+    expect(screen.getByText(/Tool result triggered Self-harm content at severe severity \(6\), which met threshold 4\./)).toBeInTheDocument();
+    expect(screen.getByText(/The system withheld the tool result from the model\./)).toBeInTheDocument();
+    expect(screen.getByText('Tool result withheld')).toBeInTheDocument();
+  });
+
+  it('renders fail-open passes as plain operator wording', async () => {
+    installFetchMock();
+    renderWithTheme(<GuardrailsDashboard />);
+    const dashboard = await screen.findByTestId('guardrails-dashboard');
+    expect(screen.getByText('Content Safety was unreachable while checking SystemPrompt for general.')).toBeInTheDocument();
+    expect(screen.getByText(/The system allowed the request through because fail-open policy is active\./)).toBeInTheDocument();
+    expect(screen.getByText('Allowed through')).toBeInTheDocument();
+    expect(dashboard.textContent ?? '').not.toContain('agent=general field=SystemPrompt rule=safety.content-safety-unavailable');
   });
 });

--- a/src/RetailPulse.Web/src/__tests__/guardrailsApi.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/guardrailsApi.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { updateGuardrailsConfig } from '../services/guardrailsApi';
+import { fetchGuardrailsLog, updateGuardrailsConfig } from '../services/guardrailsApi';
 import type { GuardrailsConfigData } from '../types';
 
 function baseConfig(overrides?: Partial<GuardrailsConfigData>): GuardrailsConfigData {
@@ -65,5 +65,39 @@ describe('guardrailsApi config contract', () => {
 
     await expect(updateGuardrailsConfig(baseConfig({ jailbreakDetectionEnabled: false })))
       .rejects.toThrow(/jailbreakDetectionEnabled/);
+  });
+
+  it('maps audit row detail fields from the log endpoint', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: 'row-1',
+          timestamp: '2026-08-29T18:19:24Z',
+          requestText: "Tool result from 'GetStorePerformance' blocked by Content Safety",
+          detectionType: 'content-safety-sexual',
+          action: 'blocked',
+          reason: 'Content Safety classified the tool result as Sexual content at severity 4, which met threshold 4.',
+          category: 'Sexual',
+          severity: 4,
+          decision: 'Blocked',
+          stage: 'ToolResult',
+          threshold: 4,
+        },
+      ],
+    } as Response);
+
+    await expect(fetchGuardrailsLog(1)).resolves.toEqual([
+      expect.objectContaining({
+        requestPreview: "Tool result from 'GetStorePerformance' blocked by Content Safety",
+        actionTaken: 'blocked',
+        reason: 'Content Safety classified the tool result as Sexual content at severity 4, which met threshold 4.',
+        category: 'Sexual',
+        severity: 4,
+        decision: 'Blocked',
+        stage: 'ToolResult',
+        threshold: 4,
+      }),
+    ]);
   });
 });

--- a/src/RetailPulse.Web/src/components/guardrails/GuardrailsDashboard.tsx
+++ b/src/RetailPulse.Web/src/components/guardrails/GuardrailsDashboard.tsx
@@ -10,6 +10,7 @@ import {
   classifyBlockFamily,
   describeCategory,
   describeSeverity,
+  normaliseCategoryName,
 } from '../../utils/safetyDisplay';
 import { ContentSafetyStatusBadge } from './ContentSafetyStatusBadge';
 
@@ -94,7 +95,7 @@ const useStyles = makeStyles({
   },
   entry: {
     display: 'grid',
-    gridTemplateColumns: '140px 1fr 100px 120px',
+    gridTemplateColumns: 'max-content minmax(220px, 1fr) minmax(220px, 320px) max-content',
     gap: '12px',
     alignItems: 'center',
     padding: '10px 14px',
@@ -102,34 +103,69 @@ const useStyles = makeStyles({
     backgroundColor: tokens.colorNeutralBackground2,
     border: `1px solid ${tokens.colorNeutralStroke2}`,
     fontSize: '13px',
-    '@media (max-width: 640px)': {
+    '@media (max-width: 900px)': {
       gridTemplateColumns: '1fr',
-      gap: '4px',
+      gap: '8px',
     },
   },
   timestamp: {
     color: tokens.colorNeutralForeground3,
     fontSize: '12px',
     fontFamily: "'Courier New', monospace",
+    whiteSpace: 'nowrap',
   },
-  preview: {
+  entrySummary: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '3px',
+    minWidth: 0,
+  },
+  entryPrimary: {
     color: tokens.colorNeutralForeground1,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
+  entryDetail: {
+    color: tokens.colorNeutralForeground2,
+    fontSize: '12px',
+    lineHeight: '1.4',
+  },
   typeBadge: {
     display: 'inline-flex',
     alignItems: 'center',
     gap: '4px',
+    justifySelf: 'end',
+    maxWidth: '100%',
+    minWidth: 0,
     padding: '2px 8px',
     borderRadius: tokens.borderRadiusCircular,
     fontSize: '11px',
     fontWeight: '600',
     textTransform: 'uppercase',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
     backgroundColor: tokens.colorNeutralBackground3,
     color: tokens.colorNeutralForeground2,
     border: `1px solid ${tokens.colorNeutralStroke2}`,
+    '@media (max-width: 900px)': {
+      justifySelf: 'start',
+    },
+  },
+  typeBadgeText: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  actionPill: {
+    justifySelf: 'end',
+    color: tokens.colorNeutralForeground3,
+    fontSize: '12px',
+    whiteSpace: 'nowrap',
+    '@media (max-width: 900px)': {
+      justifySelf: 'start',
+    },
   },
   chartSection: {
     borderRadius: tokens.borderRadiusLarge,
@@ -162,6 +198,13 @@ const TYPE_ICONS: Record<GuardrailDetectionType, string> = {
   'content-safety-prompt-shield': '🛡️',
   'content-safety-indirect-injection': '🎯',
   'content-safety-unavailable': '⏱️',
+  'content-safety-block': '⚠️',
+  'agent-definition-structural': '⚙️',
+  'agent-definition-policy': '⚙️',
+  'agent-definition-jailbreak': '🚫',
+  'agent-definition-content-safety': '⚠️',
+  'agent-definition-privileged-grant': '🔒',
+  'agent-definition-content-safety-unavailable': '⏱️',
 };
 
 /** Plain-language labels used in the filter chip row. */
@@ -176,6 +219,13 @@ const TYPE_LABELS: Record<GuardrailDetectionType, string> = {
   'content-safety-prompt-shield': 'Prompt shield',
   'content-safety-indirect-injection': 'Indirect injection',
   'content-safety-unavailable': 'Unavailable',
+  'content-safety-block': 'Content Safety',
+  'agent-definition-structural': 'Definition structure',
+  'agent-definition-policy': 'Definition policy',
+  'agent-definition-jailbreak': 'Definition jailbreak',
+  'agent-definition-content-safety': 'Definition safety',
+  'agent-definition-privileged-grant': 'Privileged grant',
+  'agent-definition-content-safety-unavailable': 'Definition safety unavailable',
 };
 
 /** Bar-chart accents. Uses semantic Fluent tokens so they follow tenant theme. */
@@ -184,6 +234,155 @@ function familyStrokes() {
     pattern: tokens.colorBrandBackground,
     model: tokens.colorPaletteRedBackground3,
   };
+}
+
+type AuditStage = 'input' | 'output' | 'tool-result' | 'retrieved-knowledge' | 'agent-definition' | 'unknown';
+
+const STAGE_LABELS: Record<AuditStage, string> = {
+  input: 'Input',
+  output: 'Output',
+  'tool-result': 'Tool result',
+  'retrieved-knowledge': 'Retrieved knowledge',
+  'agent-definition': 'Agent definition',
+  unknown: 'Content',
+};
+
+function normaliseStage(entry: BlockedRequest): AuditStage {
+  const stage = entry.stage?.trim().toLowerCase();
+  if (stage === 'input') return 'input';
+  if (stage === 'output') return 'output';
+  if (stage === 'toolresult' || stage === 'tool-result' || stage === 'tool result') return 'tool-result';
+  if (stage === 'retrievedknowledge' || stage === 'retrieved-knowledge' || stage === 'retrieved knowledge') return 'retrieved-knowledge';
+  if (stage === 'agentdefinition' || stage === 'agent-definition' || stage === 'agent definition') return 'agent-definition';
+
+  if (entry.detectionType.startsWith('agent-definition-')) return 'agent-definition';
+  if (entry.requestPreview.startsWith('Tool result from ')) return 'tool-result';
+  if (entry.requestPreview.startsWith('Retrieved-knowledge chunk ')) return 'retrieved-knowledge';
+  if (entry.requestPreview.startsWith('PII redacted from output')) return 'output';
+  return 'input';
+}
+
+function thresholdFromConfig(category: string | undefined, contentSafety: ContentSafetyConfigData | null): number | undefined {
+  const normalised = normaliseCategoryName(category);
+  if (!normalised || !contentSafety) return undefined;
+  if (normalised === 'Hate') return contentSafety.hateThreshold;
+  if (normalised === 'Sexual') return contentSafety.sexualThreshold;
+  if (normalised === 'Violence') return contentSafety.violenceThreshold;
+  return contentSafety.selfHarmThreshold;
+}
+
+function parseAgentDefinitionPreview(preview: string): { agent?: string; field?: string } {
+  return {
+    agent: preview.match(/(?:^|\s)agent=([^\s]+)/)?.[1],
+    field: preview.match(/(?:^|\s)field=([^\s]+)/)?.[1],
+  };
+}
+
+function summarizeAuditEvent(entry: BlockedRequest, stage: AuditStage): string {
+  const agentDefinition = parseAgentDefinitionPreview(entry.requestPreview);
+  const action = entry.actionTaken.toLowerCase();
+
+  if (stage === 'agent-definition' && (agentDefinition.agent || agentDefinition.field)) {
+    const field = agentDefinition.field ?? 'a field';
+    const agent = agentDefinition.agent ? ` for ${agentDefinition.agent}` : '';
+    if (action === 'failopen-passed') {
+      return `Content Safety was unreachable while checking ${field}${agent}.`;
+    }
+    return `Agent definition ${field}${agent} triggered a guardrail.`;
+  }
+
+  const tool = entry.requestPreview.match(/^Tool result from '([^']+)' (blocked|flagged) by Content Safety$/i);
+  if (tool) {
+    return `Tool result from ${tool[1]} was ${tool[2].toLowerCase()} by Content Safety.`;
+  }
+
+  const retrieved = entry.requestPreview.match(/^Retrieved-knowledge chunk '([^']+)' (dropped|flagged) by Content Safety$/i);
+  if (retrieved) {
+    return `Retrieved knowledge ${retrieved[1]} was ${retrieved[2].toLowerCase()} by Content Safety.`;
+  }
+
+  if (entry.requestPreview.trim().length > 0) return entry.requestPreview;
+  return `${STAGE_LABELS[stage]} guardrail event`;
+}
+
+function describeSystemAction(entry: BlockedRequest, stage: AuditStage): string {
+  const action = entry.actionTaken.toLowerCase();
+  if (action === 'failopen-passed') return 'allowed it because fail-open policy is active';
+  if (action === 'failclosed-blocked') return 'blocked it because fail-closed policy is active';
+  if (action === 'dropped') return 'dropped the retrieved knowledge before it reached the model';
+  if (action === 'flagged') return 'allowed it and recorded a flag for review';
+  if (action === 'redacted') return 'redacted sensitive values before continuing';
+  if (action === 'quarantined') return 'quarantined the affected agent definition';
+  if (action === 'blocked') {
+    if (stage === 'output') return 'withheld the model output';
+    if (stage === 'tool-result') return 'withheld the tool result from the model';
+    if (stage === 'retrieved-knowledge') return 'withheld the retrieved knowledge';
+    if (stage === 'agent-definition') return 'blocked the affected agent definition';
+    return 'blocked the request';
+  }
+  return `recorded action ${entry.actionTaken}`;
+}
+
+function formatActionLabel(entry: BlockedRequest, stage: AuditStage): string {
+  const action = entry.actionTaken.toLowerCase();
+  if (action === 'failopen-passed') return 'Allowed through';
+  if (action === 'failclosed-blocked') return 'Fail-closed block';
+  if (action === 'flagged') return 'Flagged';
+  if (action === 'dropped') return 'Dropped';
+  if (action === 'redacted') return 'Redacted';
+  if (action === 'quarantined') return 'Quarantined';
+  if (action === 'blocked') {
+    if (stage === 'output') return 'Output withheld';
+    if (stage === 'tool-result') return 'Tool result withheld';
+    if (stage === 'retrieved-knowledge') return 'Knowledge withheld';
+    return 'Blocked';
+  }
+  return entry.actionTaken;
+}
+
+function explainAuditDecision(
+  entry: BlockedRequest,
+  stage: AuditStage,
+  contentSafety: ContentSafetyConfigData | null,
+): string {
+  const action = entry.actionTaken.toLowerCase();
+  if (action === 'failopen-passed') {
+    return 'The system allowed the request through because fail-open policy is active. Review Content Safety availability.';
+  }
+  if (entry.decision?.toLowerCase() === 'serviceunavailable'
+    || entry.detectionType.endsWith('content-safety-unavailable')) {
+    return `Content Safety was unreachable while checking ${STAGE_LABELS[stage].toLowerCase()}. The system ${describeSystemAction(entry, stage)}.`;
+  }
+
+  const categoryLabel = describeCategory(entry.category, entry.detectionType);
+  const severityLabel = describeSeverity(entry.severity);
+  const threshold = entry.threshold ?? thresholdFromConfig(entry.category, contentSafety);
+
+  let reason: string;
+  if (categoryLabel && entry.severity !== undefined && threshold !== undefined) {
+    const comparison = entry.severity >= threshold ? 'met' : 'did not meet';
+    reason = `${STAGE_LABELS[stage]} triggered ${categoryLabel} at ${severityLabel ?? 'recorded'} severity (${entry.severity}), which ${comparison} threshold ${threshold}.`;
+  } else if (categoryLabel && entry.severity !== undefined) {
+    reason = `${STAGE_LABELS[stage]} triggered ${categoryLabel} at ${severityLabel ?? 'recorded'} severity (${entry.severity}).`;
+  } else if (categoryLabel) {
+    reason = `${STAGE_LABELS[stage]} triggered ${categoryLabel}.`;
+  } else if (entry.reason) {
+    reason = entry.reason;
+  } else {
+    reason = `${STAGE_LABELS[stage]} triggered a configured guardrail.`;
+  }
+
+  return `${reason} The system ${describeSystemAction(entry, stage)}.`;
+}
+
+function buildBadgeText(entry: BlockedRequest): string {
+  const family = classifyBlockFamily(entry.detectionType);
+  const categoryLabel = describeCategory(entry.category, entry.detectionType)
+    ?? TYPE_LABELS[entry.detectionType]
+    ?? 'Guardrail';
+  const severityLabel = describeSeverity(entry.severity);
+  const familyLabel = family === 'model' ? 'Model' : family === 'pattern' ? 'Pattern' : 'Other';
+  return [familyLabel, categoryLabel, severityLabel].filter(Boolean).join(' · ');
 }
 
 export function GuardrailsDashboard() {
@@ -425,6 +624,7 @@ export function GuardrailsDashboard() {
           'content-safety-hate', 'content-safety-sexual', 'content-safety-violence',
           'content-safety-selfharm', 'content-safety-prompt-shield',
           'content-safety-indirect-injection', 'content-safety-unavailable',
+          'content-safety-block', 'agent-definition-content-safety-unavailable',
         ] as const).map(type => (
           <button
             key={type}
@@ -444,8 +644,11 @@ export function GuardrailsDashboard() {
         ) : (
           filteredRequests.map((req: BlockedRequest) => {
             const family = classifyBlockFamily(req.detectionType);
-            const categoryLabel = describeCategory(req.category, req.detectionType);
-            const severityLabel = describeSeverity(req.severity);
+            const stage = normaliseStage(req);
+            const summary = summarizeAuditEvent(req, stage);
+            const explanation = explainAuditDecision(req, stage, contentSafety);
+            const badgeText = buildBadgeText(req);
+            const actionLabel = formatActionLabel(req, stage);
             return (
               <div
                 key={req.id}
@@ -456,21 +659,26 @@ export function GuardrailsDashboard() {
                 <span className={styles.timestamp}>
                   {new Date(req.timestamp).toLocaleString()}
                 </span>
-                <span className={styles.preview} title={req.requestPreview}>
-                  {req.requestPreview}
+                <span className={styles.entrySummary}>
+                  <span className={styles.entryPrimary} title={summary}>
+                    {summary}
+                  </span>
+                  <span className={styles.entryDetail}>
+                    {explanation}
+                  </span>
                 </span>
                 <span
                   className={styles.typeBadge}
                   data-testid="log-entry-type"
                   data-safety-family={family}
+                  title={badgeText}
                 >
                   {TYPE_ICONS[req.detectionType] ?? '⚠️'}{' '}
-                  {family === 'model' ? 'Model' : family === 'pattern' ? 'Pattern' : 'Other'}
-                  {' · '}
-                  {categoryLabel ?? TYPE_LABELS[req.detectionType] ?? req.detectionType}
-                  {severityLabel ? ` · ${severityLabel}` : ''}
+                  <span className={styles.typeBadgeText}>{badgeText}</span>
                 </span>
-                <span className={styles.timestamp}>{req.actionTaken}</span>
+                <span className={styles.actionPill} title={`System action: ${describeSystemAction(req, stage)}`}>
+                  {actionLabel}
+                </span>
               </div>
             );
           })

--- a/src/RetailPulse.Web/src/services/guardrailsApi.ts
+++ b/src/RetailPulse.Web/src/services/guardrailsApi.ts
@@ -48,6 +48,8 @@ export async function fetchGuardrailsLog(count = 50): Promise<BlockedRequest[]> 
       category: typeof entry.category === 'string' ? entry.category : undefined,
       severity: typeof entry.severity === 'number' ? entry.severity : undefined,
       decision: typeof entry.decision === 'string' ? entry.decision : undefined,
+      stage: typeof entry.stage === 'string' ? entry.stage : undefined,
+      threshold: typeof entry.threshold === 'number' ? entry.threshold : undefined,
     }));
 }
 

--- a/src/RetailPulse.Web/src/types/index.ts
+++ b/src/RetailPulse.Web/src/types/index.ts
@@ -516,7 +516,14 @@ export type GuardrailDetectionType =
   | 'content-safety-selfharm'
   | 'content-safety-prompt-shield'
   | 'content-safety-indirect-injection'
-  | 'content-safety-unavailable';
+  | 'content-safety-unavailable'
+  | 'content-safety-block'
+  | 'agent-definition-structural'
+  | 'agent-definition-policy'
+  | 'agent-definition-jailbreak'
+  | 'agent-definition-content-safety'
+  | 'agent-definition-privileged-grant'
+  | 'agent-definition-content-safety-unavailable';
 
 export interface BlockedRequest {
   id: string;
@@ -542,6 +549,10 @@ export interface BlockedRequest {
    * the dashboard to split the pattern-family and model-family aggregates.
    */
   decision?: string;
+  /** Content Safety pipeline stage supplied by the API. */
+  stage?: string;
+  /** Category threshold in effect when the audit row was written. */
+  threshold?: number;
 }
 
 export interface GuardrailsStats {

--- a/src/RetailPulse.Web/src/utils/safetyDisplay.ts
+++ b/src/RetailPulse.Web/src/utils/safetyDisplay.ts
@@ -19,6 +19,7 @@ const PATTERN_DETECTION_TYPES: ReadonlySet<GuardrailDetectionType> = new Set([
   'jailbreak',
   'pii',
   'access',
+  'agent-definition-jailbreak',
 ]);
 
 const MODEL_DETECTION_TYPES: ReadonlySet<GuardrailDetectionType> = new Set([
@@ -29,6 +30,9 @@ const MODEL_DETECTION_TYPES: ReadonlySet<GuardrailDetectionType> = new Set([
   'content-safety-prompt-shield',
   'content-safety-indirect-injection',
   'content-safety-unavailable',
+  'content-safety-block',
+  'agent-definition-content-safety',
+  'agent-definition-content-safety-unavailable',
 ]);
 
 /** Detection types the frontend recognises. Unknown types render as a
@@ -72,6 +76,13 @@ const DETECTION_LABELS: Partial<Record<GuardrailDetectionType, string>> = {
   'content-safety-prompt-shield': 'Prompt-shield safety',
   'content-safety-indirect-injection': 'Indirect injection',
   'content-safety-unavailable': 'Safety service unavailable',
+  'content-safety-block': 'Content Safety',
+  'agent-definition-content-safety': 'Agent definition safety',
+  'agent-definition-content-safety-unavailable': 'Safety service unavailable',
+  'agent-definition-jailbreak': 'Prompt jailbreak',
+  'agent-definition-structural': 'Agent definition structure',
+  'agent-definition-policy': 'Agent definition policy',
+  'agent-definition-privileged-grant': 'Privileged tool grant',
   jailbreak: 'Prompt jailbreak',
   pii: 'Personal information',
   access: 'Restricted data',

--- a/tests/RetailPulse.Tests/Guardrails/AgentDefinition/AgentDefinitionValidatorAuditTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/AgentDefinition/AgentDefinitionValidatorAuditTests.cs
@@ -74,7 +74,10 @@ public class AgentDefinitionValidatorAuditTests
         rows.Should().OnlyContain(r =>
             r.DetectionType == AgentDefinitionDetectionTypes.ContentSafetyUnavailable
             && r.Action == AgentDefinitionDetectionTypes.ActionFailOpenPassed
-            && r.UserContext == AgentDefinitionDetectionTypes.StartupValidatorContext);
+            && r.UserContext == AgentDefinitionDetectionTypes.StartupValidatorContext
+            && r.Stage == ContentSafetyStage.AgentDefinition.ToString()
+            && r.Reason != null
+            && r.Reason.Contains("unreachable"));
         rows.Count.Should().BeGreaterThan(0,
             "every fail-open pass must be visible in the audit feed.");
     }

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyAuditFieldsTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyAuditFieldsTests.cs
@@ -41,6 +41,10 @@ public class ContentSafetyAuditFieldsTests
         row.Category.Should().Be("Hate");
         row.Severity.Should().Be(6);
         row.Decision.Should().Be(ContentSafetyDecision.Blocked.ToString());
+        row.Stage.Should().Be(ContentSafetyStage.Input.ToString());
+        row.Threshold.Should().Be(4);
+        row.Reason.Should().Contain("severity 6");
+        row.Reason.Should().Contain("threshold 4");
     }
 
     [Fact]
@@ -63,6 +67,9 @@ public class ContentSafetyAuditFieldsTests
         row.Category.Should().Be("Sexual");
         row.Severity.Should().Be(4);
         row.Decision.Should().Be(ContentSafetyDecision.Blocked.ToString());
+        row.Stage.Should().Be(ContentSafetyStage.Output.ToString());
+        row.Threshold.Should().Be(4);
+        row.Reason.Should().Contain("the output");
     }
 
     [Fact]
@@ -110,6 +117,9 @@ public class ContentSafetyAuditFieldsTests
         row.Severity.Should().Be(4);
         row.Decision.Should().Be(ContentSafetyDecision.Blocked.ToString());
         row.DetectionType.Should().Be(ContentSafetyDetectionTypes.IndirectInjection);
+        row.Stage.Should().Be(ContentSafetyStage.RetrievedKnowledge.ToString());
+        row.Threshold.Should().Be(4);
+        row.Reason.Should().Contain("retrieved knowledge");
     }
 
     [Fact]
@@ -145,6 +155,9 @@ public class ContentSafetyAuditFieldsTests
         row.Category.Should().Be("SelfHarm");
         row.Severity.Should().Be(6);
         row.Decision.Should().Be(ContentSafetyDecision.Blocked.ToString());
+        row.Stage.Should().Be(ContentSafetyStage.ToolResult.ToString());
+        row.Threshold.Should().Be(4);
+        row.Reason.Should().Contain("the tool result");
     }
 
     [Fact]
@@ -160,6 +173,9 @@ public class ContentSafetyAuditFieldsTests
         row.Decision.Should().Be(ContentSafetyDecision.ServiceUnavailable.ToString());
         row.Category.Should().BeNull();
         row.Severity.Should().BeNull();
+        row.Stage.Should().Be(ContentSafetyStage.Input.ToString());
+        row.Threshold.Should().BeNull();
+        row.Reason.Should().Contain("unreachable");
     }
 
     private static (GuardrailsMiddleware mw, InMemorySuspiciousRequestLog log) Middleware(IContentSafetyEvaluator evaluator)


### PR DESCRIPTION
Fixes #243

## What changed
- Layout: audit rows use a responsive grid with nonwrapping timestamps, a truncating category chip, and a separate action pill so rows stay aligned across normal widths.
- Row meaning: each row now states the checked stage, category, severity, threshold, and system action, including tool result and retrieved knowledge events.
- Fail-open: Content Safety unavailable rows now say the request was allowed through because fail-open policy is active and that operators should review service availability.

## API fields
The UI already mapped `reason`, `category`, `severity`, and `detectionType`, and the API exposed `action`, but `reason`, `stage`, and `threshold` were not populated and returned end to end. This PR adds those fields to the audit contract and populates them for input, output, RAG, tool result, and agent definition paths.