### PR TITLE
Count every audit row so the security header cannot read zero

### DIFF
--- a/src/RetailPulse.Api/Guardrails/InMemorySuspiciousRequestLog.cs
+++ b/src/RetailPulse.Api/Guardrails/InMemorySuspiciousRequestLog.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using RetailPulse.Api.Guardrails.AgentDefinition;
 using RetailPulse.Api.Guardrails.ContentSafety;
 using RetailPulse.Contracts.Guardrails;
 
@@ -17,6 +18,7 @@ public class InMemorySuspiciousRequestLog : ISuspiciousRequestLog
     private int _accessDenialCount;
     private int _contentSafetyBlocks;
     private int _contentSafetyFlags;
+    private int _otherCount;
     private readonly DateTime _since = DateTime.UtcNow;
 
     public InMemorySuspiciousRequestLog(int maxEntries = 100)
@@ -28,25 +30,31 @@ public class InMemorySuspiciousRequestLog : ISuspiciousRequestLog
     {
         _entries.Enqueue(request);
 
-        // Track stats by type
+        // Every audit row must land in exactly one counter. A row that matches
+        // nothing is invisible in the header cards while still being drawn in
+        // the family and severity charts, which the client derives from the log
+        // itself, so the same screen contradicts itself. That is how blocked
+        // injections and every agent-definition event came to read as zero.
         switch (request.DetectionType.ToLowerInvariant())
         {
-            // Injection shares the jailbreak toggle and the jailbreak counter.
-            // It previously matched no case and no Content Safety prefix, so a
-            // blocked injection incremented nothing and never reached
-            // TotalBlocked.
+            // Injection shares the jailbreak toggle, so it shares the counter.
             case PatternDetectionTypes.Jailbreak:
             case PatternDetectionTypes.Injection:
+            case AgentDefinitionDetectionTypes.Jailbreak:
                 Interlocked.Increment(ref _jailbreakCount);
                 break;
             case PatternDetectionTypes.Pii:
                 Interlocked.Increment(ref _piiCount);
                 break;
             case "access_denial":
+            // A definition asking for a tool it was never granted is an access
+            // denial in every sense the dashboard means by the word.
+            case AgentDefinitionDetectionTypes.PrivilegedGrant:
+            case AgentDefinitionDetectionTypes.Policy:
                 Interlocked.Increment(ref _accessDenialCount);
                 break;
             default:
-                if (ContentSafetyDetectionTypes.IsContentSafety(request.DetectionType))
+                if (IsModelBasedSafety(request.DetectionType))
                 {
                     // A "flagged" action is a non-blocking Content Safety hit that
                     // must still increment the audit feed; every other content-safety
@@ -62,6 +70,13 @@ public class InMemorySuspiciousRequestLog : ISuspiciousRequestLog
                         Interlocked.Increment(ref _contentSafetyBlocks);
                     }
                 }
+                else
+                {
+                    // Structural definition rejections and any future detection
+                    // type land here. Counting them keeps TotalBlocked honest
+                    // rather than silently discarding the row.
+                    Interlocked.Increment(ref _otherCount);
+                }
                 break;
         }
 
@@ -71,6 +86,18 @@ public class InMemorySuspiciousRequestLog : ISuspiciousRequestLog
 
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Whether a detection type belongs to the model-based safety family. This
+    /// must stay in step with <c>classifyBlockFamily</c> in the web client's
+    /// safetyDisplay module, which classifies the same rows for the dashboard
+    /// charts. When the two disagree, the header cards and the charts on the
+    /// same screen report different totals for the same audit feed.
+    /// </summary>
+    private static bool IsModelBasedSafety(string detectionType) =>
+        ContentSafetyDetectionTypes.IsContentSafety(detectionType)
+        || string.Equals(detectionType, AgentDefinitionDetectionTypes.ContentSafety, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(detectionType, AgentDefinitionDetectionTypes.ContentSafetyUnavailable, StringComparison.OrdinalIgnoreCase);
 
     public Task<IReadOnlyList<SuspiciousRequest>> GetRecentAsync(int count = 50, CancellationToken ct = default)
     {
@@ -83,7 +110,10 @@ public class InMemorySuspiciousRequestLog : ISuspiciousRequestLog
 
     public Task<GuardrailsStats> GetStatsAsync(CancellationToken ct = default)
     {
-        int total = _jailbreakCount + _piiCount + _accessDenialCount + _contentSafetyBlocks;
+        // Flags are excluded because a flag is explicitly a non-blocking hit.
+        // Everything else that was logged is counted, so TotalBlocked can never
+        // read lower than the number of blocking rows the audit feed is showing.
+        int total = _jailbreakCount + _piiCount + _accessDenialCount + _contentSafetyBlocks + _otherCount;
         return Task.FromResult(new GuardrailsStats(
             TotalBlocked: total,
             JailbreakAttempts: _jailbreakCount,

--- a/tests/RetailPulse.Tests/Guardrails/GuardrailAuditFieldsTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/GuardrailAuditFieldsTests.cs
@@ -222,6 +222,64 @@ public class GuardrailAuditFieldsTests
         stats.JailbreakAttempts.Should().Be(1);
     }
 
+    // The dashboard derives its family and severity charts from the audit feed
+    // on the client, while the header cards come from these counters. If any
+    // detection type falls through to no counter, the same screen shows rows in
+    // the charts and zero in the header. This pins every known type.
+    [Theory]
+    [InlineData("jailbreak")]
+    [InlineData("injection")]
+    [InlineData("pii")]
+    [InlineData("access_denial")]
+    [InlineData("content-safety-hate")]
+    [InlineData("content-safety-sexual")]
+    [InlineData("content-safety-violence")]
+    [InlineData("content-safety-selfharm")]
+    [InlineData("content-safety-prompt-shield")]
+    [InlineData("content-safety-indirect-injection")]
+    [InlineData("content-safety-unavailable")]
+    [InlineData("content-safety-block")]
+    [InlineData("agent-definition-structural")]
+    [InlineData("agent-definition-policy")]
+    [InlineData("agent-definition-jailbreak")]
+    [InlineData("agent-definition-content-safety")]
+    [InlineData("agent-definition-privileged-grant")]
+    [InlineData("agent-definition-content-safety-unavailable")]
+    public async Task EveryDetectionType_LandsInTotalBlocked(string detectionType)
+    {
+        var log = new InMemorySuspiciousRequestLog();
+
+        await log.LogAsync(new SuspiciousRequest(
+            Id: "1",
+            Timestamp: DateTime.UtcNow,
+            RequestText: "payload",
+            DetectionType: detectionType,
+            UserContext: "u",
+            Action: "blocked"));
+
+        GuardrailsStats stats = await log.GetStatsAsync();
+        stats.TotalBlocked.Should().Be(1, "detection type '{0}' must increment a counter", detectionType);
+    }
+
+    [Fact]
+    public async Task FlaggedContentSafety_CountsAsFlagNotBlock()
+    {
+        var log = new InMemorySuspiciousRequestLog();
+
+        await log.LogAsync(new SuspiciousRequest(
+            Id: "1",
+            Timestamp: DateTime.UtcNow,
+            RequestText: "payload",
+            DetectionType: ContentSafetyDetectionTypes.Hate,
+            UserContext: "u",
+            Action: ContentSafetyActions.Flagged));
+
+        GuardrailsStats stats = await log.GetStatsAsync();
+        stats.ContentSafetyFlags.Should().Be(1);
+        stats.ContentSafetyBlocks.Should().Be(0);
+        stats.TotalBlocked.Should().Be(0);
+    }
+
     private static (GuardrailsMiddleware mw, InMemorySuspiciousRequestLog log) PatternMiddleware(bool redactPii = false)
     {
         var log = new InMemorySuspiciousRequestLog();


### PR DESCRIPTION
Count every audit row so the security header cannot read zero

The Guardrails Security page showed TOTAL BLOCKED 0, MODEL-BASED BLOCKS 0,
and every other header card at 0 while the charts directly below it plotted
four model-family events and the audit feed listed them in full. The same
screen contradicted itself.

The header cards come from GetStatsAsync on the server. The charts are
derived on the client from the audit feed via classifyBlockFamily. The two
classify rows differently, so any detection type the server switch does not
name is drawn in the charts and counted nowhere.

InMemorySuspiciousRequestLog matched jailbreak, injection, pii, and
access_denial by name, then fell back to a content-safety- prefix test.
Every agent-definition-* type matches none of those, so all six of them
incremented nothing. Those are exactly the rows the live page was showing:
agent-definition-content-safety-unavailable from the startup validator.

This was the same defect class as the injection miscount fixed in #253. That
fix named one more case rather than closing the hole, so the next unnamed
type fell through just as silently.

Now every row lands in a counter:
- agent-definition-jailbreak counts with the pattern jailbreak family.
- agent-definition-policy and agent-definition-privileged-grant count as
  access denials, which is what a definition reaching for an ungranted tool
  is.
- agent-definition-content-safety and its unavailable variant count with the
  model-based safety family, matching what the client charts already do.
- Anything unrecognised, including future detection types, counts toward
  TotalBlocked instead of being discarded.

Flagged rows are still excluded from TotalBlocked because a flag is
explicitly a non-blocking hit, and that is now pinned by a test.

IsModelBasedSafety carries a comment tying it to classifyBlockFamily on the
client, since those two are the pair that must agree.

A theory test asserts all 18 known detection types reach TotalBlocked, so a
new type added without a counter fails rather than silently reading zero.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
