### PR TITLE
Run CI on dev and guard the dev-first branching model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,15 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
+
+# Without this, a push to dev and its promotion PR to main run the same suite twice,
+# and superseded runs keep burning minutes after a force-push.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   DOTNET_VERSION: '10.0.x'
@@ -13,9 +19,34 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
+  # Structural guard for the dev-first model. `main` is release-only, so the only
+  # legitimate sources for a PR into it are `dev` and an urgent `hotfix/*`.
+  # Without this, `gh pr create` silently defaults to the repo default branch and
+  # feature work lands on `main`, which is exactly how dev fell 51 commits behind.
+  branch-policy:
+    name: Branch policy (dev-first)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    steps:
+      - name: Reject non-promotion PRs into main
+        run: |
+          head='${{ github.head_ref }}'
+          echo "PR head branch: $head -> main"
+          case "$head" in
+            dev|hotfix/*)
+              echo "Allowed: '$head' is a promotion or hotfix branch."
+              exit 0
+              ;;
+          esac
+          echo "::error::PR into 'main' from '$head' is not allowed. Feature work targets 'dev'."
+          echo "Retarget with: gh pr edit ${{ github.event.pull_request.number }} --base dev"
+          exit 1
+
   build:
     name: Build & Test (.NET)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -126,6 +157,7 @@ jobs:
   frontend:
     name: Frontend (React/Vite)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: src/RetailPulse.Web
@@ -165,6 +197,7 @@ jobs:
   security:
     name: Security (Vulnerable Packages)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -196,6 +229,7 @@ jobs:
   provider-matrix:
     name: Auth Provider Matrix (Entra/GitHub/Anonymous)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -255,6 +289,7 @@ jobs:
   lint:
     name: Lint (dotnet format)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -272,6 +307,7 @@ jobs:
   bicep:
     name: Bicep (compile + lint)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -296,6 +332,7 @@ jobs:
   verify-script-selftest:
     name: Verify-ApimAiGateway offline self-test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -310,6 +347,7 @@ jobs:
   synthetic-monitor-selftest:
     name: Invoke-SyntheticChatMonitor offline self-test (#57)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,6 +5,40 @@ the repo. The [README](../README.md#quick-start) covers the runtime
 prerequisites (.NET 10 SDK, Node.js 20+, OpenAI credentials); this doc covers
 the developer ergonomics that keep pull requests healthy.
 
+## Branching model (dev-first)
+
+All feature work branches from `dev` and targets `dev`. `main` carries released
+code only, and the sole route into it is a promotion PR from `dev` (or an urgent
+`hotfix/*`).
+
+| Branch | Purpose | Accepts PRs from |
+| --- | --- | --- |
+| `main` | Released code | `dev`, `hotfix/*` |
+| `dev` | Integration branch, where all feature work lands | any `squad/*` branch |
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b squad/{issue-number}-{slug}
+# work, commit, push
+gh pr create --base dev --title "..." --body "Closes #{issue-number}"
+```
+
+Two mechanisms enforce this, because documentation alone did not:
+
+1. **CI runs on `dev`.** [`ci.yml`](../.github/workflows/ci.yml) triggers on both
+   `main` and `dev` for `push` and `pull_request`. Previously it ran on `main`
+   only, so a PR into `dev` got no signal at all and every branch was pushed to
+   `main` instead to obtain one. That single gap is how `dev` fell 51 commits
+   behind.
+2. **The `branch-policy` job fails PRs into `main`** whose head branch is not
+   `dev` or `hotfix/*`. `gh pr create` defaults to the repository default branch,
+   so without this guard the wrong base is one forgotten flag away.
+
+Every CI job also carries an explicit `timeout-minutes`. A `Build & Test (.NET)`
+run once hung for six hours before GitHub's own job cap cancelled it, which
+consumed the runner budget and produced no signal.
+
 ## Pre-commit and pre-push formatting hooks
 
 Retail Pulse ships two versioned Git hooks under


### PR DESCRIPTION
Closes #255

## Problem

`ci.yml` triggered on `main` only. A pull request into `dev` received no
CI signal whatsoever, so targeting `dev` meant shipping blind and every branch
was retargeted at `main` to obtain a build. `dev` fell 51 commits behind
`main` while carrying zero unique commits of its own.

Documentation could not have prevented this. The incentive pointed the other way.

## Changes

| Change | Why |
| --- | --- |
| `push` and `pull_request` now trigger on `dev` as well as `main` | Removes the reason to retarget at `main` |
| New `branch-policy` job | Fails a PR into `main` whose head is not `dev` or `hotfix/*`. `gh pr create` defaults to the repo default branch, so the wrong base is one forgotten flag away |
| `timeout-minutes` on all nine jobs | Run 33276314929 hung on `Build & Test (.NET)` for 6h0m24s until GitHub's own job cap cancelled it. The same tree passed in 4m14s on the PR run |
| `concurrency` group with `cancel-in-progress` | A push to `dev` and its promotion PR to `main` would otherwise run the same suite twice, and superseded runs kept burning minutes after a force-push |
| Branching model section in `docs/contributing.md` | The doc covered hooks and the lint gate but never stated which branch to target |

## Note on self-application

`pull_request` workflow selection resolves against the PR merge commit, so the
new triggers apply to this PR itself. This PR is its own first test: if CI
reports on it, the fix works.

`branch-policy` is gated on `github.base_ref == 'main'` and is correctly
skipped here.

## Validation

- `ci.yml` parses; nine jobs resolve: `branch-policy`, `build`, `frontend`, `security`, `provider-matrix`, `lint`, `bicep`, `verify-script-selftest`, `synthetic-monitor-selftest`.
- No source, test, or infrastructure file is touched. Workflow and docs only.