### PR TITLE
Add a typecheck script that actually type-checks

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -39,6 +39,28 @@ Every CI job also carries an explicit `timeout-minutes`. A `Build & Test (.NET)`
 run once hung for six hours before GitHub's own job cap cancelled it, which
 consumed the runner budget and produced no signal.
 
+## Type-checking the frontend
+
+Use `npm run typecheck` from `src/RetailPulse.Web`.
+
+Do **not** use `npx tsc --noEmit -p tsconfig.json`. It looks like a type-check
+gate, passes instantly, and checks nothing:
+
+```
+> npx tsc --noEmit -p tsconfig.json --listFiles
+(no output)
+exit: 0
+```
+
+`tsconfig.json` is a solution-style config: it declares `"files": []` and
+delegates to project references. `tsc -p` does not follow project references,
+so it resolves zero files and cannot fail. Only `tsc -b` honours them, which is
+what both `npm run typecheck` and `npm run build` use.
+
+CI was never exposed to this, because the `Frontend (React/Vite)` job runs
+`npm run build` (`tsc -b && vite build`). The gap was local: a "type-check
+passed" claim made with the `-p` form carries no information at all.
+
 ## Pre-commit and pre-push formatting hooks
 
 Retail Pulse ships two versioned Git hooks under

--- a/src/RetailPulse.Web/package.json
+++ b/src/RetailPulse.Web/package.json
@@ -12,6 +12,7 @@
     "test:provider-matrix:gate": "node scripts/provider-build-matrix.mjs --gate-only",
     "prebuild": "node scripts/validate-auth-config.mjs",
     "build": "tsc -b && vite build",
+    "typecheck": "tsc -b --noEmit",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",


### PR DESCRIPTION
Closes #258

## The problem

`npx tsc --noEmit -p tsconfig.json` checks **zero files** and can never fail.

```
> npx tsc --noEmit -p tsconfig.json --listFiles
(no output)
exit: 0
```

`tsconfig.json` is a solution-style config: `""files"": []` plus project
references. `tsc -p` does not follow project references, so it resolves an
empty file set. The command looks like a type-check gate, passes instantly, and
carries no information whatsoever.

CI was never exposed to this. The `Frontend (React/Vite)` job runs
`npm run build`, which is `tsc -b && vite build`, and `-b` does honour the
references. The gap was purely local, which is worse in one respect: it is the
form a human or an agent reaches for when validating a change before pushing.

## Changes

- `npm run typecheck` in `src/RetailPulse.Web/package.json`, running
  `tsc -b --noEmit`. One obvious correct command, and it is the short one.
- A section in `docs/contributing.md` stating plainly that the `-p` form is
  a silent no-op, alongside the existing hook and lint-gate notes.

## Validation

I did not take `exit 0` as evidence of anything, given that is the whole bug.
On the pinned TypeScript 6.0.3:

| Tree state | `tsc -b --noEmit` |
| --- | --- |
| Deliberate `const probe: number = ""not a number""` added | `error TS2322`, **exit 2** |
| Probe file removed | **exit 0** |

So the new command both detects and clears. The probe file was deleted and the
working tree is clean.

`package-lock.json` is untouched: a `scripts` entry does not affect the
dependency tree, so the `npm ci` lockfile-integrity gate is unaffected.