### PR TITLE
Promote dev to main: #244 root cause established by measurement

### DIFF
--- a/docs/adr/015-tool-result-content-safety-policy.md
+++ b/docs/adr/015-tool-result-content-safety-policy.md
@@ -62,8 +62,10 @@ Concretely:
    `ToolResultTextNormalizer` walks the payload and emits one readable
    `Label: value` line per scalar.
 
-The third point is the substantive fix for #244, and it is deliberately a
-**presentation** change rather than a **coverage** change:
+The third point was intended as the substantive fix for #244. Measurement later
+showed it is not (see *Measured against the live service* below), but it stands
+on its own merits as a deliberate **presentation** change rather than a
+**coverage** change:
 
 * Every scalar is preserved, including numbers and identifiers.
 * Every property name is preserved, because an attacker-controlled key is
@@ -93,16 +95,39 @@ evaluation including segmented moderation calls. On a timeout the stage returns
 exactly as before. Operators running large tool payloads with a tight timeout
 should review `content-safety-unavailable` rows after enabling this.
 
-**What is not proven.** We cannot measure a false-positive rate without a live
-Content Safety resource, and neither could PR #247. What is proven by test is
-that coverage is unchanged, that the scanned text is prose rather than JSON,
-and that Prompt Shields runs. Whether the observed `GetStorePerformance` block
-disappears is a live-deployment observation, not a unit-test result, and #244
-should be verified against the deployed Security dashboard.
+**Measured against the live service.** The hedge above has since been resolved
+by measurement rather than deployment observation. Running the payloads directly
+against the project's own Azure Content Safety resource
+(`text:analyze`, `FourSeverityLevels`) gives:
 
-**The *Shopping Center* rename stays.** Reverting it would be a second
-unmeasured guess in the opposite direction. It costs nothing to keep, and
-*Shopping Center* is an ordinary retail term.
+| Text submitted | Sexual |
+| --- | --- |
+| Raw JSON containing `Strip Center #11` | 4 |
+| Prose rendering containing `Strip Center #11` | 4 |
+| Raw JSON containing `Shopping Center #11` | 0 |
+| Prose rendering containing `Shopping Center #11` | 0 |
+| The bare phrase `Strip Center` | 0 |
+| `Store Format: Strip Center` | 2 |
+| `Strip Center` in an explicit real-estate sentence | 0 |
+| `Strip Mall #11`, `Power Center #11` | 0 |
+
+This disproves the raw-JSON theory. The classifier is responding to the phrase
+in the generated store-name context, not to the JSON framing, and prose
+rendering does not change the score. It also shows the trigger is contextual and
+fragile: the same phrase alone scores 0, while adding a brand prefix and a store
+number takes it to 4. No framing we control reliably clears it.
+
+Therefore **the *Shopping Center* rename is the fix for #244, not a workaround.**
+Keeping harmful vocabulary out of generated demo data is the only remedy
+available to us that does not weaken the control, since the alternatives are
+raising the tool-result threshold or allow-listing a term, both of which trade
+real safety coverage for a cosmetic win. `SeedVocabulary_AvoidsTheTermTheLive
+ClassifierScoresAsSexualSeverityFour` pins the seed so the term cannot be
+reintroduced on the mistaken belief that normalization covers it.
+
+Normalization is retained regardless. It is sound hygiene, it demonstrably does
+not reduce coverage, and it removes JSON punctuation noise from the scanned
+text. It is simply not what fixed #244.
 
 ## Alternatives rejected
 

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyToolResultScanPolicyTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyToolResultScanPolicyTests.cs
@@ -200,6 +200,97 @@ public class ContentSafetyToolResultScanPolicyTests
         text.Should().Contain("Intimate Apparel", "no term is skipped, the payload is only presented as prose");
     }
 
+    /// <summary>
+    /// #244 root cause, established against the live Azure Content Safety
+    /// service rather than assumed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The original theory was that raw JSON put the conversational classifier
+    /// out of distribution, so rendering tool results as prose would clear the
+    /// false positive. Measured against the live service, that theory is wrong.
+    /// The generated store-name pattern scores Sexual severity 4 in both
+    /// framings, and no amount of surrounding context reliably clears it:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>raw JSON containing "Strip Center #11": Sexual 4</description></item>
+    /// <item><description>prose containing "Strip Center #11": Sexual 4</description></item>
+    /// <item><description>the bare phrase "Strip Center" on its own: Sexual 0</description></item>
+    /// <item><description>"Store Name: Apex Retail Group Shopping Center #11": Sexual 0</description></item>
+    /// </list>
+    /// <para>
+    /// So the trigger is the phrase in the generated store-name context, and the
+    /// only robust remedy is to keep that vocabulary out of the seed data. The
+    /// rename is the fix, not a workaround. This test pins the seed so the term
+    /// cannot be reintroduced on the mistaken belief that normalization covers it.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void SeedVocabulary_AvoidsTheTermTheLiveClassifierScoresAsSexualSeverityFour()
+    {
+        string scenario = Path.Combine(FindRepoRoot(), "packs", "default", "seed", "scenario.yaml");
+
+        File.Exists(scenario).Should().BeTrue($"the default pack seed should exist at {scenario}");
+
+        string text = File.ReadAllText(scenario);
+        text.Should().NotContain(
+            "Strip Center",
+            "the live classifier scores the generated store-name pattern as Sexual severity 4, "
+            + "and prose normalization does not change that, so the term stays out of the seed");
+        text.Should().Contain("Shopping Center", "the safe replacement vocabulary must remain in place");
+    }
+
+    /// <summary>
+    /// #244, point 5: a representative GetStorePerformance payload reaches the
+    /// classifier as prose with every value intact. Normalization is not the
+    /// fix for #244, but it is still the shape the scanner sees, so the coverage
+    /// guarantee is worth pinning here.
+    /// </summary>
+    [Fact]
+    public async Task StorePerformancePayload_ReachesTheClassifierAsProseWithEveryValueIntact()
+    {
+        var fake = new FakeContentSafetyEvaluator();
+        ContentSafetyToolResultInspector inspector = BuildInspector(fake, new InMemorySuspiciousRequestLog());
+
+        const string payload = /*lang=json,strict*/ """
+            {"stores":[{"storeName":"Apex Retail Group Shopping Center #11","region":"Southwest","revenue":1835988.67,"target":1997181.15,"performanceIndex":0.919,"issues":"Below target"}],"count":1}
+            """;
+
+        ContentSafetyToolResultOutcome outcome = await inspector.InspectAsync(
+            "GetStorePerformance",
+            payload,
+            "user-244",
+            CancellationToken.None);
+
+        (string text, ContentSafetyStage stage, ContentSafetyEvaluationContext _) =
+            fake.Calls.Should().ContainSingle().Subject;
+
+        stage.Should().Be(ContentSafetyStage.ToolResult);
+        text.Should().NotContain("{", "the scanner sees prose, not raw JSON");
+        text.Should().Contain("Store Name: Apex Retail Group Shopping Center #11");
+        text.Should().Contain("Region: Southwest");
+        text.Should().Contain("1835988.67", "normalization is presentation only and must not drop values");
+        outcome.WasBlocked.Should().BeFalse();
+        outcome.Payload.Should().Be(payload, "the model receives the original payload, never the prose rendering");
+    }
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "RetailPulse.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate repo root (RetailPulse.slnx) walking up from " + AppContext.BaseDirectory);
+    }
+
     private static ContentSafetyToolResultInspector BuildInspector(
         FakeContentSafetyEvaluator evaluator,
         ISuspiciousRequestLog log) =>


### PR DESCRIPTION
Promotes the merged work on dev to main.

Contains PR #262, which establishes the real root cause of #244 by measuring against the live Content Safety resource, corrects ADR-015, pins the seed vocabulary, and adds the representative payload coverage test the issue asked for.

CI was green on the dev-targeted PR across all jobs.