### PR TITLE
Fix security counter semantics: do not count fail-open passes as blocks

### DIFF
--- a/src/RetailPulse.Api/Endpoints/GuardrailEndpoints.cs
+++ b/src/RetailPulse.Api/Endpoints/GuardrailEndpoints.cs
@@ -42,6 +42,7 @@ public static class GuardrailEndpoints
                 accessDenials = stats.AccessDenials,
                 contentSafetyBlocks = stats.ContentSafetyBlocks,
                 contentSafetyFlags = stats.ContentSafetyFlags,
+                failOpenPasses = stats.FailOpenPasses,
                 since = stats.Since
             });
         })

--- a/src/RetailPulse.Api/Guardrails/InMemorySuspiciousRequestLog.cs
+++ b/src/RetailPulse.Api/Guardrails/InMemorySuspiciousRequestLog.cs
@@ -18,6 +18,7 @@ public class InMemorySuspiciousRequestLog : ISuspiciousRequestLog
     private int _accessDenialCount;
     private int _contentSafetyBlocks;
     private int _contentSafetyFlags;
+    private int _failOpenPasses;
     private int _otherCount;
     private readonly DateTime _since = DateTime.UtcNow;
 
@@ -56,14 +57,22 @@ public class InMemorySuspiciousRequestLog : ISuspiciousRequestLog
             default:
                 if (IsModelBasedSafety(request.DetectionType))
                 {
-                    // A "flagged" action is a non-blocking Content Safety hit that
-                    // must still increment the audit feed; every other content-safety
-                    // action (block, dropped chunk, fail-open pass, fail-closed block)
-                    // counts against the block counter so the dashboard reflects the
-                    // safety-critical decisions.
+                    // A model-based safety row carries an Action that says what the
+                    // system actually DID, and the counter must match that verb:
+                    //  - Flagged: a non-blocking hit. Informational only.
+                    //  - FailOpenPassed: the request was ALLOWED THROUGH because the
+                    //    safety service was unreachable. This is the opposite of a
+                    //    block; counting it as one inflated TotalBlocked and hid the
+                    //    outage. It gets its own fail-open counter instead.
+                    //  - everything else (block, dropped chunk, fail-closed block):
+                    //    the request was stopped, so it counts against blocks.
                     if (string.Equals(request.Action, ContentSafetyActions.Flagged, StringComparison.OrdinalIgnoreCase))
                     {
                         Interlocked.Increment(ref _contentSafetyFlags);
+                    }
+                    else if (string.Equals(request.Action, ContentSafetyActions.FailOpenPassed, StringComparison.OrdinalIgnoreCase))
+                    {
+                        Interlocked.Increment(ref _failOpenPasses);
                     }
                     else
                     {
@@ -110,9 +119,11 @@ public class InMemorySuspiciousRequestLog : ISuspiciousRequestLog
 
     public Task<GuardrailsStats> GetStatsAsync(CancellationToken ct = default)
     {
-        // Flags are excluded because a flag is explicitly a non-blocking hit.
-        // Everything else that was logged is counted, so TotalBlocked can never
-        // read lower than the number of blocking rows the audit feed is showing.
+        // Flags are excluded because a flag is explicitly a non-blocking hit,
+        // and fail-open passes are excluded because they were ALLOWED THROUGH,
+        // not blocked. Everything else that stopped a request is counted, so
+        // TotalBlocked can never read lower than the number of blocking rows the
+        // audit feed is showing, nor higher by counting passes it let through.
         int total = _jailbreakCount + _piiCount + _accessDenialCount + _contentSafetyBlocks + _otherCount;
         return Task.FromResult(new GuardrailsStats(
             TotalBlocked: total,
@@ -121,6 +132,7 @@ public class InMemorySuspiciousRequestLog : ISuspiciousRequestLog
             AccessDenials: _accessDenialCount,
             Since: _since,
             ContentSafetyBlocks: _contentSafetyBlocks,
-            ContentSafetyFlags: _contentSafetyFlags));
+            ContentSafetyFlags: _contentSafetyFlags,
+            FailOpenPasses: _failOpenPasses));
     }
 }

--- a/src/RetailPulse.Contracts/Guardrails/ISuspiciousRequestLog.cs
+++ b/src/RetailPulse.Contracts/Guardrails/ISuspiciousRequestLog.cs
@@ -60,4 +60,10 @@ public record GuardrailsStats(
     int AccessDenials,
     DateTime Since,
     int ContentSafetyBlocks = 0,
-    int ContentSafetyFlags = 0);
+    int ContentSafetyFlags = 0,
+    // A fail-open pass is a request the system ALLOWED THROUGH because Content
+    // Safety was unreachable. It is the opposite of a block, so it must never
+    // fold into TotalBlocked. Surfaced as its own figure so an operator can see
+    // the system degraded to fail-open rather than having a silent outage hide
+    // inside an inflated block count.
+    int FailOpenPasses = 0);

--- a/src/RetailPulse.Web/src/__tests__/GuardrailsDashboard.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/GuardrailsDashboard.test.tsx
@@ -29,6 +29,7 @@ const mockStats: GuardrailsStats = {
   accessDenials: 7,
   contentSafetyBlocks: 3,
   contentSafetyFlags: 1,
+  failOpenPasses: 9,
   recentBlocked: [
     { id: '1', timestamp: '2026-05-13T14:00:00Z', requestPreview: 'Ignore all previous instructions...', detectionType: 'jailbreak', reason: 'Jailbreak pattern', actionTaken: 'Blocked' },
     { id: '2', timestamp: '2026-05-13T13:30:00Z', requestPreview: 'My SSN is 123-45-6789', detectionType: 'pii', reason: 'PII detected', actionTaken: 'Redacted' },
@@ -206,7 +207,21 @@ describe('GuardrailsDashboard', () => {
     const patternCard = await screen.findByTestId('stat-pattern-total');
     expect(patternCard).toHaveTextContent('42'); // 15+20+7
     const modelCard = screen.getByTestId('stat-model-total');
-    expect(modelCard).toHaveTextContent('4'); // 3+1
+    // Model-based Blocks now counts blocks ONLY. It previously read
+    // contentSafetyBlocks + contentSafetyFlags (3+1=4), which double-counted
+    // the informational flag and broke reconciliation with Total Blocked, since
+    // a flagged row is a non-blocking hit. Blocks only = 3.
+    expect(modelCard).toHaveTextContent('3');
+  });
+
+  it('renders fail-open passes as a distinct counter separate from blocks', async () => {
+    installFetchMock();
+    renderWithTheme(<GuardrailsDashboard />);
+    const failOpenCard = await screen.findByTestId('stat-failopen-total');
+    // A request allowed through on service failure is the opposite of a block,
+    // so it surfaces on its own card and never inflates Total Blocked.
+    expect(failOpenCard).toHaveTextContent('9');
+    expect(failOpenCard).toHaveTextContent('Fail-open Passes');
   });
 
   it('renders the category and severity distribution sections', async () => {

--- a/src/RetailPulse.Web/src/components/guardrails/GuardrailsDashboard.tsx
+++ b/src/RetailPulse.Web/src/components/guardrails/GuardrailsDashboard.tsx
@@ -474,7 +474,7 @@ export function GuardrailsDashboard() {
         </Card>
         <Card className={styles.statCard} appearance="subtle" data-testid="stat-model-total">
           <span className={styles.statValue}>
-            {(stats.contentSafetyBlocks ?? 0) + (stats.contentSafetyFlags ?? 0)}
+            {stats.contentSafetyBlocks ?? 0}
           </span>
           <span className={styles.statLabel}>Model-based Blocks</span>
         </Card>
@@ -497,6 +497,10 @@ export function GuardrailsDashboard() {
         <Card className={styles.statCard} appearance="subtle">
           <span className={styles.statValue}>{stats.contentSafetyFlags ?? 0}</span>
           <span className={styles.statLabel}>Content Safety Flags</span>
+        </Card>
+        <Card className={styles.statCard} appearance="subtle" data-testid="stat-failopen-total">
+          <span className={styles.statValue}>{stats.failOpenPasses ?? 0}</span>
+          <span className={styles.statLabel}>Fail-open Passes</span>
         </Card>
       </div>
 

--- a/src/RetailPulse.Web/src/services/guardrailsApi.ts
+++ b/src/RetailPulse.Web/src/services/guardrailsApi.ts
@@ -19,6 +19,7 @@ export async function fetchGuardrailsStats(): Promise<GuardrailsStats> {
   const data = await res.json();
   return {
     ...data,
+    failOpenPasses: data.failOpenPasses ?? 0,
     recentBlocked: data.recentBlocked ?? [],
     blocksPerHour: data.blocksPerHour ?? [],
   };

--- a/src/RetailPulse.Web/src/types/index.ts
+++ b/src/RetailPulse.Web/src/types/index.ts
@@ -570,6 +570,12 @@ export interface GuardrailsStats {
   accessDenials: number;
   contentSafetyBlocks: number;
   contentSafetyFlags: number;
+  /**
+   * Requests ALLOWED THROUGH because Content Safety was unreachable and the
+   * deployment fails open. Reported on its own so a degraded safety service is
+   * visible to operators and is never folded into a block count.
+   */
+  failOpenPasses: number;
   recentBlocked: BlockedRequest[];
   blocksPerHour: Array<{ hour: string; count: number }>;
 }

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyStatsCountersTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyStatsCountersTests.cs
@@ -40,16 +40,44 @@ public class ContentSafetyStatsCountersTests
     }
 
     [Fact]
-    public async Task FailOpen_IsCountedAsBlock_ForOperatorVisibility()
+    public async Task FailOpen_DoesNotCountAsBlock_AndIncrementsFailOpenCounter()
     {
         var log = new InMemorySuspiciousRequestLog();
         await LogAsync(log, ContentSafetyDetectionTypes.Unavailable, ContentSafetyActions.FailOpenPassed);
 
         GuardrailsStats stats = await log.GetStatsAsync();
-        // Fail-open still lands in the block counter so a persistent outage is
-        // visible on the dashboard even though the request itself continued.
-        stats.ContentSafetyBlocks.Should().Be(1);
+        // A fail-open pass ALLOWED the request through; it is the opposite of a
+        // block. It must not touch any block counter and must surface on its own
+        // FailOpenPasses figure so a degraded safety service is visible.
+        stats.FailOpenPasses.Should().Be(1);
+        stats.ContentSafetyBlocks.Should().Be(0);
         stats.ContentSafetyFlags.Should().Be(0);
+        stats.TotalBlocked.Should().Be(0, "a request allowed through on service failure was not blocked");
+    }
+
+    [Fact]
+    public async Task LiveScenario_FourFailOpenPassesPlusOneBlock_ReconcilesCounters()
+    {
+        // Reproduces the exact five audit rows measured on the deployed app: one
+        // genuine prompt-shield block and four cold-start fail-open passes.
+        var log = new InMemorySuspiciousRequestLog();
+        await LogAsync(log, ContentSafetyDetectionTypes.IndirectInjection, ContentSafetyActions.Blocked);
+        for (int i = 0; i < 4; i++)
+        {
+            await LogAsync(log, ContentSafetyDetectionTypes.Unavailable, ContentSafetyActions.FailOpenPassed);
+        }
+
+        GuardrailsStats stats = await log.GetStatsAsync();
+        stats.TotalBlocked.Should().Be(1, "only one of the five rows was actually blocked");
+        stats.ContentSafetyBlocks.Should().Be(1);
+        stats.FailOpenPasses.Should().Be(4, "the four cold-start rows were allowed through, not blocked");
+        stats.ContentSafetyFlags.Should().Be(0);
+        stats.JailbreakAttempts.Should().Be(0);
+
+        // Pattern-based blocks plus model-based blocks must reconcile with the
+        // total (structural "other" rejections are zero in this scenario).
+        int patternBlocks = stats.JailbreakAttempts + stats.PiiDetections + stats.AccessDenials;
+        (patternBlocks + stats.ContentSafetyBlocks).Should().Be(stats.TotalBlocked);
     }
 
     private static Task LogAsync(InMemorySuspiciousRequestLog log, string detection, string action) =>


### PR DESCRIPTION
## ProblemOn the deployed Security dashboard the counters read `TOTAL BLOCKED 5` and `CONTENT SAFETY BLOCKS 5`, but the audit trail held only ONE genuine block. The other four rows were cold-start fail-open passes (`content-safety-unavailable`, action `failopen-passed`) that the system explicitly ALLOWED THROUGH.Root cause: in `InMemorySuspiciousRequestLog.LogAsync`, any model-based-safety row whose action was not `flagged` incremented `_contentSafetyBlocks`. The `failopen-passed` action fell into that else branch, so a request the system let through was counted as blocked. `TotalBlocked` included `_contentSafetyBlocks`, so it inflated too. `CONTENT SAFETY BLOCKS` had the identical defect and the same root cause.## Fix- New `FailOpenPasses` counter. The `failopen-passed` action now increments it and is excluded from every block counter and from `TotalBlocked`.- `GuardrailsStats` contract and the `/api/guardrails/stats` endpoint expose `failOpenPasses`; TypeScript `GuardrailsStats` updated to match.- New `Fail-open Passes` stat card (reuses existing card markup and classes).- `Model-based Blocks` card now counts blocks only. It previously read `contentSafetyBlocks + contentSafetyFlags`, which double-counted the non-blocking flag and broke reconciliation.- Fail-open audit rows are unchanged and still visible; only the counters changed.## Corrected reading for the exact five audit rowsFour fail-open passes (`9:43:18` to `9:43:33`) plus one genuine prompt-shield block (`11:46:05`):| Counter | Before | After | Why || --- | --- | --- | --- || TOTAL BLOCKED | 5 | **1** | Only the prompt-shield row was blocked; the four fail-open rows were allowed through || PATTERN-BASED BLOCKS | 0 | **0** | No jailbreak/PII/access pattern block occurred || MODEL-BASED BLOCKS | 5 | **1** | Blocks only (1 content-safety block, 0 flags) || JAILBREAK ATTEMPTS | 0 | **0** | The block was classified as indirect-injection, not the jailbreak family || PII DETECTIONS | 0 | **0** | None || ACCESS DENIALS | 0 | **0** | None || CONTENT SAFETY BLOCKS | 5 | **1** | Same defect fixed; fail-open passes removed || CONTENT SAFETY FLAGS | 0 | **0** | No flagged rows || FAIL-OPEN PASSES (new) | n/a | **4** | The four cold-start rows the system allowed on service failure |Reconciliation: PATTERN-BASED (0) + MODEL-BASED BLOCKS (1) = TOTAL BLOCKED (1). Verified by `LiveScenario_FourFailOpenPassesPlusOneBlock_ReconcilesCounters`. Structural "other" rejections are zero in this scenario.## Updated test (buggy expectation corrected)`ContentSafetyStatsCountersTests.FailOpen_IsCountedAsBlock_ForOperatorVisibility` asserted the buggy behaviour ("Fail-open still lands in the block counter"). That expectation was wrong: a request allowed through on service failure is the opposite of a block, and counting it as one is exactly the reported defect. Replaced with `FailOpen_DoesNotCountAsBlock_AndIncrementsFailOpenCounter` (fail-open increments the new counter, touches no block counter, keeps `TotalBlocked` at 0) and the live-scenario reconciliation test. Operator visibility is preserved by the dedicated `Fail-open Passes` counter and card rather than by corrupting the block count.The frontend `renders the pattern-vs-model split cards` expectation moved from `4` (blocks+flags) to `3` (blocks only) for the same reason.## Verification- Backend: `dotnet test ... --filter "FullyQualifiedName~ContentSafetyStatsCounters|SuspiciousLog|GuardrailAuditFields"` -> 44 passed.- Frontend: `npm test -- --run` -> 911 passed.- `dotnet format --verify-no-changes` on changed files -> clean.

## Follow-up: client-side charts reconciled with the corrected cards
The header cards above were corrected server-side, but three dashboard charts still classified rows purely by `detectionType` on the client, so they contradicted the cards on the same screen for the same five-row feed:

- "Blocks by family" Model bar read **5** (a fail-open row's `*-content-safety-unavailable` type is model-family) while the Model-based Blocks card read 1.
- "Model-based blocks by severity" drew **4** phantom low-severity blocks (a fail-open row has null severity, which bucketed as `low`).
- "Model-based blocks by category" was unaffected (fail-open rows carry no category) but is now guarded too.

Fix: added a shared `isFailOpenPass(entry)` predicate in `safetyDisplay.ts` and had `aggregateByFamily`, `aggregateByCategory` and `aggregateBySeverity` skip fail-open rows. The predicate keys off the precise `actionTaken` string `failopen-passed`, NOT the `decision` field: a fail-CLOSED block also carries decision `ServiceUnavailable` (action `failclosed-blocked`) and must still count as a block, so keying off the decision would silently drop real blocks. `classifyBlockFamily` is unchanged: a fail-open row genuinely IS the model family, it just is not a block.

For operator visibility the family chart gains a distinct "Fail-open" bar (value **4** for this feed) so a degraded safety service stays on the charts instead of vanishing. For the live five-row feed the charts now read: family Model = 1, severity buckets sum to 1, Fail-open = 4, matching the header cards exactly.

New tests in `safetyDisplay.test.ts`: the live scenario (1 block + 4 fail-open -> family model = 1, severity sum = 1, failOpen = 4) and a fail-CLOSED-on-unavailable case proving the predicate does not over-exclude a genuine block.

## Verification (updated)
- Backend: `dotnet test tests\RetailPulse.Tests\RetailPulse.Tests.csproj --configuration Release --filter "FullyQualifiedName~ContentSafetyStatsCountersTests" --logger "console;verbosity=minimal"` -> 4 passed.
- Frontend: `cd src\RetailPulse.Web; npm test -- --run` -> 916 passed (98 files), including 5 new fail-open aggregation tests.