### PR TITLE
Fix Security page text overflow at narrow widths

### DIFF
--- a/src/RetailPulse.Web/src/components/guardrails/BlockedRequestMessage.tsx
+++ b/src/RetailPulse.Web/src/components/guardrails/BlockedRequestMessage.tsx
@@ -46,10 +46,14 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     gap: '6px',
+    // Sit next to a flex-shrink:0 icon, so claim a shrinkable track that lets
+    // long reason sentences wrap instead of widening the alert.
+    minWidth: 0,
   },
   reason: {
     color: tokens.colorNeutralForeground1,
     fontWeight: 500,
+    overflowWrap: 'anywhere',
   },
   metaRow: {
     display: 'flex',

--- a/src/RetailPulse.Web/src/components/guardrails/GuardrailsDashboard.tsx
+++ b/src/RetailPulse.Web/src/components/guardrails/GuardrailsDashboard.tsx
@@ -43,18 +43,25 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     gap: '4px',
+    // Let the card shrink inside its grid track so long labels wrap within
+    // the card instead of forcing the track wider than its column.
+    minWidth: 0,
   },
   statValue: {
     fontSize: '28px',
     fontWeight: '700',
     fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
     color: tokens.colorNeutralForeground1,
+    overflowWrap: 'anywhere',
   },
   statLabel: {
     fontSize: '12px',
     color: tokens.colorNeutralForeground3,
     textTransform: 'uppercase',
     letterSpacing: '0.5px',
+    // Long labels (e.g. "Content Safety Blocks") wrap under the value rather
+    // than clip; anywhere handles an unbroken token defensively.
+    overflowWrap: 'anywhere',
   },
   filterRow: {
     display: 'flex',
@@ -94,7 +101,7 @@ const useStyles = makeStyles({
   },
   entry: {
     display: 'grid',
-    gridTemplateColumns: 'max-content minmax(220px, 1fr) minmax(220px, 320px) max-content',
+    gridTemplateColumns: 'max-content minmax(0, 1fr) minmax(0, 320px) max-content',
     gap: '12px',
     alignItems: 'center',
     padding: '10px 14px',
@@ -121,14 +128,19 @@ const useStyles = makeStyles({
   },
   entryPrimary: {
     color: tokens.colorNeutralForeground1,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
+    // The prompt echoed here is the evidence, so it must stay fully legible:
+    // wrap it (breaking unbroken tokens such as KeywordFastPaths[7]) instead
+    // of clipping it to one line with an ellipsis.
+    minWidth: 0,
+    overflowWrap: 'anywhere',
+    wordBreak: 'break-word',
   },
   entryDetail: {
     color: tokens.colorNeutralForeground2,
     fontSize: '12px',
     lineHeight: '1.4',
+    overflowWrap: 'anywhere',
+    wordBreak: 'break-word',
   },
   typeBadge: {
     display: 'inline-flex',
@@ -142,9 +154,9 @@ const useStyles = makeStyles({
     fontSize: '11px',
     fontWeight: '600',
     textTransform: 'uppercase',
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
+    // Wrap the badge text rather than truncate it so the category label stays
+    // readable in the badge's own grid column.
+    overflowWrap: 'anywhere',
     backgroundColor: tokens.colorNeutralBackground3,
     color: tokens.colorNeutralForeground2,
     border: `1px solid ${tokens.colorNeutralStroke2}`,
@@ -153,9 +165,8 @@ const useStyles = makeStyles({
     },
   },
   typeBadgeText: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
+    minWidth: 0,
+    overflowWrap: 'anywhere',
   },
   actionPill: {
     justifySelf: 'end',

--- a/src/RetailPulse.Web/src/components/guardrails/KnowledgeIngestionBlock.tsx
+++ b/src/RetailPulse.Web/src/components/guardrails/KnowledgeIngestionBlock.tsx
@@ -43,6 +43,7 @@ const useStyles = makeStyles({
   reason: {
     color: tokens.colorNeutralForeground2,
     fontSize: '13px',
+    overflowWrap: 'anywhere',
   },
   docTitle: {
     color: tokens.colorNeutralForeground3,

--- a/src/RetailPulse.Web/src/components/guardrails/PlanStepSafetyBlock.tsx
+++ b/src/RetailPulse.Web/src/components/guardrails/PlanStepSafetyBlock.tsx
@@ -60,9 +60,11 @@ const useStyles = makeStyles({
   action: {
     color: tokens.colorNeutralForeground2,
     fontSize: '13px',
+    overflowWrap: 'anywhere',
   },
   reason: {
     color: tokens.colorNeutralForeground1,
+    overflowWrap: 'anywhere',
   },
   metaRow: {
     display: 'flex',

--- a/src/RetailPulse.Web/src/components/guardrails/WithheldOutputMessage.tsx
+++ b/src/RetailPulse.Web/src/components/guardrails/WithheldOutputMessage.tsx
@@ -36,6 +36,7 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     gap: '6px',
+    minWidth: 0,
   },
   title: {
     color: tokens.colorNeutralForeground1,
@@ -44,6 +45,7 @@ const useStyles = makeStyles({
   reason: {
     color: tokens.colorNeutralForeground2,
     fontSize: '13px',
+    overflowWrap: 'anywhere',
   },
   metaRow: {
     display: 'flex',


### PR DESCRIPTION
## Problem
The Security (Guardrails) page overflowed at narrow viewports: verbatim prompts were clipped to one line with an ellipsis, long unbroken tokens (for example `KeywordFastPaths[7]`) pushed rows past the viewport, and long reason sentences plus the eight stat cards had no wrapping guarantees. This is the re-verification that the earlier partial fix never got.

## Change (styling / responsive structure only)
- `GuardrailsDashboard.tsx`
  - Audit rows: relaxed the grid tracks from `minmax(220px, ...)` to `minmax(0, ...)` so columns can shrink; below 900px they already stack vertically (timestamp, prompt, reason, badge, status).
  - `entryPrimary` (the echoed prompt): removed `nowrap` + `overflow: hidden` + ellipsis so the full prompt stays readable and wraps; added `overflow-wrap: anywhere` / `word-break: break-word` so unbroken tokens break instead of overflowing.
  - `entryDetail` (reason) and the type badge now wrap rather than truncate.
  - Stat cards: added `min-width: 0` and `overflow-wrap` so long labels (for example "Content Safety Blocks") wrap under the value without clipping or overlap.
- `BlockedRequestMessage`, `WithheldOutputMessage`, `KnowledgeIngestionBlock`, `PlanStepSafetyBlock`: gave the text column `min-width: 0` and added `overflow-wrap: anywhere` to reason/action text so long sentences and tokens wrap in place next to the fixed icon.

No copy wording changed and no counter semantics changed. No meaningful text is truncated with an ellipsis: prompts and block reasons remain fully readable.

## Verification (actually rendered, not just reasoned)
Rendered the real `GuardrailsDashboard` in headless Chromium (Playwright) via the Vite dev server, seeded with the exact realistic overflow content from the report (eight stat cards, the prompt-shield override prompt, the `KeywordFastPaths[7] on agent memory-management` token, the fail-open reason sentence, and the four agent-definition rows). At each width I measured `documentElement.scrollWidth` vs `clientWidth` and scanned every `body` descendant for a right edge beyond the viewport and for `scrollWidth > clientWidth`.

| Width | Horizontal page scroll | Elements overflowing viewport | Rows with clipped content |
| --- | --- | --- | --- |
| 1440px | none | 0 | 0 |
| 1024px | none | 0 | 0 |
| 768px | none | 0 | 0 |
| 414px | none | 0 | 0 |
| 360px | none | 0 | 0 |

At 360px I additionally confirmed per element that the `KeywordFastPaths[7] ...` token wraps within its container (no overflow) and every audit row has `scrollWidth == clientWidth` (no clipped descendants). Screenshots at 360px confirmed the stat grid reflows to two columns with labels wrapping under values, and audit rows stack legibly.

## Checks
- Frontend tests: `npm test -- --run` = 910 passed (98 files).
- Typecheck: `npm run typecheck` clean.
- Lint: my five files add no new lint errors (the one pre-existing `set-state-in-effect` error in `GuardrailsDashboard` is present on `dev` unchanged; the other repo lint errors are in `usePlanController.ts`, untouched here).

## Unverified / honest notes
- `GuardrailsConfig` (the config toggle panel) was intentionally left untouched to avoid conflicting with a sibling agent restructuring that section; its layout was not part of the reported overflow and was not re-measured here.
- Verification used a scratch render harness (deleted before commit), not the live authenticated app, because the dev backend was not running; the component and CSS under test are identical.
