### PR TITLE
Fix Content Safety cold-start fail-open with token warm-up and failure classification

### DIFF
--- a/docs/adr/016-content-safety-cold-start-warmup.md
+++ b/docs/adr/016-content-safety-cold-start-warmup.md
@@ -1,0 +1,136 @@
+# ADR-016: Content Safety cold-start warm-up and failure classification
+
+## Status
+
+Accepted. Extends [ADR-015](015-tool-result-content-safety-policy.md) and
+[ADR-010](010-content-safety-layering.md). Does not change the fail-open or
+fail-closed policy set by those ADRs.
+
+## Context
+
+On the deployed app, four Content Safety audit rows clustered inside a 15 second
+window immediately after service start:
+
+```
+9:43:18 PM  KeywordFastPaths[7] on agent memory-management
+9:43:23 PM  SystemPrompt on agent general
+9:43:28 PM  DisplayName on agent router
+9:43:33 PM  SystemPrompt on agent router
+```
+
+Every one recorded `MODEL - SAFETY SERVICE UNAVAILABLE`, status **Allowed
+through**: "Content Safety was unreachable when the tool result was scanned, and
+the system allowed it because fail-open policy is active." A later call at
+11:46:05 PM to the same resource succeeded and correctly blocked an injection
+attempt, so the resource is reachable at runtime. This is a cold-start artefact,
+not an outage.
+
+Fail-open means these four payloads passed **unscanned**. Four unscanned passes
+on every cold start is a security gap, not a logging annoyance.
+
+### Diagnosis
+
+Reading the code establishes the mechanism:
+
+1. **The token fetch shared the scan timeout budget.** `EvaluateAsync` opened one
+   `CancellationTokenSource` with `cts.CancelAfter(TimeoutMs)` (default 1500 ms)
+   that covered both the managed-identity token acquisition and the scan calls.
+   The raw Prompt Shields path fetched its bearer through
+   `ContentSafetyTokenProvider` inside that budget, and the SDK moderation path
+   fetched its token through the same `DefaultAzureCredential` inside the same
+   budget.
+2. **The first fetch after start is unprimed.** The first
+   `DefaultAzureCredential.GetTokenAsync` has an empty cache and must walk the
+   managed-identity chain (IMDS probe plus an AAD round-trip), which routinely
+   takes seconds. Folded into a 1500 ms budget that also has to run the scan, it
+   expires, surfaces as `OperationCanceledException`, and the call returns
+   `ServiceUnavailable`, so fail-open lets the content through.
+3. **The startup agent-definition scan is the first caller.** The
+   `AgentDefinitionValidator` runs synchronously during host configuration,
+   before the host starts, and issues the very first Content Safety calls. Those
+   are the four fields in the audit rows (KeywordFastPaths, SystemPrompt twice,
+   DisplayName across agents). By 11:46 PM the credential and connection are warm,
+   so the same resource answers.
+4. **Every failure collapsed into one generic outcome.** All catch blocks returned
+   the same `ContentSafetyResult.ServiceUnavailable` singleton, so
+   `GuardrailAuditFields.BuildReason` produced identical "unreachable" text for a
+   timeout, an auth rejection, and a transport failure. An operator staring at the
+   four rows could not tell a cold-start timeout from a 401. Worse, a 401/403
+   `RequestFailedException` from the SDK path was not caught at all and would
+   propagate rather than route to the fail policy.
+
+What is proven and what is not: the mechanism is established from the code. The
+live first-token latency could not be measured, because data-plane RBAC on the
+deployed resource was deliberately revoked for the developer identity. The root
+cause is therefore strongly narrowed from code, not empirically timed against the
+live resource.
+
+## Decision
+
+Four changes, each proportionate to a finding above. None touches the fail-open
+policy, the audit visibility, or the counter aggregation owned elsewhere.
+
+1. **Separate the token budget from the scan budget.** `AcquireBearerAsync`
+   pre-acquires the bearer under its own `TokenTimeoutMs` budget (default 5000 ms)
+   before the scan `CancellationTokenSource` is created. A slow first-token fetch
+   can no longer consume the scan timeout. Priming the shared credential here also
+   warms the SDK moderation path, because it fetches through the same credential
+   singleton and hits the primed cache.
+
+2. **Warm the token before any real scan.** A time-boxed warm-up pre-acquires the
+   token so the first real scan is never the one paying the cold login:
+   * `ContentSafetyTokenProvider.WarmUpAsync(budget)` fetches and caches a token,
+     bounded by the budget, retrying only genuinely transient failures
+     (`CredentialUnavailableException`, for example an IMDS endpoint not answering
+     yet) with a short backoff. It never retries `AuthenticationFailedException`,
+     because a misconfigured identity does not become valid by asking again, and
+     it never throws.
+   * `ContentSafetyWarmUpService` is a hosted service whose `StartAsync` is
+     fire-and-forget, so host startup is never gated on a remote credential call.
+     It covers the runtime pipeline.
+   * The startup agent-definition scan runs before the host starts and uses a
+     separate DI provider, so it is warmed directly in `Program.cs`, best-effort
+     and time-boxed, before the validator runs.
+
+3. **Classify the failure.** `ContentSafetyFailureReason`
+   (`Timeout`, `Authentication`, `Transport`, `CircuitOpen`) is carried on
+   `ContentSafetyResult`, and each catch path sets the matching value. The SDK
+   auth gap is closed: 401/403 from `RequestFailedException` and
+   `HttpRequestException`, plus `AuthenticationFailedException`, now route to
+   `Authentication` rather than escaping.
+
+4. **Name the failure in the audit reason.** `GuardrailAuditFields.UnavailableReason`
+   varies the operator-visible text by failure class. Every variant still contains
+   the word "unreachable", and the unclassified case keeps the exact original
+   sentence, so existing audit consumers see no regression.
+
+Two configuration knobs are added to `ContentSafetyConfig`: `TokenTimeoutMs` and
+`WarmUpTimeoutMs`, both defaulting to 5000 ms.
+
+## Consequences
+
+**What an operator sees on cold start now.** When the warm-up succeeds, the first
+scan is warm and the four fail-open rows do not appear. If a cold-start fetch
+still fails, the row remains visible (fail-open behaviour is unchanged) but its
+reason now names the cause, for example "the call timed out before the service
+responded" versus "managed-identity authentication was rejected", so a timeout is
+no longer indistinguishable from a 401.
+
+**What is unchanged.** The fail-open / fail-closed policy is untouched. Fail-open
+rows are not suppressed. The warm-up cannot stall startup: it is fire-and-forget
+and time-boxed, and a hanging credential returns `TimedOut` within the budget.
+Retry is bounded and applies to transient failures only, never to auth or 4xx.
+
+**Interaction with the fail-open counter work.** A sibling change adds a fail-open
+counter on the dashboard. This change alters only the Reason **string**; it does
+not change `DetectionType` or `Action` constants, and it does not touch counter
+aggregation or the stats API. A counter keyed on the outcome or on the word
+"unreachable" continues to match every variant.
+
+**Recommendation left open.** Whether the tool-result stage should fail closed
+rather than fail open is a product decision that has not been made, and this
+change does not make it. The evidence here is that fail-open silently passed four
+unscanned payloads on every cold start. If the owner wants that class of content
+guaranteed scanned, the warm-up narrows the window but does not eliminate it, and
+only a fail-closed policy for that stage would close it. That decision is left to
+the policy owner.

--- a/src/RetailPulse.Api/Guardrails/AgentDefinition/AgentDefinitionValidator.cs
+++ b/src/RetailPulse.Api/Guardrails/AgentDefinition/AgentDefinitionValidator.cs
@@ -454,7 +454,7 @@ public sealed class AgentDefinitionValidator
                             Decision: ContentSafetyDecision.ServiceUnavailable.ToString(),
                             Stage: ContentSafetyStage.AgentDefinition.ToString(),
                             Threshold: null,
-                            Reason: $"Content Safety was unreachable while checking {field} for agent {agentKey}.",
+                            Reason: BuildUnavailableReason(result.FailureReason, field, agentKey),
                             Subject: $"{field} on agent {agentKey}"),
                             cancellationToken).ConfigureAwait(false);
                     }
@@ -467,6 +467,27 @@ public sealed class AgentDefinitionValidator
         }
 
         return 1;
+    }
+
+    /// <summary>
+    /// Cold-start fail-open rows used to all read the same "was unreachable"
+    /// sentence, so an operator could not tell a first-call timeout from a 401.
+    /// The classification (when known) is appended while the base wording is
+    /// preserved for existing audit consumers.
+    /// </summary>
+    private static string BuildUnavailableReason(ContentSafetyFailureReason? reason, string field, string agentKey)
+    {
+        string baseReason = $"Content Safety was unreachable while checking {field} for agent {agentKey}.";
+        string? classification = reason switch
+        {
+            ContentSafetyFailureReason.Timeout => "The call timed out before the service responded.",
+            ContentSafetyFailureReason.Authentication => "Managed-identity authentication was rejected.",
+            ContentSafetyFailureReason.Transport => "The connection failed before a response.",
+            ContentSafetyFailureReason.CircuitOpen => "The circuit breaker was open.",
+            _ => null,
+        };
+
+        return classification is null ? baseReason : $"{baseReason} {classification}";
     }
 
     private static void AddDuplicateNameViolations(

--- a/src/RetailPulse.Api/Guardrails/ContentSafety/AzureContentSafetyEvaluator.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/AzureContentSafetyEvaluator.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Azure;
 using Azure.AI.ContentSafety;
+using Azure.Identity;
 using Polly.CircuitBreaker;
 using Polly.Timeout;
 using RetailPulse.Api.Middleware;
@@ -20,7 +22,7 @@ namespace RetailPulse.Api.Guardrails.ContentSafety;
 /// timeout + circuit breaker guard both paths.
 /// </summary>
 /// <remarks>
-/// Authentication is <see cref="Azure.Identity.DefaultAzureCredential"/>-based.
+/// Authentication is <see cref="DefaultAzureCredential"/>-based.
 /// The evaluator resolves the current
 /// <see cref="ContentSafetyConfig"/> on every call from the DI-registered
 /// <see cref="GuardrailsConfig"/> so runtime toggles (fail policy, thresholds,
@@ -83,6 +85,35 @@ internal sealed class AzureContentSafetyEvaluator : IContentSafetyEvaluator
         activity?.SetTag("guardrails.contentsafety.stage", stage.ToString());
 
         long startTicks = Stopwatch.GetTimestamp();
+
+        // Acquire the managed-identity bearer on its own budget, separate from the
+        // scan timeout. The first token fetch after start is unprimed and must
+        // reach AAD/IMDS, which routinely takes seconds; folding that into the
+        // per-scan timeout is what made the very first cold-start scans fail open.
+        // Priming the shared credential here also warms the SDK moderation path,
+        // which fetches its token through the same credential singleton, so its
+        // own fetch is a cache hit and stays out of the scan budget.
+        string bearer;
+        try
+        {
+            bearer = await AcquireBearerAsync(config, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("Content Safety token acquisition timed out at {Stage} (limit {TokenTimeoutMs}ms).",
+                stage, config.TokenTimeoutMs);
+            return Unavailable(activity, ContentSafetyFailureReason.Timeout, startTicks);
+        }
+        catch (AuthenticationFailedException ex)
+        {
+            _logger.LogWarning(ex, "Content Safety managed-identity authentication failed at {Stage}.", stage);
+            return Unavailable(activity, ContentSafetyFailureReason.Authentication, startTicks);
+        }
+
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMilliseconds(Math.Max(200, config.TimeoutMs)));
 
@@ -95,7 +126,7 @@ internal sealed class AzureContentSafetyEvaluator : IContentSafetyEvaluator
 
             if (context.CheckPromptShield && config.PromptShieldsEnabled)
             {
-                PromptShieldResult shield = await CallPromptShieldAsync(text, stage, cts.Token).ConfigureAwait(false);
+                PromptShieldResult shield = await CallPromptShieldAsync(text, stage, bearer, cts.Token).ConfigureAwait(false);
                 jailbreak = shield.UserPromptAttackDetected;
                 indirect = shield.DocumentAttackDetected;
                 correlation = shield.CorrelationId;
@@ -149,16 +180,25 @@ internal sealed class AzureContentSafetyEvaluator : IContentSafetyEvaluator
         {
             _logger.LogWarning("Content Safety call timed out at {Stage} (limit {TimeoutMs}ms).",
                 stage, config.TimeoutMs);
-            activity?.SetTag("guardrails.contentsafety.decision", ContentSafetyDecision.ServiceUnavailable.ToString());
-            activity?.SetTag("guardrails.contentsafety.timeout", true);
-            return WithLatency(ContentSafetyResult.ServiceUnavailable, startTicks);
+            return Unavailable(activity, ContentSafetyFailureReason.Timeout, startTicks);
+        }
+        catch (AuthenticationFailedException ex)
+        {
+            // The SDK moderation path fetches its token through the same
+            // credential; a rejection here is an auth failure, not a transient
+            // outage, and retrying it would be pointless.
+            _logger.LogWarning(ex, "Content Safety authentication failed at {Stage}.", stage);
+            return Unavailable(activity, ContentSafetyFailureReason.Authentication, startTicks);
+        }
+        catch (RequestFailedException ex) when (IsAuthFailure(ex))
+        {
+            _logger.LogWarning(ex, "Content Safety rejected authentication at {Stage} (status {Status}).", stage, ex.Status);
+            return Unavailable(activity, ContentSafetyFailureReason.Authentication, startTicks);
         }
         catch (RequestFailedException ex) when (IsServiceUnavailable(ex))
         {
             _logger.LogWarning(ex, "Content Safety service returned unavailable status at {Stage}.", stage);
-            activity?.SetTag("guardrails.contentsafety.decision", ContentSafetyDecision.ServiceUnavailable.ToString());
-            activity?.SetTag("guardrails.contentsafety.transport_error", true);
-            return WithLatency(ContentSafetyResult.ServiceUnavailable, startTicks);
+            return Unavailable(activity, ContentSafetyFailureReason.Transport, startTicks);
         }
         catch (BrokenCircuitException ex)
         {
@@ -167,25 +207,61 @@ internal sealed class AzureContentSafetyEvaluator : IContentSafetyEvaluator
             // ServiceUnavailable so the middleware's fail-open / fail-closed
             // policy decides the request outcome and the audit row is written.
             _logger.LogWarning(ex, "Content Safety circuit breaker open at {Stage}.", stage);
-            activity?.SetTag("guardrails.contentsafety.decision", ContentSafetyDecision.ServiceUnavailable.ToString());
-            activity?.SetTag("guardrails.contentsafety.breaker_open", true);
-            return WithLatency(ContentSafetyResult.ServiceUnavailable, startTicks);
+            return Unavailable(activity, ContentSafetyFailureReason.CircuitOpen, startTicks);
         }
         catch (TimeoutRejectedException ex)
         {
             _logger.LogWarning(ex, "Content Safety Polly timeout rejected at {Stage} (limit {TimeoutMs}ms).",
                 stage, config.TimeoutMs);
-            activity?.SetTag("guardrails.contentsafety.decision", ContentSafetyDecision.ServiceUnavailable.ToString());
-            activity?.SetTag("guardrails.contentsafety.timeout", true);
-            return WithLatency(ContentSafetyResult.ServiceUnavailable, startTicks);
+            return Unavailable(activity, ContentSafetyFailureReason.Timeout, startTicks);
+        }
+        catch (HttpRequestException ex) when (IsAuthStatus(ex.StatusCode))
+        {
+            _logger.LogWarning(ex, "Content Safety rejected authentication at {Stage} (status {Status}).", stage, ex.StatusCode);
+            return Unavailable(activity, ContentSafetyFailureReason.Authentication, startTicks);
         }
         catch (HttpRequestException ex)
         {
             _logger.LogWarning(ex, "Content Safety transport error at {Stage}.", stage);
-            activity?.SetTag("guardrails.contentsafety.decision", ContentSafetyDecision.ServiceUnavailable.ToString());
-            activity?.SetTag("guardrails.contentsafety.transport_error", true);
-            return WithLatency(ContentSafetyResult.ServiceUnavailable, startTicks);
+            return Unavailable(activity, ContentSafetyFailureReason.Transport, startTicks);
         }
+    }
+
+    /// <summary>
+    /// Acquires the managed-identity bearer under a budget that is independent of
+    /// the scan timeout, so a slow first-token fetch cannot consume the moderation
+    /// call's time.
+    /// </summary>
+    private async Task<string> AcquireBearerAsync(ContentSafetyConfig config, CancellationToken cancellationToken)
+    {
+        using var tokenCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        tokenCts.CancelAfter(TimeSpan.FromMilliseconds(Math.Max(200, config.TokenTimeoutMs)));
+        return await _tokens.GetBearerAsync(tokenCts.Token).ConfigureAwait(false);
+    }
+
+    private static ContentSafetyResult Unavailable(Activity? activity, ContentSafetyFailureReason reason, long startTicks)
+    {
+        activity?.SetTag("guardrails.contentsafety.decision", ContentSafetyDecision.ServiceUnavailable.ToString());
+        activity?.SetTag("guardrails.contentsafety.failure_reason", reason.ToString());
+        switch (reason)
+        {
+            case ContentSafetyFailureReason.Timeout:
+                activity?.SetTag("guardrails.contentsafety.timeout", true);
+                break;
+            case ContentSafetyFailureReason.Authentication:
+                activity?.SetTag("guardrails.contentsafety.auth_error", true);
+                break;
+            case ContentSafetyFailureReason.Transport:
+                activity?.SetTag("guardrails.contentsafety.transport_error", true);
+                break;
+            case ContentSafetyFailureReason.CircuitOpen:
+                activity?.SetTag("guardrails.contentsafety.breaker_open", true);
+                break;
+            default:
+                break;
+        }
+
+        return WithLatency(ContentSafetyResult.Unavailable(reason), startTicks);
     }
 
     private static ContentSafetyResult Decide(
@@ -251,6 +327,7 @@ internal sealed class AzureContentSafetyEvaluator : IContentSafetyEvaluator
     private async Task<PromptShieldResult> CallPromptShieldAsync(
         string text,
         ContentSafetyStage stage,
+        string bearer,
         CancellationToken ct)
     {
         // Input is the user speaking, so it is submitted as a user prompt and
@@ -264,10 +341,9 @@ internal sealed class AzureContentSafetyEvaluator : IContentSafetyEvaluator
 
         using HttpContent content = JsonContent.Create(body, options: _jsonOptions);
         using HttpRequestMessage request = new(HttpMethod.Post, _promptShieldPath) { Content = content };
-        // Managed-identity bearer — matches Bicep's disableLocalAuth=true.
-        // The token provider caches under a semaphore so this call is
-        // synchronous once per rotation and never issues a per-request login.
-        string bearer = await _tokens.GetBearerAsync(ct).ConfigureAwait(false);
+        // Managed-identity bearer, matching Bicep's disableLocalAuth=true. The
+        // token is pre-acquired on a separate budget by the caller so this path
+        // never pays an AAD login round-trip inside the scan timeout.
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
         using HttpResponseMessage response = await _http.SendAsync(
             request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
@@ -353,6 +429,12 @@ internal sealed class AzureContentSafetyEvaluator : IContentSafetyEvaluator
 
     private static bool IsServiceUnavailable(RequestFailedException ex) =>
         ex.Status is 0 or 408 or 429 or 500 or 502 or 503 or 504;
+
+    private static bool IsAuthFailure(RequestFailedException ex) =>
+        ex.Status is 401 or 403;
+
+    private static bool IsAuthStatus(HttpStatusCode? status) =>
+        status is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
 
     private static string SpanName(ContentSafetyStage stage) => stage switch
     {

--- a/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyServiceCollectionExtensions.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyServiceCollectionExtensions.cs
@@ -102,6 +102,12 @@ public static class ContentSafetyServiceCollectionExtensions
                 sp.GetRequiredService<ILogger<AzureContentSafetyEvaluator>>());
         });
 
+        // Pre-acquire the managed-identity token at host start so the first
+        // runtime scan does not pay the cold AAD/IMDS round-trip inside its own
+        // timeout. Time-boxed and fire-and-forget, so it cannot delay startup.
+        services.TryAddSingleton<ContentSafetyWarmUpService>();
+        services.AddHostedService(sp => sp.GetRequiredService<ContentSafetyWarmUpService>());
+
         return services;
     }
 }

--- a/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyTokenProvider.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyTokenProvider.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Threading;
 using Azure.Core;
+using Azure.Identity;
 
 namespace RetailPulse.Api.Guardrails.ContentSafety;
 
@@ -69,4 +71,141 @@ public sealed class ContentSafetyTokenProvider
 
     private static bool HasSufficientLifetime(AccessToken token) =>
         token.Token is { Length: > 0 } && token.ExpiresOn - RefreshBuffer > DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Pre-acquires a token before any real scan runs so the first scan does not
+    /// pay the unprimed AAD/IMDS round-trip inside its own timeout budget. This
+    /// is the cold-start remedy: the expensive first login is moved here, off the
+    /// per-scan critical path.
+    /// </summary>
+    /// <remarks>
+    /// The whole call is bounded by <paramref name="budget"/> and never throws, so
+    /// it cannot stall host startup. Only genuinely transient failures are retried
+    /// with a short backoff; an authentication rejection is terminal and is NOT
+    /// retried, because a bad identity configuration does not become valid by
+    /// asking again.
+    /// </remarks>
+    public async Task<ContentSafetyWarmUpResult> WarmUpAsync(TimeSpan budget, CancellationToken cancellationToken)
+    {
+        if (HasSufficientLifetime(_cached))
+        {
+            return ContentSafetyWarmUpResult.AlreadyWarm;
+        }
+
+        TimeSpan boundedBudget = budget < _minWarmUpBudget ? _minWarmUpBudget : budget;
+        long deadline = Stopwatch.GetTimestamp() + (long)(boundedBudget.TotalSeconds * Stopwatch.Frequency);
+
+        for (int attempt = 1; attempt <= _maxWarmUpAttempts; attempt++)
+        {
+            TimeSpan remaining = RemainingBudget(deadline);
+            if (remaining <= TimeSpan.Zero)
+            {
+                return ContentSafetyWarmUpResult.TimedOut;
+            }
+
+            using var attemptCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            attemptCts.CancelAfter(remaining);
+            try
+            {
+                AccessToken token = await _credential.GetTokenAsync(
+                    new TokenRequestContext(_scopes),
+                    attemptCts.Token).ConfigureAwait(false);
+                await StoreAsync(token, cancellationToken).ConfigureAwait(false);
+                return ContentSafetyWarmUpResult.Warmed;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return ContentSafetyWarmUpResult.Cancelled;
+            }
+            catch (OperationCanceledException)
+            {
+                // The attempt exceeded the remaining budget. The whole warm-up is
+                // time-boxed, so stop rather than burn the next attempt on a
+                // credential endpoint that is not answering in time.
+                return ContentSafetyWarmUpResult.TimedOut;
+            }
+            catch (CredentialUnavailableException)
+            {
+                // The credential source (for example the IMDS endpoint) is not
+                // answering yet. That is exactly the cold-start condition warm-up
+                // exists to ride out, so this is transient and retried.
+                if (attempt == _maxWarmUpAttempts || !await BackoffAsync(deadline, cancellationToken).ConfigureAwait(false))
+                {
+                    return ContentSafetyWarmUpResult.TransientExhausted;
+                }
+            }
+            catch (AuthenticationFailedException)
+            {
+                // The identity was reached and rejected. Retrying cannot fix a
+                // misconfigured identity, so fail fast and let the operator see it.
+                return ContentSafetyWarmUpResult.AuthenticationFailed;
+            }
+        }
+
+        return ContentSafetyWarmUpResult.TransientExhausted;
+    }
+
+    private async Task StoreAsync(AccessToken token, CancellationToken cancellationToken)
+    {
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _cached = token;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    private static TimeSpan RemainingBudget(long deadline)
+    {
+        long ticks = deadline - Stopwatch.GetTimestamp();
+        return ticks <= 0 ? TimeSpan.Zero : TimeSpan.FromSeconds((double)ticks / Stopwatch.Frequency);
+    }
+
+    private static async Task<bool> BackoffAsync(long deadline, CancellationToken cancellationToken)
+    {
+        TimeSpan remaining = RemainingBudget(deadline);
+        if (remaining <= _warmUpBackoff)
+        {
+            return false;
+        }
+
+        try
+        {
+            await Task.Delay(_warmUpBackoff, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    private const int _maxWarmUpAttempts = 3;
+    private static readonly TimeSpan _warmUpBackoff = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan _minWarmUpBudget = TimeSpan.FromMilliseconds(200);
+}
+
+/// <summary>Outcome of <see cref="ContentSafetyTokenProvider.WarmUpAsync"/>.</summary>
+public enum ContentSafetyWarmUpResult
+{
+    /// <summary>A token was acquired and cached; the first scan will be warm.</summary>
+    Warmed,
+
+    /// <summary>A valid token was already cached; no acquisition was needed.</summary>
+    AlreadyWarm,
+
+    /// <summary>Authentication was rejected. Terminal, not retried.</summary>
+    AuthenticationFailed,
+
+    /// <summary>The time box elapsed before a token could be acquired.</summary>
+    TimedOut,
+
+    /// <summary>Every transient attempt failed within the budget.</summary>
+    TransientExhausted,
+
+    /// <summary>The caller cancelled the warm-up.</summary>
+    Cancelled,
 }

--- a/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyWarmUpService.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyWarmUpService.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.Hosting;
+using RetailPulse.Contracts.Guardrails;
+
+namespace RetailPulse.Api.Guardrails.ContentSafety;
+
+/// <summary>
+/// Pre-acquires the Content Safety managed-identity token at host start so the
+/// first real scan is not the one paying the cold AAD/IMDS round-trip inside its
+/// own timeout budget. This covers the runtime pipeline; the startup
+/// agent-definition scan is warmed separately, before it runs, because it
+/// executes during host configuration rather than after the host starts.
+/// </summary>
+/// <remarks>
+/// The warm-up is time-boxed and fire-and-forget: <see cref="StartAsync"/>
+/// returns immediately so host startup is never gated on a remote credential
+/// call, and the underlying warm-up is bounded so an unreachable credential
+/// endpoint cannot stall the service.
+/// </remarks>
+internal sealed class ContentSafetyWarmUpService : IHostedService
+{
+    private readonly ContentSafetyTokenProvider _tokens;
+    private readonly GuardrailsConfig _guardrails;
+    private readonly ILogger<ContentSafetyWarmUpService> _logger;
+
+    public ContentSafetyWarmUpService(
+        ContentSafetyTokenProvider tokens,
+        GuardrailsConfig guardrails,
+        ILogger<ContentSafetyWarmUpService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+        ArgumentNullException.ThrowIfNull(guardrails);
+        ArgumentNullException.ThrowIfNull(logger);
+        _tokens = tokens;
+        _guardrails = guardrails;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Exposed for tests so they can await the fire-and-forget warm-up
+    /// deterministically. Null until <see cref="StartAsync"/> has run.
+    /// </summary>
+    public Task? WarmUpCompletion { get; private set; }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var budget = TimeSpan.FromMilliseconds(
+            Math.Max(200, _guardrails.ContentSafety.WarmUpTimeoutMs));
+
+        // Fire-and-forget on a background task so a slow credential endpoint can
+        // never delay host startup. The warm-up itself is bounded by budget.
+        WarmUpCompletion = Task.Run(() => WarmAsync(budget), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private async Task WarmAsync(TimeSpan budget)
+    {
+        try
+        {
+            ContentSafetyWarmUpResult result = await _tokens
+                .WarmUpAsync(budget, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            if (result is ContentSafetyWarmUpResult.Warmed or ContentSafetyWarmUpResult.AlreadyWarm)
+            {
+                _logger.LogInformation("Content Safety token warm-up completed ({Result}).", result);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Content Safety token warm-up did not prime a token ({Result}); the first scan may pay the cold token cost.",
+                    result);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Warm-up is best-effort. A failure here must never surface at startup.
+            _logger.LogWarning(ex, "Content Safety token warm-up failed unexpectedly.");
+        }
+    }
+}

--- a/src/RetailPulse.Api/Guardrails/ContentSafety/IContentSafetyEvaluator.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/IContentSafetyEvaluator.cs
@@ -70,6 +70,27 @@ public enum ContentSafetyDecision
     ServiceUnavailable,
 }
 
+/// <summary>
+/// Why a <see cref="ContentSafetyDecision.ServiceUnavailable"/> outcome happened.
+/// The evaluator previously collapsed every failure into one generic outcome, so
+/// an operator reading the audit trail could not tell a cold-start timeout from a
+/// 401 or a dropped connection. Carrying the class lets the audit reason name it.
+/// </summary>
+public enum ContentSafetyFailureReason
+{
+    /// <summary>The call did not complete inside its time budget.</summary>
+    Timeout,
+
+    /// <summary>Managed-identity authentication was rejected (for example 401/403).</summary>
+    Authentication,
+
+    /// <summary>The connection failed before a response (DNS, TLS, socket, 5xx).</summary>
+    Transport,
+
+    /// <summary>The resilience circuit breaker was open and short-circuited the call.</summary>
+    CircuitOpen,
+}
+
 /// <summary>Structured decision + evidence used for auditing and telemetry.</summary>
 public sealed record ContentSafetyResult(
     ContentSafetyDecision Decision,
@@ -78,7 +99,8 @@ public sealed record ContentSafetyResult(
     bool PromptShieldIndirectInjectionDetected,
     TimeSpan Latency,
     string? CorrelationId,
-    string? PrimaryCategory = null)
+    string? PrimaryCategory = null,
+    ContentSafetyFailureReason? FailureReason = null)
 {
     /// <summary>Cached passed-with-no-hits singleton returned by the no-op evaluator.</summary>
     public static readonly ContentSafetyResult Passed = new(
@@ -97,6 +119,20 @@ public sealed record ContentSafetyResult(
         PromptShieldIndirectInjectionDetected: false,
         Latency: TimeSpan.Zero,
         CorrelationId: null);
+
+    /// <summary>
+    /// Service-unavailable result carrying the failure class so the audit reason
+    /// can distinguish a timeout from an auth or transport failure.
+    /// </summary>
+    public static ContentSafetyResult Unavailable(ContentSafetyFailureReason reason) => new(
+        ContentSafetyDecision.ServiceUnavailable,
+        [],
+        PromptShieldJailbreakDetected: false,
+        PromptShieldIndirectInjectionDetected: false,
+        Latency: TimeSpan.Zero,
+        CorrelationId: null,
+        PrimaryCategory: null,
+        FailureReason: reason);
 }
 
 /// <summary>A single category hit from text moderation.</summary>

--- a/src/RetailPulse.Api/Guardrails/GuardrailAuditFields.cs
+++ b/src/RetailPulse.Api/Guardrails/GuardrailAuditFields.cs
@@ -64,7 +64,7 @@ internal static class GuardrailAuditFields
         if (evaluation.Decision == ContentSafetyDecision.ServiceUnavailable
             || string.Equals(detectionType, ContentSafetyDetectionTypes.Unavailable, StringComparison.Ordinal))
         {
-            return $"Content Safety was unreachable while checking {target}.";
+            return UnavailableReason(evaluation.FailureReason, target);
         }
 
         if (string.Equals(detectionType, ContentSafetyDetectionTypes.PromptShield, StringComparison.Ordinal))
@@ -91,6 +91,25 @@ internal static class GuardrailAuditFields
             ? $"Content Safety classified {target} as {categoryText} at severity {severity.Value}."
             : $"Content Safety classified {target} as {categoryText}.";
     }
+
+    /// <summary>
+    /// Reason text for a service-unavailable outcome, named by failure class so
+    /// an operator can tell a cold-start timeout from an auth or transport
+    /// failure. The unclassified case keeps the original wording so existing
+    /// audit consumers see no change.
+    /// </summary>
+    public static string UnavailableReason(ContentSafetyFailureReason? reason, string target) => reason switch
+    {
+        ContentSafetyFailureReason.Timeout =>
+            $"Content Safety was unreachable while checking {target}: the call timed out before the service responded.",
+        ContentSafetyFailureReason.Authentication =>
+            $"Content Safety was unreachable while checking {target}: managed-identity authentication was rejected.",
+        ContentSafetyFailureReason.Transport =>
+            $"Content Safety was unreachable while checking {target}: the connection failed before a response.",
+        ContentSafetyFailureReason.CircuitOpen =>
+            $"Content Safety was unreachable while checking {target}: the circuit breaker was open.",
+        _ => $"Content Safety was unreachable while checking {target}.",
+    };
 
     /// <summary>
     /// Reason for the pattern-matching layer, which runs before Content Safety

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -300,6 +300,23 @@ using (ILoggerFactory validatorLoggerFactory = LoggerFactory.Create(lb =>
             evaluatorScope = evaluatorServices.BuildServiceProvider();
 #pragma warning restore ASP0000
             validatorEvaluator = evaluatorScope.GetRequiredService<IContentSafetyEvaluator>();
+
+            // Pre-acquire the managed-identity token before the agent-definition
+            // scan runs. That scan is the very first caller on a cold start, and
+            // without a primed token its four checks race an unprimed AAD/IMDS
+            // round-trip inside the per-scan timeout and fail open. Time-boxed and
+            // best-effort so a slow or unreachable credential endpoint can never
+            // block startup.
+            ContentSafetyTokenProvider validatorTokens =
+                evaluatorScope.GetRequiredService<ContentSafetyTokenProvider>();
+            var warmUpBudget = TimeSpan.FromMilliseconds(
+                Math.Max(200, guardrailsConfig.ContentSafety.WarmUpTimeoutMs));
+            ContentSafetyWarmUpResult warmUp = validatorTokens
+                .WarmUpAsync(warmUpBudget, CancellationToken.None)
+                .GetAwaiter()
+                .GetResult();
+            validatorLogger.LogInformation(
+                "Content Safety startup warm-up before agent-definition scan: {Result}.", warmUp);
         }
         else
         {

--- a/src/RetailPulse.Contracts/Guardrails/ContentSafetyConfig.cs
+++ b/src/RetailPulse.Contracts/Guardrails/ContentSafetyConfig.cs
@@ -31,6 +31,23 @@ public class ContentSafetyConfig
     /// <summary>Bounded per-call timeout in milliseconds for a single Content Safety call.</summary>
     public int TimeoutMs { get; set; } = 1500;
 
+    /// <summary>
+    /// Budget for managed-identity token acquisition, kept separate from
+    /// <see cref="TimeoutMs"/>. The first token fetch after start is unprimed and
+    /// must reach AAD/IMDS, which routinely takes several seconds; folding that
+    /// into the per-scan timeout is what makes the very first scans fail open on a
+    /// cold start. The scan timeout only covers the moderation call once a bearer
+    /// is in hand.
+    /// </summary>
+    public int TokenTimeoutMs { get; set; } = 5000;
+
+    /// <summary>
+    /// Overall time box for the startup warm-up that pre-acquires the token
+    /// before any real scan runs. Bounded so a slow or unreachable credential
+    /// endpoint can never stall host startup.
+    /// </summary>
+    public int WarmUpTimeoutMs { get; set; } = 5000;
+
     /// <summary>When <c>true</c>, evaluates user input.</summary>
     public bool CheckInput { get; set; } = true;
 

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyColdStartClassificationTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyColdStartClassificationTests.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Net.Http.Json;
+using Azure.AI.ContentSafety;
+using Azure.Core;
+using Azure.Identity;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using RetailPulse.Api.Guardrails.ContentSafety;
+using RetailPulse.Contracts.Guardrails;
+
+namespace RetailPulse.Tests.Guardrails.ContentSafety;
+
+/// <summary>
+/// Cold-start classification behaviour of <see cref="AzureContentSafetyEvaluator"/>.
+///
+/// The original defect had two halves. First, the managed-identity token fetch
+/// ran inside the per-scan timeout, so the unprimed first fetch blew the scan
+/// budget and every cold-start scan failed open. Second, every failure collapsed
+/// into one generic "unreachable" outcome, so an operator could not tell a
+/// timeout from a 401. These tests pin the fix for both:
+///
+/// * A slow token fetch that stays within its own (separate) budget no longer
+///   consumes the scan budget, so the scan still passes.
+/// * A token timeout, an authentication rejection, and a transport failure each
+///   produce a distinct <see cref="ContentSafetyFailureReason"/>.
+/// * An authentication rejection is not retried.
+/// </summary>
+[Collection("AzureContentSafetyEvaluatorActivity")]
+public class ContentSafetyColdStartClassificationTests
+{
+    [Fact]
+    public async Task SlowTokenWithinItsOwnBudget_DoesNotConsumeScanBudget()
+    {
+        // Token fetch is deliberately slower than the scan floor (200 ms) but well
+        // inside the token budget. If the two budgets were still shared this scan
+        // would time out and fail open; with them separated it must pass.
+        var slowProviderCredential = new ProgrammableTokenCredential(async (_, ct) =>
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(350), ct);
+            return ProgrammableTokenCredential.FreshToken("primed-after-delay");
+        });
+
+        AzureContentSafetyEvaluator evaluator = BuildEvaluator(
+            new CapturingHttpMessageHandler(),
+            providerCredential: slowProviderCredential,
+            sdkCredential: new FakeTokenCredential(token: "sdk-instant"),
+            configure: cfg =>
+            {
+                cfg.TimeoutMs = 1;          // scan floor clamps to 200 ms
+                cfg.TokenTimeoutMs = 5000;  // token fetch has its own generous budget
+            });
+
+        ContentSafetyResult result = await evaluator.EvaluateAsync(
+            "benign text",
+            ContentSafetyStage.Input,
+            new ContentSafetyEvaluationContext(UserId: "u", CheckPromptShield: true),
+            CancellationToken.None);
+
+        result.Decision.Should().Be(ContentSafetyDecision.Passed,
+            "a slow first-token fetch inside its own budget must not steal the scan timeout");
+    }
+
+    [Fact]
+    public async Task AuthenticationRejection_IsClassifiedAsAuthentication_AndNotRetried()
+    {
+        var rejectingCredential = new ProgrammableTokenCredential((_, _) =>
+            throw new AuthenticationFailedException("managed identity is not authorised"));
+
+        AzureContentSafetyEvaluator evaluator = BuildEvaluator(
+            new CapturingHttpMessageHandler(),
+            providerCredential: rejectingCredential,
+            sdkCredential: rejectingCredential,
+            configure: cfg => cfg.TokenTimeoutMs = 5000);
+
+        ContentSafetyResult result = await evaluator.EvaluateAsync(
+            "benign text",
+            ContentSafetyStage.Input,
+            new ContentSafetyEvaluationContext(UserId: "u", CheckPromptShield: true),
+            CancellationToken.None);
+
+        result.Decision.Should().Be(ContentSafetyDecision.ServiceUnavailable);
+        result.FailureReason.Should().Be(ContentSafetyFailureReason.Authentication,
+            "a rejected identity must be distinguishable from a timeout in the audit reason");
+        rejectingCredential.Calls.Should().Be(1,
+            "an authentication rejection is terminal and must not be retried inside the evaluator");
+    }
+
+    [Fact]
+    public async Task TokenFetchExceedingTokenBudget_IsClassifiedAsTimeout()
+    {
+        var hangingCredential = new ProgrammableTokenCredential(async (_, ct) =>
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            return default;
+        });
+
+        AzureContentSafetyEvaluator evaluator = BuildEvaluator(
+            new CapturingHttpMessageHandler(),
+            providerCredential: hangingCredential,
+            sdkCredential: new FakeTokenCredential(),
+            configure: cfg =>
+            {
+                cfg.TimeoutMs = 1500;
+                cfg.TokenTimeoutMs = 250; // token budget is what expires here
+            });
+
+        ContentSafetyResult result = await evaluator.EvaluateAsync(
+            "benign text",
+            ContentSafetyStage.Input,
+            new ContentSafetyEvaluationContext(UserId: "u", CheckPromptShield: true),
+            CancellationToken.None);
+
+        result.Decision.Should().Be(ContentSafetyDecision.ServiceUnavailable);
+        result.FailureReason.Should().Be(ContentSafetyFailureReason.Timeout,
+            "a token fetch that blows its own budget is a timeout, not an auth failure");
+    }
+
+    [Fact]
+    public async Task TransportFailure_IsClassifiedAsTransport()
+    {
+        var handler = new CapturingHttpMessageHandler
+        {
+            Responder = (req, _) => Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)),
+        };
+
+        AzureContentSafetyEvaluator evaluator = BuildEvaluator(
+            handler,
+            providerCredential: new FakeTokenCredential(token: "ok"),
+            sdkCredential: new FakeTokenCredential(token: "ok"),
+            configure: cfg =>
+            {
+                cfg.TimeoutMs = 1500;
+                cfg.TokenTimeoutMs = 5000;
+            });
+
+        ContentSafetyResult result = await evaluator.EvaluateAsync(
+            "benign text",
+            ContentSafetyStage.Input,
+            new ContentSafetyEvaluationContext(UserId: "u", CheckPromptShield: true),
+            CancellationToken.None);
+
+        result.Decision.Should().Be(ContentSafetyDecision.ServiceUnavailable);
+        result.FailureReason.Should().Be(ContentSafetyFailureReason.Transport,
+            "an HTTP failure with a token in hand is a transport problem, not an auth or timeout one");
+    }
+
+    private static AzureContentSafetyEvaluator BuildEvaluator(
+        CapturingHttpMessageHandler handler,
+        TokenCredential providerCredential,
+        TokenCredential sdkCredential,
+        Action<ContentSafetyConfig> configure)
+    {
+        var http = new HttpClient(handler, disposeHandler: false)
+        {
+            BaseAddress = new Uri("https://fake.cognitiveservices.azure.com"),
+        };
+
+        // Default the Prompt Shields + AnalyzeText responses to benign shapes so
+        // the only variable under test is the failure classification path.
+        handler.Responder ??= (req, ct) =>
+        {
+            if (req.RequestUri!.AbsolutePath.EndsWith("text:analyze", StringComparison.Ordinal))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new { categoriesAnalysis = Array.Empty<object>() }),
+                });
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new
+                {
+                    userPromptAnalysis = new { attackDetected = false },
+                    documentsAnalysis = Array.Empty<object>(),
+                }),
+            });
+        };
+
+        var sdkOptions = new ContentSafetyClientOptions
+        {
+            Transport = new Azure.Core.Pipeline.HttpClientTransport(http),
+        };
+        var sdkClient = new ContentSafetyClient(http.BaseAddress!, sdkCredential, sdkOptions);
+
+        var config = new GuardrailsConfig
+        {
+            ContentSafety = new ContentSafetyConfig
+            {
+                Enabled = true,
+                Endpoint = http.BaseAddress!.ToString(),
+                PromptShieldsEnabled = true,
+            },
+        };
+        configure(config.ContentSafety);
+
+        var tokens = new ContentSafetyTokenProvider(providerCredential);
+        return new AzureContentSafetyEvaluator(
+            sdkClient, http, tokens, config,
+            NullLoggerFactory.Instance.CreateLogger<AzureContentSafetyEvaluator>());
+    }
+}

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyTokenProviderWarmUpTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyTokenProviderWarmUpTests.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+using Azure.Core;
+using Azure.Identity;
+using FluentAssertions;
+using RetailPulse.Api.Guardrails.ContentSafety;
+
+namespace RetailPulse.Tests.Guardrails.ContentSafety;
+
+/// <summary>
+/// Cold-start warm-up invariants for <see cref="ContentSafetyTokenProvider"/>.
+///
+/// The four fail-open audit rows measured immediately after service start came
+/// from the agent-definition scan racing an unprimed managed-identity token
+/// fetch inside the per-scan timeout. Warm-up moves that first fetch off the
+/// scan critical path. These tests pin its contract:
+///
+/// 1. A genuinely transient credential failure is retried and the warm-up
+///    succeeds.
+/// 2. An authentication rejection is NOT retried. Retrying a bad identity is
+///    pointless and wasteful.
+/// 3. The warm-up is time-boxed: a credential that never answers cannot stall
+///    startup.
+/// </summary>
+public class ContentSafetyTokenProviderWarmUpTests
+{
+    [Fact]
+    public async Task WarmUpAsync_TransientFirstFailure_IsRetried_AndPrimesCache()
+    {
+        var credential = new ProgrammableTokenCredential((attempt, _) => attempt == 1
+            ? throw new CredentialUnavailableException("IMDS endpoint still warming")
+            : ValueTask.FromResult(ProgrammableTokenCredential.FreshToken("primed")));
+        var provider = new ContentSafetyTokenProvider(credential);
+
+        ContentSafetyWarmUpResult result = await provider.WarmUpAsync(
+            TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        result.Should().Be(ContentSafetyWarmUpResult.Warmed);
+        credential.Calls.Should().Be(2, "a transient credential failure must be retried");
+
+        // The primed token must satisfy the fast path so the first real scan is a
+        // cache hit and never pays the login round-trip again.
+        string bearer = await provider.GetBearerAsync(CancellationToken.None);
+        bearer.Should().Be("primed");
+        credential.Calls.Should().Be(2, "warm-up must have primed the cache; no extra fetch on first use");
+    }
+
+    [Fact]
+    public async Task WarmUpAsync_AuthenticationFailure_IsNotRetried()
+    {
+        var credential = new ProgrammableTokenCredential((_, _) =>
+            throw new AuthenticationFailedException("managed identity is misconfigured"));
+        var provider = new ContentSafetyTokenProvider(credential);
+
+        ContentSafetyWarmUpResult result = await provider.WarmUpAsync(
+            TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        result.Should().Be(ContentSafetyWarmUpResult.AuthenticationFailed);
+        credential.Calls.Should().Be(1,
+            "an authentication rejection is terminal; retrying a bad identity cannot succeed");
+    }
+
+    [Fact]
+    public async Task WarmUpAsync_CredentialNeverAnswers_IsTimeBoxed_AndDoesNotBlock()
+    {
+        var credential = new ProgrammableTokenCredential(async (_, ct) =>
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            return default;
+        });
+        var provider = new ContentSafetyTokenProvider(credential);
+
+        var sw = Stopwatch.StartNew();
+        ContentSafetyWarmUpResult result = await provider.WarmUpAsync(
+            TimeSpan.FromMilliseconds(300), CancellationToken.None);
+        sw.Stop();
+
+        result.Should().Be(ContentSafetyWarmUpResult.TimedOut);
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3),
+            "a hanging credential must be bounded by the warm-up budget, never block startup indefinitely");
+    }
+
+    [Fact]
+    public async Task WarmUpAsync_WhenAlreadyCached_DoesNotCallCredential()
+    {
+        var credential = new ProgrammableTokenCredential((_, _) =>
+            ValueTask.FromResult(ProgrammableTokenCredential.FreshToken("first")));
+        var provider = new ContentSafetyTokenProvider(credential);
+
+        _ = await provider.GetBearerAsync(CancellationToken.None);
+        credential.Calls.Should().Be(1);
+
+        ContentSafetyWarmUpResult result = await provider.WarmUpAsync(
+            TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        result.Should().Be(ContentSafetyWarmUpResult.AlreadyWarm);
+        credential.Calls.Should().Be(1, "a valid cached token needs no warm-up fetch");
+    }
+}

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyUnavailableReasonTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyUnavailableReasonTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using RetailPulse.Api.Guardrails;
+using RetailPulse.Api.Guardrails.ContentSafety;
+
+namespace RetailPulse.Tests.Guardrails;
+
+/// <summary>
+/// The audit dashboard renders the fail-open Reason string verbatim. Before this
+/// change every service-unavailable row read the same generic "unreachable"
+/// sentence, so four cold-start rows looked identical and an operator could not
+/// tell a timeout from a 401. These tests pin that each failure class now yields
+/// distinct, operator-readable text while the unclassified case keeps the exact
+/// original wording so existing audit consumers see no regression.
+/// </summary>
+public class ContentSafetyUnavailableReasonTests
+{
+    [Fact]
+    public void UnclassifiedReason_KeepsOriginalWording()
+    {
+        string reason = GuardrailAuditFields.UnavailableReason(null, "the tool result");
+        reason.Should().Be("Content Safety was unreachable while checking the tool result.");
+    }
+
+    [Theory]
+    [InlineData(ContentSafetyFailureReason.Timeout, "timed out")]
+    [InlineData(ContentSafetyFailureReason.Authentication, "authentication")]
+    [InlineData(ContentSafetyFailureReason.Transport, "connection")]
+    [InlineData(ContentSafetyFailureReason.CircuitOpen, "circuit breaker")]
+    public void ClassifiedReason_NamesTheFailure_AndStaysUnreachable(
+        ContentSafetyFailureReason reason, string expectedFragment)
+    {
+        string text = GuardrailAuditFields.UnavailableReason(reason, "the tool result");
+
+        text.Should().Contain("unreachable",
+            "the audit test suite and any counter keyed on 'unreachable' must keep matching");
+        text.Should().Contain(expectedFragment,
+            "each failure class must be distinguishable in the operator-visible reason");
+    }
+
+    [Fact]
+    public void EveryFailureClass_ProducesDistinctText()
+    {
+        string[] variants =
+        [
+            GuardrailAuditFields.UnavailableReason(ContentSafetyFailureReason.Timeout, "x"),
+            GuardrailAuditFields.UnavailableReason(ContentSafetyFailureReason.Authentication, "x"),
+            GuardrailAuditFields.UnavailableReason(ContentSafetyFailureReason.Transport, "x"),
+            GuardrailAuditFields.UnavailableReason(ContentSafetyFailureReason.CircuitOpen, "x"),
+            GuardrailAuditFields.UnavailableReason(null, "x"),
+        ];
+
+        variants.Should().OnlyHaveUniqueItems(
+            "an operator must be able to tell the failure classes apart at a glance");
+    }
+}

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyWarmUpServiceTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyWarmUpServiceTests.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using RetailPulse.Api.Guardrails.ContentSafety;
+using RetailPulse.Contracts.Guardrails;
+
+namespace RetailPulse.Tests.Guardrails.ContentSafety;
+
+/// <summary>
+/// <see cref="ContentSafetyWarmUpService"/> primes the runtime token before the
+/// first real scan, but it must never gate host startup on a remote credential
+/// call. These tests pin both halves: <see cref="ContentSafetyWarmUpService.StartAsync"/>
+/// returns effectively immediately even when the credential never answers, and
+/// the background warm-up is itself time-boxed.
+/// </summary>
+public class ContentSafetyWarmUpServiceTests
+{
+    [Fact]
+    public async Task StartAsync_ReturnsImmediately_EvenWhenCredentialHangs()
+    {
+        var hangingCredential = new ProgrammableTokenCredential(async (_, ct) =>
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            return default;
+        });
+        ContentSafetyWarmUpService service = Build(hangingCredential, warmUpTimeoutMs: 300);
+
+        var sw = Stopwatch.StartNew();
+        await service.StartAsync(CancellationToken.None);
+        sw.Stop();
+
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromMilliseconds(200),
+            "warm-up is fire-and-forget; host startup must not wait on the credential");
+
+        // The background warm-up must still terminate within its own budget rather
+        // than run forever.
+        Task completion = service.WarmUpCompletion
+            ?? throw new InvalidOperationException("StartAsync must set WarmUpCompletion.");
+        await completion.WaitAsync(TimeSpan.FromSeconds(3));
+        completion.IsCompletedSuccessfully.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task StartAsync_WarmsToken_WhenCredentialSucceeds()
+    {
+        var credential = new ProgrammableTokenCredential((_, _) =>
+            ValueTask.FromResult(ProgrammableTokenCredential.FreshToken("warm")));
+        var provider = new ContentSafetyTokenProvider(credential);
+        var service = new ContentSafetyWarmUpService(
+            provider,
+            ConfigWith(warmUpTimeoutMs: 5000),
+            NullLogger<ContentSafetyWarmUpService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        Task completion = service.WarmUpCompletion
+            ?? throw new InvalidOperationException("StartAsync must set WarmUpCompletion.");
+        await completion.WaitAsync(TimeSpan.FromSeconds(3));
+
+        // The primed token must serve the first real scan without another fetch.
+        string bearer = await provider.GetBearerAsync(CancellationToken.None);
+        bearer.Should().Be("warm");
+        credential.Calls.Should().Be(1, "warm-up primed the cache; the first scan must be a cache hit");
+    }
+
+    private static ContentSafetyWarmUpService Build(
+        ProgrammableTokenCredential credential, int warmUpTimeoutMs)
+    {
+        return new ContentSafetyWarmUpService(
+            new ContentSafetyTokenProvider(credential),
+            ConfigWith(warmUpTimeoutMs),
+            NullLogger<ContentSafetyWarmUpService>.Instance);
+    }
+
+    private static GuardrailsConfig ConfigWith(int warmUpTimeoutMs) => new()
+    {
+        ContentSafety = new ContentSafetyConfig
+        {
+            Enabled = true,
+            PromptShieldsEnabled = true,
+            WarmUpTimeoutMs = warmUpTimeoutMs,
+        },
+    };
+}

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ProgrammableTokenCredential.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ProgrammableTokenCredential.cs
@@ -1,0 +1,39 @@
+using Azure.Core;
+
+namespace RetailPulse.Tests.Guardrails.ContentSafety;
+
+/// <summary>
+/// A <see cref="TokenCredential"/> whose behaviour is scripted per call, used by
+/// the cold-start warm-up tests. Unlike <see cref="FakeTokenCredential"/> (which
+/// always answers instantly) this can throw, delay, or fail on the first call and
+/// succeed on a later one, so the retry / no-retry / time-box invariants can be
+/// asserted deterministically.
+/// </summary>
+internal sealed class ProgrammableTokenCredential : TokenCredential
+{
+    private readonly Func<int, CancellationToken, ValueTask<AccessToken>> _onCall;
+    private int _calls;
+
+    public ProgrammableTokenCredential(Func<int, CancellationToken, ValueTask<AccessToken>> onCall)
+    {
+        _onCall = onCall;
+    }
+
+    public int Calls => Volatile.Read(ref _calls);
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        int attempt = Interlocked.Increment(ref _calls);
+        return _onCall(attempt, cancellationToken).AsTask().GetAwaiter().GetResult();
+    }
+
+    public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        int attempt = Interlocked.Increment(ref _calls);
+        return await _onCall(attempt, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>A far-future token so <c>HasSufficientLifetime</c> treats it as fresh.</summary>
+    public static AccessToken FreshToken(string token = "warmed-token") =>
+        new(token, DateTimeOffset.UtcNow.AddHours(1));
+}


### PR DESCRIPTION
## Diagnosis (with evidence)

Four Content Safety audit rows cluster inside a 15 second window immediately after service start:

```
9:43:18 PM  KeywordFastPaths[7] on agent memory-management
9:43:23 PM  SystemPrompt on agent general
9:43:28 PM  DisplayName on agent router
9:43:33 PM  SystemPrompt on agent router
```

Every one is `MODEL - SAFETY SERVICE UNAVAILABLE`, status **Allowed through**, reason "Content Safety was unreachable ... the system allowed it because fail-open policy is active." A later call at 11:46:05 PM to the same resource succeeded and correctly blocked an injection attempt, so the resource is reachable at runtime. This is a cold-start artefact, not an outage, and fail-open means those four payloads passed **unscanned**.

Reading the code establishes the mechanism:

1. **The token fetch shared the scan timeout budget.** `AzureContentSafetyEvaluator.EvaluateAsync` opened one CTS with `cts.CancelAfter(TimeoutMs)` (default 1500 ms, lines 86 to 87 of the original) covering both the managed-identity token acquisition and the scan. The raw Prompt Shields path fetched its bearer via `ContentSafetyTokenProvider` inside that budget, and the SDK moderation path fetched its token through the same `DefaultAzureCredential` inside the same budget.
2. **The first fetch after start is unprimed.** The first `DefaultAzureCredential.GetTokenAsync` has an empty cache and must walk the managed-identity chain (IMDS probe plus an AAD round-trip), which routinely takes seconds. Folded into a 1500 ms budget that also has to run the scan, it expires, surfaces as `OperationCanceledException`, and the call returns `ServiceUnavailable`, so fail-open lets the content through.
3. **The startup agent-definition scan is the first caller.** `AgentDefinitionValidator` runs synchronously during host configuration, before the host starts, and issues the very first Content Safety calls. Those are the four fields in the rows (KeywordFastPaths, SystemPrompt twice, DisplayName across agents). By 11:46 PM the credential and connection are warm.
4. **Every failure collapsed into one generic outcome.** All catch blocks returned the same `ContentSafetyResult.ServiceUnavailable` singleton, so `GuardrailAuditFields.BuildReason` produced identical "unreachable" text for a timeout, an auth rejection, and a transport failure. An operator staring at the four rows could not tell a cold-start timeout from a 401. Worse, a 401/403 `RequestFailedException` from the SDK path was not caught at all and would escape the fail policy entirely.

**What is proven vs. narrowed.** The mechanism is established from the code. The live first-token latency could not be measured, because data-plane RBAC on the deployed resource was deliberately revoked for the developer identity, so no live call was made. The root cause is therefore strongly narrowed from code, not empirically timed against the live resource.

## The fix

Four changes, each proportionate to a finding, none touching the fail-open policy, the audit visibility, or the counter aggregation owned by the sibling change.

1. **Separate the token budget from the scan budget.** `AcquireBearerAsync` pre-acquires the bearer under its own `TokenTimeoutMs` budget (default 5000 ms) before the scan CTS is created. A slow first-token fetch can no longer consume the scan timeout. Priming the shared credential here also warms the SDK moderation path, which fetches through the same credential singleton.
2. **Warm the token before any real scan.**
   - `ContentSafetyTokenProvider.WarmUpAsync(budget)` pre-acquires and caches a token, bounded by the budget, retrying only genuinely transient failures (`CredentialUnavailableException`) with a short backoff. It never retries `AuthenticationFailedException` and never throws.
   - `ContentSafetyWarmUpService` is a hosted service whose `StartAsync` is fire-and-forget, covering the runtime pipeline without gating startup.
   - The startup agent-definition scan runs before the host starts on a separate DI provider, so it is warmed directly in `Program.cs`, best-effort and time-boxed, before the validator runs.
3. **Classify the failure.** `ContentSafetyFailureReason` (Timeout, Authentication, Transport, CircuitOpen) is carried on `ContentSafetyResult`. The SDK auth gap is closed: 401/403 from `RequestFailedException` and `HttpRequestException`, plus `AuthenticationFailedException`, now route to `Authentication` rather than escaping.
4. **Name the failure in the audit reason.** `GuardrailAuditFields.UnavailableReason` varies the operator-visible text by failure class. Every variant still contains "unreachable", and the unclassified case keeps the exact original sentence, so existing audit consumers see no regression.

Two config knobs are added to `ContentSafetyConfig`: `TokenTimeoutMs` and `WarmUpTimeoutMs` (both default 5000 ms). Full write-up in `docs/adr/016-content-safety-cold-start-warmup.md`.

## What an operator sees on cold start now

- When the warm-up succeeds, the first scan is warm and the four fail-open rows do not appear at all.
- If a cold-start fetch still fails, the row remains visible (fail-open behaviour is unchanged) but its reason now names the cause, for example "the call timed out before the service responded" versus "managed-identity authentication was rejected." A timeout is no longer indistinguishable from a 401.

## Scope note for the fail-open counter work

This change alters only the audit Reason **string**. It does not change `DetectionType` or `Action` constants and does not touch counter aggregation or the stats API. A counter keyed on the outcome or on the word "unreachable" continues to match every variant. The new `ContentSafetyFailureReason` is available if the counter wants to break fail-open counts down by cause.

## Policy recommendation (left to the owner)

Whether the tool-result stage should fail closed rather than fail open is a product decision that has not been made, and this change does not make it. The evidence here is that fail-open silently passed four unscanned payloads on every cold start. The warm-up narrows that window but does not eliminate it; only a fail-closed policy for that stage would close it. That decision is left to the policy owner.

## Tests

New tests (all green, using fakes, no live calls):
- `ContentSafetyTokenProviderWarmUpTests`: transient failure retried then warmed (credential called twice); auth failure not retried (called once); a hanging credential is time-boxed and returns `TimedOut`; an already-cached token needs no fetch.
- `ContentSafetyColdStartClassificationTests`: a slow token within its own budget does not consume the scan budget (scan still passes); auth is classified `Authentication` and not retried; a token fetch over its budget is `Timeout`; an HTTP failure is `Transport`.
- `ContentSafetyWarmUpServiceTests`: `StartAsync` returns immediately even when the credential hangs, and the background warm-up terminates within its budget.
- `ContentSafetyUnavailableReasonTests`: each failure class yields distinct, operator-readable text; the unclassified case keeps the original wording.

Existing Content Safety and validator tests still pass. Full suite: 3632 passed, 9 skipped (live-only), 0 failed. `dotnet format --verify-no-changes` is clean.
