### PR TITLE
Add client/API contract test layer (round-trip fixtures)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,20 @@ jobs:
             --configuration Release \
             --filter "FullyQualifiedName~RetailPulse.Tests.Eval"
 
+      # Explicit fail-fast gate for the client/API contract layer. The round-trip
+      # fixtures under contracts/fixtures/ are serialised from the real response DTOs;
+      # this step reasserts them against the committed snapshots so an API-side rename,
+      # removal, or type change trips CI with the endpoint and field named, instead of
+      # reaching the deployed UI as an empty page or a zeroed value. Regenerating a
+      # fixture is deliberate (UPDATE_CONTRACT_FIXTURES=1), so this never rubber-stamps
+      # itself. The matching consumer assertions run in the frontend job.
+      - name: Client/API contract fixtures (backend)
+        run: |
+          dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj \
+            --no-build \
+            --configuration Release \
+            --filter "FullyQualifiedName~ApiClientContractFixtureTests"
+
       - name: Upload eval harness report
         uses: actions/upload-artifact@v4
         if: always()
@@ -193,6 +207,13 @@ jobs:
       # a targeted, easy-to-diagnose failure.
       - name: Chart acceptance matrix (frontend)
         run: npx vitest run src/__tests__/chartAcceptance.contract.test.ts src/__tests__/chartAcceptance.matrix.test.tsx
+
+      # Explicit fail-fast gate for the consumer side of the client/API contract. The
+      # same committed fixtures the backend produced are fed through the real client
+      # services/mappers here, so a client that starts reading a field the API does not
+      # send (or under a different name) trips CI with the endpoint and field named.
+      - name: Client/API contract fixtures (frontend)
+        run: npx vitest run src/__tests__/apiClientContract.contract.test.ts
 
   security:
     name: Security (Vulnerable Packages)

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,80 @@
+# Client/API contract fixtures
+
+This folder holds the shared contract between the API response shapes and the
+TypeScript types the SPA consumes. Both test suites assert against the same
+committed JSON files, so a field renamed, removed, or retyped on either side
+fails a test that names the endpoint and the field.
+
+## Why this exists
+
+Over one development cycle, five separate client/API contract mismatches reached
+the deployed app and were caught by a human clicking through the live UI: a page
+rendered empty, a value showed as zero, a feature looked broken while the backend
+was fine. In every case the client read a field the API did not send, or sent
+under a different name or shape. Both sides had green tests: the C# tests asserted
+what the API produced, the TypeScript tests asserted what the client consumed, and
+nothing asserted that the two agreed. These fixtures close that gap.
+
+## How it works (round-trip fixtures)
+
+1. The backend test
+   `tests/RetailPulse.Tests/ContractFixtures/ApiClientContractFixtureTests.cs`
+   builds the real response DTO for each covered endpoint and serialises it with
+   the API's own JSON options (`JsonSerializerDefaults.Web`: camelCase, integer
+   enums, ISO-8601 dates). It compares the result structurally against the
+   committed fixture in this folder and fails with a per-path diff on any drift.
+
+2. The frontend test
+   `src/RetailPulse.Web/src/__tests__/apiClientContract.contract.test.ts` loads
+   the same fixtures, feeds each one through the real client service or mapper
+   (for example `fetchGuardrailsStats`, `fetchGuardrailsLog`, `fetchActiveCards`,
+   `fetchScorecard`), and asserts every field the SPA reads is present and
+   correctly typed. If the client starts reading a wire field the fixture (the
+   real API shape) does not contain, this test fails.
+
+Together this means:
+
+- API renames, removes, or retypes a field -> the C# snapshot test fails.
+- Client reads a field the API does not send -> the TypeScript test fails.
+- An additive API change (for example a new counter) shows up as a reviewable
+  diff in the regenerated fixture, which is easy to accept on purpose.
+
+No server and no Azure resources are required: the fixtures are static files, so
+this runs cheaply on every PR.
+
+## Updating a fixture (deliberate, reviewable)
+
+Fixtures are never regenerated silently. When an API change is intentional,
+regenerate and commit the diff:
+
+```powershell
+# PowerShell
+$env:UPDATE_CONTRACT_FIXTURES = '1'
+dotnet test tests\RetailPulse.Tests\RetailPulse.Tests.csproj --configuration Release `
+  --filter "FullyQualifiedName~ApiClientContractFixtureTests"
+Remove-Item Env:\UPDATE_CONTRACT_FIXTURES
+```
+
+```bash
+# bash
+UPDATE_CONTRACT_FIXTURES=1 dotnet test tests/RetailPulse.Tests/RetailPulse.Tests.csproj \
+  --configuration Release --filter "FullyQualifiedName~ApiClientContractFixtureTests"
+```
+
+Review the resulting fixture diff, then update the client mapper and its
+assertions to match before committing. The regeneration is an explicit act, so a
+broken shape cannot pass by quietly rewriting the snapshot.
+
+## Coverage
+
+Covered (the API serialises a DTO directly, so both sides are unambiguous):
+
+- `GET /api/guardrails/stats` -> `guardrails-stats.json`
+- `GET /api/guardrails/log` -> `guardrails-log.json`
+- `GET /api/cards` -> `cards.json`
+- `POST /api/scorecard` -> `portfolio-scorecard.json`
+
+Deferred (documented in the PR): Health Council, Campaign Planner (Promo), and
+Financials (Margin). Their wire shapes are hand-built in the endpoint or owned by
+the McpServer process, so there is no directly-serialisable Api/Contracts DTO to
+round-trip without a production refactor or an in-memory host.

--- a/contracts/fixtures/cards.json
+++ b/contracts/fixtures/cards.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "card-council-42",
+    "title": "Contoso council verdict",
+    "type": 0,
+    "lifecycle": 1,
+    "createdBy": "system",
+    "createdAt": "2026-08-30T17:05:24Z",
+    "votes": [
+      {
+        "userId": "user-7",
+        "userName": "Ada Lovelace",
+        "vote": "Red",
+        "timestamp": "2026-08-30T17:05:24Z"
+      }
+    ],
+    "comments": [
+      {
+        "userId": "user-9",
+        "userName": "Alan Turing",
+        "text": "Agree with the downgrade.",
+        "timestamp": "2026-08-30T17:05:24Z"
+      }
+    ],
+    "data": {
+      "brand": "Contoso",
+      "overall_rating": "Red",
+      "synthesis": "Demand is softening faster than supply can adjust."
+    },
+    "escalationReason": "Two specialists rated Red."
+  }
+]

--- a/contracts/fixtures/guardrails-log.json
+++ b/contracts/fixtures/guardrails-log.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "req-1024",
+    "timestamp": "2026-08-30T17:05:24Z",
+    "requestText": "Tool result from \u0027GetStorePerformance\u0027 blocked by Content Safety",
+    "detectionType": "content-safety-sexual",
+    "userContext": "analyst@contoso.com",
+    "action": "blocked",
+    "category": "Sexual",
+    "severity": 4,
+    "decision": "Blocked",
+    "stage": "ToolResult",
+    "threshold": 4,
+    "reason": "Content Safety classified the tool result as Sexual content at severity 4, which met threshold 4.",
+    "subject": "GetStorePerformance"
+  }
+]

--- a/contracts/fixtures/guardrails-stats.json
+++ b/contracts/fixtures/guardrails-stats.json
@@ -1,0 +1,10 @@
+{
+  "totalBlocked": 128,
+  "jailbreakAttempts": 37,
+  "piiDetections": 52,
+  "accessDenials": 14,
+  "since": "2026-08-30T17:05:24Z",
+  "contentSafetyBlocks": 19,
+  "contentSafetyFlags": 8,
+  "failOpenPasses": 5
+}

--- a/contracts/fixtures/portfolio-scorecard.json
+++ b/contracts/fixtures/portfolio-scorecard.json
@@ -1,0 +1,63 @@
+{
+  "brands": [
+    {
+      "brand": "Contoso",
+      "overallScore": 6.1,
+      "dimensions": {
+        "Demand Momentum": {
+          "dimension": "Demand Momentum",
+          "score": 7.5,
+          "weight": 0.25,
+          "weightedScore": 1.875,
+          "assessment": "Strong sell-through.",
+          "agentKey": "demand-forecasting"
+        },
+        "Competitive Position": {
+          "dimension": "Competitive Position",
+          "score": 6,
+          "weight": 0.2,
+          "weightedScore": 1.2,
+          "assessment": "Holding share.",
+          "agentKey": "competitive-intel"
+        },
+        "Supply Reliability": {
+          "dimension": "Supply Reliability",
+          "score": 5.5,
+          "weight": 0.2,
+          "weightedScore": 1.1,
+          "assessment": "Some stockout risk.",
+          "agentKey": "supply-chain"
+        },
+        "Store Execution": {
+          "dimension": "Store Execution",
+          "score": 6.5,
+          "weight": 0.2,
+          "weightedScore": 1.3,
+          "assessment": "Good placement.",
+          "agentKey": "store-ops"
+        },
+        "Margin Health": {
+          "dimension": "Margin Health",
+          "score": 4.5,
+          "weight": 0.15,
+          "weightedScore": 0.675,
+          "assessment": "Cost pressure.",
+          "agentKey": "margin-analysis"
+        }
+      },
+      "summary": "Contoso is mixed: strong demand, soft margin.",
+      "actionItems": [
+        "Protect margin on hero SKUs.",
+        "Lean into demand momentum."
+      ],
+      "durationMs": 8421
+    }
+  ],
+  "executiveSummary": "",
+  "topActions": [
+    "Protect margin on hero SKUs.",
+    "Lean into demand momentum."
+  ],
+  "generatedAt": "2026-08-30T17:05:24Z",
+  "totalDurationMs": 8421
+}

--- a/src/RetailPulse.Web/src/__tests__/apiClientContract.contract.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/apiClientContract.contract.test.ts
@@ -21,6 +21,9 @@ import { fetchScorecard } from '../services/operationsApi';
  *  - API stops sending a field -> the C# fixture changes -> the C# snapshot test
  *    fails until the fixture is regenerated; once it is, the mapper below produces
  *    an empty/undefined value and this test fails until the client is updated.
+ *    Where a mapper substitutes a default for a missing field, assert the value
+ *    against the fixture rather than only its type: a default turns a dropped
+ *    field into a plausible zero, which is the failure a type check cannot see.
  *  - Client starts reading a different wire field -> the mapper reads something the
  *    fixture (the real API shape) does not contain -> this test fails here.
  *
@@ -85,6 +88,13 @@ describe('contract: GET /api/guardrails/stats -> GuardrailsStats', () => {
     ] as const;
     for (const field of counters) {
       expect(typeof stats[field], `guardrails/stats.${field} must be a number the client can read`).toBe('number');
+      // Assert the value carried through, not merely that it is numeric. The mapper
+      // defaults failOpenPasses to 0 when absent, so a type-only assertion would still
+      // pass after the API renamed or dropped the field and the counter would silently
+      // read zero on the Security page. Comparing against the fixture value is what
+      // makes the default visible instead of protective.
+      expect(stats[field], `guardrails/stats.${field} must carry the API value, not a client default`)
+        .toBe(fixture[field] as number);
     }
     expect(Array.isArray(stats.recentBlocked)).toBe(true);
     expect(Array.isArray(stats.blocksPerHour)).toBe(true);

--- a/src/RetailPulse.Web/src/__tests__/apiClientContract.contract.test.ts
+++ b/src/RetailPulse.Web/src/__tests__/apiClientContract.contract.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchActiveCards } from '../services/cardsApi';
+import { fetchGuardrailsLog, fetchGuardrailsStats } from '../services/guardrailsApi';
+import { fetchScorecard } from '../services/operationsApi';
+
+/**
+ * Client/API contract, consumer side.
+ *
+ * Each case loads a JSON fixture that the C# suite produced by serialising the
+ * real response DTO with the API's own JSON options
+ * (tests/RetailPulse.Tests/ContractFixtures/ApiClientContractFixtureTests.cs), then
+ * runs the actual client service/mapper against it and asserts every field the SPA
+ * reads is present and correctly typed. Because both suites assert the same
+ * committed files, a field renamed, removed, or retyped on either side breaks a
+ * test that names the endpoint and the field:
+ *
+ *  - API stops sending a field -> the C# fixture changes -> the C# snapshot test
+ *    fails until the fixture is regenerated; once it is, the mapper below produces
+ *    an empty/undefined value and this test fails until the client is updated.
+ *  - Client starts reading a different wire field -> the mapper reads something the
+ *    fixture (the real API shape) does not contain -> this test fails here.
+ *
+ * No server and no Azure: the fixtures are static files, so this runs on every PR.
+ */
+
+// Walk up to the repository root (the directory holding RetailPulse.slnx) so the
+// fixtures resolve regardless of the vitest working directory.
+function repositoryRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let depth = 0; depth < 12; depth += 1) {
+    try {
+      readFileSync(join(dir, 'RetailPulse.slnx'));
+      return dir;
+    } catch {
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+  throw new Error('Could not locate the repository root (no RetailPulse.slnx above this test).');
+}
+
+function loadFixture(name: string): unknown {
+  const path = join(repositoryRoot(), 'contracts', 'fixtures', `${name}.json`);
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function mockFetchJson(payload: unknown): void {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  } as Response);
+}
+
+// The panel keys its style maps by name; the wire carries integers. Mirrors the
+// C# CardType / CardLifecycle declaration order.
+const CARD_TYPES = ['voting', 'drilldown', 'dashboard', 'briefing'] as const;
+const CARD_LIFECYCLES = ['active', 'voting', 'decided', 'archived'] as const;
+const SCORECARD_DIMENSION_KEYS = ['demand', 'competitive', 'supply', 'store', 'margin'] as const;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('contract: GET /api/guardrails/stats -> GuardrailsStats', () => {
+  it('exposes every counter the security dashboard reads', async () => {
+    const fixture = loadFixture('guardrails-stats') as Record<string, unknown>;
+    mockFetchJson(fixture);
+
+    const stats = await fetchGuardrailsStats();
+
+    const counters = [
+      'totalBlocked',
+      'jailbreakAttempts',
+      'piiDetections',
+      'accessDenials',
+      'contentSafetyBlocks',
+      'contentSafetyFlags',
+      'failOpenPasses',
+    ] as const;
+    for (const field of counters) {
+      expect(typeof stats[field], `guardrails/stats.${field} must be a number the client can read`).toBe('number');
+    }
+    expect(Array.isArray(stats.recentBlocked)).toBe(true);
+    expect(Array.isArray(stats.blocksPerHour)).toBe(true);
+  });
+});
+
+describe('contract: GET /api/guardrails/log -> BlockedRequest[]', () => {
+  it('maps every audit-row field the dashboard renders', async () => {
+    const fixture = loadFixture('guardrails-log') as Array<Record<string, unknown>>;
+    mockFetchJson(fixture);
+
+    const rows = await fetchGuardrailsLog(1);
+    expect(rows.length).toBe(fixture.length);
+
+    const row = rows[0];
+    const wire = fixture[0];
+    // requestPreview is sourced from the API `requestText` field; a rename would
+    // leave it empty, which was one of the shipped regressions.
+    expect(row.requestPreview, 'guardrails/log.requestText -> requestPreview').toBe(wire.requestText);
+    expect(row.actionTaken, 'guardrails/log.action -> actionTaken').toBe(wire.action);
+    expect(row.reason).toBe(wire.reason);
+    expect(row.category).toBe(wire.category);
+    expect(typeof row.severity, 'guardrails/log.severity').toBe('number');
+    expect(row.decision).toBe(wire.decision);
+    expect(row.stage).toBe(wire.stage);
+    expect(typeof row.threshold, 'guardrails/log.threshold').toBe('number');
+    expect(row.subject).toBe(wire.subject);
+  });
+});
+
+describe('contract: GET /api/cards -> AdaptiveCard[]', () => {
+  it('maps integer enums and vote/comment shapes the panel depends on', async () => {
+    const fixture = loadFixture('cards') as Array<Record<string, unknown>>;
+    mockFetchJson(fixture);
+
+    const cards = await fetchActiveCards();
+    const card = cards[0];
+    const wire = fixture[0];
+
+    // Enums cross the wire as integers.
+    expect(typeof wire.type, 'cards[].type must be an integer enum').toBe('number');
+    expect(typeof wire.lifecycle, 'cards[].lifecycle must be an integer enum').toBe('number');
+    expect(card.type).toBe(CARD_TYPES[wire.type as number]);
+    // Server sends `lifecycle`; the view model exposes `state`. A rename back to a
+    // wire `state` field would silently fall back to 'active'.
+    expect(card.state).toBe(CARD_LIFECYCLES[wire.lifecycle as number]);
+
+    const wireVote = (wire.votes as Array<Record<string, unknown>>)[0];
+    const vote = card.votes?.[0];
+    expect(vote, 'cards[].votes must be present').toBeDefined();
+    // Server sends { vote, timestamp }; the panel reads { choice, votedAt }.
+    expect(vote?.votedAt, 'cards[].votes[].timestamp -> votedAt').toBe(wireVote.timestamp);
+    expect(['approve', 'reject', 'abstain']).toContain(vote?.choice);
+
+    const wireComment = (wire.comments as Array<Record<string, unknown>>)[0];
+    const comment = card.comments?.[0];
+    expect(comment?.text, 'cards[].comments[].text').toBe(wireComment.text);
+    expect(card.createdBy).toBe(wire.createdBy);
+    expect(card.createdAt).toBe(wire.createdAt);
+  });
+});
+
+describe('contract: POST /api/scorecard -> PortfolioScorecard', () => {
+  it('binds every brand dimension and duration the scorecard reads', async () => {
+    const fixture = loadFixture('portfolio-scorecard') as {
+      brands: Array<{ brand: string; overallScore: number; durationMs: number }>;
+      totalDurationMs: number;
+    };
+    mockFetchJson(fixture);
+
+    const { brands, durationMs } = await fetchScorecard(['Contoso']);
+    const brand = brands[0];
+    const wireBrand = fixture.brands[0];
+
+    expect(brand.brandName).toBe(wireBrand.brand);
+    // overallScore is reported 0-10; the card health score is 0-100.
+    expect(brand.healthScore).toBe(Math.round(wireBrand.overallScore * 10));
+    // All five dimensions must bind via agentKey; a rename empties this map and the
+    // card shows every dimension at zero.
+    expect(Object.keys(brand.dimensionDetails ?? {}).sort()).toEqual([...SCORECARD_DIMENSION_KEYS].sort());
+    expect(brand.durationMs, 'scorecard brand.durationMs').toBe(wireBrand.durationMs);
+    expect(durationMs, 'scorecard totalDurationMs -> durationMs').toBe(fixture.totalDurationMs);
+  });
+});

--- a/src/RetailPulse.Web/tsconfig.app.json
+++ b/src/RetailPulse.Web/tsconfig.app.json
@@ -26,6 +26,7 @@
   "exclude": [
     "src/__tests__/lockfileIntegrity.test.ts",
     "src/__tests__/chartAcceptance.contract.test.ts",
-    "src/__tests__/promptAcceptance.contract.test.ts"
+    "src/__tests__/promptAcceptance.contract.test.ts",
+    "src/__tests__/apiClientContract.contract.test.ts"
   ]
 }

--- a/tests/RetailPulse.Tests/ContractFixtures/ApiClientContractFixtureTests.cs
+++ b/tests/RetailPulse.Tests/ContractFixtures/ApiClientContractFixtureTests.cs
@@ -1,0 +1,265 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using RetailPulse.Api.Scorecard;
+using RetailPulse.Contracts.Cards;
+using RetailPulse.Contracts.Guardrails;
+
+namespace RetailPulse.Tests.ContractFixtures;
+
+/// <summary>
+/// Client/API contract fixtures.
+///
+/// Both sides of every response used to be tested in isolation: the C# tests
+/// asserted what the API produced and the TypeScript tests asserted what the SPA
+/// consumed, but nothing asserted the two agreed. Five field mismatches reached
+/// production through that gap. This suite closes it.
+///
+/// Each fact serialises a real response DTO with the same options ASP.NET Core
+/// minimal APIs use for <c>Results.Ok(...)</c> (<see cref="JsonSerializerDefaults.Web"/>:
+/// camelCase names, enums as integers because no <c>JsonStringEnumConverter</c> is
+/// registered in Program.cs, ISO-8601 dates) and asserts the JSON matches a
+/// committed fixture under <c>contracts/fixtures</c>. The identical fixtures are
+/// consumed by the TypeScript suite
+/// (<c>src/RetailPulse.Web/src/__tests__/apiClientContract.contract.test.ts</c>),
+/// so a field renamed, removed, or retyped on either side breaks a test that names
+/// the endpoint and the field.
+///
+/// Why a snapshot and not a live call: CI has no server and no Azure. Serialising
+/// the DTO the endpoint returns reproduces the exact wire shape without a host, and
+/// a committed snapshot turns drift into a reviewable diff instead of a silent
+/// change. Regeneration is deliberate, never automatic: set
+/// <c>UPDATE_CONTRACT_FIXTURES=1</c> to rewrite the committed fixtures.
+/// </summary>
+public sealed class ApiClientContractFixtureTests
+{
+    private static readonly JsonSerializerOptions WireOptions =
+        new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    // A fixed instant keeps serialised fixtures deterministic across runs; the
+    // contract under test is the shape, not the value.
+    private static readonly DateTime Instant =
+        new(2026, 8, 30, 17, 5, 24, DateTimeKind.Utc);
+
+    [Fact]
+    public void GuardrailsStats_matches_committed_fixture()
+    {
+        // GuardrailEndpoints /api/guardrails/stats projects GuardrailsStats 1:1 to
+        // camelCase. Serialising the DTO tracks additive counter fields
+        // automatically, which is the intent: a new fail-open counter surfaces as a
+        // reviewable fixture diff rather than silent drift.
+        var stats = new GuardrailsStats(
+            TotalBlocked: 128,
+            JailbreakAttempts: 37,
+            PiiDetections: 52,
+            AccessDenials: 14,
+            Since: Instant,
+            ContentSafetyBlocks: 19,
+            ContentSafetyFlags: 8,
+            FailOpenPasses: 5);
+
+        AssertMatchesFixture("guardrails-stats", stats);
+    }
+
+    [Fact]
+    public void GuardrailsLog_matches_committed_fixture()
+    {
+        // GuardrailEndpoints /api/guardrails/log projects SuspiciousRequest 1:1 to
+        // camelCase. Every optional detail field is populated so the fixture proves
+        // the whole audit-row surface the dashboard reads, not just the required
+        // prefix.
+        SuspiciousRequest[] log =
+        [
+            new SuspiciousRequest(
+                Id: "req-1024",
+                Timestamp: Instant,
+                RequestText: "Tool result from 'GetStorePerformance' blocked by Content Safety",
+                DetectionType: "content-safety-sexual",
+                UserContext: "analyst@contoso.com",
+                Action: "blocked",
+                Category: "Sexual",
+                Severity: 4,
+                Decision: "Blocked",
+                Stage: "ToolResult",
+                Threshold: 4,
+                Reason: "Content Safety classified the tool result as Sexual content at severity 4, which met threshold 4.",
+                Subject: "GetStorePerformance"),
+        ];
+
+        AssertMatchesFixture("guardrails-log", log);
+    }
+
+    [Fact]
+    public void Cards_matches_committed_fixture()
+    {
+        // CardEndpoints GET /api/cards returns AdaptiveCard directly. Enums cross the
+        // wire as integers (Type/Lifecycle) and votes carry vote/timestamp: exactly
+        // the shape cardsApi.ts normalises. Two of the five production mismatches
+        // lived here (lifecycle vs state, vote vs choice).
+        AdaptiveCard[] cards =
+        [
+            new AdaptiveCard(
+                Id: "card-council-42",
+                Title: "Contoso council verdict",
+                Type: CardType.Voting,
+                Lifecycle: CardLifecycle.Voting,
+                CreatedBy: "system",
+                CreatedAt: Instant,
+                Votes: [new CardVote("user-7", "Ada Lovelace", "Red", Instant)],
+                Comments: [new CardComment("user-9", "Alan Turing", "Agree with the downgrade.", Instant)],
+                Data: new Dictionary<string, object>
+                {
+                    ["brand"] = "Contoso",
+                    ["overall_rating"] = "Red",
+                    ["synthesis"] = "Demand is softening faster than supply can adjust.",
+                },
+                EscalationReason: "Two specialists rated Red."),
+        ];
+
+        AssertMatchesFixture("cards", cards);
+    }
+
+    [Fact]
+    public void PortfolioScorecard_matches_committed_fixture()
+    {
+        // ScorecardEndpoints POST /api/scorecard returns
+        // ScorecardOrchestrator.PortfolioScorecard directly. The dimension agentKey
+        // values are the join the SPA uses (dimensionKeyFromAgent) to bind each
+        // dimension to a card, so all five are exercised.
+        var dimensions = new Dictionary<string, ScorecardOrchestrator.DimensionScore>
+        {
+            ["Demand Momentum"] = new("Demand Momentum", 7.5, 0.25, 1.875, "Strong sell-through.", "demand-forecasting"),
+            ["Competitive Position"] = new("Competitive Position", 6.0, 0.20, 1.2, "Holding share.", "competitive-intel"),
+            ["Supply Reliability"] = new("Supply Reliability", 5.5, 0.20, 1.1, "Some stockout risk.", "supply-chain"),
+            ["Store Execution"] = new("Store Execution", 6.5, 0.20, 1.3, "Good placement.", "store-ops"),
+            ["Margin Health"] = new("Margin Health", 4.5, 0.15, 0.675, "Cost pressure.", "margin-analysis"),
+        };
+
+        var scorecard = new ScorecardOrchestrator.PortfolioScorecard(
+            Brands:
+            [
+                new ScorecardOrchestrator.BrandScore(
+                    Brand: "Contoso",
+                    OverallScore: 6.1,
+                    Dimensions: dimensions,
+                    Summary: "Contoso is mixed: strong demand, soft margin.",
+                    ActionItems: ["Protect margin on hero SKUs.", "Lean into demand momentum."],
+                    DurationMs: 8421),
+            ],
+            // The SPA passes includeSummary=false and renders per-brand cards, so the
+            // executive summary is empty on the contract path.
+            ExecutiveSummary: "",
+            TopActions: ["Protect margin on hero SKUs.", "Lean into demand momentum."],
+            GeneratedAt: Instant,
+            TotalDurationMs: 8421);
+
+        AssertMatchesFixture("portfolio-scorecard", scorecard);
+    }
+
+    private static void AssertMatchesFixture<T>(string name, T value)
+    {
+        string actualJson = JsonSerializer.Serialize(value, WireOptions);
+        string fixturePath = Path.Combine(FixturesDirectory(), name + ".json");
+
+        if (ShouldUpdate)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(fixturePath)!);
+            // LF endings so the committed fixture is stable across platforms and the
+            // gitattributes eol=lf normalisation is a no-op.
+            File.WriteAllText(fixturePath, actualJson.ReplaceLineEndings("\n") + "\n");
+            return;
+        }
+
+        Assert.True(
+            File.Exists(fixturePath),
+            $"Contract fixture '{name}' is missing at {fixturePath}. Regenerate committed " +
+            "fixtures with: UPDATE_CONTRACT_FIXTURES=1 dotnet test " +
+            "--filter FullyQualifiedName~ApiClientContractFixtureTests");
+
+        var expected = JsonNode.Parse(File.ReadAllText(fixturePath));
+        var actual = JsonNode.Parse(actualJson);
+
+        var diffs = new List<string>();
+        DiffJson(name, expected, actual, diffs);
+
+        Assert.True(
+            diffs.Count == 0,
+            $"API response shape for '{name}' drifted from the committed contract fixture " +
+            $"({fixturePath}). Each line below names the JSON path that changed. If the change " +
+            "is intentional, regenerate with UPDATE_CONTRACT_FIXTURES=1, review the diff, and " +
+            "update the matching TypeScript client types/mappers so both sides agree:\n  " +
+            string.Join("\n  ", diffs));
+    }
+
+    // Structural, order-insensitive JSON compare that reports one line per drifted
+    // path so a failure names the endpoint and the exact field.
+    private static void DiffJson(string path, JsonNode? expected, JsonNode? actual, List<string> diffs)
+    {
+        if (expected is null || actual is null)
+        {
+            if (expected is not null || actual is not null)
+                diffs.Add($"{path}: {(expected is null ? "value present in API output but null in contract" : "value missing from API output")}");
+            return;
+        }
+
+        if (expected is JsonObject expectedObject && actual is JsonObject actualObject)
+        {
+            foreach (KeyValuePair<string, JsonNode?> field in expectedObject)
+            {
+                if (!actualObject.ContainsKey(field.Key))
+                    diffs.Add($"{path}.{field.Key}: field in committed contract but missing from API output (removed or renamed)");
+                else
+                    DiffJson($"{path}.{field.Key}", field.Value, actualObject[field.Key], diffs);
+            }
+
+            foreach (KeyValuePair<string, JsonNode?> field in actualObject)
+            {
+                if (!expectedObject.ContainsKey(field.Key))
+                    diffs.Add($"{path}.{field.Key}: field in API output but not in committed contract (added or renamed)");
+            }
+
+            return;
+        }
+
+        if (expected is JsonArray expectedArray && actual is JsonArray actualArray)
+        {
+            if (expectedArray.Count != actualArray.Count)
+                diffs.Add($"{path}: array length changed ({expectedArray.Count} -> {actualArray.Count})");
+
+            for (int i = 0; i < Math.Min(expectedArray.Count, actualArray.Count); i++)
+                DiffJson($"{path}[{i}]", expectedArray[i], actualArray[i], diffs);
+
+            return;
+        }
+
+        JsonValueKind expectedKind = expected.GetValueKind();
+        JsonValueKind actualKind = actual.GetValueKind();
+        if (expectedKind != actualKind)
+        {
+            diffs.Add($"{path}: type changed ({expectedKind} -> {actualKind})");
+            return;
+        }
+
+        if (!string.Equals(expected.ToJsonString(), actual.ToJsonString(), StringComparison.Ordinal))
+            diffs.Add($"{path}: value changed ({expected.ToJsonString()} -> {actual.ToJsonString()})");
+    }
+
+    private static bool ShouldUpdate =>
+        string.Equals(Environment.GetEnvironmentVariable("UPDATE_CONTRACT_FIXTURES"), "1", StringComparison.Ordinal)
+        || string.Equals(Environment.GetEnvironmentVariable("UPDATE_CONTRACT_FIXTURES"), "true", StringComparison.OrdinalIgnoreCase);
+
+    private static string FixturesDirectory() => Path.Combine(RepositoryRoot(), "contracts", "fixtures");
+
+    private static string RepositoryRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "RetailPulse.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate the repository root (no RetailPulse.slnx found above {AppContext.BaseDirectory}).");
+    }
+}


### PR DESCRIPTION
## What and why

Over the last cycle, five separate client/API contract mismatches reached the deployed app and were found by a human clicking through the live UI: pages rendering empty, values showing as zero, features looking broken while the backend was fine. In every case the client read a field the API did not send, or under a different name or shape.

Both sides had green tests. The C# tests asserted what the API produced. The TypeScript tests asserted what the client consumed. Nothing asserted that those two agreed. This PR closes that gap with a contract test layer that FAILS when the API response shape and the TS types the client consumes drift apart. It is tests and test infrastructure plus CI wiring only. No production behaviour changes.

## Approach chosen: round-trip fixtures (option 2), and why

I picked **round-trip fixtures** over generate-and-diff (option 1) and client-side runtime schema validation (option 3):

- The covered endpoints are minimal APIs that return a DTO directly via `Results.Ok(...)` using `JsonSerializerDefaults.Web`. There is no Swashbuckle/OpenAPI document emitted in this repo, so option 1 would mean standing up a schema generator and teaching it the exact `JsonSerializerDefaults.Web` conventions (camelCase, integer enums, ISO-8601). Round-trip fixtures reuse the API's own serializer, so the fixture is the ground truth by construction, with no generator to drift.
- Option 3 only checks the client against a schema derived from the TS types; it never sees the real server shape, so it cannot catch an API-side rename. That is exactly the failure class that shipped.
- Round-trip fixtures give both properties in one shared artifact: the C# side proves the fixture equals what the API serializes, and the TS side proves the client can consume that same fixture. A rename/removal/retype on either side breaks a test.

How it works:

- `tests/RetailPulse.Tests/ContractFixtures/ApiClientContractFixtureTests.cs` builds the real response DTOs, serialises them with the API's own JSON options, and compares structurally against committed snapshots in `contracts/fixtures/`. Drift fails with a per-JSON-path diff. Regeneration is explicit via `UPDATE_CONTRACT_FIXTURES=1`, so the snapshot can never silently rewrite itself into a green rubber stamp.
- `src/RetailPulse.Web/src/__tests__/apiClientContract.contract.test.ts` loads those same fixtures, feeds each through the real client service/mapper (`fetchGuardrailsStats`, `fetchGuardrailsLog`, `fetchActiveCards`, `fetchScorecard`), and asserts every consumed field is present and correctly typed, with messages naming the endpoint and field. Where a client mapper substitutes a default for a missing field (for example `failOpenPasses ?? 0`), the test also asserts the value equals the fixture, so a dropped field surfaces as a failure instead of a plausible zero.

Mandatory properties, satisfied: fails on rename/removal/type change on either side (proof below); needs no running server or Azure (fixtures are static files); cheap enough for every PR; diagnostics name the endpoint and field; snapshot updates are explicit. An additive change (for example a sibling agent adding a fail-open counter to the guardrails stats response) simply appears in the regenerated fixture as a reviewable diff, which is the "easy to accept" requirement.

## Endpoint / type inventory

| Endpoint | Producer (API) | Consumer (client) | Status |
| --- | --- | --- | --- |
| `GET /api/guardrails/stats` | `GuardrailsStats` DTO (`RetailPulse.Contracts`) | `GuardrailsStats` via `fetchGuardrailsStats` | Covered |
| `GET /api/guardrails/log` | `SuspiciousRequest` DTO | `BlockedRequest` via `fetchGuardrailsLog` | Covered |
| `GET /api/cards` | `AdaptiveCard` DTO | `AdaptiveCard` via `fetchActiveCards`/`toCard` | Covered |
| `POST /api/scorecard` | `ScorecardOrchestrator.PortfolioScorecard` | `BrandScore[]` via `fetchScorecard`/`toBrandScores` | Covered |
| `POST /api/council/convene`, `GET /api/council/history` | hand-built snake_case anonymous objects in `ChatEndpoints.cs` | `CouncilSession` via `councilApi` | Deferred |
| Campaign Planner `POST /api/promo/*` | reverse-proxy to `RetailPulse.McpServer` | promo client types | Deferred |
| Financials `POST /api/margin/*` | reverse-proxy to `RetailPulse.McpServer` | `MarginAnalysis` client types | Deferred |

## Covered vs deferred, and why

**Covered (4):** these endpoints serialise an Api/Contracts DTO directly, so the wire shape is unambiguous and reproducible offline without a host. They also carry the highest field counts and sit behind the pages that broke (Guardrails/Security, Cards, Portfolio Scorecard).

**Deferred (3), with justification:**

- **Health Council** (`/api/council/convene`, `/api/council/history`): the endpoints hand-build snake_case anonymous objects inline in `ChatEndpoints.cs` rather than serialising a DTO. Reproducing that exact wire shape in a fixture test would require either an in-memory host driving the endpoint or a production refactor to introduce a real response DTO. Both are out of scope for a tests-only PR. Flagged for a follow-up.
- **Campaign Planner (Promo)** and **Financials (Margin)**: `PromoEndpoints.cs` and `MarginEndpoints.cs` are thin reverse-proxies to `RetailPulse.McpServer`. The response shape is owned and serialised by the McpServer (`RetailPulseDb`), not by an Api/Contracts DTO. For example the margin wire carries per-period `financials[]` with `revenue/cogs/marketing/distribution/grossMargin/netMargin`, which does not match `Contracts.Margin.MarginAnalysis`. There is no directly-serialisable API DTO to round-trip, so a faithful fixture would again need a live McpServer. Deferred and flagged.

## Proof: it FAILS on an injected mismatch (then reverted)

**API-side (C#), renamed field.** Renamed `failOpenPasses` to `failOpenPassCount` in `contracts/fixtures/guardrails-stats.json` to simulate an API-side rename, then ran the backend contract test:

```
RetailPulse.Tests.ContractFixtures.ApiClientContractFixtureTests.GuardrailsStats_matches_committed_fixture [FAIL]
  API response shape for 'guardrails-stats' drifted from the committed contract fixture
  (contracts/fixtures/guardrails-stats.json). Each line below names the JSON path that changed. If the
  change is intentional, regenerate with UPDATE_CONTRACT_FIXTURES=1, review the diff, and update the
  matching TypeScript client types/mappers so both sides agree:
    guardrails-stats.failOpenPassCount: field in committed contract but missing from API output (removed or renamed)
    guardrails-stats.failOpenPasses: field in API output but not in committed contract (added or renamed)
  Failed: 1
```

**Client-side (TS), removed field caught as a silent zero.** `failOpenPasses` is mapped with a `?? 0` default, so a type-only check would still see a number after the API dropped it, and the Security page counter would silently read zero. Removing `failOpenPasses` from the fixture makes the value assertion catch it:

```
FAIL  src/__tests__/apiClientContract.contract.test.ts > contract: GET /api/guardrails/stats -> GuardrailsStats
      > exposes every counter the security dashboard reads
AssertionError: guardrails/stats.failOpenPasses must carry the API value, not a client default:
  expected +0 to be undefined
- Expected: undefined
+ Received: 0
```

That value assertion is the follow-up commit "Assert contract counter values, not just their types". Both injections were reverted; the committed fixtures are the canonical, unmodified shapes. On unmodified `dev` the backend contract test reports `Passed: 4` and the frontend contract test reports `4 passed`.

## Accepted additive change already landed on dev

Sibling PRs #265 and #267 landed a new `failOpenPasses` fail-open counter on the guardrails stats response (`GuardrailsStats` DTO, the API projection, `types/index.ts`, and the Security dashboard). This branch is rebased onto that `dev`, and the contract layer absorbed the addition exactly as designed: `guardrails-stats.json` now carries `failOpenPasses`, the C# producer test sets it explicitly, and the TS test asserts both its type and value. This is the "additive change is easy to accept" requirement demonstrated end to end on a real sibling change rather than a hypothetical.

## Real mismatch discovered (not fixed, for a human to decide)

`src/RetailPulse.Web/src/services/scorecardApi.ts` `fetchPortfolioScorecard()` issues `GET /api/portfolio/scorecard`, but no such route is mapped anywhere in the API (only `POST /api/scorecard` exists). The live, working scorecard consumer is `operationsApi.ts` `fetchScorecard()` posting `/api/scorecard`, which is the path this contract covers. `scorecardApi.ts` therefore appears to be dead/legacy code hitting a nonexistent route. I did not change it; flagging so a human can decide whether to delete it or wire a route. I did not encode the broken shape as correct.

## CI wiring

Wired into the existing `.github/workflows/ci.yml` rather than a new workflow: a fail-fast backend step (`--filter FullyQualifiedName~ApiClientContractFixtureTests`) in the `build` job, and a fail-fast frontend step running the contract test file in the `frontend` job. The `branch-policy` job is unaffected and correctly skips for a PR whose base is `dev`.

## Verification (re-run after rebase onto latest dev)

- Backend suite: `Passed: 3637, Skipped: 9, Failed: 0`.
- Backend contract test only: `Passed: 4`.
- Frontend contract test only: `4 passed`; full frontend suite `924 passed` (99 files), including `chartAcceptance.contract.test.ts` (`3 passed`).
- `dotnet format RetailPulse.slnx --verify-no-changes`: clean.
- `npm run typecheck` (`tsc -b --noEmit`): clean.
- CI on this PR head is green across all jobs (Build & Test .NET, Frontend, Lint dotnet format, and the rest); branch-policy skips as expected for a dev-base PR.

## Notes for reviewers

- `contracts/README.md` documents the mechanism and the explicit regeneration command (`UPDATE_CONTRACT_FIXTURES=1 dotnet test --filter FullyQualifiedName~ApiClientContractFixtureTests`).
- To accept a future additive field: regenerate the fixture with that command, review the one-line additive diff, and add the matching client assertion.
