### PR TITLE
Harden guardrails config panel against narrow-width overflow

### DIFF
--- a/src/RetailPulse.Web/src/components/guardrails/GuardrailsConfig.tsx
+++ b/src/RetailPulse.Web/src/components/guardrails/GuardrailsConfig.tsx
@@ -57,17 +57,22 @@ const useStyles = makeStyles({
     gap: '2px',
     fontSize: '12px',
     color: tokens.colorNeutralForeground2,
+    // Break any unbroken token in the explainer sentences (added by #264) so
+    // it wraps inside the callout instead of widening it at narrow widths.
+    overflowWrap: 'anywhere',
   },
   layerRowHead: {
     display: 'flex',
     alignItems: 'center',
     gap: '8px',
     flexWrap: 'wrap',
+    minWidth: 0,
   },
   layerRowName: {
     fontSize: '12px',
     fontWeight: 600,
     color: 'var(--color-text, #e2e8f0)',
+    overflowWrap: 'anywhere',
   },
   layerNoteStrong: {
     fontSize: '12px',
@@ -78,6 +83,7 @@ const useStyles = makeStyles({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
+    gap: '12px',
     padding: '8px 0',
     borderBottom: '1px solid var(--color-border, #334155)',
     ':last-child': {
@@ -88,13 +94,19 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     gap: '2px',
+    // Let the label column shrink so the longer #264 descriptions wrap here
+    // rather than pushing the switch off the row at narrow widths.
+    minWidth: 0,
   },
   toggleDescription: {
     fontSize: '12px',
     color: 'var(--color-text-muted, #94a3b8)',
+    overflowWrap: 'anywhere',
   },
   textarea: {
     width: '100%',
+    boxSizing: 'border-box',
+    minWidth: 0,
     minHeight: '120px',
     padding: '12px',
     borderRadius: '8px',
@@ -133,6 +145,8 @@ const useStyles = makeStyles({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: '8px',
     padding: '6px 0',
     fontSize: '13px',
     color: tokens.colorNeutralForeground2,
@@ -141,6 +155,11 @@ const useStyles = makeStyles({
     display: 'inline-flex',
     alignItems: 'center',
     gap: '4px',
+    maxWidth: '100%',
+    // The read-only badges carry long labels such as
+    // "MODEL · PROMPT-SHIELD SAFETY"; wrap them within the pill instead of
+    // letting them overflow a non-wrapping row.
+    overflowWrap: 'anywhere',
     padding: '2px 8px',
     borderRadius: tokens.borderRadiusCircular,
     fontSize: '11px',


### PR DESCRIPTION
## What and why

Follow-up hardening to the guardrails **config** panel. My earlier overflow fix (PR #266, already merged into `dev`) covered `GuardrailsDashboard.tsx` but did not touch the config module at all. PR #264 then added the two-layer injection explainer, longer inline read-only badges (`MODEL · PROMPT-SHIELD SAFETY`) and a longer jailbreak toggle description. Those are new places text can overflow at narrow widths, so this makes the config module's overflow handling explicit and robust for that new copy.

Styling only. No copy, testids or counter semantics are changed. #264's wording is left exactly as approved.

## Changes (all inside `GuardrailsConfig.tsx` griffel `makeStyles`)
- `readOnlyRow`: `flex-wrap: wrap` + `gap` so a long label plus a long badge wrap instead of overflowing a `space-between` row.
- `readOnlyValue`: `max-width: 100%` + `overflow-wrap: anywhere` so the long `MODEL · PROMPT-SHIELD SAFETY` badge wraps within its pill.
- `toggleRow` / `toggleLabel` / `toggleDescription`: `gap`, `min-width: 0`, `overflow-wrap` so the longer #264 description wraps in the label column rather than pushing the switch off-row.
- `layerRow` / `layerRowHead` / `layerRowName`: `overflow-wrap: anywhere` + `min-width: 0` for the explainer rows.
- number input (`textarea` style): `box-sizing: border-box` to remove a small self-overflow.

## Viewport widths verified and HOW

Rendered the real `GuardrailsConfig` and `GuardrailsDashboard` (byte-identical to current `origin/dev`, so with #264's explainer, #265/#267 counters) in headless Chromium via a Vite harness with stubbed guardrails endpoints and the realistic content from the report (eight-plus stat cards, the `KeywordFastPaths[7]` audit row, the verbatim jailbreak prompt, the fail-open reason sentence, and the injection-defense explainer). At each width I walked every element under the root and measured document horizontal scroll and any element whose box or scrollWidth exceeded its container (recharts SVG internals excluded).

| Width | Page h-scroll | Elements overflowing (after) |
|------|----------------|------------------------------|
| 1440px | none | 0 |
| 1024px | none | 0 |
| 768px  | none | 0 |
| 414px  | none | 0 |
| 360px  | none | 0 |

Before this change, at every width the only offender was the number-input section self-overflowing by 10px (it never reached the viewport edge, so no page scroll); after `box-sizing: border-box` that is 0. The `MODEL · PROMPT-SHIELD SAFETY` badge measures 189px and sits fully inside the viewport at 360px with 0 clipping; the explainer block right edge is 304px at 360px. All measurements were rendered, not reasoned. Screenshots of the explainer/settings section at 360px were captured during verification.

## Honesty notes
- PR #266 (my first overflow fix) is already merged into `dev`. This is a separate, additive PR; it is left open for review and I will not merge it.
- The raw `KeywordFastPaths[7]` token renders inside the audit summary text (transformed), not verbatim; it still wraps.