### PR TITLE
chore: promote dev to main (lead sign-off gate + dev sync)

### DIFF
--- a/.github/workflows/squad-lead-gate.yml
+++ b/.github/workflows/squad-lead-gate.yml
@@ -1,0 +1,122 @@
+name: Squad Lead Gate
+
+# Every agent and every orchestration run pushes with the same `swigerb` token, so
+# GitHub sees a single human and `required_approving_review_count` would deadlock
+# rather than protect: no second identity exists that could ever satisfy it. On
+# 2026-08-31 five PRs merged themselves inside 31 minutes with no review and the
+# attribution was unrecoverable for exactly that reason.
+#
+# This gate replaces the identity barrier with a deliberate, logged act. It reports
+# a commit status named `Squad lead sign-off`, red until a reviewer posts a comment
+# pinning their approval to the PR's current head SHA:
+#
+#     Squad-Lead-Approved: <head-sha>
+#     Reviewer: <agent or person>
+#     Evidence: <test run or verification link>
+#
+# The SHA pin is the load-bearing part. Push a new commit and the recorded SHA no
+# longer matches the head, so the check flips back to red on its own and code can
+# never be amended in behind an approval that was granted earlier.
+#
+# This is a governance gate, not a security gate. Anyone holding the repo token
+# could post the comment. Its value is that a silent self-merge becomes a permanent,
+# SHA-pinned entry in the PR timeline that a human chose to write.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  statuses: write
+
+concurrency:
+  group: lead-gate-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    name: Evaluate lead sign-off
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # `issue_comment` also fires for plain issues, which have no head SHA to pin.
+    if: github.event_name == 'pull_request' || github.event.issue.pull_request != null
+    steps:
+      - name: Publish sign-off status
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
+        with:
+          script: |
+            const STATUS_CONTEXT = 'Squad lead sign-off';
+            const MARKER = /Squad-Lead-Approved:\s*([0-9a-f]{7,40})/i;
+
+            // A commit status is used rather than a job name because `issue_comment`
+            // events carry no PR head SHA of their own. A job-name check run would
+            // only ever attach to the push that opened the PR, so posting the
+            // approval comment would never turn the check green.
+            const prNumber = context.eventName === 'pull_request'
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const head = pr.head.sha.toLowerCase();
+
+            // OWNER, MEMBER and COLLABORATOR all imply push access. Anything weaker
+            // is a drive-by comment and must not be able to unblock a merge.
+            const ALLOWED = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            let approval = null;
+            for (const comment of comments) {
+              if (comment.user?.type === 'Bot') continue;
+              if (!ALLOWED.has(comment.author_association)) continue;
+              const match = MARKER.exec(comment.body || '');
+              // Last match wins so a superseded sign-off can be corrected by posting
+              // a newer one, rather than forcing the reviewer to edit history.
+              if (match) {
+                approval = {
+                  sha: match[1].toLowerCase(),
+                  user: comment.user.login,
+                  url: comment.html_url,
+                };
+              }
+            }
+
+            let state;
+            let description;
+            if (!approval) {
+              state = 'failure';
+              description = `Awaiting sign-off. Comment: Squad-Lead-Approved: ${head.slice(0, 7)}`;
+            } else if (!head.startsWith(approval.sha)) {
+              state = 'failure';
+              description = `Sign-off pins ${approval.sha.slice(0, 7)} but head is ${head.slice(0, 7)}.`;
+            } else {
+              state = 'success';
+              description = `Signed off by @${approval.user} for ${head.slice(0, 7)}.`;
+            }
+
+            const params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: head,
+              state,
+              context: STATUS_CONTEXT,
+              description: description.slice(0, 140),
+            };
+            if (approval) params.target_url = approval.url;
+
+            await github.rest.repos.createCommitStatus(params);
+            core.info(`${STATUS_CONTEXT} = ${state}: ${description}`);

--- a/.github/workflows/squad-sync-dev.yml
+++ b/.github/workflows/squad-sync-dev.yml
@@ -1,0 +1,67 @@
+name: Sync dev with main
+
+# Promoting dev to main creates a merge commit on main that dev never receives, so
+# dev silently falls behind every release. It reached 51 commits behind once. The
+# fix was a manual `git push origin origin/main:refs/heads/dev` run straight after
+# each promotion, which only holds for as long as someone remembers to run it.
+#
+# Protecting dev takes that manual push away, so the sync moves here. This workflow
+# runs as github-actions[bot], which is the only actor granted a bypass on the dev
+# ruleset. No human or agent needs direct push access to dev for the sync to work.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-dev
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync dev with main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync dev with main
+        run: |
+          set -euo pipefail
+          git fetch origin main dev
+
+          main_sha=$(git rev-parse origin/main)
+          dev_sha=$(git rev-parse origin/dev)
+
+          if [ "$main_sha" = "$dev_sha" ]; then
+            echo "dev already matches main at ${main_sha}"
+            exit 0
+          fi
+
+          # After a normal promotion, dev is an ancestor of the merge commit on main,
+          # so a fast-forward is both possible and lossless.
+          if git merge-base --is-ancestor "$dev_sha" "$main_sha"; then
+            git push origin "${main_sha}:refs/heads/dev"
+            echo "Fast-forwarded dev to ${main_sha}"
+            exit 0
+          fi
+
+          # dev picked up work after the promotion branched. Merging preserves it;
+          # fast-forwarding would discard it.
+          echo "::notice::dev has diverged from main, merging instead of fast-forwarding"
+          git checkout -B dev "$dev_sha"
+          git merge --no-edit origin/main
+          git push origin dev
+          echo "Merged main into dev"

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -19,6 +19,40 @@
 | Scribe | Session Logger | `.squad/agents/scribe/charter.md` | 📋 Silent |
 | Ralph | Work Monitor | `.squad/agents/ralph/charter.md` | 🔄 Monitor |
 
+## Merge Authority
+
+Every agent, and the orchestrator, pushes with the same `swigerb` token. GitHub
+therefore sees one human, and a `required_approving_review_count` rule would
+deadlock every PR instead of protecting anything. Authority is enforced by a
+deliberate, logged act instead.
+
+**No agent may merge its own pull request.** On 2026-08-31 five PRs merged
+themselves inside 31 minutes with no review, and attribution was unrecoverable
+because `mergedBy` read `swigerb` for all of them.
+
+`dev` and `main` both require the `Squad lead sign-off` status check, published by
+`.github/workflows/squad-lead-gate.yml`. It stays red until a reviewer with push
+access posts a comment on the PR:
+
+```
+Squad-Lead-Approved: <head-sha>
+Reviewer: <agent or person>
+Evidence: <test run or verification link>
+```
+
+The SHA pin is what makes this real. Push another commit and the check flips back
+to red on its own, so nothing can be amended in behind an approval.
+
+| Rule | Who |
+|------|-----|
+| Decides whether a PR merges | Brian, or Kroger acting as Lead |
+| Posts the sign-off comment | Only on Brian's explicit instruction |
+| Runs `gh pr merge` | Only after the sign-off check is green |
+| Pushes directly to `dev` | Nobody. `squad-sync-dev.yml` holds the only bypass. |
+
+The orchestrator never posts a sign-off comment on its own initiative and never
+merges unprompted. Reviewing a PR and approving it are separate acts.
+
 ## Coding Agent
 
 <!-- copilot-auto-assign: false -->


### PR DESCRIPTION
Promotes the Squad lead sign-off gate and the automated dev sync to the default branch.

This promotion is required before any ruleset is applied. The \issue_comment\ trigger is repository-scoped and runs the workflow from the **default branch**, which was confirmed empirically on #274: posting a comment there fired no workflow run because the gate existed only on the PR branch.

Consequence: if the ruleset were applied first, every PR would show a permanently red \Squad lead sign-off\ with no comment able to turn it green. Gate to main first, then enforce.

Also exercises \squad-sync-dev.yml\ for the first time, which should fast-forward dev back to main once this merges.