### PR TITLE
ci: sync dev through branch protection instead of bypassing it

### DIFF
--- a/.github/workflows/squad-lead-gate.yml
+++ b/.github/workflows/squad-lead-gate.yml
@@ -68,6 +68,30 @@ jobs:
             });
             const head = pr.head.sha.toLowerCase();
 
+            // A PR whose head is already contained in the release branch introduces
+            // no new code: every commit in it passed this same gate on the way into
+            // main. The automated dev resync is exactly that shape, so it clears
+            // itself instead of waiting on a human to re-approve released code.
+            //
+            // This is a statement about content, not about who opened the PR or what
+            // the branch is called, so it cannot be borrowed by a PR that actually
+            // changes something. Releases are excluded: a PR into main always needs a
+            // real sign-off, even a no-op one.
+            let alreadyOnMain = false;
+            if (pr.base.ref !== 'main') {
+              try {
+                const { data: cmp } = await github.rest.repos.compareCommitsWithBasehead({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  basehead: `main...${head}`,
+                });
+                alreadyOnMain = cmp.status === 'identical' || cmp.status === 'behind';
+              } catch (error) {
+                // Fail closed: an unreadable comparison must not hand out a free pass.
+                core.warning(`Could not compare against main, requiring sign-off: ${error.message}`);
+              }
+            }
+
             // OWNER, MEMBER and COLLABORATOR all imply push access. Anything weaker
             // is a drive-by comment and must not be able to unblock a merge.
             const ALLOWED = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
@@ -97,7 +121,10 @@ jobs:
 
             let state;
             let description;
-            if (!approval) {
+            if (alreadyOnMain) {
+              state = 'success';
+              description = 'Already released on main, so there is no new code to review.';
+            } else if (!approval) {
               state = 'failure';
               description = `Awaiting sign-off. Comment: Squad-Lead-Approved: ${head.slice(0, 7)}`;
             } else if (!head.startsWith(approval.sha)) {

--- a/.github/workflows/squad-sync-dev.yml
+++ b/.github/workflows/squad-sync-dev.yml
@@ -2,12 +2,21 @@ name: Sync dev with main
 
 # Promoting dev to main creates a merge commit on main that dev never receives, so
 # dev silently falls behind every release. It reached 51 commits behind once. The
-# fix was a manual `git push origin origin/main:refs/heads/dev` run straight after
-# each promotion, which only holds for as long as someone remembers to run it.
+# old fix was a manual `git push origin origin/main:refs/heads/dev` after each
+# promotion, which only holds for as long as someone remembers to run it.
 #
-# Protecting dev takes that manual push away, so the sync moves here. This workflow
-# runs as github-actions[bot], which is the only actor granted a bypass on the dev
-# ruleset. No human or agent needs direct push access to dev for the sync to work.
+# Protecting dev removes that manual push, and a direct push cannot be restored:
+# GitHub refuses the Actions integration as a ruleset bypass actor outside an
+# organization ("must be part of the ruleset source or owner organization"), and the
+# only bypasses a personal repo accepts are the admin and maintain roles, which is
+# precisely the access every agent already holds. A bypass there would protect
+# nothing.
+#
+# So the sync goes through the protection instead of around it: push main to a sync
+# branch, open a PR into dev, and let auto-merge land it once CI passes. The lead
+# gate clears it automatically because its commits are already on main, which means
+# they already passed the gate on the way in. No bypass actor and no standing
+# credential exist on dev as a result.
 
 on:
   push:
@@ -16,6 +25,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: sync-dev
@@ -30,38 +40,42 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Sync dev with main
+      - name: Open sync pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SYNC_BRANCH: sync/main-to-dev
         run: |
           set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin main dev
 
+          # "dev is behind main" is the only state worth acting on. dev being ahead is
+          # normal in-flight work, not drift.
+          if git merge-base --is-ancestor origin/main origin/dev; then
+            echo "dev already contains main, nothing to sync"
+            exit 0
+          fi
+
           main_sha=$(git rev-parse origin/main)
-          dev_sha=$(git rev-parse origin/dev)
+          git push --force origin "${main_sha}:refs/heads/${SYNC_BRANCH}"
 
-          if [ "$main_sha" = "$dev_sha" ]; then
-            echo "dev already matches main at ${main_sha}"
-            exit 0
+          pr=$(gh pr list --base dev --head "$SYNC_BRANCH" --state open \
+                 --json number --jq '.[0].number // empty')
+
+          if [ -z "$pr" ]; then
+            body='Automated resync so dev does not fall behind main. Every commit here is already on main, so the Squad lead gate clears this PR on its own: the code passed the gate on its way into the release branch and there is nothing new to review. Opened by squad-sync-dev.yml, auto-merges once CI passes.'
+            pr=$(gh pr create --base dev --head "$SYNC_BRANCH" \
+                   --title "chore: sync dev with main" \
+                   --body "$body" | grep -oE '[0-9]+$')
+            echo "Opened sync PR #${pr}"
+          else
+            echo "Sync PR #${pr} already open, reusing it"
           fi
 
-          # After a normal promotion, dev is an ancestor of the merge commit on main,
-          # so a fast-forward is both possible and lossless.
-          if git merge-base --is-ancestor "$dev_sha" "$main_sha"; then
-            git push origin "${main_sha}:refs/heads/dev"
-            echo "Fast-forwarded dev to ${main_sha}"
-            exit 0
-          fi
-
-          # dev picked up work after the promotion branched. Merging preserves it;
-          # fast-forwarding would discard it.
-          echo "::notice::dev has diverged from main, merging instead of fast-forwarding"
-          git checkout -B dev "$dev_sha"
-          git merge --no-edit origin/main
-          git push origin dev
-          echo "Merged main into dev"
+          # Auto-merge still honours every required check, including the lead gate, so
+          # this waits for CI rather than short-circuiting it.
+          gh pr merge "$pr" --merge --auto
+          echo "Auto-merge armed on #${pr}"

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -48,10 +48,24 @@ to red on its own, so nothing can be amended in behind an approval.
 | Decides whether a PR merges | Brian, or Kroger acting as Lead |
 | Posts the sign-off comment | Only on Brian's explicit instruction |
 | Runs `gh pr merge` | Only after the sign-off check is green |
-| Pushes directly to `dev` | Nobody. `squad-sync-dev.yml` holds the only bypass. |
+| Pushes directly to `dev` or `main` | Nobody. Neither branch has a bypass actor. |
 
 The orchestrator never posts a sign-off comment on its own initiative and never
 merges unprompted. Reviewing a PR and approving it are separate acts.
+
+### The one automatic exemption
+
+The gate passes itself when a PR's commits are **already on `main`**. Such a PR
+introduces no new code, because everything in it cleared this same gate on the way
+into the release branch. This is a statement about content rather than about who
+opened the PR or what the branch is called, so a PR that actually changes something
+can never borrow it. PRs into `main` are excluded and always need a real sign-off.
+
+That exemption is what lets `squad-sync-dev.yml` keep `dev` level with `main` without
+a bypass. GitHub refuses the Actions integration as a bypass actor outside an
+organization, and the only bypasses a personal repo accepts are the admin and
+maintain roles, which is exactly the access every agent already holds through the
+shared token. Granting one would have protected nothing.
 
 ## Coding Agent
 


### PR DESCRIPTION
Follow-up to #274, correcting the mechanism after measuring what GitHub actually permits.

**What I got wrong:** the plan was to grant \squad-sync-dev.yml\ a ruleset bypass so it could keep pushing directly to a protected \dev\. GitHub rejects that on a personal repo:

\\\
422: Actor GitHub Actions integration must be part of the ruleset source or owner organization
\\\

Probing the API, the only bypass actor types this repo accepts are \RepositoryRole\ **admin** and **maintain**. Both are exactly the access every agent already holds through the shared token, so a bypass there would have protected nothing.

**The fix:** the sync goes *through* the protection rather than around it. It pushes main to \sync/main-to-dev\, opens a PR into dev, and arms auto-merge. The lead gate clears it automatically via a new rule: a PR whose commits are **already on main** introduces no new code, because it all passed this same gate on the way into the release branch.

That test is content-based, not actor-based or branch-name-based, so a PR that changes anything cannot borrow it. PRs into \main\ are excluded and always need a real sign-off. The comparison fails closed if it cannot be read.

**Net result:** neither \dev\ nor \main\ has a bypass actor or a standing credential.