### PR TITLE
test: admin override probe (do not merge)

### DIFF
--- a/.github/ADMIN-OVERRIDE-PROBE.md
+++ b/.github/ADMIN-OVERRIDE-PROBE.md
@@ -1,0 +1,1 @@
+Throwaway probe testing whether admin privileges can bypass the ruleset. Never merged.


### PR DESCRIPTION
Throwaway probe. Attempts an admin-privileged merge against the dev ruleset to determine whether repository admin can bypass it. Closed regardless of outcome.