### PR TITLE
docs(squad): record sync status source and the upgrade strip hazard

### DIFF
--- a/.squad/team.md
+++ b/.squad/team.md
@@ -67,6 +67,30 @@ organization, and the only bypasses a personal repo accepts are the admin and
 maintain roles, which is exactly the access every agent already holds through the
 shared token. Granting one would have protected nothing.
 
+The exemption is not the only thing holding the sync open, and on PR #283 it was not
+what fired. A sync PR shares its head SHA with `main`, so it inherits every check run
+`main` already earned, and the gate's own PR-triggered run can be starved of a runner
+and killed the moment the PR merges. `squad-sync-dev.yml` therefore publishes the
+`Squad lead sign-off` status directly against that SHA rather than waiting to be
+evaluated. Both paths reach the same verdict from the same fact, that the commit is
+already on `main`, so neither one widens what can merge.
+
+Expect the sync PR's own `CI`, `Squad CI` and `Squad Lead Gate` runs to end as
+`failure` with zero jobs. Those are the starved duplicates described above, not a
+broken build. The checks that satisfied the ruleset are the ones attached to the SHA.
+
+## Squad upgrades
+
+`squad upgrade` rewrites `.github/skills/` from the built-in copies and will silently
+strip local edits. On 2026-08-31 it deleted the merge gate rules from
+`.github/skills/reviewer-protocol/SKILL.md`, which is the section describing why
+verdicts are comments under the shared `swigerb` identity. Nothing upstream replaced
+them, so the change was a pure loss.
+
+After any upgrade, diff before committing and keep only files whose content actually
+changed. `git diff --numstat` is the quickest filter, because the run also rewrites
+line endings across roughly seventy files that are otherwise untouched.
+
 ## Coding Agent
 
 <!-- copilot-auto-assign: false -->


### PR DESCRIPTION
## What

Runs the Squad 0.12.0 upgrade and records the two findings it produced.

## The upgrade itself is a no-op

The CLI is already at 0.12.0, the newest published version, and npm already resolves through `https://packagefeedproxy.microsoft.io/npm/` rather than the public registry, so there was nothing to fetch.

Measured effect of `squad upgrade` on this repo:

| Area | Result |
|------|--------|
| All 15 files in `.github/workflows/` | SHA-256 identical before and after |
| `.github/agents/squad.agent.md` | byte-identical to its own backup |
| ~70 files under `.squad/templates/` and `.github/skills/` | line-ending churn only, zero content change |
| `.github/skills/reviewer-protocol/SKILL.md` | **30 lines deleted, 0 added** |

The feared scaffolding resync did not happen. `squad-lead-gate.yml`, `squad-sync-dev.yml`, `squad-promote.yml` and `ci.yml` were untouched, so the branch protection work survived intact.

The single real change was a regression: the upgrade stripped the merge gate rules from `reviewer-protocol/SKILL.md`, including the section explaining why verdicts are PR comments under the shared `swigerb` identity. Nothing upstream replaced them. That deletion was reverted and the working tree is back to a clean state, so this PR carries no upgrade output at all.

## Why #283 actually went green

`team.md` credited the containment exemption. That is not what fired.

PR #283's own `CI`, `Squad CI` and `Squad Lead Gate` runs all ended `failure` with **zero jobs**, created 17:52:05Z and terminated 17:56:42Z, the exact second the PR merged. They were starved of runners and killed. Verified against a known-good run to rule out an API artifact.

What satisfied the ruleset was the SHA. A sync PR shares its head commit with `main`, so it inherits main's green check runs, and `squad-sync-dev.yml` publishes `Squad lead sign-off` directly against that SHA. Both the exemption and the self-published status reason from the same fact, that the commit is already on `main`, so neither widens what can merge.

## Changes

Documentation only, `.squad/team.md`:

- correct the sync explanation to match the measured behaviour
- note that starved duplicate runs are expected and are not a broken build
- add a **Squad upgrades** section recording the strip hazard and the `git diff --numstat` habit that catches it

## Verification

- `git diff --numstat` after restore: clean tree, no upgrade residue
- diff on this branch: `24 0 .squad/team.md`, additions only
- no em dashes in the added text