### PR TITLE
fix: clear the sync run noise, the Save button contrast (#272), and the residual cold-start fail-open (#273)

### DIFF
--- a/.github/workflows/squad-sync-dev.yml
+++ b/.github/workflows/squad-sync-dev.yml
@@ -26,6 +26,13 @@ name: Sync dev with main
 # would put a human approval back in the loop on every release. This job posts the gate
 # status itself instead, on main's head commit, under the same containment reasoning the
 # gate applies: the commit is already on main, so it has already been signed off.
+#
+# The same GITHUB_TOKEN authorship has a cosmetic side effect: GitHub records a workflow
+# run for the sync pull request and then never dispatches it, so it ends as a zero-job
+# "failure" the moment the pull request merges. Those shells publish no check runs and
+# gate nothing, but they make a healthy Actions tab read as a failing one. The last step
+# deletes them, guarded on a run having zero jobs so a real failure can never be caught
+# by it.
 
 on:
   push:
@@ -33,6 +40,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
   statuses: write
@@ -45,13 +53,16 @@ jobs:
   sync:
     name: Sync dev with main
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Covers the wait for CI on the sync pull request, which is bounded by the
+    # slowest required check rather than by anything this job does.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 
       - name: Open sync pull request
+        id: open
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SYNC_BRANCH: sync/main-to-dev
@@ -66,6 +77,7 @@ jobs:
           # normal in-flight work, not drift.
           if git merge-base --is-ancestor origin/main origin/dev; then
             echo "dev already contains main, nothing to sync"
+            echo "pr=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -97,3 +109,66 @@ jobs:
           # this waits for CI rather than short-circuiting it.
           gh pr merge "$pr" --merge --auto
           echo "Auto-merge armed on #${pr}"
+          echo "pr=${pr}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the sync pull request to merge
+        if: steps.open.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.open.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          # Auto-merge is what actually lands the pull request; this job only watches.
+          # Watching matters because the empty runs described in the next step cannot
+          # be deleted until they have settled, which happens at the merge.
+          for _ in $(seq 1 90); do
+            state=$(gh pr view "$PR" --json state --jq .state)
+            case "$state" in
+              MERGED) echo "Sync PR #${PR} merged."; exit 0 ;;
+              CLOSED) echo "Sync PR #${PR} was closed without merging."; exit 0 ;;
+            esac
+            sleep 10
+          done
+
+          echo "::warning::Sync PR #${PR} has not merged yet. Auto-merge stays armed, so it will land when its checks finish."
+
+      - name: Delete the empty runs GitHub leaves on bot pull requests
+        # always() so the sweep still runs when the wait above timed out or the
+        # pull request was closed rather than merged.
+        if: always() && steps.open.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SYNC_BRANCH: sync/main-to-dev
+        run: |
+          set -euo pipefail
+
+          # Opening this pull request with GITHUB_TOKEN makes GitHub record a workflow
+          # run for the pull_request event and then never dispatch it: measured on runs
+          # 33421887474/532/550, every one had zero jobs, published zero check runs, and
+          # was resolved as "failure" the second the pull request merged. Proven by
+          # re-running one by hand, which executed normally under a human actor.
+          #
+          # Nothing reads them. The sync branch head is main's head, so the required
+          # checks are already satisfied by the runs from the push to main. These
+          # shells are pure noise, and three red entries per release make a healthy
+          # Actions tab unreadable.
+          #
+          # The zero-job test is the safety property: a run that dispatched anything
+          # has at least one job and is never touched, so this cannot delete evidence
+          # of a real failure.
+          deleted=0
+          for id in $(gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${SYNC_BRANCH}&event=pull_request&per_page=100" \
+                --jq '.workflow_runs[] | select(.status == "completed") | .id'); do
+            jobs=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${id}/jobs" --jq '.total_count')
+            if [ "$jobs" -eq 0 ]; then
+              if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/runs/${id}"; then
+                deleted=$((deleted + 1))
+                echo "Deleted empty run ${id}"
+              else
+                echo "::warning::Could not delete empty run ${id}"
+              fi
+            fi
+          done
+          echo "Removed ${deleted} empty run(s)."

--- a/.github/workflows/squad-sync-dev.yml
+++ b/.github/workflows/squad-sync-dev.yml
@@ -117,13 +117,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.open.outputs.pr }}
         run: |
-          set -euo pipefail
+          # Also not `set -e`. Auto-merge is what lands the pull request; this step
+          # only watches, so a transient API blip must not fail the release sync.
+          set -uo pipefail
 
-          # Auto-merge is what actually lands the pull request; this job only watches.
           # Watching matters because the empty runs described in the next step cannot
           # be deleted until they have settled, which happens at the merge.
           for _ in $(seq 1 90); do
-            state=$(gh pr view "$PR" --json state --jq .state)
+            state=$(gh pr view "$PR" --json state --jq .state) || state="UNKNOWN"
             case "$state" in
               MERGED) echo "Sync PR #${PR} merged."; exit 0 ;;
               CLOSED) echo "Sync PR #${PR} was closed without merging."; exit 0 ;;
@@ -141,7 +142,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SYNC_BRANCH: sync/main-to-dev
         run: |
-          set -euo pipefail
+          # Deliberately not `set -e`. This step is cosmetic housekeeping, and a
+          # transient API error here must not fail the release sync, which would
+          # create precisely the kind of red run it exists to remove.
+          set -uo pipefail
 
           # Opening this pull request with GITHUB_TOKEN makes GitHub record a workflow
           # run for the pull_request event and then never dispatch it: measured on runs
@@ -158,17 +162,25 @@ jobs:
           # has at least one job and is never touched, so this cannot delete evidence
           # of a real failure.
           deleted=0
-          for id in $(gh api \
+          ids=$(gh api \
                 "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${SYNC_BRANCH}&event=pull_request&per_page=100" \
-                --jq '.workflow_runs[] | select(.status == "completed") | .id'); do
-            jobs=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${id}/jobs" --jq '.total_count')
-            if [ "$jobs" -eq 0 ]; then
-              if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/runs/${id}"; then
-                deleted=$((deleted + 1))
-                echo "Deleted empty run ${id}"
-              else
-                echo "::warning::Could not delete empty run ${id}"
-              fi
+                --jq '.workflow_runs[] | select(.status == "completed") | .id') || ids=""
+
+          for id in $ids; do
+            jobs=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${id}/jobs" --jq '.total_count') || jobs=""
+
+            # Anything other than a confirmed zero is left alone. An unreadable job
+            # count is not evidence that a run is empty.
+            case "$jobs" in
+              0) ;;
+              *) continue ;;
+            esac
+
+            if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/runs/${id}"; then
+              deleted=$((deleted + 1))
+              echo "Deleted empty run ${id}"
+            else
+              echo "::warning::Could not delete empty run ${id}"
             fi
           done
           echo "Removed ${deleted} empty run(s)."

--- a/docs/adr/016-content-safety-cold-start-warmup.md
+++ b/docs/adr/016-content-safety-cold-start-warmup.md
@@ -134,3 +134,48 @@ unscanned payloads on every cold start. If the owner wants that class of content
 guaranteed scanned, the warm-up narrows the window but does not eliminate it, and
 only a fail-closed policy for that stage would close it. That decision is left to
 the policy owner.
+
+## Follow-up: warming the transport as well as the token (issue #273)
+
+The warm-up above was deployed and measured. The cold-start burst fell from four
+fail-open rows to one. The survivor was:
+
+```
+SystemPrompt on agent general
+"The connection failed before a response."
+```
+
+That reason is the `Transport` classification added by decision 3, and it names the
+residual precisely: the token was warm, so the first scan no longer paid the AAD
+round-trip, but it was still the call opening the connection. DNS, the TCP connect
+and the TLS handshake all landed inside the 1500 ms scan budget, leaving too little
+of it for the scan itself.
+
+Of the two options this ADR left open, retrying was rejected. The Content Safety
+resilience handler documents "no retries" as a deliberate choice, so that the caller
+applies its fail-open policy on the first failure rather than multiplying the
+per-call latency budget. Adding a retry to the runtime path would contradict a
+standing decision to fix a startup-only problem.
+
+So the handshake moves into the warm-up, alongside the token:
+
+* `ContentSafetyWarmUpService` now issues one throwaway request to the endpoint root
+  through the shared named `HttpClient` after priming the token. Any response
+  establishes the pooled connection; the status is not inspected, because this is a
+  handshake and not a health check. Both evaluator paths are registered against that
+  same client, so one warm-up primes both.
+* Two attempts are allowed. The resilience handler caps every attempt at `TimeoutMs`,
+  so extra budget only converts into a better chance of success by re-attempting.
+  There is no backoff, because a refused connection is not rate limited.
+* Token and transport share one deadline, `WarmUpTimeoutMs`. If the token consumes
+  the whole budget the handshake is skipped rather than overrunning the time box,
+  because that time box is what keeps warm-up unable to stall startup.
+* The startup agent-definition scan calls the same `WarmAsync` the hosted service
+  calls. It previously re-implemented the budget and the token call inline, which
+  meant the startup path (the one actually producing the fail-open row) could drift
+  from the runtime path.
+
+Retrying was not the only thing rejected. Suppressing the fail-open row was too: a
+row means content passed unscanned, and hiding it would trade a visible security
+signal for a tidy dashboard. The policy remains fail-open and the row remains
+visible if the warm-up does not win the race.

--- a/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyServiceCollectionExtensions.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyServiceCollectionExtensions.cs
@@ -102,9 +102,10 @@ public static class ContentSafetyServiceCollectionExtensions
                 sp.GetRequiredService<ILogger<AzureContentSafetyEvaluator>>());
         });
 
-        // Pre-acquire the managed-identity token at host start so the first
-        // runtime scan does not pay the cold AAD/IMDS round-trip inside its own
-        // timeout. Time-boxed and fire-and-forget, so it cannot delay startup.
+        // Prime the managed-identity token and the HTTPS connection at host start so
+        // the first runtime scan pays neither the cold AAD/IMDS round-trip nor the
+        // TLS handshake inside its own timeout. Time-boxed and fire-and-forget, so it
+        // cannot delay startup.
         services.TryAddSingleton<ContentSafetyWarmUpService>();
         services.AddHostedService(sp => sp.GetRequiredService<ContentSafetyWarmUpService>());
 

--- a/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyWarmUpService.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyWarmUpService.cs
@@ -1,36 +1,60 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Hosting;
 using RetailPulse.Contracts.Guardrails;
 
 namespace RetailPulse.Api.Guardrails.ContentSafety;
 
 /// <summary>
-/// Pre-acquires the Content Safety managed-identity token at host start so the
-/// first real scan is not the one paying the cold AAD/IMDS round-trip inside its
-/// own timeout budget. This covers the runtime pipeline; the startup
-/// agent-definition scan is warmed separately, before it runs, because it
-/// executes during host configuration rather than after the host starts.
+/// Primes both halves of a Content Safety cold start before the first real scan:
+/// the managed-identity token, and the pooled HTTPS connection to the endpoint.
 /// </summary>
 /// <remarks>
-/// The warm-up is time-boxed and fire-and-forget: <see cref="StartAsync"/>
-/// returns immediately so host startup is never gated on a remote credential
-/// call, and the underlying warm-up is bounded so an unreachable credential
-/// endpoint cannot stall the service.
+/// <para>
+/// Warming the token alone was measurably not enough. ADR-016 primed the credential
+/// and the cold-start fail-open burst fell from four audit rows to one, but the
+/// survivor was a transport failure, "the connection failed before a response"
+/// (issue #273). With a warm token the first scan was still the call paying DNS,
+/// TCP and the TLS handshake inside its own scan budget, so the handshake is moved
+/// here too, off the scan's critical path.
+/// </para>
+/// <para>
+/// One warm-up request covers both evaluator paths. The Prompt Shields raw path and
+/// the SDK moderation path are deliberately registered against the same named
+/// <see cref="HttpClient"/>, so they share a single connection pool.
+/// </para>
+/// <para>
+/// The whole warm-up runs against one deadline and never throws, so host startup is
+/// never gated on a remote call. <see cref="StartAsync"/> covers the runtime
+/// pipeline; the startup agent-definition scan calls <see cref="WarmAsync"/>
+/// directly because it runs during host configuration, before hosted services start.
+/// </para>
 /// </remarks>
 internal sealed class ContentSafetyWarmUpService : IHostedService
 {
+    // The shared client's resilience handler caps every attempt at
+    // ContentSafety.TimeoutMs, so a larger warm-up budget buys nothing on a single
+    // attempt. A second attempt is what actually turns spare budget into a second
+    // chance at the handshake. There is no backoff between them because a refused
+    // or timed-out connection is not rate limited: there is nothing to wait for.
+    private const int _maxTransportAttempts = 2;
+
     private readonly ContentSafetyTokenProvider _tokens;
+    private readonly IHttpClientFactory _httpFactory;
     private readonly GuardrailsConfig _guardrails;
     private readonly ILogger<ContentSafetyWarmUpService> _logger;
 
     public ContentSafetyWarmUpService(
         ContentSafetyTokenProvider tokens,
+        IHttpClientFactory httpFactory,
         GuardrailsConfig guardrails,
         ILogger<ContentSafetyWarmUpService> logger)
     {
         ArgumentNullException.ThrowIfNull(tokens);
+        ArgumentNullException.ThrowIfNull(httpFactory);
         ArgumentNullException.ThrowIfNull(guardrails);
         ArgumentNullException.ThrowIfNull(logger);
         _tokens = tokens;
+        _httpFactory = httpFactory;
         _guardrails = guardrails;
         _logger = logger;
     }
@@ -43,23 +67,35 @@ internal sealed class ContentSafetyWarmUpService : IHostedService
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        var budget = TimeSpan.FromMilliseconds(
-            Math.Max(200, _guardrails.ContentSafety.WarmUpTimeoutMs));
-
-        // Fire-and-forget on a background task so a slow credential endpoint can
-        // never delay host startup. The warm-up itself is bounded by budget.
-        WarmUpCompletion = Task.Run(() => WarmAsync(budget), CancellationToken.None);
+        // Fire-and-forget on a background task so a slow credential endpoint or a
+        // slow handshake can never delay host startup. WarmAsync is itself bounded.
+        WarmUpCompletion = Task.Run(() => WarmAsync(CancellationToken.None), CancellationToken.None);
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-    private async Task WarmAsync(TimeSpan budget)
+    /// <summary>
+    /// Runs the full warm-up: token first, then transport with whatever remains of
+    /// the budget. Public so the startup agent-definition scan primes exactly the
+    /// way the runtime pipeline does, rather than the two priming paths drifting.
+    /// </summary>
+    public async Task WarmAsync(CancellationToken cancellationToken)
+    {
+        var budget = TimeSpan.FromMilliseconds(
+            Math.Max(200, _guardrails.ContentSafety.WarmUpTimeoutMs));
+        long deadline = Stopwatch.GetTimestamp() + (long)(budget.TotalSeconds * Stopwatch.Frequency);
+
+        await WarmTokenAsync(budget, cancellationToken).ConfigureAwait(false);
+        await WarmTransportAsync(deadline, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task WarmTokenAsync(TimeSpan budget, CancellationToken cancellationToken)
     {
         try
         {
             ContentSafetyWarmUpResult result = await _tokens
-                .WarmUpAsync(budget, CancellationToken.None)
+                .WarmUpAsync(budget, cancellationToken)
                 .ConfigureAwait(false);
 
             if (result is ContentSafetyWarmUpResult.Warmed or ContentSafetyWarmUpResult.AlreadyWarm)
@@ -78,5 +114,71 @@ internal sealed class ContentSafetyWarmUpService : IHostedService
             // Warm-up is best-effort. A failure here must never surface at startup.
             _logger.LogWarning(ex, "Content Safety token warm-up failed unexpectedly.");
         }
+    }
+
+    private async Task WarmTransportAsync(long deadline, CancellationToken cancellationToken)
+    {
+        HttpClient http;
+        try
+        {
+            http = _httpFactory.CreateClient(ContentSafetyServiceCollectionExtensions.HttpClientName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Content Safety transport warm-up could not resolve the shared client.");
+            return;
+        }
+
+        for (int attempt = 1; attempt <= _maxTransportAttempts; attempt++)
+        {
+            TimeSpan remaining = RemainingBudget(deadline);
+            if (remaining <= TimeSpan.Zero)
+            {
+                _logger.LogWarning(
+                    "Content Safety transport warm-up skipped: the warm-up budget was spent acquiring the token.");
+                return;
+            }
+
+            using var attemptCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            attemptCts.CancelAfter(remaining);
+
+            try
+            {
+                // Any response at all proves DNS, TCP and TLS completed and leaves a
+                // pooled connection behind for the first real scan. The status is
+                // deliberately not inspected: this is a handshake, not a health check,
+                // so a 404 on the endpoint root serves the purpose as well as a 200.
+                using var request = new HttpRequestMessage(HttpMethod.Get, "/");
+                using HttpResponseMessage response = await http
+                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, attemptCts.Token)
+                    .ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "Content Safety transport warm-up established a connection on attempt {Attempt} (status {Status}).",
+                    attempt,
+                    (int)response.StatusCode);
+                return;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                if (attempt == _maxTransportAttempts)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Content Safety transport warm-up did not establish a connection in {Attempts} attempt(s); the first scan may pay the TLS handshake.",
+                        attempt);
+                }
+            }
+        }
+    }
+
+    private static TimeSpan RemainingBudget(long deadline)
+    {
+        long ticks = deadline - Stopwatch.GetTimestamp();
+        return ticks <= 0 ? TimeSpan.Zero : TimeSpan.FromSeconds((double)ticks / Stopwatch.Frequency);
     }
 }

--- a/src/RetailPulse.Api/Program.cs
+++ b/src/RetailPulse.Api/Program.cs
@@ -301,22 +301,18 @@ using (ILoggerFactory validatorLoggerFactory = LoggerFactory.Create(lb =>
 #pragma warning restore ASP0000
             validatorEvaluator = evaluatorScope.GetRequiredService<IContentSafetyEvaluator>();
 
-            // Pre-acquire the managed-identity token before the agent-definition
-            // scan runs. That scan is the very first caller on a cold start, and
-            // without a primed token its four checks race an unprimed AAD/IMDS
-            // round-trip inside the per-scan timeout and fail open. Time-boxed and
-            // best-effort so a slow or unreachable credential endpoint can never
-            // block startup.
-            ContentSafetyTokenProvider validatorTokens =
-                evaluatorScope.GetRequiredService<ContentSafetyTokenProvider>();
-            var warmUpBudget = TimeSpan.FromMilliseconds(
-                Math.Max(200, guardrailsConfig.ContentSafety.WarmUpTimeoutMs));
-            ContentSafetyWarmUpResult warmUp = validatorTokens
-                .WarmUpAsync(warmUpBudget, CancellationToken.None)
+            // Prime the managed-identity token AND the HTTPS connection before the
+            // agent-definition scan runs. That scan is the very first caller on a
+            // cold start, and unprimed its checks race an AAD/IMDS round-trip and an
+            // unopened TLS connection inside the per-scan timeout, then fail open.
+            // Reusing the hosted service's warm-up rather than re-priming here keeps
+            // the startup and runtime paths identical instead of letting them drift.
+            ContentSafetyWarmUpService validatorWarmUp =
+                evaluatorScope.GetRequiredService<ContentSafetyWarmUpService>();
+            validatorWarmUp
+                .WarmAsync(CancellationToken.None)
                 .GetAwaiter()
                 .GetResult();
-            validatorLogger.LogInformation(
-                "Content Safety startup warm-up before agent-definition scan: {Result}.", warmUp);
         }
         else
         {

--- a/src/RetailPulse.Web/src/__tests__/GuardrailsConfig.test.tsx
+++ b/src/RetailPulse.Web/src/__tests__/GuardrailsConfig.test.tsx
@@ -205,3 +205,50 @@ describe('GuardrailsConfig two-layer injection clarity', () => {
     expect(note.textContent).toMatch(/can still be blocked/i);
   });
 });
+
+/**
+ * Issue #272: the Save button rendered white text on amber #f59e0b, a measured
+ * 2.15:1 against the WCAG AA minimum of 4.5:1. The assertion is on the ratio
+ * rather than on a literal hex so any future restyle is judged by whether it is
+ * readable, not by whether it matches the colour that happened to fix it.
+ */
+describe('GuardrailsConfig save button contrast', () => {
+  function relativeLuminance(hex: string): number {
+    const channels = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255);
+    const [r, g, b] = channels.map((c) =>
+      c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4),
+    );
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  }
+
+  function contrastRatio(foreground: string, background: string): number {
+    const a = relativeLuminance(foreground);
+    const b = relativeLuminance(background);
+    const [lighter, darker] = a > b ? [a, b] : [b, a];
+    return (lighter + 0.05) / (darker + 0.05);
+  }
+
+  it('computes a known ratio, so a passing contrast assertion means something', () => {
+    // The exact failure recorded in issue #272, kept as the helper's own check.
+    expect(contrastRatio('#ffffff', '#f59e0b')).toBeCloseTo(2.15, 2);
+  });
+
+  it('renders the Save button at WCAG AA contrast against its white label', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => baseConfig(),
+    } as Response);
+
+    renderWithTheme(<GuardrailsConfig />);
+
+    const save = await screen.findByTestId('guardrails-save-button');
+    const background = (save as HTMLElement).style.backgroundColor;
+
+    // jsdom normalises the inline hex to rgb(), so convert back before measuring.
+    const rgb = background.match(/\d+/g);
+    expect(rgb).toHaveLength(3);
+    const hex = `#${rgb!.map((v) => Number(v).toString(16).padStart(2, '0')).join('')}`;
+
+    expect(contrastRatio('#ffffff', hex)).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/src/RetailPulse.Web/src/components/guardrails/GuardrailsConfig.tsx
+++ b/src/RetailPulse.Web/src/components/guardrails/GuardrailsConfig.tsx
@@ -406,11 +406,18 @@ export function GuardrailsConfig() {
         <Button appearance="subtle" onClick={handleReset} disabled={saving}>
           Reset to Defaults
         </Button>
+        {/*
+          The Security page's amber accent (#f59e0b) measures 2.15:1 under white
+          button text, well below the 4.5:1 WCAG AA minimum (issue #272). Amber-700
+          keeps the page identity and measures 5.02:1, so the accent survives and
+          the text becomes legible.
+        */}
         <Button
           appearance="primary"
           onClick={handleSave}
           disabled={saving}
-          style={{ backgroundColor: '#f59e0b', borderColor: '#f59e0b' }}
+          data-testid="guardrails-save-button"
+          style={{ backgroundColor: '#b45309', borderColor: '#b45309' }}
         >
           {saving ? <Spinner size="tiny" /> : 'Save Configuration'}
         </Button>

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyWarmUpServiceTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyWarmUpServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using RetailPulse.Api.Guardrails.ContentSafety;
@@ -7,11 +8,13 @@ using RetailPulse.Contracts.Guardrails;
 namespace RetailPulse.Tests.Guardrails.ContentSafety;
 
 /// <summary>
-/// <see cref="ContentSafetyWarmUpService"/> primes the runtime token before the
-/// first real scan, but it must never gate host startup on a remote credential
-/// call. These tests pin both halves: <see cref="ContentSafetyWarmUpService.StartAsync"/>
-/// returns effectively immediately even when the credential never answers, and
-/// the background warm-up is itself time-boxed.
+/// <see cref="ContentSafetyWarmUpService"/> primes the token and the HTTPS
+/// connection before the first real scan, and must never gate host startup on
+/// either. These tests pin all three halves: <see cref="ContentSafetyWarmUpService.StartAsync"/>
+/// returns effectively immediately even when the credential never answers, the
+/// background warm-up is time-boxed, and the connection to the shared client is
+/// actually opened (issue #273, where a warm token still left the first scan
+/// paying the TLS handshake and failing open).
 /// </summary>
 public class ContentSafetyWarmUpServiceTests
 {
@@ -23,7 +26,7 @@ public class ContentSafetyWarmUpServiceTests
             await Task.Delay(Timeout.Infinite, ct);
             return default;
         });
-        ContentSafetyWarmUpService service = Build(hangingCredential, warmUpTimeoutMs: 300);
+        ContentSafetyWarmUpService service = Build(hangingCredential, warmUpTimeoutMs: 300, out _);
 
         var sw = Stopwatch.StartNew();
         await service.StartAsync(CancellationToken.None);
@@ -36,7 +39,7 @@ public class ContentSafetyWarmUpServiceTests
         // than run forever.
         Task completion = service.WarmUpCompletion
             ?? throw new InvalidOperationException("StartAsync must set WarmUpCompletion.");
-        await completion.WaitAsync(TimeSpan.FromSeconds(3));
+        await completion.WaitAsync(TimeSpan.FromSeconds(5));
         completion.IsCompletedSuccessfully.Should().BeTrue();
     }
 
@@ -46,15 +49,17 @@ public class ContentSafetyWarmUpServiceTests
         var credential = new ProgrammableTokenCredential((_, _) =>
             ValueTask.FromResult(ProgrammableTokenCredential.FreshToken("warm")));
         var provider = new ContentSafetyTokenProvider(credential);
+        var factory = new StubHttpClientFactory();
         var service = new ContentSafetyWarmUpService(
             provider,
+            factory,
             ConfigWith(warmUpTimeoutMs: 5000),
             NullLogger<ContentSafetyWarmUpService>.Instance);
 
         await service.StartAsync(CancellationToken.None);
         Task completion = service.WarmUpCompletion
             ?? throw new InvalidOperationException("StartAsync must set WarmUpCompletion.");
-        await completion.WaitAsync(TimeSpan.FromSeconds(3));
+        await completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         // The primed token must serve the first real scan without another fetch.
         string bearer = await provider.GetBearerAsync(CancellationToken.None);
@@ -62,11 +67,79 @@ public class ContentSafetyWarmUpServiceTests
         credential.Calls.Should().Be(1, "warm-up primed the cache; the first scan must be a cache hit");
     }
 
-    private static ContentSafetyWarmUpService Build(
-        ProgrammableTokenCredential credential, int warmUpTimeoutMs)
+    [Fact]
+    public async Task WarmAsync_OpensAConnectionOnTheSharedClient()
     {
+        ContentSafetyWarmUpService service = Build(SucceedingCredential(), warmUpTimeoutMs: 5000, out StubHttpClientFactory factory);
+
+        await service.WarmAsync(CancellationToken.None);
+
+        factory.Handler.CallCount.Should().Be(1,
+            "one round trip is enough to complete DNS, TCP and TLS and leave a pooled connection");
+
+        // Warming a different pool would prime nothing the scan can use, so the name
+        // is the load-bearing part of this assertion.
+        factory.RequestedNames.Should().ContainSingle()
+            .Which.Should().Be(ContentSafetyServiceCollectionExtensions.HttpClientName);
+    }
+
+    [Fact]
+    public async Task WarmAsync_RetriesTheHandshakeOnce_WhenTheFirstAttemptFails()
+    {
+        ContentSafetyWarmUpService service = Build(SucceedingCredential(), warmUpTimeoutMs: 5000, out StubHttpClientFactory factory);
+        factory.Handler.Responder = (_, _) => factory.Handler.CallCount == 1
+            ? throw new HttpRequestException("connection refused")
+            : Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        await service.WarmAsync(CancellationToken.None);
+
+        factory.Handler.CallCount.Should().Be(2,
+            "the per-attempt timeout is fixed, so a second attempt is the only way spare budget helps");
+    }
+
+    [Fact]
+    public async Task WarmAsync_DoesNotThrow_WhenEveryHandshakeAttemptFails()
+    {
+        ContentSafetyWarmUpService service = Build(SucceedingCredential(), warmUpTimeoutMs: 5000, out StubHttpClientFactory factory);
+        factory.Handler.Responder = (_, _) => throw new HttpRequestException("endpoint unreachable");
+
+        // Fail-open policy is unchanged by warm-up: an unreachable endpoint at start
+        // must degrade to a cold first scan, never to a failed host start.
+        Func<Task> act = () => service.WarmAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        factory.Handler.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task WarmAsync_SkipsTheHandshake_WhenTheTokenConsumedTheWholeBudget()
+    {
+        var hangingCredential = new ProgrammableTokenCredential(async (_, ct) =>
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            return default;
+        });
+        ContentSafetyWarmUpService service = Build(hangingCredential, warmUpTimeoutMs: 300, out StubHttpClientFactory factory);
+
+        await service.WarmAsync(CancellationToken.None);
+
+        // One deadline covers the whole warm-up. Overrunning it to squeeze in a
+        // handshake would break the time-box that keeps startup safe.
+        factory.Handler.CallCount.Should().Be(0);
+    }
+
+    private static ProgrammableTokenCredential SucceedingCredential() =>
+        new((_, _) => ValueTask.FromResult(ProgrammableTokenCredential.FreshToken("warm")));
+
+    private static ContentSafetyWarmUpService Build(
+        ProgrammableTokenCredential credential,
+        int warmUpTimeoutMs,
+        out StubHttpClientFactory factory)
+    {
+        factory = new StubHttpClientFactory();
         return new ContentSafetyWarmUpService(
             new ContentSafetyTokenProvider(credential),
+            factory,
             ConfigWith(warmUpTimeoutMs),
             NullLogger<ContentSafetyWarmUpService>.Instance);
     }
@@ -80,4 +153,24 @@ public class ContentSafetyWarmUpServiceTests
             WarmUpTimeoutMs = warmUpTimeoutMs,
         },
     };
+
+    /// <summary>
+    /// Hands out one client backed by <see cref="CapturingHttpMessageHandler"/> and
+    /// records the names asked for, so a test can prove the warm-up primed the
+    /// shared Content Safety pool rather than an unrelated one.
+    /// </summary>
+    private sealed class StubHttpClientFactory : IHttpClientFactory
+    {
+        public CapturingHttpMessageHandler Handler { get; } = new();
+        public List<string> RequestedNames { get; } = [];
+
+        public HttpClient CreateClient(string name)
+        {
+            RequestedNames.Add(name);
+            return new HttpClient(Handler, disposeHandler: false)
+            {
+                BaseAddress = new Uri("https://cs-test.cognitiveservices.azure.com/"),
+            };
+        }
+    }
 }


### PR DESCRIPTION
Closes #272. Closes #273. Also removes the failed workflow runs left behind by every sync pull request.

## The empty runs on sync pull requests

Every release left three runs reading `failure` with zero jobs. Root cause, measured rather than assumed: opening the sync pull request with `GITHUB_TOKEN` makes GitHub record a run for the `pull_request` event and then never dispatch it.

Evidence across two release cycles: runs `33421887474`, `33421887532`, `33421887550`, `33416614117` and `33416614221` all had `triggering_actor: github-actions[bot]`, zero jobs, zero check runs, and terminated at the merge second. Run `33416614154` is the control: same second, same branch, but `run_attempt: 2` with `triggering_actor: swigerb` because it was re-run by hand, and it executed normally with one job and a success.

They gate nothing. The sync branch head is main's head, and check runs attach to a commit, so the required checks were already satisfied by the push to main. But three red entries per release make a healthy Actions tab read as a failing one.

The job now waits for auto-merge to land the pull request, then deletes runs that have zero jobs. **The zero-job test is the safety property**: a run that dispatched anything has at least one job and is never touched, so this cannot erase evidence of a real failure. The five historical shells were swept with the same predicate and the one genuine run was correctly spared.

## #272 Save Configuration contrast

`#f59e0b` under white text measures 2.15:1 against the 4.5:1 AA minimum. Amber-700 keeps the Security page identity at 5.02:1.

The test asserts the computed ratio, not the hex, so a future restyle is judged on readability. A second test pins the helper against the 2.15:1 originally reported, so a passing assertion cannot come from a broken calculator.

## #273 residual cold-start fail-open row

The survivor of the ADR-016 warm-up was classified `Transport`, "the connection failed before a response". The token was warm; the first scan was still the call paying DNS, TCP and the TLS handshake inside its 1500 ms budget.

**Retrying was rejected.** `AddContentSafetyResilienceHandler` documents "no retries" as a deliberate choice so the caller applies fail-open on the first failure rather than tripling per-call latency. Adding a runtime retry to fix a startup-only problem would contradict a standing decision.

So the handshake moves into the warm-up: one throwaway request to the endpoint root through the shared named `HttpClient`, which both evaluator paths are registered against, so one request primes both. Two attempts, because the handler caps each attempt at `TimeoutMs` and spare budget only helps by re-attempting. No backoff, because a refused connection is not rate limited. Token and transport share one deadline and the handshake is skipped rather than overrun it.

`Program.cs` now calls the same `WarmAsync` the hosted service calls. It previously re-implemented the budget and token call inline, so the startup path, the one that actually produced the row, could drift from the runtime path.

Fail-open policy and audit visibility are unchanged. The row still appears if the warm-up loses the race, because a row means content passed unscanned.

## Verification

- Backend: **3641 passed, 0 failed**, 9 skipped (live-conformance, expected)
- Frontend: **926 passed** across 99 files
- `dotnet format --verify-no-changes`: clean
- `npm run build`: clean
- Warm-up tests: 6, covering connection opened on the shared client by name, retry on first-attempt failure, no throw when every attempt fails, and handshake skipped when the token consumes the budget

Live verification of the contrast fix and the cold-start row follows deployment.
