### PR TITLE
fix(api): floor the transport warm-up budget so a doomed handshake is skipped

### DIFF
--- a/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyWarmUpService.cs
+++ b/src/RetailPulse.Api/Guardrails/ContentSafety/ContentSafetyWarmUpService.cs
@@ -38,6 +38,21 @@ internal sealed class ContentSafetyWarmUpService : IHostedService
     // or timed-out connection is not rate limited: there is nothing to wait for.
     private const int _maxTransportAttempts = 2;
 
+    // A cold handshake is DNS plus TCP plus TLS, so it needs tens of milliseconds
+    // at minimum. Starting one on whatever slice of budget happens to survive the
+    // token warm-up is guaranteed to cancel mid-flight: it burns a socket, leaves a
+    // half-open connection the first scan cannot reuse, and logs a warning that
+    // reads like a real transport fault. Below this floor, skipping is the honest
+    // outcome.
+    //
+    // The floor also removes a sub-millisecond race. When the credential hangs, the
+    // token warm-up is meant to consume this whole budget and leave nothing. But it
+    // stops itself with CancellationTokenSource.CancelAfter(TimeSpan), which
+    // truncates to whole milliseconds, so it can return up to a millisecond before
+    // the shared deadline. A real endpoint could do nothing with that sliver, but a
+    // test double answers instantly, which made the "budget fully spent" case flake.
+    private static readonly TimeSpan _minHandshakeBudget = TimeSpan.FromMilliseconds(100);
+
     private readonly ContentSafetyTokenProvider _tokens;
     private readonly IHttpClientFactory _httpFactory;
     private readonly GuardrailsConfig _guardrails;
@@ -132,10 +147,23 @@ internal sealed class ContentSafetyWarmUpService : IHostedService
         for (int attempt = 1; attempt <= _maxTransportAttempts; attempt++)
         {
             TimeSpan remaining = RemainingBudget(deadline);
-            if (remaining <= TimeSpan.Zero)
+            if (remaining < _minHandshakeBudget)
             {
-                _logger.LogWarning(
-                    "Content Safety transport warm-up skipped: the warm-up budget was spent acquiring the token.");
+                if (attempt == 1)
+                {
+                    _logger.LogWarning(
+                        "Content Safety transport warm-up skipped: {Remaining}ms of the warm-up budget survived the token acquisition, below the {Floor}ms a handshake needs.",
+                        (int)remaining.TotalMilliseconds,
+                        (int)_minHandshakeBudget.TotalMilliseconds);
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Content Safety transport warm-up not retried: {Remaining}ms of the warm-up budget is left, below the {Floor}ms a handshake needs.",
+                        (int)remaining.TotalMilliseconds,
+                        (int)_minHandshakeBudget.TotalMilliseconds);
+                }
+
                 return;
             }
 

--- a/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyWarmUpServiceTests.cs
+++ b/tests/RetailPulse.Tests/Guardrails/ContentSafety/ContentSafetyWarmUpServiceTests.cs
@@ -123,8 +123,9 @@ public class ContentSafetyWarmUpServiceTests
 
         await service.WarmAsync(CancellationToken.None);
 
-        // One deadline covers the whole warm-up. Overrunning it to squeeze in a
-        // handshake would break the time-box that keeps startup safe.
+        // One deadline covers the whole warm-up, and a handshake needs a viable
+        // slice of it. Starting one on the remnant of a budget the token already
+        // spent would cancel mid-flight and leave nothing pooled for the first scan.
         factory.Handler.CallCount.Should().Be(0);
     }
 


### PR DESCRIPTION
## Why

Promoting #285 to `main` surfaced a real flake, not a CI hiccup:
`WarmAsync_SkipsTheHandshake_WhenTheTokenConsumedTheWholeBudget` failed on the push run.

The token warm-up and the transport warm-up share a single deadline. When the credential hangs, the token half is supposed to consume the entire budget and leave nothing behind. It stops itself with `CancellationTokenSource.CancelAfter(TimeSpan)`, which truncates to whole milliseconds, so it can hand back control up to a millisecond *before* the shared deadline. The transport half then saw a sliver of remaining budget and started a handshake.

## Why this matters in production, not just in the test

That sliver is worse than no budget at all. A cold handshake is DNS plus TCP plus TLS and needs tens of milliseconds at minimum, so the attempt gets cancelled mid-flight. It burns a socket, leaves a half-open connection the first scan cannot reuse, and logs a warning that reads exactly like a genuine transport fault. The test double answers instantly, which is the only reason the race was visible at all.

## The change

- Require 100ms of surviving budget before attempting the handshake. Below that, skipping is the honest outcome, and the margin is large enough that millisecond truncation and timer jitter cannot reach it.
- The skip log now reports how much budget actually survived, and distinguishes the first attempt from a retry that has run the budget out.

## Validation

- 3641 backend tests pass, 9 skipped.
- `ContentSafetyWarmUpServiceTests` run 15 consecutive times with no failures.
- `dotnet format --verify-no-changes` clean, API build clean at 0 warnings (the first cut of this fix tripped CA2254 with a varying log template; that is fixed).

Follow-up to #273.
